### PR TITLE
Fix Install box overflow on mobile

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -378,6 +378,7 @@
     .btn{width:100%;max-width:280px;justify-content:center}
     .key-row{padding:8px 16px}
     .key-row kbd{min-width:70px}
+    .install-box code {white-space:pre-wrap;word-break:break-all;}
   }
 </style>
 </head>


### PR DESCRIPTION
Fixes the install command box overflowing its container on mobile screens (< 640px).
Changes:
- Added responsive styles to `.install-box` and `code` in mobile breakpoint
- Text now wraps properly instead of overflowing