### PR TITLE
Fix space key not working in text input modes

### DIFF
--- a/ui/keys.go
+++ b/ui/keys.go
@@ -374,6 +374,10 @@ func (m *Model) handleSearchKey(msg tea.KeyMsg) tea.Cmd {
 			m.updateSearch()
 		}
 
+	case tea.KeySpace:
+		m.searchQuery += " "
+		m.updateSearch()
+
 	default:
 		if msg.Type == tea.KeyRunes {
 			m.searchQuery += string(msg.Runes)
@@ -555,6 +559,8 @@ func (m *Model) handlePlMgrNewNameKey(msg tea.KeyMsg) tea.Cmd {
 			_, size := utf8.DecodeLastRuneInString(m.plMgrNewName)
 			m.plMgrNewName = m.plMgrNewName[:len(m.plMgrNewName)-size]
 		}
+	case tea.KeySpace:
+		m.plMgrNewName += " "
 	default:
 		if msg.Type == tea.KeyRunes {
 			m.plMgrNewName += string(msg.Runes)
@@ -701,6 +707,9 @@ func (m *Model) handleKeymapKey(msg tea.KeyMsg) tea.Cmd {
 			m.keymapSearch = m.keymapSearch[:len(m.keymapSearch)-size]
 			m.updateKeymapFilter()
 		}
+	case tea.KeySpace:
+		m.keymapSearch += " "
+		m.updateKeymapFilter()
 	default:
 		switch msg.String() {
 		case "ctrl+c":


### PR DESCRIPTION
## Summary
- Bubbletea sends the space key as `tea.KeySpace` rather than `tea.KeyRunes`, so all text input handlers that only check for `KeyRunes` silently drop spaces
- Adds explicit `tea.KeySpace` handling to the search overlay, playlist name input, and keymap filter

## Test plan
- [ ] Open search with `/`, type a query containing spaces — spaces should appear in the search field
- [ ] Create a new playlist with `p` → `+ New Playlist...`, type a name with spaces — spaces should appear
- [ ] Open keymap with `Ctrl+K`, type a filter with spaces — spaces should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)