### PR TITLE
Add album separator headers in playlist view

### DIFF
--- a/ui/view.go
+++ b/ui/view.go
@@ -638,7 +638,30 @@ func (m Model) renderPlaylist() string {
 	scroll = max(0, scroll)
 
 	lines := make([]string, 0, visible)
-	for i := scroll; i < scroll+visible && i < len(tracks); i++ {
+	prevAlbum := ""
+	if scroll > 0 {
+		prevAlbum = tracks[scroll-1].Album
+	}
+	for i := scroll; i < len(tracks) && len(lines) < visible; i++ {
+		// Insert album separator when album changes
+		if album := tracks[i].Album; album != "" && album != prevAlbum {
+			label := "── " + album
+			if tracks[i].Year != 0 {
+				label += fmt.Sprintf(" (%d)", tracks[i].Year)
+			}
+			label += " "
+			pw := panelWidth
+			labelLen := len([]rune(label))
+			if labelLen < pw {
+				label += strings.Repeat("─", pw-labelLen)
+			}
+			lines = append(lines, dimStyle.Render(label))
+			if len(lines) >= visible {
+				break
+			}
+		}
+		prevAlbum = tracks[i].Album
+
 		prefix := "  "
 		style := playlistItemStyle
 


### PR DESCRIPTION
## Summary
- Adds visual album separator headers in the playlist view, grouping tracks by album
- Format: `── Album Name (Year) ──────` rendered with dim styling
- Separators only appear when tracks have album metadata — untagged files show no separators
- Separator lines count against the visible line budget so scrolling works correctly

## Test plan
- [ ] Load a directory with multiple albums — verify separator headers appear between album groups
- [ ] Load untagged files — verify no separators, playlist looks identical to before
- [ ] Scroll through the playlist — verify separators appear/disappear correctly at scroll boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)