### PR TITLE
Fix non-Latin metadata display for legacy-encoded tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gopxl/beep/v2 v2.1.1
 	github.com/jfreymuth/oggvorbis v1.0.5
 	github.com/madelynnblue/go-dsp v1.0.0
+	golang.org/x/text v0.14.0
 )
 
 require (
@@ -37,5 +38,4 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sys v0.36.0 // indirect
-	golang.org/x/text v0.14.0 // indirect
 )

--- a/playlist/encoding.go
+++ b/playlist/encoding.go
@@ -1,0 +1,91 @@
+package playlist
+
+import (
+	"unicode"
+	"unicode/utf8"
+
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/charmap"
+)
+
+// legacyEncodings lists codepages commonly used by music taggers that wrote
+// non-Latin text but marked the encoding as Latin-1.
+var legacyEncodings = []encoding.Encoding{
+	charmap.Windows1255, // Hebrew
+	charmap.Windows1256, // Arabic
+	charmap.Windows1251, // Cyrillic
+	charmap.Windows1253, // Greek
+	charmap.Windows874,  // Thai
+}
+
+// sanitizeTag detects mojibake from legacy codepages and re-decodes to UTF-8.
+//
+// Many old ID3 taggers write non-Latin text using a Windows codepage but mark
+// the encoding as Latin-1. The tag library faithfully decodes those bytes as
+// Latin-1, producing garbled text. We detect this by checking for a high
+// density of Latin-1 supplement characters (U+0080–U+00FF), reverse the
+// Latin-1 decode to recover the original bytes, then try common codepages
+// and pick the one that produces the most non-Latin script characters.
+func sanitizeTag(s string) string {
+	if s == "" {
+		return s
+	}
+
+	// Count runes in the Latin-1 supplement range (U+0080–U+00FF).
+	// Real Latin text (French, German) rarely exceeds ~10% accented chars.
+	// Mojibake from non-Latin scripts is almost entirely in this range.
+	var total, highCount int
+	for _, r := range s {
+		total++
+		if r >= 0x80 && r <= 0xFF {
+			highCount++
+		}
+	}
+	if total == 0 || highCount*3 < total {
+		return s
+	}
+
+	// Reverse the Latin-1 decode to recover the original tag bytes.
+	raw := make([]byte, 0, total)
+	for _, r := range s {
+		if r > 0xFF {
+			return s // Contains runes outside Latin-1 — not simple mojibake
+		}
+		raw = append(raw, byte(r))
+	}
+
+	// The original bytes might be valid UTF-8 that was double-decoded.
+	if utf8.Valid(raw) {
+		return string(raw)
+	}
+
+	// Try legacy codepages; pick the one that produces the most
+	// non-Latin letters (Hebrew, Cyrillic, Arabic, Greek, Thai, etc.).
+	var bestText string
+	var bestScore int
+	for _, enc := range legacyEncodings {
+		decoded, err := enc.NewDecoder().Bytes(raw)
+		if err != nil {
+			continue
+		}
+		text := string(decoded)
+		if !utf8.ValidString(text) {
+			continue
+		}
+		score := 0
+		for _, r := range text {
+			if unicode.IsLetter(r) && r > 0x024F {
+				score++
+			}
+		}
+		if score > bestScore {
+			bestScore = score
+			bestText = text
+		}
+	}
+
+	if bestText != "" {
+		return bestText
+	}
+	return s
+}

--- a/playlist/tags.go
+++ b/playlist/tags.go
@@ -25,10 +25,10 @@ func ReadTags(path string) Track {
 
 	t := Track{
 		Path:   path,
-		Title:  strings.TrimSpace(m.Title()),
-		Artist: strings.TrimSpace(m.Artist()),
-		Album:  strings.TrimSpace(m.Album()),
-		Genre:  strings.TrimSpace(m.Genre()),
+		Title:  sanitizeTag(strings.TrimSpace(m.Title())),
+		Artist: sanitizeTag(strings.TrimSpace(m.Artist())),
+		Album:  sanitizeTag(strings.TrimSpace(m.Album())),
+		Genre:  sanitizeTag(strings.TrimSpace(m.Genre())),
 		Year:   m.Year(),
 	}
 	trackNum, _ := m.Track()
@@ -40,7 +40,7 @@ func ReadTags(path string) Track {
 // filename, or using the bare filename as the title.
 func trackFromFilename(path string) Track {
 	base := filepath.Base(path)
-	name := strings.TrimSuffix(base, filepath.Ext(base))
+	name := sanitizeTag(strings.TrimSuffix(base, filepath.Ext(base)))
 	parts := strings.SplitN(name, " - ", 2)
 	if len(parts) == 2 {
 		return Track{Path: path, Artist: strings.TrimSpace(parts[0]), Title: strings.TrimSpace(parts[1])}


### PR DESCRIPTION
## Summary
- Detect mojibake from Windows codepages (1255/Hebrew, 1256/Arabic, 1251/Cyrillic, 1253/Greek, 874/Thai) misread as Latin-1 by the tag library and re-decode to proper UTF-8
- Applies to both embedded ID3/Vorbis/MP4 tag values and filename-based track parsing
- Adds `playlist/encoding.go` with `sanitizeTag()`, promotes `golang.org/x/text` from indirect to direct dependency

## Test plan
- [ ] Load local files with Hebrew/Arabic/Cyrillic ID3 tags encoded in legacy Windows codepages
- [ ] Verify artist, title, album, genre display correctly in the TUI
- [ ] Verify files with Latin-accented text (French, German) are not affected
- [ ] Verify filename fallback parsing also handles legacy-encoded filenames

🤖 Generated with [Claude Code](https://claude.com/claude-code)