### PR TITLE
Refactor Navidrome configuration to use config section instead of env

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -34,3 +34,14 @@ eq_preset = "Flat"
 # Bands: 70Hz, 180Hz, 320Hz, 600Hz, 1kHz, 3kHz, 6kHz, 12kHz, 14kHz, 16kHz
 # Only used when eq_preset is "Custom" or empty
 eq = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+
+# ---
+# Navidrome / Subsonic server (optional)
+# When configured, cliamp opens the playlist browser on startup and streams
+# tracks directly from your server.
+# These values take precedence over the NAVIDROME_URL / NAVIDROME_USER /
+# NAVIDROME_PASS environment variables when both are present.
+# [navidrome]
+# url      = "https://music.example.com"
+# user     = "alice"
+# password = "secret"

--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,19 @@ func configPath() (string, error) {
 	return filepath.Join(home, ".config", "cliamp", "config.toml"), nil
 }
 
+// NavidromeConfig holds credentials for a Navidrome/Subsonic server.
+// All three fields must be non-empty for a client to be constructed.
+type NavidromeConfig struct {
+	URL      string // e.g. "https://music.example.com"
+	User     string
+	Password string
+}
+
+// IsSet reports whether all three Navidrome credentials are present.
+func (n NavidromeConfig) IsSet() bool {
+	return n.URL != "" && n.User != "" && n.Password != ""
+}
+
 // Config holds user preferences loaded from the config file.
 type Config struct {
 	Volume          float64     // dB, range [-30, +6]
@@ -29,10 +42,11 @@ type Config struct {
 	Repeat          string      // "off", "all", or "one"
 	Shuffle         bool
 	Mono            bool
-	Theme           string // theme name, or "" for ANSI default
-	SampleRate      int    // output sample rate: 22050, 44100, 48000, 96000, 192000
-	BufferMs        int    // speaker buffer in milliseconds (50–500)
-	ResampleQuality int    // beep resample quality factor (1–4)
+	Theme           string          // theme name, or "" for ANSI default
+	SampleRate      int             // output sample rate: 22050, 44100, 48000, 96000, 192000
+	BufferMs        int             // speaker buffer in milliseconds (50–500)
+	ResampleQuality int             // beep resample quality factor (1–4)
+	Navidrome       NavidromeConfig // optional Navidrome/Subsonic server credentials
 }
 
 // Default returns a Config with sensible defaults.
@@ -65,11 +79,19 @@ func Load() (Config, error) {
 	defer f.Close()
 
 	scanner := bufio.NewScanner(f)
+	section := "" // current [section] header, empty = top-level
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
+
+		// Section header: [navidrome]
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section = strings.ToLower(line[1 : len(line)-1])
+			continue
+		}
+
 		key, val, ok := strings.Cut(line, "=")
 		if !ok {
 			continue
@@ -77,38 +99,50 @@ func Load() (Config, error) {
 		key = strings.TrimSpace(key)
 		val = strings.TrimSpace(val)
 
-		switch key {
-		case "volume":
-			if v, err := strconv.ParseFloat(val, 64); err == nil {
-				cfg.Volume = v
+		switch section {
+		case "navidrome":
+			switch key {
+			case "url":
+				cfg.Navidrome.URL = strings.Trim(val, `"'`)
+			case "user":
+				cfg.Navidrome.User = strings.Trim(val, `"'`)
+			case "password":
+				cfg.Navidrome.Password = strings.Trim(val, `"'`)
 			}
-		case "repeat":
-			val = strings.Trim(val, `"'`)
-			switch strings.ToLower(val) {
-			case "all", "one", "off":
-				cfg.Repeat = strings.ToLower(val)
-			}
-		case "shuffle":
-			cfg.Shuffle = val == "true"
-		case "mono":
-			cfg.Mono = val == "true"
-		case "eq":
-			cfg.EQ = parseEQ(val)
-		case "eq_preset":
-			cfg.EQPreset = strings.Trim(val, `"'`)
-		case "theme":
-			cfg.Theme = strings.Trim(val, `"'`)
-		case "sample_rate":
-			if v, err := strconv.Atoi(val); err == nil {
-				cfg.SampleRate = v
-			}
-		case "buffer_ms":
-			if v, err := strconv.Atoi(val); err == nil {
-				cfg.BufferMs = v
-			}
-		case "resample_quality":
-			if v, err := strconv.Atoi(val); err == nil {
-				cfg.ResampleQuality = v
+		default:
+			switch key {
+			case "volume":
+				if v, err := strconv.ParseFloat(val, 64); err == nil {
+					cfg.Volume = v
+				}
+			case "repeat":
+				val = strings.Trim(val, `"'`)
+				switch strings.ToLower(val) {
+				case "all", "one", "off":
+					cfg.Repeat = strings.ToLower(val)
+				}
+			case "shuffle":
+				cfg.Shuffle = val == "true"
+			case "mono":
+				cfg.Mono = val == "true"
+			case "eq":
+				cfg.EQ = parseEQ(val)
+			case "eq_preset":
+				cfg.EQPreset = strings.Trim(val, `"'`)
+			case "theme":
+				cfg.Theme = strings.Trim(val, `"'`)
+			case "sample_rate":
+				if v, err := strconv.Atoi(val); err == nil {
+					cfg.SampleRate = v
+				}
+			case "buffer_ms":
+				if v, err := strconv.Atoi(val); err == nil {
+					cfg.BufferMs = v
+				}
+			case "resample_quality":
+				if v, err := strconv.Atoi(val); err == nil {
+					cfg.ResampleQuality = v
+				}
 			}
 		}
 	}

--- a/external/navidrome/client.go
+++ b/external/navidrome/client.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"time"
 
+	"cliamp/config"
 	"cliamp/playlist"
 )
 
@@ -38,6 +39,15 @@ func NewFromEnv() *NavidromeClient {
 		return nil
 	}
 	return New(u, user, pass)
+}
+
+// NewFromConfig creates a NavidromeClient from a config.NavidromeConfig value.
+// Returns nil if any of the required fields (URL, User, Password) are empty.
+func NewFromConfig(cfg config.NavidromeConfig) *NavidromeClient {
+	if !cfg.IsSet() {
+		return nil
+	}
+	return New(cfg.URL, cfg.User, cfg.Password)
 }
 
 func (c *NavidromeClient) Name() string {

--- a/main.go
+++ b/main.go
@@ -30,7 +30,10 @@ func run(overrides config.Overrides, positional []string) error {
 	overrides.Apply(&cfg)
 
 	var navProv playlist.Provider
-	if c := navidrome.NewFromEnv(); c != nil {
+	// Config file takes precedence; fall back to environment variables.
+	if c := navidrome.NewFromConfig(cfg.Navidrome); c != nil {
+		navProv = c
+	} else if c := navidrome.NewFromEnv(); c != nil {
 		navProv = c
 	}
 	localProv := local.New()
@@ -153,8 +156,9 @@ Examples:
   cliamp https://www.youtube.com/watch?v=...
 
 Environment:
-  NAVIDROME_URL, NAVIDROME_USER, NAVIDROME_PASS   Navidrome server
+  NAVIDROME_URL, NAVIDROME_USER, NAVIDROME_PASS   Navidrome server (env fallback)
 
+Config:    ~/.config/cliamp/config.toml  (see config.toml.example)
 Playlists: ~/.config/cliamp/playlists/*.toml
 Formats:   mp3, wav, flac, ogg, m4a, aac, opus, wma (aac/opus/wma need ffmpeg)
 SoundCloud/YouTube/Bandcamp require yt-dlp`


### PR DESCRIPTION
Add navidrome to the configuration toml file, while still allowing fallback to the environment variables. 

**Navidrome configuration:**

* Added a new `[navidrome]` section in `config.toml.example` for specifying server URL, user, and password, with clear documentation about precedence over environment variables.
* Introduced a new `NavidromeConfig` struct in `config/config.go` to hold server credentials, along with an `IsSet` method to validate completeness.
* Extended the main `Config` struct to include the new `Navidrome` field for optional credentials.

**Config file parsing enhancements:**

* Updated the config file loader to parse the `[navidrome]` section and populate the `NavidromeConfig` struct, supporting section-based config parsing. [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R82-R112) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R148)

**Client initialization logic:**

* Added `NewFromConfig` to `external/navidrome/client.go` to construct a client from config credentials, falling back to environment variables only if config is not set. [[1]](diffhunk://#diff-34252a1eee0fabcdc7ff923d46de750f5375a77a12c2fe0d31575f2d1d70eb77R44-R52) [[2]](diffhunk://#diff-34252a1eee0fabcdc7ff923d46de750f5375a77a12c2fe0d31575f2d1d70eb77R13)
* Updated `main.go` to prioritize config-based credentials for Navidrome client initialization and clarified documentation for config precedence. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L33-R36) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L156-R161)