### PR TITLE
Implement Navidrome browser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Flags can appear before, after, or between file arguments. See [docs/cli.md](doc
 | `/` | Search playlist |
 | `x` | Expand/collapse playlist |
 | `o` | Open file browser |
+| `N` | Navidrome browser |
 | `a` | Toggle queue (play next) |
 | `A` | Queue manager |
 | `p` | Playlist manager |

--- a/config.toml.example
+++ b/config.toml.example
@@ -45,3 +45,9 @@ eq = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 # url      = "https://music.example.com"
 # user     = "alice"
 # password = "secret"
+#
+# Album browse sort order for the Navidrome browser (press N to open).
+# Valid values: alphabeticalByName, alphabeticalByArtist, newest, recent,
+#               frequent, starred, byYear, byGenre
+# This is updated automatically when you press [s] inside the browser.
+# browse_sort = alphabeticalByName

--- a/config/config.go
+++ b/config/config.go
@@ -24,9 +24,10 @@ func configPath() (string, error) {
 // NavidromeConfig holds credentials for a Navidrome/Subsonic server.
 // All three fields must be non-empty for a client to be constructed.
 type NavidromeConfig struct {
-	URL      string // e.g. "https://music.example.com"
-	User     string
-	Password string
+	URL        string // e.g. "https://music.example.com"
+	User       string
+	Password   string
+	BrowseSort string // album browse sort order, e.g. "alphabeticalByName"
 }
 
 // IsSet reports whether all three Navidrome credentials are present.
@@ -108,6 +109,8 @@ func Load() (Config, error) {
 				cfg.Navidrome.User = strings.Trim(val, `"'`)
 			case "password":
 				cfg.Navidrome.Password = strings.Trim(val, `"'`)
+			case "browse_sort":
+				cfg.Navidrome.BrowseSort = strings.Trim(val, `"'`)
 			}
 		default:
 			switch key {
@@ -191,6 +194,79 @@ func Save(key, value string) error {
 	}
 	if !found {
 		lines = append(lines, line)
+	}
+
+	return os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o644)
+}
+
+// SaveNavidromeSort persists the given album browse sort type to the
+// [navidrome] section of the config file. It rewrites the browse_sort key
+// in-place, or appends it after the [navidrome] section if not present.
+// If no [navidrome] section exists, one is appended along with the key.
+func SaveNavidromeSort(sortType string) error {
+	path, err := configPath()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+
+	line := fmt.Sprintf("browse_sort = %s", sortType)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return err
+		}
+		// No file: create with section + key.
+		return os.WriteFile(path, []byte("[navidrome]\n"+line+"\n"), 0o644)
+	}
+
+	lines := strings.Split(string(data), "\n")
+
+	// Try to replace an existing browse_sort inside [navidrome].
+	inNavidrome := false
+	for i, l := range lines {
+		trimmed := strings.TrimSpace(l)
+		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+			inNavidrome = strings.ToLower(trimmed[1:len(trimmed)-1]) == "navidrome"
+			continue
+		}
+		if inNavidrome {
+			k, _, ok := strings.Cut(trimmed, "=")
+			if ok && strings.TrimSpace(k) == "browse_sort" {
+				lines[i] = line
+				return os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o644)
+			}
+		}
+	}
+
+	// Key not found: append after the last line in the [navidrome] section,
+	// or append a new [navidrome] section at the end.
+	inNavidrome = false
+	insertAt := -1
+	for i, l := range lines {
+		trimmed := strings.TrimSpace(l)
+		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+			if inNavidrome && insertAt >= 0 {
+				break // we've moved past [navidrome]
+			}
+			inNavidrome = strings.ToLower(trimmed[1:len(trimmed)-1]) == "navidrome"
+		}
+		if inNavidrome {
+			insertAt = i
+		}
+	}
+
+	if insertAt >= 0 {
+		// Insert after the last line we saw inside [navidrome].
+		tail := append([]string{line}, lines[insertAt+1:]...)
+		lines = append(lines[:insertAt+1], tail...)
+	} else {
+		// No [navidrome] section found: append one.
+		lines = append(lines, "[navidrome]", line)
 	}
 
 	return os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o644)

--- a/docs/navidrome.md
+++ b/docs/navidrome.md
@@ -39,8 +39,63 @@ When focused on the provider panel:
 | `Up` `Down` / `j` `k` | Navigate playlists |
 | `Enter` | Load the selected playlist |
 | `Tab` | Switch between provider and playlist focus |
+| `N` | Open the Navidrome browser |
 
 After loading a playlist you return to the standard playlist view with all the usual controls (seek, volume, EQ, shuffle, repeat, queue, search).
+
+## Navidrome Browser
+
+Press `N` at any time (or from the provider panel) to open the full-screen Navidrome browser. It lets you explore your library in three modes:
+
+- **By Album** — browse a paginated list of all albums, then open any album to see its tracks.
+- **By Artist** — browse all artists; selecting one loads every track across all their albums, grouped by album with separator headers.
+- **By Artist / Album** — three-level drill-down: artist → album list → track list.
+
+### Browser controls
+
+**Mode menu:**
+
+| Key | Action |
+|---|---|
+| `↑` `↓` / `j` `k` | Navigate |
+| `Enter` | Select mode |
+| `Esc` / `N` | Close browser |
+
+**Artist or album list:**
+
+| Key | Action |
+|---|---|
+| `↑` `↓` / `j` `k` | Navigate |
+| `Enter` / `→` | Drill in |
+| `s` | Cycle album sort order (album list only) |
+| `Esc` / `←` | Back |
+
+**Track list:**
+
+| Key | Action |
+|---|---|
+| `↑` `↓` / `j` `k` | Navigate |
+| `Enter` | Append selected track to playlist |
+| `a` | Append all tracks to playlist |
+| `R` | Replace playlist with all tracks and start playing |
+| `Esc` / `←` | Back |
+
+### Album sort order
+
+While viewing the global album list, press `s` to cycle through sort modes:
+
+| Value | Description |
+|---|---|
+| `alphabeticalByName` | A → Z by album title (default) |
+| `alphabeticalByArtist` | A → Z by artist name |
+| `newest` | Most recently added |
+| `recent` | Most recently played |
+| `frequent` | Most frequently played |
+| `starred` | Starred / favourited |
+| `byYear` | Chronological by release year |
+| `byGenre` | Grouped by genre |
+
+The chosen sort is saved automatically to `~/.config/cliamp/config.toml` under the `[navidrome]` section as `browse_sort` and is restored on the next launch.
 
 ## Architecture
 

--- a/external/navidrome/client.go
+++ b/external/navidrome/client.go
@@ -17,6 +17,72 @@ import (
 // httpClient is used for all Navidrome API calls with a finite timeout.
 var httpClient = &http.Client{Timeout: 30 * time.Second}
 
+// Sort type constants for album browsing (Subsonic getAlbumList2 "type" parameter).
+const (
+	SortAlphabeticalByName   = "alphabeticalByName"
+	SortAlphabeticalByArtist = "alphabeticalByArtist"
+	SortNewest               = "newest"
+	SortRecent               = "recent"
+	SortFrequent             = "frequent"
+	SortStarred              = "starred"
+	SortByYear               = "byYear"
+	SortByGenre              = "byGenre"
+)
+
+// SortTypes is the ordered list of sort modes used for cycling.
+var SortTypes = []string{
+	SortAlphabeticalByName,
+	SortAlphabeticalByArtist,
+	SortNewest,
+	SortRecent,
+	SortFrequent,
+	SortStarred,
+	SortByYear,
+	SortByGenre,
+}
+
+// SortTypeLabel returns a human-readable label for a sort type constant.
+func SortTypeLabel(s string) string {
+	switch s {
+	case SortAlphabeticalByName:
+		return "Alphabetical by Name"
+	case SortAlphabeticalByArtist:
+		return "Alphabetical by Artist"
+	case SortNewest:
+		return "Newest"
+	case SortRecent:
+		return "Recently Played"
+	case SortFrequent:
+		return "Most Played"
+	case SortStarred:
+		return "Starred"
+	case SortByYear:
+		return "By Year"
+	case SortByGenre:
+		return "By Genre"
+	default:
+		return s
+	}
+}
+
+// Artist represents a Navidrome/Subsonic artist entry.
+type Artist struct {
+	ID         string
+	Name       string
+	AlbumCount int
+}
+
+// Album represents a Navidrome/Subsonic album entry.
+type Album struct {
+	ID        string
+	Name      string
+	Artist    string
+	ArtistID  string
+	Year      int
+	SongCount int
+	Genre     string
+}
+
 // NavidromeClient implements playlist.Provider for a Navidrome/Subsonic server.
 type NavidromeClient struct {
 	url      string
@@ -124,9 +190,13 @@ func (c *NavidromeClient) Tracks(id string) ([]playlist.Track, error) {
 		SubsonicResponse struct {
 			Playlist struct {
 				Entry []struct {
-					ID     string `json:"id"`
-					Title  string `json:"title"`
-					Artist string `json:"artist"`
+					ID          string `json:"id"`
+					Title       string `json:"title"`
+					Artist      string `json:"artist"`
+					Album       string `json:"album"`
+					Year        int    `json:"year"`
+					TrackNumber int    `json:"track"`
+					Genre       string `json:"genre"`
 				} `json:"entry"`
 			} `json:"playlist"`
 		} `json:"subsonic-response"`
@@ -138,10 +208,204 @@ func (c *NavidromeClient) Tracks(id string) ([]playlist.Track, error) {
 	var tracks []playlist.Track
 	for _, t := range result.SubsonicResponse.Playlist.Entry {
 		tracks = append(tracks, playlist.Track{
-			Path:   c.streamURL(t.ID),
-			Title:  t.Title,
-			Artist: t.Artist,
-			Stream: true,
+			Path:        c.streamURL(t.ID),
+			Title:       t.Title,
+			Artist:      t.Artist,
+			Album:       t.Album,
+			Year:        t.Year,
+			TrackNumber: t.TrackNumber,
+			Genre:       t.Genre,
+			Stream:      true,
+		})
+	}
+	return tracks, nil
+}
+
+// Artists returns all artists from the server, flattening the index structure.
+func (c *NavidromeClient) Artists() ([]Artist, error) {
+	resp, err := httpClient.Get(c.buildURL("getArtists", nil))
+	if err != nil {
+		return nil, fmt.Errorf("navidrome: getArtists: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("navidrome: getArtists: http status %s", resp.Status)
+	}
+
+	var result struct {
+		SubsonicResponse struct {
+			Artists struct {
+				Index []struct {
+					Artist []struct {
+						ID         string `json:"id"`
+						Name       string `json:"name"`
+						AlbumCount int    `json:"albumCount"`
+					} `json:"artist"`
+				} `json:"index"`
+			} `json:"artists"`
+		} `json:"subsonic-response"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("navidrome: getArtists: %w", err)
+	}
+
+	var artists []Artist
+	for _, idx := range result.SubsonicResponse.Artists.Index {
+		for _, a := range idx.Artist {
+			artists = append(artists, Artist{
+				ID:         a.ID,
+				Name:       a.Name,
+				AlbumCount: a.AlbumCount,
+			})
+		}
+	}
+	return artists, nil
+}
+
+// ArtistAlbums returns all albums for the given artist ID.
+func (c *NavidromeClient) ArtistAlbums(artistID string) ([]Album, error) {
+	resp, err := httpClient.Get(c.buildURL("getArtist", url.Values{"id": {artistID}}))
+	if err != nil {
+		return nil, fmt.Errorf("navidrome: getArtist: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("navidrome: getArtist: http status %s", resp.Status)
+	}
+
+	var result struct {
+		SubsonicResponse struct {
+			Artist struct {
+				Album []struct {
+					ID        string `json:"id"`
+					Name      string `json:"name"`
+					Artist    string `json:"artist"`
+					ArtistID  string `json:"artistId"`
+					Year      int    `json:"year"`
+					SongCount int    `json:"songCount"`
+					Genre     string `json:"genre"`
+				} `json:"album"`
+			} `json:"artist"`
+		} `json:"subsonic-response"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("navidrome: getArtist: %w", err)
+	}
+
+	var albums []Album
+	for _, a := range result.SubsonicResponse.Artist.Album {
+		albums = append(albums, Album{
+			ID:        a.ID,
+			Name:      a.Name,
+			Artist:    a.Artist,
+			ArtistID:  a.ArtistID,
+			Year:      a.Year,
+			SongCount: a.SongCount,
+			Genre:     a.Genre,
+		})
+	}
+	return albums, nil
+}
+
+// AlbumList returns a page of albums sorted by sortType.
+// offset and size control pagination; size should be ≤ 500.
+func (c *NavidromeClient) AlbumList(sortType string, offset, size int) ([]Album, error) {
+	if sortType == "" {
+		sortType = SortAlphabeticalByName
+	}
+	params := url.Values{
+		"type":   {sortType},
+		"offset": {fmt.Sprintf("%d", offset)},
+		"size":   {fmt.Sprintf("%d", size)},
+	}
+	resp, err := httpClient.Get(c.buildURL("getAlbumList2", params))
+	if err != nil {
+		return nil, fmt.Errorf("navidrome: getAlbumList2: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("navidrome: getAlbumList2: http status %s", resp.Status)
+	}
+
+	var result struct {
+		SubsonicResponse struct {
+			AlbumList2 struct {
+				Album []struct {
+					ID        string `json:"id"`
+					Name      string `json:"name"`
+					Artist    string `json:"artist"`
+					ArtistID  string `json:"artistId"`
+					Year      int    `json:"year"`
+					SongCount int    `json:"songCount"`
+					Genre     string `json:"genre"`
+				} `json:"album"`
+			} `json:"albumList2"`
+		} `json:"subsonic-response"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("navidrome: getAlbumList2: %w", err)
+	}
+
+	var albums []Album
+	for _, a := range result.SubsonicResponse.AlbumList2.Album {
+		albums = append(albums, Album{
+			ID:        a.ID,
+			Name:      a.Name,
+			Artist:    a.Artist,
+			ArtistID:  a.ArtistID,
+			Year:      a.Year,
+			SongCount: a.SongCount,
+			Genre:     a.Genre,
+		})
+	}
+	return albums, nil
+}
+
+// AlbumTracks returns all tracks for the given album ID with full metadata.
+func (c *NavidromeClient) AlbumTracks(albumID string) ([]playlist.Track, error) {
+	resp, err := httpClient.Get(c.buildURL("getAlbum", url.Values{"id": {albumID}}))
+	if err != nil {
+		return nil, fmt.Errorf("navidrome: getAlbum: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("navidrome: getAlbum: http status %s", resp.Status)
+	}
+
+	var result struct {
+		SubsonicResponse struct {
+			Album struct {
+				Song []struct {
+					ID          string `json:"id"`
+					Title       string `json:"title"`
+					Artist      string `json:"artist"`
+					Album       string `json:"album"`
+					Year        int    `json:"year"`
+					TrackNumber int    `json:"track"`
+					Genre       string `json:"genre"`
+				} `json:"song"`
+			} `json:"album"`
+		} `json:"subsonic-response"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("navidrome: getAlbum: %w", err)
+	}
+
+	var tracks []playlist.Track
+	for _, s := range result.SubsonicResponse.Album.Song {
+		tracks = append(tracks, playlist.Track{
+			Path:        c.streamURL(s.ID),
+			Title:       s.Title,
+			Artist:      s.Artist,
+			Album:       s.Album,
+			Year:        s.Year,
+			TrackNumber: s.TrackNumber,
+			Genre:       s.Genre,
+			Stream:      true,
 		})
 	}
 	return tracks, nil

--- a/main.go
+++ b/main.go
@@ -30,10 +30,13 @@ func run(overrides config.Overrides, positional []string) error {
 	overrides.Apply(&cfg)
 
 	var navProv playlist.Provider
+	var navClient *navidrome.NavidromeClient
 	// Config file takes precedence; fall back to environment variables.
 	if c := navidrome.NewFromConfig(cfg.Navidrome); c != nil {
+		navClient = c
 		navProv = c
 	} else if c := navidrome.NewFromEnv(); c != nil {
+		navClient = c
 		navProv = c
 	}
 	localProv := local.New()
@@ -80,7 +83,7 @@ func run(overrides config.Overrides, positional []string) error {
 
 	themes := theme.LoadAll()
 
-	m := ui.NewModel(p, pl, provider, localProv, themes)
+	m := ui.NewModel(p, pl, provider, localProv, themes, cfg.Navidrome, navClient)
 	m.SetPendingURLs(resolved.Pending)
 	if len(resolved.Tracks) == 0 && len(resolved.Pending) == 0 {
 		m.StartInProvider()

--- a/ui/keys.go
+++ b/ui/keys.go
@@ -10,12 +10,21 @@ import (
 	"unicode/utf8"
 
 	tea "github.com/charmbracelet/bubbletea"
+
+	"cliamp/config"
+	"cliamp/external/navidrome"
+	"cliamp/playlist"
 )
 
 // handleKey processes a single key press and returns an optional command.
 func (m *Model) handleKey(msg tea.KeyMsg) tea.Cmd {
 	if m.showKeymap {
 		return m.handleKeymapKey(msg)
+	}
+
+	// Navidrome explore browser overlay
+	if m.showNavBrowser {
+		return m.handleNavBrowserKey(msg)
 	}
 
 	// Theme picker overlay — interactive navigation
@@ -83,6 +92,10 @@ func (m *Model) handleKey(msg tea.KeyMsg) tea.Cmd {
 			}
 		case "o":
 			m.openFileBrowser()
+		case "N":
+			if m.navClient != nil {
+				m.openNavBrowser()
+			}
 		}
 		return nil
 	}
@@ -257,6 +270,11 @@ func (m *Model) handleKey(msg tea.KeyMsg) tea.Cmd {
 
 	case "o":
 		m.openFileBrowser()
+
+	case "N":
+		if m.navClient != nil {
+			m.openNavBrowser()
+		}
 
 	case "v":
 		m.vis.CycleMode()
@@ -708,6 +726,7 @@ var keymapEntries = []keymapEntry{
 	{"a", "Toggle queue (play next)"},
 	{"A", "Queue manager"},
 	{"o", "Open file browser"},
+	{"N", "Navidrome browser"},
 	{"p", "Playlist manager"},
 	{"i", "Track info / metadata"},
 	{"S", "Save track to ~/Music"},
@@ -780,5 +799,443 @@ func (m *Model) updateKeymapFilter() {
 			strings.Contains(strings.ToLower(e.action), query) {
 			m.keymapFiltered = append(m.keymapFiltered, i)
 		}
+	}
+}
+
+// handleNavBrowserKey processes key presses while the Navidrome browser is open.
+func (m *Model) handleNavBrowserKey(msg tea.KeyMsg) tea.Cmd {
+	navClient := m.navClient
+	if navClient == nil {
+		m.showNavBrowser = false
+		return nil
+	}
+
+	// Search bar: active on any list/track screen (not the mode menu).
+	if m.navMode != navBrowseModeMenu {
+		if m.navSearching {
+			return m.handleNavSearchKey(msg)
+		}
+		if msg.String() == "/" {
+			// Toggle: if already filtered, clear; otherwise open.
+			if m.navSearch != "" {
+				m.navClearSearch()
+			} else {
+				m.navSearching = true
+			}
+			return nil
+		}
+	}
+
+	switch m.navMode {
+	case navBrowseModeMenu:
+		return m.handleNavMenuKey(msg, navClient)
+	case navBrowseModeByAlbum:
+		return m.handleNavByAlbumKey(msg, navClient)
+	case navBrowseModeByArtist:
+		return m.handleNavByArtistKey(msg, navClient)
+	case navBrowseModeByArtistAlbum:
+		return m.handleNavByArtistAlbumKey(msg, navClient)
+	}
+	return nil
+}
+
+func (m *Model) handleNavMenuKey(msg tea.KeyMsg, navClient *navidrome.NavidromeClient) tea.Cmd {
+	const menuItems = 3
+	switch msg.String() {
+	case "ctrl+c":
+		m.showNavBrowser = false
+		m.player.Close()
+		m.quitting = true
+		return tea.Quit
+	case "up", "k":
+		if m.navCursor > 0 {
+			m.navCursor--
+		}
+	case "down", "j":
+		if m.navCursor < menuItems-1 {
+			m.navCursor++
+		}
+	case "enter", "l", "right":
+		switch m.navCursor {
+		case 0: // By Album
+			m.navMode = navBrowseModeByAlbum
+			m.navScreen = navBrowseScreenList
+			m.navCursor = 0
+			m.navScroll = 0
+			m.navAlbums = nil
+			m.navAlbumLoading = true
+			m.navAlbumDone = false
+			m.navLoading = false
+			return fetchNavAlbumListCmd(navClient, m.navSortType, 0)
+		case 1: // By Artist
+			m.navMode = navBrowseModeByArtist
+			m.navScreen = navBrowseScreenList
+			m.navCursor = 0
+			m.navScroll = 0
+			m.navArtists = nil
+			m.navLoading = true
+			return fetchNavArtistsCmd(navClient)
+		case 2: // By Artist / Album
+			m.navMode = navBrowseModeByArtistAlbum
+			m.navScreen = navBrowseScreenList
+			m.navCursor = 0
+			m.navScroll = 0
+			m.navArtists = nil
+			m.navLoading = true
+			return fetchNavArtistsCmd(navClient)
+		}
+	case "esc", "N", "backspace", "b":
+		m.showNavBrowser = false
+	}
+	return nil
+}
+
+func (m *Model) handleNavByAlbumKey(msg tea.KeyMsg, navClient *navidrome.NavidromeClient) tea.Cmd {
+	switch m.navScreen {
+	case navBrowseScreenList:
+		return m.handleNavAlbumListKey(msg, navClient, false)
+	case navBrowseScreenTracks:
+		return m.handleNavTrackListKey(msg)
+	}
+	return nil
+}
+
+func (m *Model) handleNavByArtistKey(msg tea.KeyMsg, navClient *navidrome.NavidromeClient) tea.Cmd {
+	switch m.navScreen {
+	case navBrowseScreenList:
+		return m.handleNavArtistListKey(msg, navClient)
+	case navBrowseScreenTracks:
+		return m.handleNavTrackListKey(msg)
+	}
+	return nil
+}
+
+func (m *Model) handleNavByArtistAlbumKey(msg tea.KeyMsg, navClient *navidrome.NavidromeClient) tea.Cmd {
+	switch m.navScreen {
+	case navBrowseScreenList:
+		return m.handleNavArtistListKey(msg, navClient)
+	case navBrowseScreenAlbums:
+		return m.handleNavAlbumListKey(msg, navClient, true)
+	case navBrowseScreenTracks:
+		return m.handleNavTrackListKey(msg)
+	}
+	return nil
+}
+
+// handleNavArtistListKey handles the artist list screen (used by both By Artist and By Artist/Album modes).
+func (m *Model) handleNavArtistListKey(msg tea.KeyMsg, navClient *navidrome.NavidromeClient) tea.Cmd {
+	// Determine effective list length (filtered or full).
+	listLen := len(m.navArtists)
+	if len(m.navSearchIdx) > 0 {
+		listLen = len(m.navSearchIdx)
+	}
+
+	switch msg.String() {
+	case "ctrl+c":
+		m.showNavBrowser = false
+		m.player.Close()
+		m.quitting = true
+		return tea.Quit
+	case "up", "k":
+		if m.navCursor > 0 {
+			m.navCursor--
+			m.navMaybeAdjustScroll()
+		}
+	case "down", "j":
+		if m.navCursor < listLen-1 {
+			m.navCursor++
+			m.navMaybeAdjustScroll()
+		}
+	case "enter", "l", "right":
+		if m.navLoading || len(m.navArtists) == 0 {
+			return nil
+		}
+		// Resolve raw index (filtered or direct).
+		rawIdx := m.navCursor
+		if len(m.navSearchIdx) > 0 && m.navCursor < len(m.navSearchIdx) {
+			rawIdx = m.navSearchIdx[m.navCursor]
+		}
+		artist := m.navArtists[rawIdx]
+		m.navSelArtist = artist
+		m.navLoading = true
+		if m.navMode == navBrowseModeByArtistAlbum {
+			// Drill into album list for this artist.
+			m.navAlbums = nil
+			m.navAlbumLoading = false
+			m.navScreen = navBrowseScreenAlbums
+			m.navCursor = 0
+			m.navScroll = 0
+			m.navClearSearch()
+			return fetchNavArtistAlbumsCmd(navClient, artist.ID)
+		}
+		// By Artist: fetch all albums first, then all tracks via a two-step command.
+		// We use a dedicated command that fetches albums then tracks in one shot.
+		return m.fetchNavArtistAllTracksCmd(navClient, artist.ID)
+	case "esc", "h", "left", "backspace":
+		// Back to menu.
+		m.navClearSearch()
+		m.navMode = navBrowseModeMenu
+		m.navScreen = navBrowseScreenList
+	}
+	return nil
+}
+
+// handleNavAlbumListKey handles the album list screen.
+// artistAlbums=true means this is the artist's album sub-screen (ArtistAlbum mode), not the global list.
+func (m *Model) handleNavAlbumListKey(msg tea.KeyMsg, navClient *navidrome.NavidromeClient, artistAlbums bool) tea.Cmd {
+	// Determine effective list length (filtered or full).
+	listLen := len(m.navAlbums)
+	if len(m.navSearchIdx) > 0 {
+		listLen = len(m.navSearchIdx)
+	}
+
+	switch msg.String() {
+	case "ctrl+c":
+		m.showNavBrowser = false
+		m.player.Close()
+		m.quitting = true
+		return tea.Quit
+	case "up", "k":
+		if m.navCursor > 0 {
+			m.navCursor--
+			m.navMaybeAdjustScroll()
+		}
+	case "down", "j":
+		if m.navCursor < listLen-1 {
+			m.navCursor++
+			m.navMaybeAdjustScroll()
+			// Lazy-load next page: only trigger on the raw (unfiltered) list.
+			if !artistAlbums && len(m.navSearchIdx) == 0 && !m.navAlbumLoading && !m.navAlbumDone && m.navCursor >= len(m.navAlbums)-10 {
+				m.navAlbumLoading = true
+				return fetchNavAlbumListCmd(navClient, m.navSortType, len(m.navAlbums))
+			}
+		}
+	case "enter", "l", "right":
+		if (m.navLoading && !artistAlbums) || len(m.navAlbums) == 0 {
+			return nil
+		}
+		// Resolve raw index (filtered or direct).
+		rawIdx := m.navCursor
+		if len(m.navSearchIdx) > 0 && m.navCursor < len(m.navSearchIdx) {
+			rawIdx = m.navSearchIdx[m.navCursor]
+		}
+		album := m.navAlbums[rawIdx]
+		m.navSelAlbum = album
+		m.navLoading = true
+		m.navClearSearch()
+		return fetchNavAlbumTracksCmd(navClient, album.ID)
+	case "s":
+		if artistAlbums {
+			return nil // Sort only applies to global album list.
+		}
+		// Cycle to the next sort type.
+		m.navSortType = navNextSort(m.navSortType)
+		m.navAlbums = nil
+		m.navCursor = 0
+		m.navScroll = 0
+		m.navAlbumLoading = true
+		m.navAlbumDone = false
+		m.navClearSearch()
+		// Persist the new sort preference.
+		if err := config.SaveNavidromeSort(m.navSortType); err != nil {
+			m.saveMsg = fmt.Sprintf("Sort save failed: %s", err)
+			m.saveMsgTTL = 60
+		}
+		return fetchNavAlbumListCmd(navClient, m.navSortType, 0)
+	case "esc", "h", "left", "backspace":
+		m.navClearSearch()
+		if artistAlbums {
+			// Back to artist list.
+			m.navScreen = navBrowseScreenList
+		} else {
+			// Back to menu.
+			m.navMode = navBrowseModeMenu
+			m.navScreen = navBrowseScreenList
+		}
+	}
+	return nil
+}
+
+// handleNavTrackListKey handles the final track-list screen (used by all modes).
+func (m *Model) handleNavTrackListKey(msg tea.KeyMsg) tea.Cmd {
+	// Determine effective list length (filtered or full).
+	listLen := len(m.navTracks)
+	if len(m.navSearchIdx) > 0 {
+		listLen = len(m.navSearchIdx)
+	}
+
+	switch msg.String() {
+	case "ctrl+c":
+		m.showNavBrowser = false
+		m.player.Close()
+		m.quitting = true
+		return tea.Quit
+	case "up", "k":
+		if m.navCursor > 0 {
+			m.navCursor--
+			m.navMaybeAdjustScroll()
+		}
+	case "down", "j":
+		if m.navCursor < listLen-1 {
+			m.navCursor++
+			m.navMaybeAdjustScroll()
+		}
+	case "enter":
+		// Play the selected track immediately, then enqueue everything from that
+		// position to the end of the list (capped at 500 total tracks added).
+		if len(m.navTracks) == 0 {
+			return nil
+		}
+		rawIdx := m.navCursor
+		if len(m.navSearchIdx) > 0 && m.navCursor < len(m.navSearchIdx) {
+			rawIdx = m.navSearchIdx[m.navCursor]
+		}
+		if rawIdx < len(m.navTracks) {
+			const maxAdd = 500
+			m.player.Stop()
+			m.player.ClearPreload()
+
+			// Build the slice of tracks to add: from rawIdx to end (or 500 max).
+			var toAdd []playlist.Track
+			if len(m.navSearchIdx) > 0 {
+				// Filtered: use positions from navCursor onward in the filtered list.
+				for j := m.navCursor; j < len(m.navSearchIdx) && len(toAdd) < maxAdd; j++ {
+					toAdd = append(toAdd, m.navTracks[m.navSearchIdx[j]])
+				}
+			} else {
+				for i := rawIdx; i < len(m.navTracks) && len(toAdd) < maxAdd; i++ {
+					toAdd = append(toAdd, m.navTracks[i])
+				}
+			}
+
+			m.playlist.Add(toAdd...)
+			newIdx := m.playlist.Len() - len(toAdd)
+			m.playlist.SetIndex(newIdx)
+			m.plCursor = newIdx
+			m.adjustScroll()
+			if len(toAdd) > 1 {
+				m.saveMsg = fmt.Sprintf("Playing: %s (+%d queued)", toAdd[0].DisplayName(), len(toAdd)-1)
+			} else {
+				m.saveMsg = fmt.Sprintf("Playing: %s", toAdd[0].DisplayName())
+			}
+			m.saveMsgTTL = 80
+			cmd := m.playCurrentTrack()
+			m.notifyMPRIS()
+			return cmd
+		}
+	case "R":
+		// Replace playlist with all displayed tracks and close browser.
+		tracks := m.navTracks
+		if len(m.navSearchIdx) > 0 {
+			// Replace with only the filtered subset.
+			filtered := make([]playlist.Track, 0, len(m.navSearchIdx))
+			for _, i := range m.navSearchIdx {
+				filtered = append(filtered, m.navTracks[i])
+			}
+			tracks = filtered
+		}
+		if len(tracks) > 0 {
+			m.player.Stop()
+			m.player.ClearPreload()
+			m.playlist.Replace(tracks)
+			m.plCursor = 0
+			m.plScroll = 0
+			m.playlist.SetIndex(0)
+			m.focus = focusPlaylist
+			m.showNavBrowser = false
+			cmd := m.playCurrentTrack()
+			m.notifyMPRIS()
+			return cmd
+		}
+	case "a":
+		// Append all displayed tracks to the playlist (keep current playback).
+		tracks := m.navTracks
+		if len(m.navSearchIdx) > 0 {
+			filtered := make([]playlist.Track, 0, len(m.navSearchIdx))
+			for _, i := range m.navSearchIdx {
+				filtered = append(filtered, m.navTracks[i])
+			}
+			tracks = filtered
+		}
+		if len(tracks) > 0 {
+			wasEmpty := m.playlist.Len() == 0
+			m.playlist.Add(tracks...)
+			m.saveMsg = fmt.Sprintf("Added %d tracks", len(tracks))
+			m.saveMsgTTL = 80
+			if wasEmpty || !m.player.IsPlaying() {
+				m.playlist.SetIndex(0)
+				cmd := m.playCurrentTrack()
+				m.notifyMPRIS()
+				return cmd
+			}
+		}
+	case "esc", "h", "left", "backspace":
+		// Navigate back one level depending on the mode and how we got here.
+		m.navClearSearch()
+		m.navCursor = 0
+		m.navScroll = 0
+		switch m.navMode {
+		case navBrowseModeByAlbum:
+			m.navScreen = navBrowseScreenList
+		case navBrowseModeByArtist:
+			m.navScreen = navBrowseScreenList
+		case navBrowseModeByArtistAlbum:
+			m.navScreen = navBrowseScreenAlbums
+		}
+	}
+	return nil
+}
+
+// handleNavSearchKey handles key input while the nav search bar is open.
+func (m *Model) handleNavSearchKey(msg tea.KeyMsg) tea.Cmd {
+	switch msg.Type {
+	case tea.KeyEscape:
+		// Close the search bar; keep the filter active so the user can act on results.
+		m.navSearching = false
+		return nil
+	case tea.KeyEnter:
+		m.navSearching = false
+		return nil
+	case tea.KeyBackspace, tea.KeyDelete:
+		if len(m.navSearch) > 0 {
+			_, size := utf8.DecodeLastRuneInString(m.navSearch)
+			m.navSearch = m.navSearch[:len(m.navSearch)-size]
+			m.navCursor = 0
+			m.navScroll = 0
+			m.navUpdateSearch()
+		}
+		return nil
+	}
+	// Printable character — append to query.
+	if msg.Type == tea.KeyRunes {
+		m.navSearch += string(msg.Runes)
+		m.navCursor = 0
+		m.navScroll = 0
+		m.navUpdateSearch()
+	}
+	return nil
+}
+
+// navNextSort returns the sort type that follows s in SortTypes, wrapping around.
+func navNextSort(s string) string {
+	for i, t := range navidrome.SortTypes {
+		if t == s {
+			return navidrome.SortTypes[(i+1)%len(navidrome.SortTypes)]
+		}
+	}
+	return navidrome.SortTypes[0]
+}
+
+// navMaybeAdjustScroll keeps navCursor visible within the rendered list window.
+func (m *Model) navMaybeAdjustScroll() {
+	visible := m.plVisible
+	if visible < 5 {
+		visible = 5
+	}
+	if m.navCursor < m.navScroll {
+		m.navScroll = m.navCursor
+	}
+	if m.navCursor >= m.navScroll+visible {
+		m.navScroll = m.navCursor - visible + 1
 	}
 }

--- a/ui/model.go
+++ b/ui/model.go
@@ -8,7 +8,9 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"cliamp/config"
 	"cliamp/external/local"
+	"cliamp/external/navidrome"
 	"cliamp/mpris"
 	"cliamp/player"
 	"cliamp/playlist"
@@ -31,6 +33,25 @@ const (
 	plMgrScreenList plMgrScreenType = iota
 	plMgrScreenTracks
 	plMgrScreenNewName
+)
+
+// navBrowseModeType identifies which Navidrome browse mode is active.
+type navBrowseModeType int
+
+const (
+	navBrowseModeMenu          navBrowseModeType = iota // top-level mode selector
+	navBrowseModeByAlbum                                // paginated album list → track list
+	navBrowseModeByArtist                               // artist list → track list (album-separated)
+	navBrowseModeByArtistAlbum                          // artist list → album list → track list
+)
+
+// navBrowseScreenType identifies which screen within the active browse mode is shown.
+type navBrowseScreenType int
+
+const (
+	navBrowseScreenList   navBrowseScreenType = iota // first-level list (artists or albums)
+	navBrowseScreenAlbums                            // artist's albums (ArtistAlbum mode only)
+	navBrowseScreenTracks                            // final song list in any mode
 )
 
 type tickMsg time.Time
@@ -126,11 +147,38 @@ type Model struct {
 	fbCursor        int
 	fbSelected      map[string]bool
 	fbErr           string
+
+	// Navidrome explore browser overlay
+	showNavBrowser  bool
+	navClient       *navidrome.NavidromeClient // nil when Navidrome is not configured
+	navMode         navBrowseModeType
+	navScreen       navBrowseScreenType
+	navCursor       int
+	navScroll       int
+	navArtists      []navidrome.Artist
+	navAlbums       []navidrome.Album
+	navTracks       []playlist.Track
+	navSelArtist    navidrome.Artist
+	navSelAlbum     navidrome.Album
+	navSortType     string // current album sort type, persisted to config
+	navAlbumLoading bool   // true while an album page fetch is in progress
+	navAlbumDone    bool   // true once the server signals no more pages (isLast)
+	navLoading      bool   // general loading flag for artists/tracks
+	navSearching    bool   // true while the nav search bar is open
+	navSearch       string // current nav search query
+	navSearchIdx    []int  // filtered indices into the active list (nil = no filter)
 }
 
 // NewModel creates a Model wired to the given player and playlist.
 // localProv is an optional direct reference to the local provider for write ops.
-func NewModel(p *player.Player, pl *playlist.Playlist, prov playlist.Provider, localProv *local.Provider, themes []theme.Theme) Model {
+// navCfg is the Navidrome config used to seed the initial browse sort preference.
+// nav is the raw NavidromeClient (may be nil); stored directly so the browser
+// key handler doesn't have to unwrap a CompositeProvider.
+func NewModel(p *player.Player, pl *playlist.Playlist, prov playlist.Provider, localProv *local.Provider, themes []theme.Theme, navCfg config.NavidromeConfig, nav *navidrome.NavidromeClient) Model {
+	sortType := navCfg.BrowseSort
+	if sortType == "" {
+		sortType = navidrome.SortAlphabeticalByName
+	}
 	m := Model{
 		player:        p,
 		playlist:      pl,
@@ -140,6 +188,8 @@ func NewModel(p *player.Player, pl *playlist.Playlist, prov playlist.Provider, l
 		themes:        themes,
 		themeIdx:      -1, // Default (ANSI)
 		localProvider: localProv,
+		navSortType:   sortType,
+		navClient:     nav,
 	}
 	if prov != nil {
 		m.provider = prov
@@ -369,6 +419,164 @@ func fetchTracksCmd(prov playlist.Provider, playlistID string) tea.Cmd {
 	}
 }
 
+// — Navidrome browser message types —
+
+// navArtistsLoadedMsg carries the full artist list from getArtists.
+type navArtistsLoadedMsg []navidrome.Artist
+
+// navAlbumsLoadedMsg carries one page of albums and the fetch offset.
+type navAlbumsLoadedMsg struct {
+	albums []navidrome.Album
+	offset int  // the offset this page was requested at
+	isLast bool // true when the server returned fewer than the requested page size
+}
+
+// navTracksLoadedMsg carries the track list for the selected album/artist.
+type navTracksLoadedMsg []playlist.Track
+
+func fetchNavArtistsCmd(c *navidrome.NavidromeClient) tea.Cmd {
+	return func() tea.Msg {
+		artists, err := c.Artists()
+		if err != nil {
+			return err
+		}
+		return navArtistsLoadedMsg(artists)
+	}
+}
+
+func fetchNavArtistAlbumsCmd(c *navidrome.NavidromeClient, artistID string) tea.Cmd {
+	return func() tea.Msg {
+		albums, err := c.ArtistAlbums(artistID)
+		if err != nil {
+			return err
+		}
+		// Artist album lists are complete in one call — treat as last page.
+		return navAlbumsLoadedMsg{albums: albums, offset: 0, isLast: true}
+	}
+}
+
+const navAlbumPageSize = 100
+
+func fetchNavAlbumListCmd(c *navidrome.NavidromeClient, sortType string, offset int) tea.Cmd {
+	return func() tea.Msg {
+		albums, err := c.AlbumList(sortType, offset, navAlbumPageSize)
+		if err != nil {
+			return err
+		}
+		return navAlbumsLoadedMsg{
+			albums: albums,
+			offset: offset,
+			isLast: len(albums) < navAlbumPageSize,
+		}
+	}
+}
+
+func fetchNavAlbumTracksCmd(c *navidrome.NavidromeClient, albumID string) tea.Cmd {
+	return func() tea.Msg {
+		tracks, err := c.AlbumTracks(albumID)
+		if err != nil {
+			return err
+		}
+		return navTracksLoadedMsg(tracks)
+	}
+}
+
+func fetchNavArtistTracksCmd(c *navidrome.NavidromeClient, albums []navidrome.Album) tea.Cmd {
+	return func() tea.Msg {
+		var all []playlist.Track
+		for _, album := range albums {
+			tracks, err := c.AlbumTracks(album.ID)
+			if err != nil {
+				return err
+			}
+			all = append(all, tracks...)
+		}
+		return navTracksLoadedMsg(all)
+	}
+}
+
+// fetchNavArtistAllTracksCmd first fetches the artist's album list, then fetches
+// all tracks across every album. This is used by the "By Artist" browse mode.
+func (m *Model) fetchNavArtistAllTracksCmd(navClient *navidrome.NavidromeClient, artistID string) tea.Cmd {
+	return func() tea.Msg {
+		albums, err := navClient.ArtistAlbums(artistID)
+		if err != nil {
+			return err
+		}
+		var all []playlist.Track
+		for _, album := range albums {
+			tracks, err := navClient.AlbumTracks(album.ID)
+			if err != nil {
+				return err
+			}
+			all = append(all, tracks...)
+		}
+		return navTracksLoadedMsg(all)
+	}
+}
+
+// navUpdateSearch rebuilds navSearchIdx from the current navSearch query
+// against whichever list is active on the current nav screen.
+func (m *Model) navUpdateSearch() {
+	q := strings.ToLower(m.navSearch)
+	if q == "" {
+		m.navSearchIdx = nil
+		return
+	}
+	m.navSearchIdx = nil
+	switch {
+	case m.navMode == navBrowseModeByArtist && m.navScreen == navBrowseScreenList,
+		m.navMode == navBrowseModeByArtistAlbum && m.navScreen == navBrowseScreenList:
+		for i, a := range m.navArtists {
+			if strings.Contains(strings.ToLower(a.Name), q) {
+				m.navSearchIdx = append(m.navSearchIdx, i)
+			}
+		}
+	case m.navMode == navBrowseModeByAlbum && m.navScreen == navBrowseScreenList,
+		m.navMode == navBrowseModeByArtistAlbum && m.navScreen == navBrowseScreenAlbums:
+		for i, a := range m.navAlbums {
+			if strings.Contains(strings.ToLower(a.Name), q) ||
+				strings.Contains(strings.ToLower(a.Artist), q) {
+				m.navSearchIdx = append(m.navSearchIdx, i)
+			}
+		}
+	case m.navScreen == navBrowseScreenTracks:
+		for i, t := range m.navTracks {
+			if strings.Contains(strings.ToLower(t.Title), q) ||
+				strings.Contains(strings.ToLower(t.Artist), q) ||
+				strings.Contains(strings.ToLower(t.Album), q) {
+				m.navSearchIdx = append(m.navSearchIdx, i)
+			}
+		}
+	}
+}
+
+// navClearSearch resets the nav search state.
+func (m *Model) navClearSearch() {
+	m.navSearching = false
+	m.navSearch = ""
+	m.navSearchIdx = nil
+	m.navCursor = 0
+	m.navScroll = 0
+}
+
+func (m *Model) openNavBrowser() {
+	m.showNavBrowser = true
+	m.navMode = navBrowseModeMenu
+	m.navScreen = navBrowseScreenList
+	m.navCursor = 0
+	m.navScroll = 0
+	m.navArtists = nil
+	m.navAlbums = nil
+	m.navTracks = nil
+	m.navLoading = false
+	m.navAlbumLoading = false
+	m.navAlbumDone = false
+	m.navSearching = false
+	m.navSearch = ""
+	m.navSearchIdx = nil
+}
+
 // Init starts the tick timer and requests the terminal size.
 func (m Model) Init() tea.Cmd {
 	cmds := []tea.Cmd{tickCmd(), tea.WindowSize()}
@@ -470,6 +678,43 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.notifyMPRIS()
 			return m, cmd
 		}
+		return m, nil
+
+	case navArtistsLoadedMsg:
+		m.navArtists = []navidrome.Artist(msg)
+		m.navLoading = false
+		m.navCursor = 0
+		m.navScroll = 0
+		return m, nil
+
+	case navAlbumsLoadedMsg:
+		if msg.offset == 0 {
+			// Fresh load (new sort or drill-in): replace the list.
+			m.navAlbums = msg.albums
+			m.navAlbumDone = false
+		} else {
+			// Lazy-load page: append.
+			m.navAlbums = append(m.navAlbums, msg.albums...)
+		}
+		if msg.isLast {
+			m.navAlbumDone = true
+		}
+		m.navAlbumLoading = false
+		if msg.offset == 0 {
+			m.navCursor = 0
+			m.navScroll = 0
+		}
+		// If we just loaded the first page and it was a full menu → list transition,
+		// also clear the general loading flag.
+		m.navLoading = false
+		return m, nil
+
+	case navTracksLoadedMsg:
+		m.navTracks = []playlist.Track(msg)
+		m.navLoading = false
+		m.navCursor = 0
+		m.navScroll = 0
+		m.navScreen = navBrowseScreenTracks
 		return m, nil
 
 	case feedsLoadedMsg:

--- a/ui/view.go
+++ b/ui/view.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 
+	"cliamp/external/navidrome"
 	"cliamp/theme"
 )
 
@@ -33,6 +34,10 @@ func (m Model) View() string {
 
 	if m.showFileBrowser {
 		return m.renderFileBrowser()
+	}
+
+	if m.showNavBrowser {
+		return m.renderNavBrowser()
 	}
 
 	if m.showPlManager {
@@ -814,4 +819,401 @@ func (m Model) renderHelp() string {
 	parts += helpKey("+-", "Vol ") + helpKey("/", "Search ") + helpKey("a", "Queue ") + helpKey("Tab", "Focus ") + helpKey("Ctrl+K", "Keys ") + helpKey("Q", "Quit")
 
 	return parts
+}
+
+// — Navidrome browser renderers —
+
+func (m Model) renderNavBrowser() string {
+	switch m.navMode {
+	case navBrowseModeMenu:
+		return m.renderNavMenu()
+	case navBrowseModeByAlbum:
+		switch m.navScreen {
+		case navBrowseScreenTracks:
+			return m.renderNavTrackList()
+		default:
+			return m.renderNavAlbumList(false)
+		}
+	case navBrowseModeByArtist:
+		switch m.navScreen {
+		case navBrowseScreenTracks:
+			return m.renderNavTrackList()
+		default:
+			return m.renderNavArtistList()
+		}
+	case navBrowseModeByArtistAlbum:
+		switch m.navScreen {
+		case navBrowseScreenAlbums:
+			return m.renderNavAlbumList(true)
+		case navBrowseScreenTracks:
+			return m.renderNavTrackList()
+		default:
+			return m.renderNavArtistList()
+		}
+	}
+	return m.renderNavMenu()
+}
+
+func (m Model) renderNavMenu() string {
+	lines := []string{
+		titleStyle.Render("N A V I D R O M E"),
+		"",
+	}
+
+	items := []string{"By Album", "By Artist", "By Artist / Album"}
+	for i, item := range items {
+		if i == m.navCursor {
+			lines = append(lines, playlistSelectedStyle.Render("> "+item))
+		} else {
+			lines = append(lines, dimStyle.Render("  "+item))
+		}
+	}
+
+	lines = append(lines, "",
+		helpKey("↑↓", "Navigate ")+helpKey("Enter", "Select ")+helpKey("Esc", "Close"))
+
+	return m.centerOverlay(strings.Join(lines, "\n"))
+}
+
+func (m Model) renderNavArtistList() string {
+	lines := []string{
+		titleStyle.Render("A R T I S T S"),
+		"",
+	}
+
+	if m.navLoading && len(m.navArtists) == 0 {
+		lines = append(lines, dimStyle.Render("  Loading artists..."))
+		lines = append(lines, "", helpKey("Esc", "Back"))
+		return m.centerOverlay(strings.Join(lines, "\n"))
+	}
+
+	if len(m.navArtists) == 0 {
+		lines = append(lines, dimStyle.Render("  No artists found."))
+		lines = append(lines, "", helpKey("Esc", "Back"))
+		return m.centerOverlay(strings.Join(lines, "\n"))
+	}
+
+	maxVisible := m.plVisible
+	if maxVisible < 5 {
+		maxVisible = 5
+	}
+
+	// Use filtered index when a search is active.
+	list := m.navArtists
+	useFilter := len(m.navSearchIdx) > 0 || m.navSearch != ""
+
+	scroll := m.navScroll
+	rendered := 0
+	if useFilter {
+		for j := scroll; j < len(m.navSearchIdx) && rendered < maxVisible; j++ {
+			i := m.navSearchIdx[j]
+			a := list[i]
+			label := fmt.Sprintf("%s (%d albums)", a.Name, a.AlbumCount)
+			maxW := panelWidth - 6
+			lr := []rune(label)
+			if len(lr) > maxW {
+				label = string(lr[:maxW-1]) + "…"
+			}
+			if j == m.navCursor {
+				lines = append(lines, playlistSelectedStyle.Render("> "+label))
+			} else {
+				lines = append(lines, dimStyle.Render("  "+label))
+			}
+			rendered++
+		}
+	} else {
+		for i := scroll; i < len(list) && rendered < maxVisible; i++ {
+			a := list[i]
+			label := fmt.Sprintf("%s (%d albums)", a.Name, a.AlbumCount)
+			maxW := panelWidth - 6
+			lr := []rune(label)
+			if len(lr) > maxW {
+				label = string(lr[:maxW-1]) + "…"
+			}
+			if i == m.navCursor {
+				lines = append(lines, playlistSelectedStyle.Render("> "+label))
+			} else {
+				lines = append(lines, dimStyle.Render("  "+label))
+			}
+			rendered++
+		}
+	}
+
+	// Pad to fixed height.
+	for range maxVisible - rendered {
+		lines = append(lines, "")
+	}
+
+	if useFilter {
+		lines = append(lines, "",
+			dimStyle.Render(fmt.Sprintf("  %d/%d artists (filtered)", len(m.navSearchIdx), len(list))))
+	} else {
+		lines = append(lines, "",
+			dimStyle.Render(fmt.Sprintf("  %d/%d artists", m.navCursor+1, len(list))))
+	}
+
+	// Search bar or hint.
+	if m.navSearching {
+		lines = append(lines, "", playlistSelectedStyle.Render("  / "+m.navSearch+"_"))
+	} else if m.navSearch != "" {
+		lines = append(lines, "", dimStyle.Render("  / "+m.navSearch)+" "+helpKey("/", "Clear"))
+	} else {
+		lines = append(lines, "", helpKey("←↑↓→", "Navigate ")+helpKey("Enter", "Open ")+helpKey("/", "Search"))
+	}
+
+	return m.centerOverlay(strings.Join(lines, "\n"))
+}
+
+func (m Model) renderNavAlbumList(artistAlbums bool) string {
+	var titleStr string
+	if artistAlbums {
+		titleStr = titleStyle.Render("A L B U M S : " + m.navSelArtist.Name)
+	} else {
+		titleStr = titleStyle.Render("A L B U M S")
+	}
+
+	lines := []string{titleStr, ""}
+
+	if !artistAlbums {
+		sortLabel := navidrome.SortTypeLabel(m.navSortType)
+		lines = append(lines, dimStyle.Render("  Sort: ")+activeToggle.Render(sortLabel), "")
+	}
+
+	if m.navLoading && len(m.navAlbums) == 0 {
+		lines = append(lines, dimStyle.Render("  Loading albums..."))
+		if artistAlbums {
+			lines = append(lines, "", helpKey("Esc", "Back"))
+		} else {
+			lines = append(lines, "", helpKey("s", "Sort ")+helpKey("Esc", "Back"))
+		}
+		return m.centerOverlay(strings.Join(lines, "\n"))
+	}
+
+	if len(m.navAlbums) == 0 {
+		lines = append(lines, dimStyle.Render("  No albums found."))
+		if artistAlbums {
+			lines = append(lines, "", helpKey("Esc", "Back"))
+		} else {
+			lines = append(lines, "", helpKey("s", "Sort ")+helpKey("Esc", "Back"))
+		}
+		return m.centerOverlay(strings.Join(lines, "\n"))
+	}
+
+	maxVisible := m.plVisible
+	if maxVisible < 5 {
+		maxVisible = 5
+	}
+
+	list := m.navAlbums
+	useFilter := len(m.navSearchIdx) > 0 || m.navSearch != ""
+
+	scroll := m.navScroll
+	rendered := 0
+	if useFilter {
+		for j := scroll; j < len(m.navSearchIdx) && rendered < maxVisible; j++ {
+			i := m.navSearchIdx[j]
+			a := list[i]
+			var label string
+			if a.Year > 0 {
+				label = fmt.Sprintf("%s — %s (%d)", a.Name, a.Artist, a.Year)
+			} else {
+				label = fmt.Sprintf("%s — %s", a.Name, a.Artist)
+			}
+			maxW := panelWidth - 6
+			lr := []rune(label)
+			if len(lr) > maxW {
+				label = string(lr[:maxW-1]) + "…"
+			}
+			if j == m.navCursor {
+				lines = append(lines, playlistSelectedStyle.Render("> "+label))
+			} else {
+				lines = append(lines, dimStyle.Render("  "+label))
+			}
+			rendered++
+		}
+	} else {
+		for i := scroll; i < len(list) && rendered < maxVisible; i++ {
+			a := list[i]
+			var label string
+			if a.Year > 0 {
+				label = fmt.Sprintf("%s — %s (%d)", a.Name, a.Artist, a.Year)
+			} else {
+				label = fmt.Sprintf("%s — %s", a.Name, a.Artist)
+			}
+			maxW := panelWidth - 6
+			lr := []rune(label)
+			if len(lr) > maxW {
+				label = string(lr[:maxW-1]) + "…"
+			}
+			if i == m.navCursor {
+				lines = append(lines, playlistSelectedStyle.Render("> "+label))
+			} else {
+				lines = append(lines, dimStyle.Render("  "+label))
+			}
+			rendered++
+		}
+	}
+
+	// Pad to fixed height.
+	for range maxVisible - rendered {
+		lines = append(lines, "")
+	}
+
+	// Loading indicator when fetching next page.
+	if m.navAlbumLoading {
+		lines = append(lines, dimStyle.Render("  Loading more..."))
+	} else if useFilter {
+		lines = append(lines, dimStyle.Render(fmt.Sprintf("  %d/%d albums (filtered)", len(m.navSearchIdx), len(list))))
+	} else {
+		lines = append(lines, dimStyle.Render(fmt.Sprintf("  %d/%d albums", m.navCursor+1, len(list))))
+	}
+	lines = append(lines, "")
+
+	// Search bar or help line.
+	if m.navSearching {
+		lines = append(lines, playlistSelectedStyle.Render("  / "+m.navSearch+"_"))
+	} else if m.navSearch != "" {
+		lines = append(lines, dimStyle.Render("  / "+m.navSearch)+" "+helpKey("/", "Clear"))
+	} else if artistAlbums {
+		lines = append(lines,
+			helpKey("←↑↓→", "Navigate ")+helpKey("Enter", "Open ")+helpKey("/", "Search"))
+	} else {
+		lines = append(lines,
+			helpKey("←↑↓→", "Navigate ")+helpKey("Enter", "Open ")+helpKey("s", "Sort ")+helpKey("/", "Search"))
+	}
+
+	return m.centerOverlay(strings.Join(lines, "\n"))
+}
+
+func (m Model) renderNavTrackList() string {
+	// Build a breadcrumb title based on the active mode.
+	var breadcrumb string
+	switch m.navMode {
+	case navBrowseModeByArtist:
+		breadcrumb = "A R T I S T : " + m.navSelArtist.Name
+	case navBrowseModeByAlbum:
+		breadcrumb = "A L B U M : " + m.navSelAlbum.Name
+	case navBrowseModeByArtistAlbum:
+		breadcrumb = m.navSelArtist.Name + " / " + m.navSelAlbum.Name
+	}
+
+	lines := []string{titleStyle.Render(breadcrumb), ""}
+
+	if m.navLoading && len(m.navTracks) == 0 {
+		lines = append(lines, dimStyle.Render("  Loading tracks..."))
+		lines = append(lines, "", helpKey("Esc", "Back"))
+		return m.centerOverlay(strings.Join(lines, "\n"))
+	}
+
+	if len(m.navTracks) == 0 {
+		lines = append(lines, dimStyle.Render("  No tracks found."))
+		lines = append(lines, "", helpKey("Esc", "Back"))
+		return m.centerOverlay(strings.Join(lines, "\n"))
+	}
+
+	maxVisible := m.plVisible
+	if maxVisible < 5 {
+		maxVisible = 5
+	}
+
+	list := m.navTracks
+	useFilter := len(m.navSearchIdx) > 0 || m.navSearch != ""
+
+	scroll := m.navScroll
+	rendered := 0
+
+	if useFilter {
+		for j := scroll; j < len(m.navSearchIdx) && rendered < maxVisible; j++ {
+			i := m.navSearchIdx[j]
+			t := list[i]
+			name := t.DisplayName()
+			maxW := panelWidth - 8
+			nr := []rune(name)
+			if len(nr) > maxW {
+				name = string(nr[:maxW-1]) + "…"
+			}
+			label := fmt.Sprintf("%d. %s", i+1, name)
+			if j == m.navCursor {
+				lines = append(lines, playlistSelectedStyle.Render("> "+label))
+			} else {
+				lines = append(lines, dimStyle.Render("  "+label))
+			}
+			rendered++
+		}
+	} else {
+		prevAlbum := ""
+		if scroll > 0 {
+			prevAlbum = list[scroll-1].Album
+		}
+
+		for i := scroll; i < len(list) && rendered < maxVisible; i++ {
+			t := list[i]
+
+			// Album separator header when album changes.
+			if album := t.Album; album != "" && album != prevAlbum {
+				label := "── " + album
+				if t.Year != 0 {
+					label += fmt.Sprintf(" (%d)", t.Year)
+				}
+				label += " "
+				labelLen := len([]rune(label))
+				if labelLen < panelWidth {
+					label += strings.Repeat("─", panelWidth-labelLen)
+				}
+				lines = append(lines, dimStyle.Render(label))
+				if rendered >= maxVisible {
+					break
+				}
+			}
+			prevAlbum = t.Album
+
+			name := t.DisplayName()
+			maxW := panelWidth - 8
+			nr := []rune(name)
+			if len(nr) > maxW {
+				name = string(nr[:maxW-1]) + "…"
+			}
+
+			label := fmt.Sprintf("%d. %s", i+1, name)
+			if i == m.navCursor {
+				lines = append(lines, playlistSelectedStyle.Render("> "+label))
+			} else {
+				lines = append(lines, dimStyle.Render("  "+label))
+			}
+			rendered++
+		}
+	}
+
+	// Pad to fixed height.
+	for range maxVisible - rendered {
+		lines = append(lines, "")
+	}
+
+	if useFilter {
+		lines = append(lines, "",
+			dimStyle.Render(fmt.Sprintf("  %d/%d tracks (filtered)", len(m.navSearchIdx), len(list))))
+	} else {
+		lines = append(lines, "",
+			dimStyle.Render(fmt.Sprintf("  %d/%d tracks", m.navCursor+1, len(list))))
+	}
+
+	// Search bar or help line.
+	if m.navSearching {
+		lines = append(lines, "", playlistSelectedStyle.Render("  / "+m.navSearch+"_"))
+	} else if m.navSearch != "" {
+		lines = append(lines, "", dimStyle.Render("  / "+m.navSearch)+" "+helpKey("/", "Clear"))
+	} else {
+		lines = append(lines, "",
+			helpKey("←↑↓→", "Navigate ")+
+				helpKey("Enter", "Play ")+
+				helpKey("R", "Replace ")+
+				helpKey("a", "Append ")+
+				helpKey("/", "Search"))
+	}
+
+	if m.saveMsg != "" {
+		lines = append(lines, "", statusStyle.Render(m.saveMsg))
+	}
+
+	return m.centerOverlay(strings.Join(lines, "\n"))
 }


### PR DESCRIPTION
Full-featured Navidrome browser overlay. Explore Navidrome library by album, artist, or a three-level artist/album/track drill-down. Configuration options for sorting. New UI controls.  Extends the Navidrome client with comprehensive browsing and metadata capabilities. The browser remembers the user's preferred album sort order and persists it to the configuration file.

![Kapture 2026-03-02 at 12 12 03](https://github.com/user-attachments/assets/ffbdc297-d7f3-4635-ab74-1fad975d8c7e)

**Navidrome Browser Integration**

* Added a Navidrome browser overlay accessible via the `N` key, enabling users to browse albums, artists, and tracks in multiple modes, with detailed documentation and UI controls (`README.md`, `docs/navidrome.md`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R224) [[2]](diffhunk://#diff-ce1124373e018541cb3ffd9be8f7cad5a2f70c7bcb381bba97b094670da57d38R42-R99)

* Implemented new browse modes and screen types in the UI model, supporting paginated album lists, artist lists, and drill-down navigation, including state management for sorting, loading, and searching (`ui/model.go`). [[1]](diffhunk://#diff-3917ba1bcc5da7878e4a76f5e44ce9135adac1fc99bae140682eca5b1342e214R38-R56) [[2]](diffhunk://#diff-3917ba1bcc5da7878e4a76f5e44ce9135adac1fc99bae140682eca5b1342e214R150-R181) [[3]](diffhunk://#diff-3917ba1bcc5da7878e4a76f5e44ce9135adac1fc99bae140682eca5b1342e214R191-R192)

**Configuration Enhancements**

* Added `browse_sort` option to Navidrome config, with logic to load, save, and persist the user's preferred album sort order automatically (`config.toml.example`, `config/config.go`). [[1]](diffhunk://#diff-514f3c6049dd26198894991be37accf7786d0b38e3a1fc21f201c14be271b642R48-R53) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R30) [[3]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R112-R113) [[4]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R202-R274)

**Navidrome Client Extensions**

* Extended the Navidrome client with new methods for fetching artists, artist albums, paginated/sorted album lists, and album tracks, including rich metadata for tracks and albums (`external/navidrome/client.go`). [[1]](diffhunk://#diff-34252a1eee0fabcdc7ff923d46de750f5375a77a12c2fe0d31575f2d1d70eb77R20-R85) [[2]](diffhunk://#diff-34252a1eee0fabcdc7ff923d46de750f5375a77a12c2fe0d31575f2d1d70eb77R196-R199) [[3]](diffhunk://#diff-34252a1eee0fabcdc7ff923d46de750f5375a77a12c2fe0d31575f2d1d70eb77R214-R407)

**Main Application Wiring**

* Updated main application logic to instantiate and pass the Navidrome client and config to the UI model, enabling browser functionality when configured (`main.go`). [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R33-R39) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L83-R86)