### PR TITLE
Add Subsonic scrobble and now-playing support for Navidrome

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,15 +24,22 @@ func configPath() (string, error) {
 // NavidromeConfig holds credentials for a Navidrome/Subsonic server.
 // All three fields must be non-empty for a client to be constructed.
 type NavidromeConfig struct {
-	URL        string // e.g. "https://music.example.com"
-	User       string
-	Password   string
-	BrowseSort string // album browse sort order, e.g. "alphabeticalByName"
+	URL              string // e.g. "https://music.example.com"
+	User             string
+	Password         string
+	BrowseSort       string // album browse sort order, e.g. "alphabeticalByName"
+	ScrobbleDisabled bool   // true only when "scrobble = false" is explicitly set
 }
 
 // IsSet reports whether all three Navidrome credentials are present.
 func (n NavidromeConfig) IsSet() bool {
 	return n.URL != "" && n.User != "" && n.Password != ""
+}
+
+// ScrobbleEnabled reports whether scrobbling is active.
+// Scrobbling is opt-out: it is enabled unless "scrobble = false" is explicitly set.
+func (n NavidromeConfig) ScrobbleEnabled() bool {
+	return !n.ScrobbleDisabled
 }
 
 // Config holds user preferences loaded from the config file.
@@ -114,6 +121,9 @@ func Load() (Config, error) {
 				cfg.Navidrome.Password = strings.Trim(val, `"'`)
 			case "browse_sort":
 				cfg.Navidrome.BrowseSort = strings.Trim(val, `"'`)
+			case "scrobble":
+				// Opt-out: only mark disabled when the value is explicitly "false".
+				cfg.Navidrome.ScrobbleDisabled = strings.ToLower(val) == "false"
 			}
 		default:
 			switch key {

--- a/external/navidrome/client.go
+++ b/external/navidrome/client.go
@@ -251,6 +251,7 @@ func (c *NavidromeClient) Tracks(id string) ([]playlist.Track, error) {
 	for _, t := range result.SubsonicResponse.Playlist.Entry {
 		tracks = append(tracks, playlist.Track{
 			Path:         c.streamURL(t.ID),
+			NavidromeID:  t.ID,
 			Title:        t.Title,
 			Artist:       t.Artist,
 			Album:        t.Album,
@@ -463,6 +464,7 @@ func (c *NavidromeClient) AlbumTracks(albumID string) ([]playlist.Track, error) 
 	for _, s := range result.SubsonicResponse.Album.Song {
 		tracks = append(tracks, playlist.Track{
 			Path:         c.streamURL(s.ID),
+			NavidromeID:  s.ID,
 			Title:        s.Title,
 			Artist:       s.Artist,
 			Album:        s.Album,
@@ -479,4 +481,25 @@ func (c *NavidromeClient) AlbumTracks(albumID string) ([]playlist.Track, error) 
 // streamURL generates the authenticated streaming URL for a track ID.
 func (c *NavidromeClient) streamURL(id string) string {
 	return c.buildURL("stream", url.Values{"id": {id}, "format": {"mp3"}})
+}
+
+// Scrobble reports playback of a track to the Subsonic server.
+// If submission is false, it registers a "now playing" notification only.
+// If submission is true, it records a full play (updates play count, last.fm, etc.).
+// The call is best-effort: errors are silently discarded.
+func (c *NavidromeClient) Scrobble(id string, submission bool) {
+	params := url.Values{
+		"id":         {id},
+		"submission": {fmt.Sprintf("%t", submission)},
+	}
+	if submission {
+		// Pass the current wall-clock time in milliseconds as required by
+		// the spec for submission=true (Subsonic API 1.8.0+).
+		params.Set("time", fmt.Sprintf("%d", time.Now().UnixMilli()))
+	}
+	resp, err := httpClient.Get(c.buildURL("scrobble", params))
+	if err != nil {
+		return // fire-and-forget; ignore network errors
+	}
+	resp.Body.Close()
 }

--- a/playlist/playlist.go
+++ b/playlist/playlist.go
@@ -38,8 +38,9 @@ type Track struct {
 	Genre        string
 	Year         int
 	TrackNumber  int
-	Stream       bool // true for HTTP/HTTPS URLs
-	DurationSecs int  // known duration in seconds (0 = unknown)
+	Stream       bool   // true for HTTP/HTTPS URLs
+	DurationSecs int    // known duration in seconds (0 = unknown)
+	NavidromeID  string // Subsonic song ID; empty for non-Navidrome tracks
 }
 
 // IsURL reports whether path is an HTTP or HTTPS URL.

--- a/ui/keys.go
+++ b/ui/keys.go
@@ -123,11 +123,19 @@ func (m *Model) handleKey(msg tea.KeyMsg) tea.Cmd {
 		m.notifyMPRIS()
 
 	case ">", ".":
+		// Scrobble the current track if ≥50% has been played.
+		if track, _ := m.playlist.Current(); track.NavidromeID != "" {
+			m.maybeScrobble(track, m.player.Position(), m.player.Duration())
+		}
 		cmd := m.nextTrack()
 		m.notifyMPRIS()
 		return cmd
 
 	case "<", ",":
+		// Scrobble the current track if ≥50% has been played.
+		if track, _ := m.playlist.Current(); track.NavidromeID != "" {
+			m.maybeScrobble(track, m.player.Position(), m.player.Duration())
+		}
 		cmd := m.prevTrack()
 		m.notifyMPRIS()
 		return cmd
@@ -182,6 +190,10 @@ func (m *Model) handleKey(msg tea.KeyMsg) tea.Cmd {
 
 	case "enter":
 		if m.focus == focusPlaylist {
+			// Scrobble the track being replaced if ≥50% was heard.
+			if track, _ := m.playlist.Current(); track.NavidromeID != "" {
+				m.maybeScrobble(track, m.player.Position(), m.player.Duration())
+			}
 			m.playlist.SetIndex(m.plCursor)
 			cmd := m.playCurrentTrack()
 			m.notifyMPRIS()

--- a/ui/model.go
+++ b/ui/model.go
@@ -175,24 +175,25 @@ type Model struct {
 	fbErr           string
 
 	// Navidrome explore browser overlay
-	showNavBrowser  bool
-	navClient       *navidrome.NavidromeClient // nil when Navidrome is not configured
-	navMode         navBrowseModeType
-	navScreen       navBrowseScreenType
-	navCursor       int
-	navScroll       int
-	navArtists      []navidrome.Artist
-	navAlbums       []navidrome.Album
-	navTracks       []playlist.Track
-	navSelArtist    navidrome.Artist
-	navSelAlbum     navidrome.Album
-	navSortType     string // current album sort type, persisted to config
-	navAlbumLoading bool   // true while an album page fetch is in progress
-	navAlbumDone    bool   // true once the server signals no more pages (isLast)
-	navLoading      bool   // general loading flag for artists/tracks
-	navSearching    bool   // true while the nav search bar is open
-	navSearch       string // current nav search query
-	navSearchIdx    []int  // filtered indices into the active list (nil = no filter)
+	showNavBrowser     bool
+	navClient          *navidrome.NavidromeClient // nil when Navidrome is not configured
+	navScrobbleEnabled bool                       // mirrors NavidromeConfig.ScrobbleEnabled(); set at init
+	navMode            navBrowseModeType
+	navScreen          navBrowseScreenType
+	navCursor          int
+	navScroll          int
+	navArtists         []navidrome.Artist
+	navAlbums          []navidrome.Album
+	navTracks          []playlist.Track
+	navSelArtist       navidrome.Artist
+	navSelAlbum        navidrome.Album
+	navSortType        string // current album sort type, persisted to config
+	navAlbumLoading    bool   // true while an album page fetch is in progress
+	navAlbumDone       bool   // true once the server signals no more pages (isLast)
+	navLoading         bool   // general loading flag for artists/tracks
+	navSearching       bool   // true while the nav search bar is open
+	navSearch          string // current nav search query
+	navSearchIdx       []int  // filtered indices into the active list (nil = no filter)
 }
 
 // NewModel creates a Model wired to the given player and playlist.
@@ -206,16 +207,17 @@ func NewModel(p *player.Player, pl *playlist.Playlist, prov playlist.Provider, l
 		sortType = navidrome.SortAlphabeticalByName
 	}
 	m := Model{
-		player:        p,
-		playlist:      pl,
-		vis:           NewVisualizer(float64(p.SampleRate())),
-		plVisible:     5,
-		eqPresetIdx:   -1, // custom until a preset is selected
-		themes:        themes,
-		themeIdx:      -1, // Default (ANSI)
-		localProvider: localProv,
-		navSortType:   sortType,
-		navClient:     nav,
+		player:             p,
+		playlist:           pl,
+		vis:                NewVisualizer(float64(p.SampleRate())),
+		plVisible:          5,
+		eqPresetIdx:        -1, // custom until a preset is selected
+		themes:             themes,
+		themeIdx:           -1, // Default (ANSI)
+		localProvider:      localProv,
+		navSortType:        sortType,
+		navClient:          nav,
+		navScrobbleEnabled: navCfg.ScrobbleEnabled(),
 	}
 	if prov != nil {
 		m.provider = prov
@@ -716,6 +718,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		var cmds []tea.Cmd
 		// Check gapless transition (audio already playing next track)
 		if m.player.GaplessAdvanced() {
+			// Capture the track that just finished before advancing the playlist.
+			// For gapless, the track played fully (100% ≥ 50%), so elapsed = duration.
+			finishedTrack, _ := m.playlist.Current()
+			fullDur := time.Duration(finishedTrack.DurationSecs) * time.Second
+			m.maybeScrobble(finishedTrack, fullDur, fullDur)
+
 			m.playlist.Next()
 			m.plCursor = m.playlist.Index()
 			m.adjustScroll()
@@ -735,6 +743,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Skip if already buffering a yt-dlp download to avoid advancing
 		// the playlist on every tick while waiting for the resolve.
 		if m.player.IsPlaying() && !m.player.IsPaused() && m.player.Drained() && !m.buffering {
+			// Track drained to end — always ≥ 50%.
+			finishedTrack, _ := m.playlist.Current()
+			drainDur := time.Duration(finishedTrack.DurationSecs) * time.Second
+			m.maybeScrobble(finishedTrack, drainDur, drainDur)
+
 			cmds = append(cmds, m.nextTrack())
 			m.notifyMPRIS()
 		}
@@ -901,11 +914,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 
 	case mpris.NextMsg:
+		if track, _ := m.playlist.Current(); track.NavidromeID != "" {
+			m.maybeScrobble(track, m.player.Position(), m.player.Duration())
+		}
 		cmd := m.nextTrack()
 		m.notifyMPRIS()
 		return m, cmd
 
 	case mpris.PrevMsg:
+		if track, _ := m.playlist.Current(); track.NavidromeID != "" {
+			m.maybeScrobble(track, m.player.Position(), m.player.Duration())
+		}
 		cmd := m.prevTrack()
 		m.notifyMPRIS()
 		return m, cmd
@@ -1005,6 +1024,8 @@ func (m *Model) playTrack(track playlist.Track) tea.Cmd {
 		_, idx := m.playlist.Current()
 		return resolveYTDLCmd(idx, track.Path)
 	}
+	// Fire now-playing notification for Navidrome tracks.
+	m.nowPlaying(track)
 	dur := time.Duration(track.DurationSecs) * time.Second
 	if track.Stream {
 		m.buffering = true
@@ -1144,4 +1165,41 @@ func (m *Model) updateSearch() {
 			m.searchResults = append(m.searchResults, i)
 		}
 	}
+}
+
+// maybeScrobble fires a submission scrobble for the given track if all
+// conditions are met:
+//   - navClient is configured
+//   - scrobbling is enabled in config
+//   - the track has a NavidromeID (i.e. it came from Navidrome)
+//   - elapsed is at least 50% of the track's known duration
+//
+// The call is dispatched in a goroutine so it never blocks the UI.
+func (m *Model) maybeScrobble(track playlist.Track, elapsed, duration time.Duration) {
+	if m.navClient == nil || !m.navScrobbleEnabled {
+		return
+	}
+	if track.NavidromeID == "" {
+		return
+	}
+	if duration <= 0 {
+		// Unknown duration: use DurationSecs metadata as fallback.
+		duration = time.Duration(track.DurationSecs) * time.Second
+	}
+	if duration <= 0 {
+		return // still unknown — skip
+	}
+	if elapsed < duration/2 {
+		return // less than 50% played
+	}
+	id := track.NavidromeID
+	go m.navClient.Scrobble(id, true)
+}
+
+// nowPlaying fires a now-playing notification for the given track if configured.
+func (m *Model) nowPlaying(track playlist.Track) {
+	if m.navClient == nil || !m.navScrobbleEnabled || track.NavidromeID == "" {
+		return
+	}
+	go m.navClient.Scrobble(track.NavidromeID, false)
 }


### PR DESCRIPTION
We should report playback activity to the Navidrome server when using Navidrome via the Subsonic scrobble API. Now-playing fires immediately when a track starts; a full scrobble fires when ≥50% of the track has been heard.

Scrobbling is opt-out: enabled by default, disabled with "scrobble = false" under [navidrome] in config.toml.

Trigger points: gapless auto-advance, drain end-of-track, user skip forward/backward (> < keys and MPRIS), and direct jump-to-track (Enter). All calls are fire-and-forget goroutines and never block the UI or audio thread. Non-Navidrome tracks are unaffected.

Closes #32