### PR TITLE
Fix Subsonic now-playing notification transition for gapless playback

### DIFF
--- a/ui/model.go
+++ b/ui/model.go
@@ -780,6 +780,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// not a user-visible problem. Clear any pending error so the red
 			// message doesn't flash at every track transition.
 			m.err = nil
+			// Fire now-playing notification for the track the audio engine just
+			// started. playTrack() is not called on this path, so we must notify
+			// here explicitly.
+			if newTrack, idx := m.playlist.Current(); idx >= 0 {
+				m.nowPlaying(newTrack)
+			}
 			cmds = append(cmds, m.preloadNext())
 			m.notifyMPRIS()
 		}


### PR DESCRIPTION
nowPlaying() was only called inside playTrack(), which bypassed gapless transitions. 

Add an explicit nowPlaying() call in the GaplessAdvanced() tick-loop block after advancing the playlist cursor, matching the notification behavior of manual next/prev and drain paths.

Fixes #43