### PR TITLE
feat: Add jump to time and configurable large seek keyboard controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ shuffle = false
 # Start with mono output (L+R downmix)
 mono = false
 
+# Shift+Left/Right seek jump in seconds
+seek_large_step_sec = 30
+
 # EQ preset: "Flat", "Rock", "Pop", "Jazz", "Classical",
 #             "Bass Boost", "Treble Boost", "Vocal", "Electronic", "Acoustic"
 # Leave empty or "Custom" to use manual eq values below
@@ -225,6 +228,7 @@ Flags can appear before, after, or between file arguments. See [docs/cli.md](doc
 | `>` `.` | Next track |
 | `<` `,` | Previous track |
 | `Left` `Right` | Seek -/+5s |
+| `Shift+Left` `Shift+Right` | Seek -/+30s (configurable) |
 | `+` `-` | Volume up/down |
 | `m` | Toggle mono |
 | `Tab` | Toggle focus (Playlist / EQ) |
@@ -237,6 +241,7 @@ Flags can appear before, after, or between file arguments. See [docs/cli.md](doc
 | `V` | Full-screen visualizer |
 | `S` | Save track to ~/Music |
 | `/` | Search playlist |
+| `J` | Jump to time |
 | `x` | Expand/collapse playlist |
 | `o` | Open file browser |
 | `N` | Navidrome browser |

--- a/config.toml.example
+++ b/config.toml.example
@@ -13,6 +13,9 @@ shuffle = false
 # Start with mono output (L+R downmix)
 mono = false
 
+# Shift+Left/Right seek jump in seconds (6-600)
+seek_large_step_sec = 30
+
 # Output sample rate in Hz (22050, 44100, 48000, 96000, 192000)
 # Higher values preserve more detail from hi-res files but use more CPU
 sample_rate = 44100

--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // configPath returns the path to the config file.
@@ -50,6 +51,7 @@ type Config struct {
 	Repeat          string      // "off", "all", or "one"
 	Shuffle         bool
 	Mono            bool
+	SeekStepLarge   int             // seconds for Shift+Left/Right seek jumps
 	Theme           string          // theme name, or "" for ANSI default
 	Visualizer      string          // visualizer mode name, or "" for default (Bars)
 	SampleRate      int             // output sample rate: 22050, 44100, 48000, 96000, 192000
@@ -63,6 +65,7 @@ type Config struct {
 func Default() Config {
 	return Config{
 		Repeat:          "off",
+		SeekStepLarge:   30,
 		SampleRate:      44100,
 		BufferMs:        100,
 		ResampleQuality: 4,
@@ -141,6 +144,10 @@ func Load() (Config, error) {
 				cfg.Shuffle = val == "true"
 			case "mono":
 				cfg.Mono = val == "true"
+			case "seek_large_step_sec":
+				if v, err := strconv.Atoi(val); err == nil {
+					cfg.SeekStepLarge = v
+				}
 			case "eq":
 				cfg.EQ = parseEQ(val)
 			case "eq_preset":
@@ -349,9 +356,15 @@ func (c Config) ApplyPlaylist(pl PlaylistConfig) {
 	}
 }
 
+// SeekStepLargeDuration returns the configured Shift+Left/Right seek jump.
+func (c Config) SeekStepLargeDuration() time.Duration {
+	return time.Duration(c.SeekStepLarge) * time.Second
+}
+
 // clamp constrains all Config fields to their valid ranges.
 func (c *Config) clamp() {
 	c.Volume = max(min(c.Volume, 6), -30)
+	c.SeekStepLarge = max(min(c.SeekStepLarge, 600), 6)
 	c.SampleRate = clampSampleRate(c.SampleRate)
 	c.BufferMs = max(min(c.BufferMs, 500), 50)
 	c.ResampleQuality = max(min(c.ResampleQuality, 4), 1)

--- a/config/config_seek_test.go
+++ b/config/config_seek_test.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestLoadSeekLargeStepSec(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	path := filepath.Join(os.Getenv("HOME"), ".config", "cliamp", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("seek_large_step_sec = 42\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.SeekStepLarge != 42 {
+		t.Fatalf("SeekStepLarge = %d, want 42", cfg.SeekStepLarge)
+	}
+}
+
+func TestLoadSeekLargeStepSecClamp(t *testing.T) {
+	tests := []struct {
+		name string
+		in   int
+		want int
+	}{
+		{name: "clamps low to minimum large step", in: 0, want: 6},
+		{name: "clamps five seconds to minimum large step", in: 5, want: 6},
+		{name: "clamps high", in: 999, want: 600},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+
+			path := filepath.Join(os.Getenv("HOME"), ".config", "cliamp", "config.toml")
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatalf("MkdirAll: %v", err)
+			}
+			data := []byte("seek_large_step_sec = " + strconv.Itoa(tt.in) + "\n")
+			if err := os.WriteFile(path, data, 0o644); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.SeekStepLarge != tt.want {
+				t.Fatalf("SeekStepLarge = %d, want %d", cfg.SeekStepLarge, tt.want)
+			}
+		})
+	}
+}
+
+func TestSeekStepLargeDuration(t *testing.T) {
+	cfg := Config{SeekStepLarge: 45}
+	if got, want := cfg.SeekStepLargeDuration(), 45*time.Second; got != want {
+		t.Fatalf("SeekStepLargeDuration = %v, want %v", got, want)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -94,6 +94,7 @@ func run(overrides config.Overrides, positional []string) error {
 	themes := theme.LoadAll()
 
 	m := ui.NewModel(p, pl, provider, localProv, themes, cfg.Navidrome, navClient)
+	m.SetSeekStepLarge(cfg.SeekStepLargeDuration())
 	m.SetPendingURLs(resolved.Pending)
 	if len(resolved.Tracks) == 0 && len(resolved.Pending) == 0 {
 		m.StartInProvider()

--- a/site/index.html
+++ b/site/index.html
@@ -994,6 +994,7 @@
         <div class="key-row"><kbd>> .</kbd><span>Next track</span></div>
         <div class="key-row"><kbd>&lt; ,</kbd><span>Previous track</span></div>
         <div class="key-row"><kbd>&larr; &rarr;</kbd><span>Seek &minus;/+5s</span></div>
+        <div class="key-row"><kbd>Shift+&larr; Shift+&rarr;</kbd><span>Seek &minus;/+large step (default 30s)</span></div>
         <div class="key-row"><kbd>+ / &minus;</kbd><span>Volume up / down</span></div>
         <div class="key-row"><kbd>m</kbd><span>Toggle mono</span></div>
         <div class="key-row"><kbd>Tab</kbd><span>Focus: Playlist / EQ</span></div>
@@ -1005,6 +1006,7 @@
         <div class="key-row"><kbd>v</kbd><span>Cycle visualizer</span></div>
         <div class="key-row"><kbd>V</kbd><span>Full-screen visualizer</span></div>
         <div class="key-row"><kbd>/</kbd><span>Search playlist</span></div>
+        <div class="key-row"><kbd>J</kbd><span>Jump to time</span></div>
         <div class="key-row"><kbd>x</kbd><span>Expand playlist</span></div>
         <div class="key-row"><kbd>o</kbd><span>Open file browser</span></div>
         <div class="key-row"><kbd>a</kbd><span>Queue (play next)</span></div>

--- a/ui/jump.go
+++ b/ui/jump.go
@@ -1,0 +1,152 @@
+package ui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func parseJumpTarget(raw string) (time.Duration, error) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return 0, fmt.Errorf("use ss, mm:ss, or hh:mm:ss format")
+	}
+
+	parts := strings.Split(s, ":")
+	switch len(parts) {
+	case 1:
+		secs, err := parseTotalSeconds(parts[0])
+		if err != nil {
+			return 0, err
+		}
+		return time.Duration(secs) * time.Second, nil
+	case 2:
+		minPart := normalizeClockField(parts[0])
+		secPart := normalizeClockField(parts[1])
+
+		mins, err := parseTotalMinutes(minPart)
+		if err != nil {
+			return 0, err
+		}
+		secs, err := parseClockSeconds(secPart)
+		if err != nil {
+			return 0, err
+		}
+		return time.Duration(mins)*time.Minute + time.Duration(secs)*time.Second, nil
+	case 3:
+		hourPart := normalizeClockField(parts[0])
+		minPart := normalizeClockField(parts[1])
+		secPart := normalizeClockField(parts[2])
+
+		hours, err := parseTotalHours(hourPart)
+		if err != nil {
+			return 0, err
+		}
+		mins, err := parseClockMinutes(minPart)
+		if err != nil {
+			return 0, err
+		}
+		secs, err := parseClockSeconds(secPart)
+		if err != nil {
+			return 0, err
+		}
+		return time.Duration(hours)*time.Hour +
+			time.Duration(mins)*time.Minute +
+			time.Duration(secs)*time.Second, nil
+	default:
+		return 0, fmt.Errorf("use ss, mm:ss, or hh:mm:ss format")
+	}
+}
+
+func normalizeClockField(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "0"
+	}
+	return s
+}
+
+func parseTotalSeconds(s string) (int, error) {
+	secs, err := parseNonNegativeInt(strings.TrimSpace(s), "seconds")
+	if err != nil {
+		return 0, err
+	}
+	return secs, nil
+}
+
+func parseTotalMinutes(s string) (int, error) {
+	mins, err := parseNonNegativeInt(s, "minutes")
+	if err != nil {
+		return 0, err
+	}
+	return mins, nil
+}
+
+func parseTotalHours(s string) (int, error) {
+	hours, err := parseNonNegativeInt(s, "hours")
+	if err != nil {
+		return 0, err
+	}
+	return hours, nil
+}
+
+func parseClockMinutes(s string) (int, error) {
+	if len(s) > 2 {
+		return 0, fmt.Errorf("minutes must be 0-59")
+	}
+
+	mins, err := parseNonNegativeInt(s, "minutes")
+	if err != nil {
+		return 0, err
+	}
+	if mins > 59 {
+		return 0, fmt.Errorf("minutes must be 0-59")
+	}
+	return mins, nil
+}
+
+func parseClockSeconds(s string) (int, error) {
+	if len(s) > 2 {
+		return 0, fmt.Errorf("seconds must be 0-59")
+	}
+
+	secs, err := parseNonNegativeInt(s, "seconds")
+	if err != nil {
+		return 0, err
+	}
+	if secs > 59 {
+		return 0, fmt.Errorf("seconds must be 0-59")
+	}
+	return secs, nil
+}
+
+func parseNonNegativeInt(s, label string) (int, error) {
+	if s == "" {
+		return 0, fmt.Errorf("%s must be a number", label)
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return 0, fmt.Errorf("%s must be a number", label)
+		}
+	}
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("%s must be a number", label)
+	}
+	return v, nil
+}
+
+func formatJumpClock(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	total := int(d.Seconds())
+	mm := total / 60
+	ss := total % 60
+	return fmt.Sprintf("%02d:%02d", mm, ss)
+}
+
+func formatJumpPlaceholder(d time.Duration) string {
+	return "00:00"
+}

--- a/ui/jump_test.go
+++ b/ui/jump_test.go
@@ -1,0 +1,98 @@
+package ui
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseJumpTarget(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    time.Duration
+		wantErr bool
+	}{
+		// Expected success cases.
+		{name: "seconds only", in: "10", want: 10 * time.Second},
+		{name: "missing minutes accepted", in: ":49", want: 49 * time.Second},
+		{name: "minutes seconds", in: "58:05", want: 58*time.Minute + 5*time.Second},
+		{name: "minutes one-digit seconds", in: "58:6", want: 58*time.Minute + 6*time.Second},
+		{name: "minutes trailing colon", in: "58:", want: 58 * time.Minute},
+		{name: "spaces trimmed", in: "  12:3  ", want: 12*time.Minute + 3*time.Second},
+		{name: "hours minutes seconds", in: "1:02:03", want: time.Hour + 2*time.Minute + 3*time.Second},
+		{name: "hours one-digit parts", in: "2:3:4", want: 2*time.Hour + 3*time.Minute + 4*time.Second},
+		{name: "hours missing minutes accepted", in: "1::03", want: time.Hour + 3*time.Second},
+		{name: "hours trailing colon accepted", in: "1:02:", want: time.Hour + 2*time.Minute},
+
+		// Expected failure cases.
+		{name: "empty", in: "", wantErr: true},
+		{name: "not number", in: "abc", wantErr: true},
+		{name: "bad minutes", in: "x:05", wantErr: true},
+		{name: "bad seconds", in: "10:x", wantErr: true},
+		{name: "hours bad minutes", in: "1:60:00", wantErr: true},
+		{name: "hours bad seconds", in: "1:00:60", wantErr: true},
+		{name: "hours non-numeric", in: "x:02:03", wantErr: true},
+		{name: "hours minutes too many digits", in: "1:123:03", wantErr: true},
+		{name: "seconds too large", in: "10:60", wantErr: true},
+		{name: "high minute high second", in: "99:99", wantErr: true},
+		{name: "too many colons", in: "1:2:3:4", wantErr: true},
+		{name: "too many second digits", in: "10:123", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseJumpTarget(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %v want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatJumpClock(t *testing.T) {
+	tests := []struct {
+		in   time.Duration
+		want string
+	}{
+		{in: 0, want: "00:00"},
+		{in: 10 * time.Second, want: "00:10"},
+		{in: 58*time.Minute + 5*time.Second, want: "58:05"},
+		{in: 1 * time.Hour, want: "60:00"},
+		{in: 75*time.Minute + 48*time.Second, want: "75:48"},
+	}
+
+	for _, tt := range tests {
+		if got := formatJumpClock(tt.in); got != tt.want {
+			t.Fatalf("formatJumpClock(%v) = %q want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestFormatJumpPlaceholder(t *testing.T) {
+	tests := []struct {
+		in   time.Duration
+		want string
+	}{
+		{in: -1 * time.Second, want: "00:00"},
+		{in: 0, want: "00:00"},
+		{in: 59 * time.Second, want: "00:00"},
+		{in: 1 * time.Minute, want: "00:00"},
+		{in: 59*time.Minute + 59*time.Second, want: "00:00"},
+		{in: 1 * time.Hour, want: "00:00"},
+	}
+
+	for _, tt := range tests {
+		if got := formatJumpPlaceholder(tt.in); got != tt.want {
+			t.Fatalf("formatJumpPlaceholder(%v) = %q want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/ui/keys.go
+++ b/ui/keys.go
@@ -61,6 +61,10 @@ func (m *Model) handleKey(msg tea.KeyMsg) tea.Cmd {
 		return nil
 	}
 
+	if m.jumping {
+		return m.handleJumpKey(msg)
+	}
+
 	if m.searching {
 		return m.handleSearchKey(msg)
 	}
@@ -100,6 +104,8 @@ func (m *Model) handleKey(msg tea.KeyMsg) tea.Cmd {
 			if m.navClient != nil {
 				m.openNavBrowser()
 			}
+		case "J":
+			m.openJumpMode()
 		}
 		return nil
 	}
@@ -156,6 +162,12 @@ func (m *Model) handleKey(msg tea.KeyMsg) tea.Cmd {
 			}
 		}
 
+	case "shift+left":
+		m.player.Seek(-m.seekStepLarge)
+		if m.mpris != nil {
+			m.mpris.EmitSeeked(m.player.Position().Microseconds())
+		}
+
 	case "right":
 		if m.focus == focusEQ {
 			if m.eqCursor < numBands-1 {
@@ -166,6 +178,12 @@ func (m *Model) handleKey(msg tea.KeyMsg) tea.Cmd {
 			if m.mpris != nil {
 				m.mpris.EmitSeeked(m.player.Position().Microseconds())
 			}
+		}
+
+	case "shift+right":
+		m.player.Seek(m.seekStepLarge)
+		if m.mpris != nil {
+			m.mpris.EmitSeeked(m.player.Position().Microseconds())
 		}
 
 	case "up", "k":
@@ -278,6 +296,9 @@ func (m *Model) handleKey(msg tea.KeyMsg) tea.Cmd {
 		m.netSearchQuery = ""
 		m.prevFocus = m.focus
 		m.focus = focusNetSearch
+
+	case "J":
+		m.openJumpMode()
 
 	case "p":
 		if m.localProvider != nil {
@@ -412,6 +433,65 @@ func copyFile(src, dst string) error {
 	if closeErr != nil {
 		os.Remove(dst)
 		return closeErr
+	}
+	return nil
+}
+
+func (m *Model) resetJumpInput() {
+	m.jumpInput = ""
+}
+
+func (m *Model) openJumpMode() {
+	m.jumping = true
+	m.resetJumpInput()
+}
+
+func (m *Model) closeJumpMode() {
+	m.jumping = false
+	m.resetJumpInput()
+}
+
+// handleJumpKey processes key presses while in jump-time mode.
+func (m *Model) handleJumpKey(msg tea.KeyMsg) tea.Cmd {
+	switch msg.String() {
+	case "ctrl+c":
+		m.closeJumpMode()
+		m.player.Close()
+		m.quitting = true
+		return tea.Quit
+	}
+
+	switch msg.Type {
+	case tea.KeyEscape:
+		m.closeJumpMode()
+		return nil
+	case tea.KeyEnter:
+		target, err := parseJumpTarget(m.jumpInput)
+		if err != nil {
+			m.resetJumpInput()
+			return nil
+		}
+		if dur := m.player.Duration(); dur > 0 && target > dur {
+			m.resetJumpInput()
+			return nil
+		}
+		m.player.Seek(target - m.player.Position())
+		m.notifyMPRIS()
+		if m.mpris != nil {
+			m.mpris.EmitSeeked(m.player.Position().Microseconds())
+		}
+		m.closeJumpMode()
+		return nil
+	case tea.KeyBackspace:
+		if len(m.jumpInput) > 0 {
+			_, size := utf8.DecodeLastRuneInString(m.jumpInput)
+			m.jumpInput = m.jumpInput[:len(m.jumpInput)-size]
+		}
+		return nil
+	}
+
+	if msg.Type == tea.KeyRunes {
+		m.jumpInput += string(msg.Runes)
 	}
 	return nil
 }
@@ -796,6 +876,7 @@ var keymapEntries = []keymapEntry{
 	{"> .", "Next track"},
 	{"< ,", "Previous track"},
 	{"← →", "Seek ±5s"},
+	{"Shift+← →", "Seek ±large step"},
 	{"+ -", "Volume up/down"},
 	{"m", "Toggle mono"},
 	{"e", "Cycle EQ preset"},
@@ -809,6 +890,7 @@ var keymapEntries = []keymapEntry{
 	{"A", "Queue manager"},
 	{"o", "Open file browser"},
 	{"N", "Navidrome browser"},
+	{"J", "Jump to time"},
 	{"p", "Playlist manager"},
 	{"i", "Track info / metadata"},
 	{"S", "Save/download track to ~/Music"},

--- a/ui/model.go
+++ b/ui/model.go
@@ -75,19 +75,20 @@ const streamPreloadLeadTime = 3 * time.Second
 
 // Model is the Bubbletea model for the CLIAMP TUI.
 type Model struct {
-	player    *player.Player
-	playlist  *playlist.Playlist
-	vis       *Visualizer
-	focus     focusArea
-	eqCursor  int // selected EQ band (0-9)
-	plCursor  int // selected playlist item
-	plScroll  int // scroll offset for playlist view
-	plVisible int // max visible playlist items
-	titleOff  int // scroll offset for long track titles
-	err       error
-	quitting  bool
-	width     int
-	height    int
+	player   *player.Player
+	playlist *playlist.Playlist
+	vis      *Visualizer
+	seekStepLarge time.Duration
+	focus         focusArea
+	eqCursor      int // selected EQ band (0-9)
+	plCursor      int // selected playlist item
+	plScroll      int // scroll offset for playlist view
+	plVisible     int // max visible playlist items
+	titleOff      int // scroll offset for long track titles
+	err           error
+	quitting      bool
+	width         int
+	height        int
 
 	provider      playlist.Provider
 	localProvider *local.Provider // direct ref for write operations (add-to-playlist)
@@ -113,6 +114,10 @@ type Model struct {
 	// Dynamic internet search
 	netSearching   bool
 	netSearchQuery string
+
+	// Jump to time mode state
+	jumping   bool
+	jumpInput string
 
 	// Async feed/M3U URL resolution
 	pendingURLs []string
@@ -212,16 +217,17 @@ func NewModel(p *player.Player, pl *playlist.Playlist, prov playlist.Provider, l
 		sortType = navidrome.SortAlphabeticalByName
 	}
 	m := Model{
-		player:             p,
-		playlist:           pl,
-		vis:                NewVisualizer(float64(p.SampleRate())),
-		plVisible:          5,
-		eqPresetIdx:        -1, // custom until a preset is selected
-		themes:             themes,
-		themeIdx:           -1, // Default (ANSI)
-		localProvider:      localProv,
-		navSortType:        sortType,
-		navClient:          nav,
+		player:        p,
+		playlist:      pl,
+		vis:           NewVisualizer(float64(p.SampleRate())),
+		seekStepLarge: 30 * time.Second,
+		plVisible:     5,
+		eqPresetIdx:   -1, // custom until a preset is selected
+		themes:        themes,
+		themeIdx:      -1, // Default (ANSI)
+		localProvider: localProv,
+		navSortType:   sortType,
+		navClient:     nav,
 		navScrobbleEnabled: navCfg.ScrobbleEnabled(),
 	}
 	if prov != nil {
@@ -232,6 +238,18 @@ func NewModel(p *player.Player, pl *playlist.Playlist, prov playlist.Provider, l
 
 // SetAutoPlay makes the player start playback immediately on Init.
 func (m *Model) SetAutoPlay(v bool) { m.autoPlay = v }
+
+// SetSeekStepLarge configures the Shift+Left/Right seek jump amount.
+func (m *Model) SetSeekStepLarge(d time.Duration) {
+	switch {
+	case d <= 0:
+		m.seekStepLarge = 30 * time.Second
+	case d <= 5*time.Second:
+		m.seekStepLarge = 6 * time.Second
+	default:
+		m.seekStepLarge = d
+	}
+}
 
 // SetTheme finds a theme by name and applies it. Returns true if found.
 func (m *Model) SetTheme(name string) bool {
@@ -277,7 +295,7 @@ func (m Model) ThemeName() string {
 func (m *Model) isOverlayActive() bool {
 	return m.showKeymap || m.showThemes || m.showFileBrowser ||
 		m.showNavBrowser || m.showPlManager || m.showQueue ||
-		m.showInfo || m.searching || m.netSearching
+		m.showInfo || m.searching || m.netSearching || m.jumping
 }
 
 // openThemePicker re-loads themes from disk (picking up new user files)

--- a/ui/model_seek_test.go
+++ b/ui/model_seek_test.go
@@ -1,0 +1,35 @@
+package ui
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSetSeekStepLarge(t *testing.T) {
+	t.Run("sets positive value", func(t *testing.T) {
+		m := Model{}
+		m.SetSeekStepLarge(45 * time.Second)
+		if got, want := m.seekStepLarge, 45*time.Second; got != want {
+			t.Fatalf("seekStepLarge = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("resets non-positive to default", func(t *testing.T) {
+		tests := []time.Duration{0, -5 * time.Second}
+		for _, in := range tests {
+			m := Model{}
+			m.SetSeekStepLarge(in)
+			if got, want := m.seekStepLarge, 30*time.Second; got != want {
+				t.Fatalf("SetSeekStepLarge(%v): seekStepLarge = %v, want %v", in, got, want)
+			}
+		}
+	})
+
+	t.Run("clamps too-small positive value", func(t *testing.T) {
+		m := Model{}
+		m.SetSeekStepLarge(5 * time.Second)
+		if got, want := m.seekStepLarge, 6*time.Second; got != want {
+			t.Fatalf("seekStepLarge = %v, want %v", got, want)
+		}
+	})
+}

--- a/ui/view.go
+++ b/ui/view.go
@@ -59,6 +59,10 @@ func (m Model) View() string {
 		return m.renderNetSearchOverlay()
 	}
 
+	if m.jumping {
+		return m.renderJumpOverlay()
+	}
+
 	if m.fullVis {
 		return m.renderFullVisualizer()
 	}
@@ -446,6 +450,26 @@ func (m Model) renderPlaylist() string {
 	return strings.Join(lines, "\n")
 }
 
+func (m Model) renderJumpOverlay() string {
+	pos := m.player.Position()
+	dur := m.player.Duration()
+	timeLine := fmt.Sprintf("%s / %s", formatJumpClock(pos), formatJumpClock(dur))
+	inputLine := dimStyle.Faint(true).Render("  " + formatJumpPlaceholder(dur))
+	if m.jumpInput != "" {
+		inputLine = playlistSelectedStyle.Render("  " + m.jumpInput + "_")
+	}
+
+	lines := []string{
+		titleStyle.Render("J U M P  T O  T I M E"),
+		"",
+		dimStyle.Render("  " + timeLine),
+		"",
+		inputLine,
+	}
+
+	lines = append(lines, "", helpKey("Enter", "Jump ")+helpKey("Esc", "Cancel"))
+	return m.centerOverlay(strings.Join(lines, "\n"))
+}
 func (m Model) renderHelp() string {
 	if m.focus == focusProvider {
 		return helpKey("↑↓", "Navigate ") + helpKey("Enter", "Load ") + helpKey("Tab", "Focus ") + helpKey("Q", "Quit")


### PR DESCRIPTION
Hi @bjarneo, thank you for this awesome project. I love this player and have been using cliamp heavily this week. I listen to a lot of long-form audio (DJ sets, live concerts, extended mixes), and I kept feeling friction when trying to move around quickly in long tracks.

So I added navigation improvements and have been using them for a few days in normal listening. Development is happening fast on this codebase, so I thought I should get this PR in quickly, even if it's not perfect.

## New features

- Jump to time navigation (J)
- Configurable large seek step (Shift+Left/Right), to be used alongside the default short seek keys.

Screenshots of the jump flow modal:

<img width="247" height="170" alt="Screenshot 2026-03-05 at 10 23 12 AM" src="https://github.com/user-attachments/assets/e44e725c-1d35-4779-913d-bd2e6a5fe8d0" />

<img width="246" height="175" alt="Screenshot 2026-03-05 at 10 23 25 AM" src="https://github.com/user-attachments/assets/0fda0427-8d64-4460-bbd9-6247c08069f7" />

## Overview of changes

- Added a jump to time mode for direct timeline navigation in long tracks
- Added jump input parsing that supports:
    - seconds only (10)
    - mm:ss (75:43)
    - hh:mm:ss (1:15:43)
- Kept display formatting aligned with the main player time format for consistency
- Added configurable large seek step so fast navigation can be tuned
- Updated docs/help text for the new navigation controls
- Added tests for jump parsing and large-seek config/model behaviour

## Why

- For long files, small-step seeking alone is too slow.
- These changes make long-track navigation faster and more practical while staying simple and keyboard-first.

## Testing/Validation

  - Used these features during regular playback for several days
  - Added/updated automated tests for parser and seek-step
  - Verified full suite passes in go test

## Notes

-  I tested a small UI enhancement to briefly highlight/flash the time display after seek (left/right), since timeline movement is subtle on long tracks. I paused this for now because my initial approach introduced playback stutter, likely from extra UI update/timer churn interacting with the audio loop. Might be worth pursuing in the future.