### PR TITLE
fix: auto-detect output device sample rate for USB audio

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -16,9 +16,10 @@ mono = false
 # Shift+Left/Right seek jump in seconds (6-600)
 seek_large_step_sec = 30
 
-# Output sample rate in Hz (22050, 44100, 48000, 96000, 192000)
+# Output sample rate in Hz (0=auto, 22050, 44100, 48000, 96000, 192000)
+# 0 = auto-detect from system default output device (recommended for USB audio)
 # Higher values preserve more detail from hi-res files but use more CPU
-sample_rate = 44100
+# sample_rate = 0
 
 # Speaker buffer size in milliseconds (50-500)
 # Lower = less latency, higher = more stable

--- a/config/config.go
+++ b/config/config.go
@@ -74,11 +74,14 @@ type Config struct {
 }
 
 // Default returns a Config with sensible defaults.
+// SampleRate defaults to 0, which means "auto-detect from the system's default
+// output device" (see player.DeviceSampleRate). This ensures USB audio devices
+// that require a specific rate (commonly 48 kHz) work out of the box.
 func Default() Config {
 	return Config{
 		Repeat:          "off",
 		SeekStepLarge:   30,
-		SampleRate:      44100,
+		SampleRate:      0,
 		BufferMs:        100,
 		ResampleQuality: 4,
 		BitDepth:        16,
@@ -391,7 +394,11 @@ func (c *Config) clamp() {
 }
 
 // clampSampleRate returns the nearest valid sample rate from the allowed set.
+// A value of 0 is preserved as-is to signal "auto-detect" to the player.
 func clampSampleRate(v int) int {
+	if v == 0 {
+		return 0 // auto-detect
+	}
 	allowed := []int{22050, 44100, 48000, 96000, 192000}
 	best := allowed[0]
 	bestDist := abs(v - best)

--- a/main.go
+++ b/main.go
@@ -103,8 +103,20 @@ func run(overrides config.Overrides, positional []string) error {
 	pl := playlist.New()
 	pl.Add(resolved.Tracks...)
 
+	// Resolve sample rate: 0 means auto-detect from the system's default
+	// output audio device (e.g. 48 kHz for USB-C headphones). Falls back
+	// to 44100 Hz if detection is unavailable or returns an unusable value.
+	sampleRate := cfg.SampleRate
+	if sampleRate == 0 {
+		if detected := player.DeviceSampleRate(); detected > 0 {
+			sampleRate = detected
+		} else {
+			sampleRate = 44100
+		}
+	}
+
 	p, err := player.New(player.Quality{
-		SampleRate:      cfg.SampleRate,
+		SampleRate:      sampleRate,
 		BufferMs:        cfg.BufferMs,
 		ResampleQuality: cfg.ResampleQuality,
 		BitDepth:        cfg.BitDepth,
@@ -180,7 +192,7 @@ Playback:
   --auto-play             Start playback immediately
 
 Audio engine:
-  --sample-rate <Hz>      Output sample rate (22050, 44100, 48000, 96000, 192000)
+  --sample-rate <Hz>      Output sample rate (0=auto, 22050, 44100, 48000, 96000, 192000)
   --buffer-ms <ms>        Speaker buffer in milliseconds (50–500)
   --resample-quality <n>  Resample quality factor (1–4)
   --bit-depth <n>         PCM bit depth: 16 (default) or 32 (lossless)

--- a/player/device_darwin.go
+++ b/player/device_darwin.go
@@ -1,0 +1,61 @@
+// player/device_darwin.go — macOS Core Audio device sample rate detection.
+//
+// Queries the system's default output audio device for its nominal sample rate.
+// USB audio devices (e.g., USB-C headphones/DACs) commonly operate at 48 kHz,
+// while the built-in speakers default to 44.1 kHz. Using the device's native
+// rate avoids silent playback failures where AudioQueue can't route to a USB
+// device that doesn't support the requested rate.
+
+//go:build darwin && !ios
+
+package player
+
+/*
+#cgo LDFLAGS: -framework CoreAudio
+#include <CoreAudio/CoreAudio.h>
+
+// defaultOutputSampleRate queries the default output device's nominal sample rate.
+// Returns 0 on any error.
+static double defaultOutputSampleRate() {
+    AudioObjectPropertyAddress addr;
+    UInt32 size;
+    OSStatus status;
+
+    // 1. Get the default output device.
+    addr.mSelector = kAudioHardwarePropertyDefaultOutputDevice;
+    addr.mScope    = kAudioObjectPropertyScopeGlobal;
+    addr.mElement  = kAudioObjectPropertyElementMain;
+
+    AudioDeviceID deviceID = kAudioObjectUnknown;
+    size = sizeof(deviceID);
+    status = AudioObjectGetPropertyData(
+        kAudioObjectSystemObject, &addr, 0, NULL, &size, &deviceID);
+    if (status != noErr || deviceID == kAudioObjectUnknown) {
+        return 0;
+    }
+
+    // 2. Get the device's nominal sample rate.
+    addr.mSelector = kAudioDevicePropertyNominalSampleRate;
+    addr.mScope    = kAudioObjectPropertyScopeOutput;
+
+    Float64 sampleRate = 0;
+    size = sizeof(sampleRate);
+    status = AudioObjectGetPropertyData(deviceID, &addr, 0, NULL, &size, &sampleRate);
+    if (status != noErr) {
+        return 0;
+    }
+    return sampleRate;
+}
+*/
+import "C"
+
+// DeviceSampleRate returns the nominal sample rate of the system's default
+// output audio device, or 0 if detection fails. Callers should fall back
+// to a sensible default (e.g. 44100) when 0 is returned.
+func DeviceSampleRate() int {
+	rate := C.defaultOutputSampleRate()
+	if rate <= 0 {
+		return 0
+	}
+	return int(rate)
+}

--- a/player/device_other.go
+++ b/player/device_other.go
@@ -1,0 +1,11 @@
+// player/device_other.go — stub for non-macOS platforms.
+
+//go:build !darwin || ios
+
+package player
+
+// DeviceSampleRate returns 0 on platforms where device detection is not
+// implemented. Callers should fall back to a sensible default (e.g. 44100).
+func DeviceSampleRate() int {
+	return 0
+}


### PR DESCRIPTION
## Summary

USB-C audio devices (e.g., Jabra Evolve2 40) commonly operate at 48 kHz and may produce **no sound** when the AudioQueue is initialized at the hardcoded 44.1 kHz default.

This PR auto-detects the system default output device's nominal sample rate on macOS via CoreAudio and uses it at startup.

## Changes

- **`player/device_darwin.go`** — Queries `kAudioHardwarePropertyDefaultOutputDevice` + `kAudioDevicePropertyNominalSampleRate` via cgo to get the active output device's sample rate
- **`player/device_other.go`** — Stub returning 0 (no-op) for non-macOS platforms
- **`config/config.go`** — Default `SampleRate` changed from `44100` to `0` (auto-detect); `clampSampleRate` preserves `0`
- **`main.go`** — Resolves `SampleRate == 0` → `DeviceSampleRate()` → fallback `44100` before creating the player
- **`config.toml.example`** — Documents `0 = auto-detect`

## Related issue

Depends on confirmation from #51 — a user reports no sound on USB-C headphones (Jabra Evolve2 40) after updating to v1.16.0. The `sample_rate = 48000` workaround has been suggested; this PR makes it automatic.

## Testing

- Built and verified on macOS (arm64) — `DeviceSampleRate()` correctly returns 48000 when USB headphones are the default output, 44100 for built-in speakers
- Existing behavior preserved when `sample_rate` is explicitly set in config
- `--sample-rate 0` flag works for CLI override to auto-detect