### PR TITLE
Add Bilibili playback support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
  ██████ ███████ ██ ██   ██ ██      ██ ██
 ```
 
-A retro terminal music player inspired by Winamp. Play local files, streams, podcasts, YouTube, SoundCloud, Spotify, and Navidrome with a spectrum visualizer, parametric EQ, and playlist management.
+A retro terminal music player inspired by Winamp. Play local files, streams, podcasts, YouTube, SoundCloud, Bilibili, Spotify, and Navidrome with a spectrum visualizer, parametric EQ, and playlist management.
 
 Built with [Bubbletea](https://github.com/charmbracelet/bubbletea), [Lip Gloss](https://github.com/charmbracelet/lipgloss), [Beep](https://github.com/gopxl/beep), and [go-librespot](https://github.com/devgianlu/go-librespot).
 
@@ -69,7 +69,7 @@ Press `Ctrl+K` to see all keybindings.
 - [CLI Flags](docs/cli.md)
 - [Streaming](docs/streaming.md)
 - [Playlists](docs/playlists.md)
-- [YouTube, SoundCloud and Bandcamp](docs/yt-dlp.md)
+- [YouTube, SoundCloud, Bandcamp and Bilibili](docs/yt-dlp.md)
 - [Lyrics](docs/lyrics.md)
 - [Spotify](docs/spotify.md)
 - [Navidrome](docs/navidrome.md)

--- a/docs/yt-dlp.md
+++ b/docs/yt-dlp.md
@@ -1,11 +1,13 @@
-# YouTube, SoundCloud and Bandcamp
+# YouTube, SoundCloud, Bandcamp and Bilibili
 
-Play from YouTube, SoundCloud, and Bandcamp URLs if [yt-dlp](https://github.com/yt-dlp/yt-dlp) is installed:
+Play from YouTube, SoundCloud, Bandcamp, and Bilibili URLs if [yt-dlp](https://github.com/yt-dlp/yt-dlp) is installed:
 
 ```sh
 cliamp https://www.youtube.com/watch?v=dQw4w9WgXcQ
 cliamp https://soundcloud.com/artist/track
 cliamp https://artist.bandcamp.com/album/name
+cliamp https://www.bilibili.com/video/BV1xxxxxxxxx
+cliamp https://space.bilibili.com/uid/lists/id  # season/series playlists
 ```
 
 Playlists and albums are supported. Press `S` to save a downloaded track to `~/Music/cliamp/`.

--- a/playlist/playlist.go
+++ b/playlist/playlist.go
@@ -132,7 +132,13 @@ func IsYTDL(path string) bool {
 	host = strings.TrimPrefix(host, "m.")
 	switch host {
 	case "soundcloud.com",
-		"bandcamp.com":
+		"bandcamp.com",
+		"bilibili.com",
+		"b23.tv":
+		return true
+	}
+	// Bilibili subdomains (e.g. space.bilibili.com)
+	if strings.HasSuffix(host, ".bilibili.com") {
 		return true
 	}
 	// Bandcamp artist subdomains (e.g. artist.bandcamp.com)


### PR DESCRIPTION
## Summary

- Add `bilibili.com`, `*.bilibili.com` (e.g. `space.bilibili.com`), and `b23.tv` (short links) to yt-dlp supported sites
- Single videos and season/series playlists are supported
- Update README and yt-dlp docs to mention Bilibili

## Test plan

- [x] `./cliamp 'https://www.bilibili.com/video/BV...'` — single video playback
- [x] `./cliamp 'https://space.bilibili.com/uid/lists/id?type=season'` — season playlist
- [x] `./cliamp 'https://b23.tv/...'` — short link

🤖 Generated with [Claude Code](https://claude.com/claude-code)