### PR TITLE
Fix YT playlists listing some music playlists under YouTube video. 

### DIFF
--- a/playlist/playlist.go
+++ b/playlist/playlist.go
@@ -86,7 +86,8 @@ func IsLocalPLS(path string) bool {
 	return !IsURL(path) && IsPLS(path)
 }
 
-// IsYouTubeURL reports whether the URL points to YouTube or YouTube Music.
+// IsYouTubeURL reports whether the URL points to YouTube (youtube.com or youtu.be).
+// YouTube Music (music.youtube.com) is excluded — use IsYouTubeMusicURL for that.
 func IsYouTubeURL(path string) bool {
 	if !IsURL(path) {
 		return false
@@ -103,10 +104,26 @@ func IsYouTubeURL(path string) bool {
 	host = strings.TrimPrefix(host, "www.")
 	host = strings.TrimPrefix(host, "m.")
 	switch host {
-	case "youtube.com", "youtu.be", "music.youtube.com":
+	case "youtube.com", "youtu.be":
 		return true
 	}
 	return false
+}
+
+// IsYouTubeMusicURL reports whether the URL points to YouTube Music (music.youtube.com).
+// These URLs require yt-dlp rather than the native YouTube API client.
+func IsYouTubeMusicURL(path string) bool {
+	if !IsURL(path) {
+		return false
+	}
+	u, err := url.Parse(path)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	host = strings.TrimPrefix(host, "www.")
+	host = strings.TrimPrefix(host, "m.")
+	return host == "music.youtube.com"
 }
 
 // IsYTDL reports whether the URL points to a site supported by yt-dlp
@@ -115,8 +132,8 @@ func IsYTDL(path string) bool {
 	if !IsURL(path) {
 		return false
 	}
-	// YouTube URLs are also handled by yt-dlp for playback.
-	if IsYouTubeURL(path) {
+	// YouTube and YouTube Music URLs are handled by yt-dlp for playback.
+	if IsYouTubeURL(path) || IsYouTubeMusicURL(path) {
 		return true
 	}
 	if strings.HasPrefix(path, "ytsearch:") || strings.HasPrefix(path, "ytsearch1:") ||

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -101,6 +101,14 @@ func Remote(urls []string) ([]playlist.Track, error) {
 	var tracks []playlist.Track
 	for _, u := range urls {
 		switch {
+		case playlist.IsYouTubeMusicURL(u):
+			// YouTube Music requires yt-dlp; the native YouTube API client
+			// does not support music.youtube.com playlists.
+			t, err := resolveYTDL(u)
+			if err != nil {
+				return nil, fmt.Errorf("resolving youtube music %s: %w", u, err)
+			}
+			tracks = append(tracks, t...)
 		case playlist.IsYouTubeURL(u):
 			t, err := resolveYouTube(u)
 			if err != nil {


### PR DESCRIPTION
there's a bug: music.youtube.com URLs were also being routed to resolveYouTube() (the kkdai library) because IsYouTubeURL() matched them.

Just merged a fix on main that:

Narrows IsYouTubeMusicURL() to a dedicated helper matching only music.youtube.com
Updates IsYouTubeURL() to only match youtube.com / youtu.be
Routes music.youtube.com URLs to resolveYTDL() in Remote() before the IsYouTubeURL case