### PR TITLE
feat: parse itunes:duration from RSS feeds to show total track time

### DIFF
--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -616,28 +616,50 @@ func findFirstFile(dir string) string {
 }
 
 // parseItunesDuration parses an <itunes:duration> value into seconds.
-// Accepts "HH:MM:SS", "MM:SS", or a plain integer seconds string.
+// Accepts "HH:MM:SS", "MM:SS", or a plain seconds string (integer or float).
+// Returns 0 for any invalid or negative input.
 func parseItunesDuration(s string) int {
 	s = strings.TrimSpace(s)
 	if s == "" {
 		return 0
 	}
+	// parseSec handles fractional seconds (e.g. "61.5" → 61).
+	parseSec := func(s string) (int, error) {
+		f, err := strconv.ParseFloat(s, 64)
+		return int(f), err
+	}
+
 	parts := strings.Split(s, ":")
+	var result int
 	switch len(parts) {
 	case 1:
-		n, _ := strconv.Atoi(parts[0])
-		return n
+		n, err := parseSec(parts[0])
+		if err != nil {
+			return 0
+		}
+		result = n
 	case 2:
-		m, _ := strconv.Atoi(parts[0])
-		sec, _ := strconv.Atoi(parts[1])
-		return m*60 + sec
+		m, err1 := strconv.Atoi(parts[0])
+		sec, err2 := parseSec(parts[1])
+		if err1 != nil || err2 != nil {
+			return 0
+		}
+		result = m*60 + sec
 	case 3:
-		h, _ := strconv.Atoi(parts[0])
-		m, _ := strconv.Atoi(parts[1])
-		sec, _ := strconv.Atoi(parts[2])
-		return h*3600 + m*60 + sec
+		h, err1 := strconv.Atoi(parts[0])
+		m, err2 := strconv.Atoi(parts[1])
+		sec, err3 := parseSec(parts[2])
+		if err1 != nil || err2 != nil || err3 != nil {
+			return 0
+		}
+		result = h*3600 + m*60 + sec
+	default:
+		return 0
 	}
-	return 0
+	if result < 0 {
+		return 0
+	}
+	return result
 }
 
 // humanizeBasename converts a URL basename like "clr-podcast-467" into "clr podcast 467".

--- a/resolve/resolve_test.go
+++ b/resolve/resolve_test.go
@@ -112,6 +112,46 @@ func TestParseXiaoyuzhouOgAudioTakesPrecedence(t *testing.T) {
 	}
 }
 
+func TestParseItunesDuration(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int
+	}{
+		// Plain seconds
+		{"3600", 3600},
+		{"90", 90},
+		{"0", 0},
+		// Fractional seconds
+		{"3661.5", 3661},
+		{"90.9", 90},
+		// MM:SS
+		{"1:30", 90},
+		{"87:05", 5225},
+		// HH:MM:SS
+		{"1:27:05", 5225},
+		{"0:01:30", 90},
+		// Whitespace
+		{" 3600 ", 3600},
+		// Empty
+		{"", 0},
+		// Invalid — return 0
+		{"abc", 0},
+		{"12:xx", 0},
+		{"1:2:xx", 0},
+		// Negative — clamp to 0
+		{"-1", 0},
+		{"0:-10", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := parseItunesDuration(tt.input)
+			if got != tt.want {
+				t.Errorf("parseItunesDuration(%q) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 type rewriteHostTransport struct {
 	target *url.URL
 	rt     http.RoundTripper


### PR DESCRIPTION
## Summary

- Parse `<itunes:duration>` from podcast RSS feeds so the total track time is displayed in the player
- Supports all common formats: `HH:MM:SS`, `MM:SS`, and plain seconds
- Previously `DurationSecs` was always 0 for RSS tracks, causing `00:39 / 00:00`

## Test plan

- [x] Load a podcast RSS feed with `cliamp <feed-url>`
- [x] Verify the time display shows `XX:XX / HH:MM:SS` with the correct total duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)