### PR TITLE
Fix 403 errors for Spotify playlists saved from other users

### DIFF
--- a/external/spotify/provider.go
+++ b/external/spotify/provider.go
@@ -38,6 +38,7 @@ type playlistCache struct {
 type SpotifyProvider struct {
 	session    *Session
 	clientID   string
+	userID     string // Spotify user ID, fetched lazily on first Playlists() call
 	mu         sync.Mutex
 	trackCache map[string]*playlistCache // playlist ID → cache entry
 }
@@ -111,13 +112,42 @@ func (p *SpotifyProvider) Close() {
 
 func (p *SpotifyProvider) Name() string { return "Spotify" }
 
+// currentUserID fetches and caches the authenticated user's Spotify ID.
+func (p *SpotifyProvider) currentUserID(ctx context.Context) string {
+	p.mu.Lock()
+	id := p.userID
+	p.mu.Unlock()
+	if id != "" {
+		return id
+	}
+	resp, err := p.webAPI(ctx, "GET", "/v1/me", nil)
+	if err != nil {
+		return ""
+	}
+	var me struct {
+		ID string `json:"id"`
+	}
+	if err := decodeBody(resp, &me); err != nil || me.ID == "" {
+		return ""
+	}
+	p.mu.Lock()
+	p.userID = me.ID
+	p.mu.Unlock()
+	return me.ID
+}
+
 // Playlists returns the authenticated user's Spotify playlists.
+// Only playlists owned by the user or marked as collaborative are returned;
+// playlists saved from other users are excluded because the Spotify API
+// returns 403 when trying to list their tracks.
 func (p *SpotifyProvider) Playlists() ([]playlist.PlaylistInfo, error) {
 	if err := p.ensureSession(); err != nil {
 		return nil, err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
+
+	userID := p.currentUserID(ctx) // empty string if fetch fails → no filtering
 
 	var all []playlist.PlaylistInfo
 	offset := 0
@@ -127,9 +157,8 @@ func (p *SpotifyProvider) Playlists() ([]playlist.PlaylistInfo, error) {
 		query := url.Values{
 			"limit":  {fmt.Sprintf("%d", limit)},
 			"offset": {fmt.Sprintf("%d", offset)},
-			// Request only the fields we need to reduce payload size and API cost.
-			// Include snapshot_id for cache invalidation.
-			"fields": {"items(id,name,snapshot_id,items.total),total"},
+			// Include owner.id and collaborative to filter inaccessible playlists.
+			"fields": {"items(id,name,snapshot_id,collaborative,owner(id),items.total),total"},
 		}
 
 		resp, err := p.webAPI(ctx, "GET", "/v1/me/playlists", query)
@@ -139,10 +168,14 @@ func (p *SpotifyProvider) Playlists() ([]playlist.PlaylistInfo, error) {
 
 		var result struct {
 			Items []struct {
-				ID         string `json:"id"`
-				Name       string `json:"name"`
-				SnapshotID string `json:"snapshot_id"`
-				Items      *struct {
+				ID            string `json:"id"`
+				Name          string `json:"name"`
+				SnapshotID    string `json:"snapshot_id"`
+				Collaborative bool   `json:"collaborative"`
+				Owner         struct {
+					ID string `json:"id"`
+				} `json:"owner"`
+				Items *struct {
 					Total int `json:"total"`
 				} `json:"items"`
 			} `json:"items"`
@@ -154,6 +187,12 @@ func (p *SpotifyProvider) Playlists() ([]playlist.PlaylistInfo, error) {
 
 		p.mu.Lock()
 		for _, item := range result.Items {
+			// Skip playlists saved from other users: they appear in the library
+			// but the Spotify API returns 403 when listing their tracks.
+			// Only include playlists we own or collaborate on.
+			if userID != "" && item.Owner.ID != userID && !item.Collaborative {
+				continue
+			}
 			count := 0
 			if item.Items != nil {
 				count = item.Items.Total
@@ -379,6 +418,10 @@ func (p *SpotifyProvider) webAPI(ctx context.Context, method, path string, query
 			case <-time.After(wait):
 				continue
 			}
+		}
+		if resp.StatusCode == http.StatusForbidden {
+			resp.Body.Close()
+			return nil, fmt.Errorf("playlist not accessible (403): only playlists you own or collaborate on can be loaded. Playlists saved from other users are not supported by the Spotify API")
 		}
 		if resp.StatusCode != http.StatusOK {
 			body, readErr := io.ReadAll(io.LimitReader(resp.Body, 512))

--- a/external/spotify/provider.go
+++ b/external/spotify/provider.go
@@ -26,6 +26,31 @@ import (
 // maxResponseBody limits JSON API responses to 10 MB.
 const maxResponseBody = 10 << 20
 
+// spotifyPlaylistItem is the raw playlist object returned by /v1/me/playlists.
+type spotifyPlaylistItem struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	SnapshotID    string `json:"snapshot_id"`
+	Collaborative bool   `json:"collaborative"`
+	Owner         struct {
+		ID string `json:"id"`
+	} `json:"owner"`
+	Items *struct {
+		Total int `json:"total"`
+	} `json:"items"`
+}
+
+// playlistAccessible reports whether the playlist should be shown to the user.
+// Playlists saved from other users (not owned, not collaborative) are excluded
+// because the Spotify API returns 403 when listing their tracks.
+// When userID is empty (fetch failed), all playlists are included as a fallback.
+func playlistAccessible(item spotifyPlaylistItem, userID string) bool {
+	if userID == "" {
+		return true
+	}
+	return item.Owner.ID == userID || item.Collaborative
+}
+
 // SpotifyProvider implements playlist.Provider using the Spotify Web API
 // for playlist/track metadata and go-librespot for audio streaming.
 // playlistCache holds a snapshot_id and the fetched tracks for a playlist,
@@ -167,19 +192,8 @@ func (p *SpotifyProvider) Playlists() ([]playlist.PlaylistInfo, error) {
 		}
 
 		var result struct {
-			Items []struct {
-				ID            string `json:"id"`
-				Name          string `json:"name"`
-				SnapshotID    string `json:"snapshot_id"`
-				Collaborative bool   `json:"collaborative"`
-				Owner         struct {
-					ID string `json:"id"`
-				} `json:"owner"`
-				Items *struct {
-					Total int `json:"total"`
-				} `json:"items"`
-			} `json:"items"`
-			Total int `json:"total"`
+			Items []spotifyPlaylistItem `json:"items"`
+			Total int                  `json:"total"`
 		}
 		if err := decodeBody(resp, &result); err != nil {
 			return nil, fmt.Errorf("spotify: parse playlists: %w", err)
@@ -187,10 +201,7 @@ func (p *SpotifyProvider) Playlists() ([]playlist.PlaylistInfo, error) {
 
 		p.mu.Lock()
 		for _, item := range result.Items {
-			// Skip playlists saved from other users: they appear in the library
-			// but the Spotify API returns 403 when listing their tracks.
-			// Only include playlists we own or collaborate on.
-			if userID != "" && item.Owner.ID != userID && !item.Collaborative {
+			if !playlistAccessible(item, userID) {
 				continue
 			}
 			count := 0

--- a/external/spotify/provider.go
+++ b/external/spotify/provider.go
@@ -98,6 +98,7 @@ func (p *SpotifyProvider) ensureSession() error {
 	}
 	p.mu.Lock()
 	p.session = sess
+	p.userID = ""
 	p.mu.Unlock()
 	return nil
 }
@@ -121,6 +122,7 @@ func (p *SpotifyProvider) Authenticate() error {
 	}
 	p.mu.Lock()
 	p.session = sess
+	p.userID = ""
 	p.mu.Unlock()
 	return nil
 }
@@ -132,6 +134,7 @@ func (p *SpotifyProvider) Close() {
 	if p.session != nil {
 		p.session.Close()
 		p.session = nil
+		p.userID = ""
 	}
 }
 
@@ -268,6 +271,9 @@ func (p *SpotifyProvider) Tracks(playlistID string) ([]playlist.Track, error) {
 		path := fmt.Sprintf("/v1/playlists/%s/items", playlistID)
 		resp, err := p.webAPI(ctx, "GET", path, query)
 		if err != nil {
+			if strings.Contains(err.Error(), "403") {
+				return nil, fmt.Errorf("spotify: playlist not accessible: only playlists you own or collaborate on can be loaded")
+			}
 			return nil, fmt.Errorf("spotify: list tracks: %w", err)
 		}
 
@@ -429,10 +435,6 @@ func (p *SpotifyProvider) webAPI(ctx context.Context, method, path string, query
 			case <-time.After(wait):
 				continue
 			}
-		}
-		if resp.StatusCode == http.StatusForbidden {
-			resp.Body.Close()
-			return nil, fmt.Errorf("playlist not accessible (403): only playlists you own or collaborate on can be loaded. Playlists saved from other users are not supported by the Spotify API")
 		}
 		if resp.StatusCode != http.StatusOK {
 			body, readErr := io.ReadAll(io.LimitReader(resp.Body, 512))

--- a/external/spotify/provider_test.go
+++ b/external/spotify/provider_test.go
@@ -1,0 +1,38 @@
+package spotify
+
+import "testing"
+
+func TestPlaylistAccessible(t *testing.T) {
+	const me = "user123"
+
+	tests := []struct {
+		name          string
+		ownerID       string
+		collaborative bool
+		userID        string
+		want          bool
+	}{
+		{"own playlist", me, false, me, true},
+		{"own collaborative", me, true, me, true},
+		{"other user's playlist", "otheruser", false, me, false},
+		{"other user's collaborative", "otheruser", true, me, true},
+		{"no userID fallback", "otheruser", false, "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			item := spotifyPlaylistItem{
+				ID:            "pl1",
+				Name:          "Test",
+				Collaborative: tt.collaborative,
+			}
+			item.Owner.ID = tt.ownerID
+
+			got := playlistAccessible(item, tt.userID)
+			if got != tt.want {
+				t.Errorf("playlistAccessible(owner=%q, collaborative=%v, userID=%q) = %v, want %v",
+					tt.ownerID, tt.collaborative, tt.userID, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `/v1/me/playlists` returns all playlists in the user's library including ones saved/followed from other users. The Spotify API returns 403 when trying to list tracks for these playlists.
- Fetch the current user's ID via `/v1/me` (cached after first call) and filter the playlist list to only show playlists the user owns or collaborates on.
- Add a clear error message for any remaining 403 errors explaining the limitation, instead of showing a raw HTTP error.

## Test plan

- [x] Spotify playlists list no longer shows playlists saved from other users
- [x] Your own playlists and collaborative playlists still appear and load correctly
- [x] Opening a playlist no longer produces `403 Forbidden` errors

Fixes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)