### PR TITLE
Use explicit realtime stream policy for pause/unpause

### DIFF
--- a/external/radio/provider.go
+++ b/external/radio/provider.go
@@ -72,9 +72,10 @@ func (p *Provider) Tracks(id string) ([]playlist.Track, error) {
 	}
 	s := p.stations[idx]
 	return []playlist.Track{{
-		Path:   s.url,
-		Title:  s.name,
-		Stream: true,
+		Path:     s.url,
+		Title:    s.name,
+		Stream:   true,
+		Realtime: true,
 	}}, nil
 }
 
@@ -127,4 +128,3 @@ func loadStations(path string) ([]station, error) {
 	}
 	return stations, nil
 }
-

--- a/playlist/playlist.go
+++ b/playlist/playlist.go
@@ -39,6 +39,7 @@ type Track struct {
 	Year         int
 	TrackNumber  int
 	Stream       bool   // true for HTTP/HTTPS URLs
+	Realtime     bool   // true for real-time/live streams (e.g. radio)
 	DurationSecs int    // known duration in seconds (0 = unknown)
 	NavidromeID  string // Subsonic song ID; empty for non-Navidrome tracks
 }
@@ -235,7 +236,7 @@ func trackFromURL(rawURL string) Track {
 
 // IsLive reports whether the track is a live stream (e.g. Icecast radio)
 func (t Track) IsLive() bool {
-	return t.Stream && t.DurationSecs == 0
+	return t.Realtime
 }
 
 // DisplayName returns a formatted display string for the track.

--- a/resolve/m3u.go
+++ b/resolve/m3u.go
@@ -83,14 +83,26 @@ func parseM3U(r io.Reader, baseDir string) ([]m3uEntry, error) {
 
 // m3uEntryToTrack converts a parsed M3U entry to a playlist.Track.
 func m3uEntryToTrack(e m3uEntry) playlist.Track {
+	isURL := playlist.IsURL(e.Path)
+	duration := 0
+	if e.Duration > 0 {
+		duration = e.Duration
+	}
+	realtime := isURL && e.Duration < 0
+
 	if e.Title != "" {
 		return playlist.Track{
-			Path:   e.Path,
-			Title:  e.Title,
-			Stream: playlist.IsURL(e.Path),
+			Path:         e.Path,
+			Title:        e.Title,
+			Stream:       isURL,
+			Realtime:     realtime,
+			DurationSecs: duration,
 		}
 	}
-	return playlist.TrackFromPath(e.Path)
+	t := playlist.TrackFromPath(e.Path)
+	t.Realtime = realtime
+	t.DurationSecs = duration
+	return t
 }
 
 // entriesToTracks converts parsed M3U entries to playlist tracks.

--- a/resolve/pls.go
+++ b/resolve/pls.go
@@ -97,9 +97,10 @@ func plsEntriesToTracks(entries []plsEntry) []playlist.Track {
 			return []playlist.Track{playlist.TrackFromPath(e.File)}
 		}
 		return []playlist.Track{{
-			Path:   e.File,
-			Title:  title,
-			Stream: true,
+			Path:     e.File,
+			Title:    title,
+			Stream:   true,
+			Realtime: true,
 		}}
 	}
 

--- a/ui/commands.go
+++ b/ui/commands.go
@@ -201,6 +201,9 @@ func resolveWrapperURLs(tracks []playlist.Track) []playlist.Track {
 					if resolved[i].Artist == "" {
 						resolved[i].Artist = t.Artist
 					}
+					if t.Realtime {
+						resolved[i].Realtime = true
+					}
 				}
 				out = append(out, resolved...)
 				continue

--- a/ui/keys.go
+++ b/ui/keys.go
@@ -20,7 +20,7 @@ func (m *Model) quit() tea.Cmd {
 	// Only save resume for seekable tracks:
 	// - local files (not stream)
 	// - HTTP streams with known duration (podcast MP3s, seek-by-reconnect)
-	// Exclude YTDL (position unreliable) and live streams (no duration).
+	// Exclude YTDL (position unreliable) and real-time live streams.
 	if track, _ := m.playlist.Current(); track.Path != "" &&
 		!playlist.IsYTDL(track.Path) && !track.IsLive() &&
 		m.player.IsPlaying() {
@@ -528,8 +528,6 @@ func (m *Model) saveTrack() tea.Cmd {
 	return nil
 }
 
-
-
 func (m *Model) resetJumpInput() {
 	m.jumpInput = ""
 }
@@ -1018,4 +1016,3 @@ func (m *Model) handleQueueKey(msg tea.KeyMsg) tea.Cmd {
 	}
 	return nil
 }
-

--- a/ui/model.go
+++ b/ui/model.go
@@ -22,7 +22,7 @@ import (
 type focusArea int
 
 const (
-	focusPlaylist      focusArea = iota
+	focusPlaylist focusArea = iota
 	focusEQ
 	focusProvPill
 	focusSearch
@@ -117,7 +117,7 @@ type Model struct {
 
 	// Provider state
 	provider      playlist.Provider
-	localProvider *local.Provider         // direct ref for write operations (add-to-playlist)
+	localProvider *local.Provider // direct ref for write operations (add-to-playlist)
 	providerLists []playlist.PlaylistInfo
 	provCursor    int
 	provLoading   bool
@@ -156,8 +156,8 @@ type Model struct {
 	feedLoading bool
 
 	// Async stream buffering (true while HTTP connect is in progress)
-	buffering    bool
-	bufferingAt  time.Time // when buffering started, for elapsed display
+	buffering   bool
+	bufferingAt time.Time // when buffering started, for elapsed display
 
 	// resume holds the path and position to seek to when the matching track
 	// starts playing. Cleared after the seek is performed.
@@ -1392,13 +1392,19 @@ func (m *Model) togglePlayPause() tea.Cmd {
 	}
 	if m.player.IsPaused() {
 		track, idx := m.playlist.Current()
-		if idx >= 0 && track.IsLive() {
+		if shouldReconnectOnUnpause(track, idx) {
 			m.player.Stop()
 			return m.playTrack(track)
 		}
 	}
 	m.player.TogglePause()
 	return nil
+}
+
+// shouldReconnectOnUnpause reports whether unpausing should reconnect and
+// restart instead of resuming buffered audio.
+func shouldReconnectOnUnpause(track playlist.Track, idx int) bool {
+	return idx >= 0 && track.IsLive()
 }
 
 // lyricsArtistTitle resolves the best artist and title for a lyrics lookup.

--- a/ui/model_pause_test.go
+++ b/ui/model_pause_test.go
@@ -1,0 +1,65 @@
+package ui
+
+import (
+	"testing"
+
+	"cliamp/playlist"
+)
+
+func TestShouldReconnectOnUnpause(t *testing.T) {
+	tests := []struct {
+		name  string
+		track playlist.Track
+		idx   int
+		want  bool
+	}{
+		{
+			name: "live http stream reconnects",
+			track: playlist.Track{
+				Path:     "https://radio.example.com/stream",
+				Stream:   true,
+				Realtime: true,
+			},
+			idx:  0,
+			want: true,
+		},
+		{
+			name: "regular stream does not reconnect",
+			track: playlist.Track{
+				Path:   "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+				Stream: true,
+			},
+			idx:  0,
+			want: false,
+		},
+		{
+			name: "invalid current index does not reconnect",
+			track: playlist.Track{
+				Path:     "https://radio.example.com/stream",
+				Stream:   true,
+				Realtime: true,
+			},
+			idx:  -1,
+			want: false,
+		},
+		{
+			name: "known duration live stream still reconnects",
+			track: playlist.Track{
+				Path:         "https://radio.example.com/show.mp3",
+				Stream:       true,
+				Realtime:     true,
+				DurationSecs: 120,
+			},
+			idx:  0,
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldReconnectOnUnpause(tt.track, tt.idx); got != tt.want {
+				t.Fatalf("shouldReconnectOnUnpause(...) = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add explicit `Track.Realtime` policy for true live streams
- reconnect on unpause only when that policy is set (instead of inferring from missing duration)
- propagate realtime semantics from radio/PLS/M3U resolution and preserve it through wrapper URL expansion
- add tests covering reconnect-on-unpause policy behavior

## Why
`yt-dlp` tracks can have unknown duration early, which previously matched live-stream inference and caused pause/unpause to restart from the beginning.

## Testing
- `go test ./... -count=1`

Fixes #98