### PR TITLE
Add telemetry opt-out controls and first-run notice

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -13,6 +13,9 @@ shuffle = false
 # Start with mono output (L+R downmix)
 mono = false
 
+# Anonymous monthly telemetry ping (UUID + app version)
+telemetry = true
+
 # Shift+Left/Right seek jump in seconds (6-600)
 seek_large_step_sec = 30
 

--- a/config/config.go
+++ b/config/config.go
@@ -108,12 +108,13 @@ func (y YouTubeMusicConfig) ResolveCredentials(fallbackFn func() (string, string
 
 // Config holds user preferences loaded from the config file.
 type Config struct {
-	Volume          float64            // dB, range [-30, +6]
-	EQ              [10]float64        // per-band gain in dB, range [-12, +12]
-	EQPreset        string             // preset name, or "" for custom
-	Repeat          string             // "off", "all", or "one"
+	Volume          float64     // dB, range [-30, +6]
+	EQ              [10]float64 // per-band gain in dB, range [-12, +12]
+	EQPreset        string      // preset name, or "" for custom
+	Repeat          string      // "off", "all", or "one"
 	Shuffle         bool
 	Mono            bool
+	Telemetry       bool               // anonymous monthly ping (UUID + app version)
 	SeekStepLarge   int                // seconds for Shift+Left/Right seek jumps
 	Provider        string             // default provider: "radio", "navidrome", "spotify", "ytmusic" (default "radio")
 	Theme           string             // theme name, or "" for ANSI default
@@ -135,6 +136,7 @@ type Config struct {
 func Default() Config {
 	return Config{
 		Repeat:          "off",
+		Telemetry:       true,
 		SeekStepLarge:   30,
 		SampleRate:      0,
 		BufferMs:        100,
@@ -223,6 +225,11 @@ func Load() (Config, error) {
 			case "cookies_from":
 				cfg.YouTubeMusic.CookiesFrom = strings.Trim(val, `"'`)
 			}
+		case "telemetry":
+			switch key {
+			case "enabled":
+				cfg.Telemetry = strings.ToLower(val) == "true"
+			}
 		default:
 			switch key {
 			case "volume":
@@ -239,6 +246,8 @@ func Load() (Config, error) {
 				cfg.Shuffle = val == "true"
 			case "mono":
 				cfg.Mono = val == "true"
+			case "telemetry", "telemetry.enabled":
+				cfg.Telemetry = strings.ToLower(val) == "true"
 			case "seek_large_step_sec":
 				if v, err := strconv.Atoi(val); err == nil {
 					cfg.SeekStepLarge = v

--- a/config/config_telemetry_test.go
+++ b/config/config_telemetry_test.go
@@ -1,0 +1,74 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultTelemetryEnabled(t *testing.T) {
+	if !Default().Telemetry {
+		t.Fatalf("Default().Telemetry = false, want true")
+	}
+}
+
+func TestLoadTelemetryTopLevel(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	path := filepath.Join(os.Getenv("HOME"), ".config", "cliamp", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("telemetry = false\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Telemetry {
+		t.Fatalf("Telemetry = true, want false")
+	}
+}
+
+func TestLoadTelemetryDottedKey(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	path := filepath.Join(os.Getenv("HOME"), ".config", "cliamp", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("telemetry.enabled = false\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Telemetry {
+		t.Fatalf("Telemetry = true, want false")
+	}
+}
+
+func TestLoadTelemetrySection(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	path := filepath.Join(os.Getenv("HOME"), ".config", "cliamp", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	data := "[telemetry]\nenabled = false\n"
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Telemetry {
+		t.Fatalf("Telemetry = true, want false")
+	}
+}

--- a/config/flags.go
+++ b/config/flags.go
@@ -12,6 +12,7 @@ type Overrides struct {
 	Shuffle         *bool
 	Repeat          *string
 	Mono            *bool
+	Telemetry       *bool
 	Provider        *string
 	Theme           *string
 	Visualizer      *string
@@ -37,6 +38,9 @@ func (o Overrides) Apply(cfg *Config) {
 	}
 	if o.Mono != nil {
 		cfg.Mono = *o.Mono
+	}
+	if o.Telemetry != nil {
+		cfg.Telemetry = *o.Telemetry
 	}
 	if o.Provider != nil {
 		cfg.Provider = *o.Provider
@@ -101,6 +105,8 @@ func ParseFlags(args []string) (action string, ov Overrides, positional []string
 			ov.Mono = ptrBool(true)
 		case "--no-mono":
 			ov.Mono = ptrBool(false)
+		case "--no-telemetry":
+			ov.Telemetry = ptrBool(false)
 		case "--auto-play":
 			ov.Play = ptrBool(true)
 		case "--compact":

--- a/config/flags_test.go
+++ b/config/flags_test.go
@@ -1,0 +1,31 @@
+package config
+
+import "testing"
+
+func TestParseFlagsNoTelemetry(t *testing.T) {
+	action, ov, positional, err := ParseFlags([]string{"--no-telemetry", "track.mp3"})
+	if err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	if action != "" {
+		t.Fatalf("action = %q, want empty", action)
+	}
+	if ov.Telemetry == nil {
+		t.Fatalf("ov.Telemetry = nil, want false pointer")
+	}
+	if *ov.Telemetry {
+		t.Fatalf("ov.Telemetry = true, want false")
+	}
+	if len(positional) != 1 || positional[0] != "track.mp3" {
+		t.Fatalf("positional = %v, want [track.mp3]", positional)
+	}
+}
+
+func TestOverridesApplyTelemetry(t *testing.T) {
+	cfg := Default()
+	ov := Overrides{Telemetry: ptrBool(false)}
+	ov.Apply(&cfg)
+	if cfg.Telemetry {
+		t.Fatalf("cfg.Telemetry = true, want false")
+	}
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -46,6 +46,7 @@ Press `f` in the player to search YouTube interactively, or `F` (Shift+F) to sea
 |------|-------|-------------|
 | `--help` | `-h` | Show help and exit |
 | `--version` | `-v` | Print version and exit |
+| `--no-telemetry` | | Disable telemetry for this session |
 | `--upgrade` | | Update to the latest release |
 
 ## Mixing flags and files
@@ -67,6 +68,7 @@ cliamp track.mp3 --repeat all --mono ~/Music
 | `--mono` / `--no-mono` | bool | false | |
 | `--auto-play` | bool | false | |
 | `--compact` | bool | false | |
+| `--no-telemetry` | bool | false | |
 | `--theme` | string | | theme name |
 | `--eq-preset` | string | | preset name |
 | `--sample-rate` | int | 44100 | 22050, 44100, 48000, 96000, 192000 |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,9 @@ shuffle = false
 # Start with mono output (L+R downmix)
 mono = false
 
+# Anonymous monthly telemetry ping (UUID + app version)
+telemetry = true
+
 # Shift+Left/Right seek jump in seconds
 seek_large_step_sec = 30
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -12,9 +12,21 @@ That's it. No IP logging, no usage data, no personal information.
 ## How it works
 
 1. On first launch, a random UUID is generated and saved to `~/.config/cliamp/.telemetry_id`
-2. Each launch checks if a ping has already been sent this month
-3. If not, a single background GET request is sent to `https://telemetry.cliamp.stream/ping`
-4. The request is fire-and-forget — it never blocks the app or surfaces errors
+2. A one-time startup notice explains telemetry and how to disable it
+3. Each launch checks if a ping has already been sent this month
+4. If not, a single background `POST` request is sent to `https://telemetry.cliamp.stream/ping`
+5. The request is fire-and-forget — it never blocks the app or surfaces errors
+
+The JSON payload is:
+
+```json
+{"uuid":"<random-id>","version":"<cliamp-version>"}
+```
+
+## Disable telemetry
+
+- Persistent: set `telemetry = false` in `~/.config/cliamp/config.toml`
+- One-off session: run `cliamp --no-telemetry`
 
 ## Storage
 

--- a/main.go
+++ b/main.go
@@ -34,6 +34,9 @@ func run(overrides config.Overrides, positional []string) error {
 		return fmt.Errorf("config: %w", err)
 	}
 	overrides.Apply(&cfg)
+	if cfg.Telemetry {
+		telemetry.Ping(version)
+	}
 
 	// Build provider list: Radio is always available, Navidrome and Spotify if configured.
 	radioProv := radio.New()
@@ -261,6 +264,7 @@ Appearance:
 General:
   -h, --help              Show this help message
   -v, --version           Show the current version
+  --no-telemetry          Disable telemetry for this session
   --upgrade               Upgrade cliamp to the latest release
 
 Examples:
@@ -310,8 +314,6 @@ func main() {
 		}
 		return
 	}
-
-	telemetry.Ping(version)
 
 	if err := run(overrides, positional); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -20,8 +20,9 @@ import (
 const endpoint = "https://telemetry.cliamp.stream/ping"
 
 type state struct {
-	ID        string `json:"id"`
-	LastMonth string `json:"last_month"` // "2006-01"
+	ID         string `json:"id"`
+	LastMonth  string `json:"last_month"` // "2006-01"
+	NoticeSeen bool   `json:"notice_seen,omitempty"`
 }
 
 func stateFile() (string, error) {
@@ -69,6 +70,7 @@ func save(path string, s state) {
 // month. It is fire-and-forget: errors are silently ignored so they
 // never affect the user experience.
 func Ping(version string) {
+	firstRun := false
 	s, path, err := load()
 	if err != nil {
 		// First run or corrupt file — generate a new ID.
@@ -78,9 +80,18 @@ func Ping(version string) {
 		}
 		path = p
 		s = state{ID: newUUID()}
+		firstRun = true
 	}
 	if s.ID == "" {
 		s.ID = newUUID()
+		firstRun = true
+	}
+
+	if firstRun && !s.NoticeSeen {
+		fmt.Fprintln(os.Stderr, "cliamp telemetry is enabled: once per month it sends an anonymous UUID and app version.")
+		fmt.Fprintln(os.Stderr, "Disable anytime with telemetry = false in ~/.config/cliamp/config.toml or by running cliamp --no-telemetry")
+		s.NoticeSeen = true
+		save(path, s)
 	}
 
 	thisMonth := time.Now().UTC().Format("2006-01")


### PR DESCRIPTION
This PR tightens telemetry transparency and user control.

Changes:
- add config opt-out via `telemetry = false` (also supports `telemetry.enabled = false` and `[telemetry] enabled = false`)
- add CLI session opt-out via `--no-telemetry`
- only call telemetry ping when enabled
- show a one-time first-run notice with disable instructions
- fix telemetry docs to match actual request method/payload (POST JSON)
- document disable options in CLI/config docs
- add tests for config + flag behavior

Fixes #102
