### PR TITLE
Persist visualizer mode selected with v

### DIFF
--- a/ui/keys.go
+++ b/ui/keys.go
@@ -429,6 +429,10 @@ func (m *Model) handleKey(msg tea.KeyMsg) tea.Cmd {
 
 	case "v":
 		m.vis.CycleMode()
+		if err := config.Save("visualizer", fmt.Sprintf("%q", m.vis.ModeName())); err != nil {
+			m.status.text = fmt.Sprintf("Config save failed: %s", err)
+			m.status.ttl = 60
+		}
 
 	case "V":
 		m.fullVis = !m.fullVis


### PR DESCRIPTION
This fixes visualizer persistence when using the `v` hotkey.

Current behavior:
- pressing `v` cycles visualizer mode for the current session
- restart goes back to default mode

Change:
- after `m.vis.CycleMode()`, save `visualizer` to config (same way `repeat` and `shuffle` are saved)
- keep the existing status message on config write failure

Fixes #106
