### PR TITLE
Fix OAuth port leak by adding context cancellation and defer lis.Clos…

### DIFF
--- a/external/spotify/provider.go
+++ b/external/spotify/provider.go
@@ -76,6 +76,7 @@ type SpotifyProvider struct {
 	userID     string // Spotify user ID, fetched lazily on first Playlists() call
 	mu         sync.Mutex
 	trackCache map[string]*playlistCache // playlist ID → cache entry
+	authCancel context.CancelFunc        // cancels any in-progress OAuth flow
 }
 
 // New creates a SpotifyProvider. If session is nil, authentication is
@@ -114,11 +115,16 @@ func (p *SpotifyProvider) ensureSession() error {
 }
 
 // Authenticate runs the interactive sign-in flow (opens browser, waits for callback).
+// Any previous in-progress OAuth flow is cancelled first to free the callback port.
 func (p *SpotifyProvider) Authenticate() error {
 	p.mu.Lock()
 	if p.session != nil {
 		p.mu.Unlock()
 		return nil
+	}
+	if p.authCancel != nil {
+		p.authCancel()
+		p.authCancel = nil
 	}
 	clientID := p.clientID
 	p.mu.Unlock()
@@ -126,7 +132,19 @@ func (p *SpotifyProvider) Authenticate() error {
 	if clientID == "" {
 		return fmt.Errorf("spotify: no client ID available")
 	}
-	sess, err := NewSession(context.Background(), clientID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	p.mu.Lock()
+	p.authCancel = cancel
+	p.mu.Unlock()
+
+	sess, err := NewSession(ctx, clientID)
+
+	p.mu.Lock()
+	p.authCancel = nil
+	p.mu.Unlock()
+	cancel()
+
 	if err != nil {
 		return err
 	}
@@ -141,6 +159,10 @@ func (p *SpotifyProvider) Authenticate() error {
 func (p *SpotifyProvider) Close() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	if p.authCancel != nil {
+		p.authCancel()
+		p.authCancel = nil
+	}
 	if p.session != nil {
 		p.session.Close()
 		p.session = nil

--- a/external/spotify/session.go
+++ b/external/spotify/session.go
@@ -111,7 +111,7 @@ func newSessionFromStored(ctx context.Context, clientID string, creds *storedCre
 			sess.Close()
 			return nil, fmt.Errorf("silent token refresh failed, interactive auth required")
 		}
-		token, err := doWebAPIAuth(clientID)
+		token, err := doWebAPIAuth(ctx, clientID)
 		if err != nil {
 			sess.Close()
 			return nil, fmt.Errorf("stored session needs fresh Web API token: %w", err)
@@ -201,11 +201,12 @@ const oauthCallbackHTML = `<!DOCTYPE html>
 
 // performOAuth2PKCE runs an OAuth2 PKCE flow: opens a browser for user consent,
 // waits for the callback, and exchanges the code for a token.
-func performOAuth2PKCE(clientID string) (*oauth2.Token, error) {
+func performOAuth2PKCE(ctx context.Context, clientID string) (*oauth2.Token, error) {
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", CallbackPort))
 	if err != nil {
 		return nil, fmt.Errorf("listen on port %d: %w", CallbackPort, err)
 	}
+	defer lis.Close() // always release the port
 
 	oauthConf := spotifyOAuthConfig(clientID)
 
@@ -228,10 +229,14 @@ func performOAuth2PKCE(clientID string) (*oauth2.Token, error) {
 
 	_ = browser.Open(authURL) // best-effort — user can open the URL manually if this fails
 
-	code := <-codeCh
-	_ = lis.Close() // server is done; ignore close error
+	var code string
+	select {
+	case code = <-codeCh:
+	case <-ctx.Done():
+		return nil, fmt.Errorf("authentication cancelled: %w", ctx.Err())
+	}
 
-	token, err := oauthConf.Exchange(context.Background(), code, oauth2.VerifierOption(verifier))
+	token, err := oauthConf.Exchange(ctx, code, oauth2.VerifierOption(verifier))
 	if err != nil {
 		return nil, fmt.Errorf("token exchange: %w", err)
 	}
@@ -241,8 +246,8 @@ func performOAuth2PKCE(clientID string) (*oauth2.Token, error) {
 
 // doWebAPIAuth performs an OAuth2 PKCE flow to get a fresh Web API access token.
 // Opens a browser for user consent, returns the full token (including refresh token).
-func doWebAPIAuth(clientID string) (*oauth2.Token, error) {
-	token, err := performOAuth2PKCE(clientID)
+func doWebAPIAuth(ctx context.Context, clientID string) (*oauth2.Token, error) {
+	token, err := performOAuth2PKCE(ctx, clientID)
 	if err != nil {
 		return nil, err
 	}
@@ -253,7 +258,7 @@ func doWebAPIAuth(clientID string) (*oauth2.Token, error) {
 func newInteractiveSession(ctx context.Context, clientID string) (*Session, error) {
 	devID := generateDeviceID()
 
-	token, err := performOAuth2PKCE(clientID)
+	token, err := performOAuth2PKCE(ctx, clientID)
 	if err != nil {
 		return nil, fmt.Errorf("spotify: %w", err)
 	}

--- a/external/ytmusic/provider.go
+++ b/external/ytmusic/provider.go
@@ -36,6 +36,7 @@ type baseProvider struct {
 	allPlaylists []playlistEntry             // cached raw playlist list
 	classified   map[string]bool             // playlist ID -> is music (from classify.go)
 	disk         *ytCache                    // lazy-loaded disk cache
+	authCancel   context.CancelFunc          // cancels any in-progress OAuth flow
 }
 
 func newBase(session *Session, clientID, clientSecret string, hasCookies bool) *baseProvider {
@@ -58,12 +59,19 @@ func (b *baseProvider) ensureDiskCache() *ytCache {
 
 // initSession creates a session if one doesn't exist yet. If interactive is
 // false, only stored credentials are tried (returning ErrNeedsAuth on failure).
-// If interactive is true, a browser-based OAuth flow is started.
+// If interactive is true, a browser-based OAuth flow is started. Any previous
+// in-progress OAuth flow is cancelled first to free the callback port.
 func (b *baseProvider) initSession(interactive bool) error {
 	b.mu.Lock()
 	if b.session != nil {
 		b.mu.Unlock()
 		return nil
+	}
+	// Cancel any previous in-progress auth attempt so the old listener
+	// on CallbackPort is released before we try to bind again.
+	if b.authCancel != nil {
+		b.authCancel()
+		b.authCancel = nil
 	}
 	clientID := b.clientID
 	clientSecret := b.clientSecret
@@ -76,7 +84,17 @@ func (b *baseProvider) initSession(interactive bool) error {
 	var sess *Session
 	var err error
 	if interactive {
-		sess, err = NewSession(context.Background(), clientID, clientSecret)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		b.mu.Lock()
+		b.authCancel = cancel
+		b.mu.Unlock()
+
+		sess, err = NewSession(ctx, clientID, clientSecret)
+
+		b.mu.Lock()
+		b.authCancel = nil
+		b.mu.Unlock()
+		cancel()
 	} else {
 		sess, err = NewSessionSilent(context.Background(), clientID, clientSecret)
 	}
@@ -101,6 +119,10 @@ func (b *baseProvider) authenticate() error   { return b.initSession(true) }
 func (b *baseProvider) close() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	if b.authCancel != nil {
+		b.authCancel()
+		b.authCancel = nil
+	}
 	if b.session != nil {
 		b.session.Close()
 		b.session = nil

--- a/external/ytmusic/session.go
+++ b/external/ytmusic/session.go
@@ -120,7 +120,7 @@ func silentTokenRefresh(clientID, clientSecret, refreshToken string) (*oauth2.To
 
 // newInteractiveSession performs an OAuth2 flow to authenticate.
 func newInteractiveSession(ctx context.Context, clientID, clientSecret string) (*Session, error) {
-	token, err := doOAuth(clientID, clientSecret)
+	token, err := doOAuth(ctx, clientID, clientSecret)
 	if err != nil {
 		return nil, err
 	}
@@ -147,12 +147,15 @@ func newInteractiveSession(ctx context.Context, clientID, clientSecret string) (
 }
 
 // doOAuth performs an OAuth2 flow: starts localhost server, opens browser,
-// exchanges code for token.
-func doOAuth(clientID, clientSecret string) (*oauth2.Token, error) {
+// exchanges code for token. The context controls cancellation — if ctx is
+// cancelled (e.g. the user retries auth), the listener is closed and the
+// function returns promptly, freeing the callback port.
+func doOAuth(ctx context.Context, clientID, clientSecret string) (*oauth2.Token, error) {
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", CallbackPort))
 	if err != nil {
 		return nil, fmt.Errorf("ytmusic: listen on port %d (is another instance running?): %w", CallbackPort, err)
 	}
+	defer lis.Close() // always release the port
 
 	oauthConf := googleOAuthConfig(clientID, clientSecret)
 
@@ -182,10 +185,14 @@ func doOAuth(clientID, clientSecret string) (*oauth2.Token, error) {
 
 	_ = browser.Open(authURL) // best-effort — user can open the URL manually if this fails
 
-	code := <-codeCh
-	_ = lis.Close() // server is done; ignore close error
+	var code string
+	select {
+	case code = <-codeCh:
+	case <-ctx.Done():
+		return nil, fmt.Errorf("ytmusic: authentication cancelled: %w", ctx.Err())
+	}
 
-	token, err := oauthConf.Exchange(context.Background(), code, oauth2.VerifierOption(verifier))
+	token, err := oauthConf.Exchange(ctx, code, oauth2.VerifierOption(verifier))
 	if err != nil {
 		return nil, fmt.Errorf("ytmusic: token exchange: %w", err)
 	}


### PR DESCRIPTION
…e() to prevent address already in use errors when retrying YouTube/Spotify authentication.

https://github.com/bjarneo/cliamp/issues/109