### PR TITLE
Reduce title scroll speed for better readability

### DIFF
--- a/ui/model.go
+++ b/ui/model.go
@@ -124,7 +124,8 @@ type Model struct {
 	plCursor  int       // selected playlist item
 	plScroll  int       // scroll offset for playlist view
 	plVisible int       // max visible playlist items
-	titleOff  int       // scroll offset for long track titles
+	titleOff        int       // scroll offset for long track titles
+	titleLastScroll time.Time // last time the title scrolled
 	err       error
 	quitting  bool
 	width     int
@@ -824,7 +825,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.notifyMPRIS()
 		}
 		if m.player.IsPlaying() && !m.player.IsPaused() {
-			m.titleOff++
+			if time.Since(m.titleLastScroll) >= 200*time.Millisecond {
+				m.titleOff++
+				m.titleLastScroll = time.Now()
+			}
 		}
 		// Retry deferred stream preload: preloadNext() returns nil (defers) when
 		// the current stream has >streamPreloadLeadTime remaining. Poll every tick


### PR DESCRIPTION
## Summary

Long track titles (common with Spotify) scroll too fast when the visualizer is active — the title moves at 20 characters/sec (one character per 50ms tick), making it hard to read.

This decouples title scrolling from the visualizer tick rate by using a time-based interval of 200ms (~5 chars/sec), so long titles are easy to read while the visualizer stays smooth.

## Changes

- Added `titleLastScroll time.Time` field to track when the title last scrolled
- Title now advances based on elapsed time (200ms) instead of every visualizer tick

## Test plan

- [x] Play a Spotify track with a long title + artist name
- [x] Confirm the title scrolls at a comfortable, readable speed
- [x] Confirm the visualizer animation is unaffected
- [x] Confirm short titles that fit the screen are unaffected (no scrolling)