### PR TITLE
Add a WSL configuration section

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,6 +77,29 @@ These appear alongside the built-in cliamp radio in the Radio provider.
 
 See [audio-quality.md](audio-quality.md) for sample rate, buffer, bit depth, and resample quality settings.
 
+## WSL2 (Windows Subsystem for Linux)
+
+cliamp uses ALSA for audio on Linux. WSL2 doesn't expose ALSA hardware directly, but WSLg provides a PulseAudio server that ALSA can route through.
+
+If you see errors like `ALSA lib pcm.c: Unknown PCM default`, fix it with two steps:
+
+**1. Install the ALSA PulseAudio plugin:**
+
+```sh
+sudo apt install libasound2-plugins
+```
+
+**2. Create `~/.asoundrc` to route ALSA through PulseAudio:**
+
+```sh
+cat > ~/.asoundrc << 'EOF'
+pcm.default pulse
+ctl.default pulse
+EOF
+```
+
+WSLg must be active (`echo $PULSE_SERVER` should print a path). If it's empty, ensure you're on Windows 11 with WSLg enabled and run `wsl --shutdown` then reopen your terminal.
+
 ## ffmpeg (optional)
 
 AAC, ALAC (`.m4a`), Opus, and WMA playback requires [ffmpeg](https://ffmpeg.org/):


### PR DESCRIPTION
Hey, I was struggling on WSL to get cliamp working
After some debugging with Claude, I figured out the two steps added were needed. I thought it would be nice to add to the config for fellow WSL users :)
I can confirm that I went from the following errors:
```
ALSA lib confmisc.c:855:(parse_card) cannot find card '0'
ALSA lib conf.c:5204:(_snd_config_evaluate) function snd_func_card_inum returned error: No such file or directory
ALSA lib confmisc.c:422:(snd_func_concat) error evaluating strings
ALSA lib conf.c:5204:(_snd_config_evaluate) function snd_func_concat returned error: No such file or directory
ALSA lib confmisc.c:1342:(snd_func_refer) error evaluating name
ALSA lib conf.c:5204:(_snd_config_evaluate) function snd_func_refer returned error: No such file or directory
ALSA lib conf.c:5727:(snd_config_expand) Evaluate error: No such file or directory
ALSA lib pcm.c:2721:(snd_pcm_open_noupdate) Unknown PCM default
ALSA lib confmisc.c:855:(parse_card) cannot find card '0'
ALSA lib conf.c:5204:(_snd_config_evaluate) function snd_func_card_inum returned error: No such file or directory
ALSA lib confmisc.c:422:(snd_func_concat) error evaluating strings
ALSA lib conf.c:5204:(_snd_config_evaluate) function snd_func_concat returned error: No such file or directory
ALSA lib confmisc.c:1342:(snd_func_refer) error evaluating name
ALSA lib conf.c:5204:(_snd_config_evaluate) function snd_func_refer returned error: No such file or directory
ALSA lib conf.c:5727:(snd_config_expand) Evaluate error: No such file or directory
ALSA lib pcm.c:2721:(snd_pcm_open_noupdate) Unknown PCM default
```

To getting the audio to work :)
Cool project btw!