### PR TITLE
Fix MPRIS state not syncing on connect, radio title changes, and position staleness

### DIFF
--- a/ui/model.go
+++ b/ui/model.go
@@ -743,6 +743,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Poll ICY stream title for live radio display.
 		if title := m.player.StreamTitle(); title != "" && title != m.streamTitle {
 			m.streamTitle = title
+			m.notifyMPRIS()
 			// Auto-fetch lyrics when the stream song changes and lyrics overlay is open.
 			if m.lyrics.visible && !m.lyrics.loading {
 				if artist, song, ok := strings.Cut(title, " - "); ok {
@@ -761,6 +762,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Update network throughput every ~1 second (20 ticks at 50ms).
 		m.network.lastTick++
 		if m.network.lastTick >= 20 {
+			m.notifyMPRIS()
 			downloaded, _ := m.player.StreamBytes()
 			delta := downloaded - m.network.lastBytes
 			if delta > 0 {
@@ -1115,6 +1117,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case mpris.InitMsg:
 		m.mpris = msg.Svc
+		m.notifyMPRIS()
 		return m, nil
 
 	case mpris.PlayPauseMsg:


### PR DESCRIPTION
Three small fixes to the MPRIS D-Bus integration that caused waybar (and other MPRIS clients) to show stale or missing data.

**InitMsg not syncing state on connect**

When cliamp was already playing before the MPRIS service finished registering on D-Bus, the client would see PlaybackStatus "Stopped" and empty metadata until the next user interaction triggered a `notifyMPRIS()` call. Fixed by calling `notifyMPRIS()` immediately after the service is attached in the `InitMsg` handler.

**Radio stream title not propagating**

ICY stream titles (the "Artist - Song" metadata from live radio) were being polled and updated in the UI on each tick, but `notifyMPRIS()` was never called when the value changed. Fixed by calling `notifyMPRIS()` when a new stream title is detected.

**Position not updating between interactions**

`notifyMPRIS()` was only called on user events (key presses, track changes, etc.), so the MPRIS `Position` property would go stale between interactions. Fixed by calling `notifyMPRIS()` every ~1 second in the tick handler, piggybacking on the existing 20-tick network throughput counter.