### PR TITLE
Improve list navigation

### DIFF
--- a/ui/filebrowser.go
+++ b/ui/filebrowser.go
@@ -105,11 +105,25 @@ func (m *Model) handleFileBrowserKey(msg tea.KeyMsg) tea.Cmd {
 	case "up", "k":
 		if m.fileBrowser.cursor > 0 {
 			m.fileBrowser.cursor--
+		} else if len(m.fileBrowser.entries) > 0 {
+			m.fileBrowser.cursor = len(m.fileBrowser.entries)-1
 		}
 
 	case "down", "j":
 		if m.fileBrowser.cursor < len(m.fileBrowser.entries)-1 {
 			m.fileBrowser.cursor++
+		} else if len(m.fileBrowser.entries) > 0 {
+			m.fileBrowser.cursor = 0
+		}
+
+	case "pgup":
+		if m.fileBrowser.cursor > 0 {
+			m.fileBrowser.cursor -= min(m.fileBrowser.cursor, 12)
+		}
+
+	case "pgdown":
+		if m.fileBrowser.cursor < len(m.fileBrowser.entries)-1 {
+			m.fileBrowser.cursor = min(len(m.fileBrowser.entries)-1, m.fileBrowser.cursor + 12)
 		}
 
 	case "enter", "l", "right":
@@ -162,10 +176,10 @@ func (m *Model) handleFileBrowserKey(msg tea.KeyMsg) tea.Cmd {
 			}
 		}
 
-	case "g":
+	case "g", "home":
 		m.fileBrowser.cursor = 0
 
-	case "G":
+	case "G", "end":
 		if len(m.fileBrowser.entries) > 0 {
 			m.fileBrowser.cursor = len(m.fileBrowser.entries) - 1
 		}

--- a/ui/keymap.go
+++ b/ui/keymap.go
@@ -61,6 +61,14 @@ func (m *Model) handleKeymapKey(msg tea.KeyMsg) tea.Cmd {
 	case tea.KeyUp:
 		if m.keymap.cursor > 0 {
 			m.keymap.cursor--
+		} else {
+			count := len(keymapEntries)
+			if m.keymap.search != "" {
+				count = len(m.keymap.filtered)
+			}
+			if count > 0 {
+				m.keymap.cursor = count-1
+			}
 		}
 	case tea.KeyDown:
 		count := len(keymapEntries)
@@ -69,6 +77,8 @@ func (m *Model) handleKeymapKey(msg tea.KeyMsg) tea.Cmd {
 		}
 		if m.keymap.cursor < count-1 {
 			m.keymap.cursor++
+		} else if count > 0 {
+			m.keymap.cursor = 0
 		}
 	case tea.KeyBackspace:
 		if m.keymap.search != "" {

--- a/ui/keys.go
+++ b/ui/keys.go
@@ -141,12 +141,16 @@ func (m *Model) handleKey(msg tea.KeyMsg) tea.Cmd {
 		case "up", "k":
 			if m.provCursor > 0 {
 				m.provCursor--
+			} else if len(m.providerLists) > 0 {
+				m.provCursor = len(m.providerLists)-1
 			}
 		case " ":
 			return m.togglePlayPause()
 		case "down", "j":
 			if m.provCursor < len(m.providerLists)-1 {
 				m.provCursor++
+			} else if len(m.providerLists) > 0 {
+				m.provCursor = 0
 			}
 		case "enter":
 			if m.provSignIn {
@@ -273,6 +277,14 @@ func (m *Model) handleKey(msg tea.KeyMsg) tea.Cmd {
 			}
 		}
 
+	case "shift+down":
+		if m.focus == focusPlaylist && m.plCursor < m.playlist.Len()-1 {
+			if m.playlist.Move(m.plCursor, m.plCursor+1) {
+				m.plCursor++
+				m.adjustScroll()
+			}
+		}
+
 	case "up", "k":
 		if m.focus == focusEQ {
 			bands := m.player.EQBands()
@@ -282,6 +294,9 @@ func (m *Model) handleKey(msg tea.KeyMsg) tea.Cmd {
 		} else {
 			if m.plCursor > 0 {
 				m.plCursor--
+				m.adjustScroll()
+			} else if m.playlist.Len() > 0 {
+				m.plCursor = m.playlist.Len()-1
 				m.adjustScroll()
 			}
 		}
@@ -296,7 +311,34 @@ func (m *Model) handleKey(msg tea.KeyMsg) tea.Cmd {
 			if m.plCursor < m.playlist.Len()-1 {
 				m.plCursor++
 				m.adjustScroll()
+			} else if m.playlist.Len() > 0 {
+				m.plCursor = 0
+				m.adjustScroll()
 			}
+		}
+
+	case "pgup":
+		if m.focus == focusPlaylist && m.plCursor > 0 {
+			m.plCursor -= min(m.plCursor, m.plVisible)
+			m.adjustScroll()
+		}
+
+	case "pgdown":
+		if m.focus == focusPlaylist && m.plCursor < m.playlist.Len()-1 {
+			m.plCursor = min(m.playlist.Len()-1, m.plCursor + m.plVisible)
+			m.adjustScroll()
+		}
+
+	case "g", "home":
+		if m.focus == focusPlaylist && m.plCursor != 0 {
+			m.plCursor = 0
+			m.adjustScroll()
+		}
+
+	case "G", "end":
+		if m.focus == focusPlaylist && m.playlist.Len() > 0 && m.plCursor != m.playlist.Len()-1 {
+			m.plCursor = m.playlist.Len()-1
+			m.adjustScroll()
 		}
 
 	case "enter":
@@ -403,14 +445,6 @@ func (m *Model) handleKey(msg tea.KeyMsg) tea.Cmd {
 		m.netSearch.soundcloud = msg.String() == "F"
 		m.prevFocus = m.focus
 		m.focus = focusNetSearch
-
-	case "shift+down":
-		if m.focus == focusPlaylist && m.plCursor < m.playlist.Len()-1 {
-			if m.playlist.Move(m.plCursor, m.plCursor+1) {
-				m.plCursor++
-				m.adjustScroll()
-			}
-		}
 
 	case "J":
 		m.openJumpMode()
@@ -845,10 +879,14 @@ func (m *Model) handlePlMgrListKey(msg tea.KeyMsg) tea.Cmd {
 	case "up", "k":
 		if m.plManager.cursor > 0 {
 			m.plManager.cursor--
+		} else if count > 0 {
+			m.plManager.cursor = count-1
 		}
 	case "down", "j":
 		if m.plManager.cursor < count-1 {
 			m.plManager.cursor++
+		} else if count > 0 {
+			m.plManager.cursor = 0
 		}
 	case "enter", "l", "right":
 		if m.plManager.cursor < len(m.plManager.playlists) {
@@ -883,10 +921,14 @@ func (m *Model) handlePlMgrTracksKey(msg tea.KeyMsg) tea.Cmd {
 	case "up", "k":
 		if m.plManager.cursor > 0 {
 			m.plManager.cursor--
+		} else if len(m.plManager.tracks) > 0 {
+			m.plManager.cursor = len(m.plManager.tracks)-1
 		}
 	case "down", "j":
 		if m.plManager.cursor < len(m.plManager.tracks)-1 {
 			m.plManager.cursor++
+		} else if len(m.plManager.tracks) > 0 {
+			m.plManager.cursor = 0
 		}
 	case "enter":
 		// Replace playlist and start playback.
@@ -1002,10 +1044,16 @@ func (m *Model) handleThemeKey(msg tea.KeyMsg) tea.Cmd {
 		if m.themePicker.cursor > 0 {
 			m.themePicker.cursor--
 			m.themePickerApply() // live preview
+		} else {
+			m.themePicker.cursor = count-1
+			m.themePickerApply() // live preview
 		}
 	case "down", "j":
 		if m.themePicker.cursor < count-1 {
 			m.themePicker.cursor++
+			m.themePickerApply() // live preview
+		} else {
+			m.themePicker.cursor = 0
 			m.themePickerApply() // live preview
 		}
 	case "enter":
@@ -1029,10 +1077,14 @@ func (m *Model) handleQueueKey(msg tea.KeyMsg) tea.Cmd {
 	case "up", "k":
 		if m.queue.cursor > 0 {
 			m.queue.cursor--
+		} else if qLen > 0 {
+			m.queue.cursor = qLen-1
 		}
 	case "down", "j":
 		if m.queue.cursor < qLen-1 {
 			m.queue.cursor++
+		} else if qLen > 0 {
+			m.queue.cursor = 0
 		}
 	case "shift+up":
 		if m.queue.cursor > 0 {


### PR DESCRIPTION
Improved navigation in lists:

1. Wrap-around scroll. You can move to list's top (end) by pressing arrow keys when cursor is at bottom (topmost) entry.
2. Scroll playlist by whole page by pressing `PageUp` / `PageDown` keys. Also supported in file browser.
3. Go to top (end) of playlist by pressing `Home` / `End` / `g` / `G` keys. Also supported in file browser.