### PR TITLE
Feature: Configurable UI Padding

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -129,7 +129,8 @@ type Config struct {
 	ResampleQuality   int                // beep resample quality factor (1–4)
 	BitDepth          int                // PCM bit depth for FFmpeg output: 16 or 32
 	Compact           bool               // compact mode: cap frame width at 80 columns
-	Padding           int                // horizontal padding for the UI frame (default 3)
+	PaddingH          int                // horizontal padding for the UI frame (default 3)
+	PaddingV          int                // vertical padding for the UI frame (default 1)
 	Navidrome         NavidromeConfig    // optional Navidrome/Subsonic server credentials
 	Spotify           SpotifyConfig      // optional Spotify provider (requires Premium)
 	YouTubeMusic      YouTubeMusicConfig // optional YouTube Music provider
@@ -149,7 +150,8 @@ func defaultConfig() Config {
 		BufferMs:        100,
 		ResampleQuality: 4,
 		BitDepth:        16,
-		Padding:         3,
+		PaddingH:        3,
+		PaddingV:        1,
 	}
 }
 
@@ -290,9 +292,13 @@ func Load() (Config, error) {
 				}
 			case "compact":
 				cfg.Compact = val == "true"
-			case "padding":
+			case "padding_horizontal":
 				if v, err := strconv.Atoi(val); err == nil {
-					cfg.Padding = v
+					cfg.PaddingH = v
+				}
+			case "padding_vertical":
+				if v, err := strconv.Atoi(val); err == nil {
+					cfg.PaddingV = v
 				}
 			}
 		}
@@ -491,7 +497,8 @@ func (c *Config) clamp() {
 	c.BufferMs = max(min(c.BufferMs, 500), 50)
 	c.ResampleQuality = max(min(c.ResampleQuality, 4), 1)
 	c.BitDepth = clampBitDepth(c.BitDepth)
-	c.Padding = max(min(c.Padding, 10), 0)
+	c.PaddingH = max(min(c.PaddingH, 10), 0)
+	c.PaddingV = max(min(c.PaddingV, 5), 0)
 }
 
 // clampSampleRate returns the nearest valid sample rate from the allowed set.
@@ -542,3 +549,5 @@ func parseEQ(val string) [10]float64 {
 	}
 	return bands
 }
+
+

--- a/main.go
+++ b/main.go
@@ -177,7 +177,7 @@ func run(overrides config.Overrides, positional []string) error {
 
 	cfg.ApplyPlayer(p)
 	cfg.ApplyPlaylist(pl)
-	ui.SetPadding(cfg.Padding)
+	ui.SetPadding(cfg.PaddingH, cfg.PaddingV)
 
 	themes := theme.LoadAll()
 

--- a/ui/model.go
+++ b/ui/model.go
@@ -652,7 +652,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			frameW = min(frameW, 80)
 		}
 		frameStyle = frameStyle.Width(frameW)
-		panelWidth = max(0, frameW-(2*padding))
+		panelWidth = max(0, frameW-2*paddingH)
 		if m.fullVis {
 			m.vis.Rows = max(defaultVisRows, (m.height-10)*4/5)
 		}
@@ -660,7 +660,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// total height, then give the remaining space to the playlist.
 		// This avoids fragile manual line counting.
 		m.plVisible = 3 // temporary minimal value for measurement
-		probe := strings.Join([]string{
+		sections := []string{
 			m.renderTitle(),
 			m.renderTrackInfo(),
 			m.renderTimeStatus(),
@@ -669,13 +669,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.renderSeekBar(),
 			"",
 			m.renderControls(),
+			m.renderProviderPill(),
 			"",
 			m.renderPlaylistHeader(),
 			"x", // placeholder for playlist (1 line)
 			"",
 			m.renderHelp(),
 			m.renderStreamStatus(),
-		}, "\n")
+		}
+		// Clean up empty trailing sections to match View() logic
+		for len(sections) > 0 && sections[len(sections)-1] == "" {
+			sections = sections[:len(sections)-1]
+		}
+		probe := strings.Join(sections, "\n")
 		probeFrame := frameStyle.Render(probe)
 		fixedLines := lipgloss.Height(probeFrame) - 1 // subtract the 1-line placeholder
 		m.plVisible = max(3, min(maxPlVisible, m.height-fixedLines))

--- a/ui/styles.go
+++ b/ui/styles.go
@@ -24,24 +24,28 @@ var (
 	spectrumHigh lipgloss.TerminalColor = lipgloss.ANSIColor(9)  // bright red
 )
 
-// padding is the horizontal padding inside the frame.
-var padding = 3
+// paddingH is the horizontal padding inside the frame.
+var paddingH = 3
+
+// paddingV is the vertical padding inside the frame.
+var paddingV = 1
 
 // panelWidth is the usable inner width of the frame.
 // Updated dynamically in WindowSizeMsg based on terminal width.
-var panelWidth = 80 - 2*padding
+var panelWidth = 80 - 2*paddingH
 
-// SetPadding updates the horizontal padding and derived styles.
-func SetPadding(p int) {
-	padding = p
-	panelWidth = 80 - 2*padding
-	frameStyle = frameStyle.Padding(1, padding)
+// SetPadding updates the frame padding and derived styles.
+func SetPadding(h, v int) {
+	paddingH = h
+	paddingV = v
+	panelWidth = 80 - 2*paddingH
+	frameStyle = frameStyle.Padding(paddingV, paddingH)
 }
 
 // Lip Gloss styles
 var (
 	frameStyle = lipgloss.NewStyle().
-			Padding(1, padding).
+			Padding(paddingV, paddingH).
 			Width(80)
 
 	titleStyle = lipgloss.NewStyle().

--- a/ui/view.go
+++ b/ui/view.go
@@ -127,6 +127,11 @@ func (m Model) View() string {
 		sections = append(sections, statusStyle.Render(m.status.text))
 	}
 
+	// Remove trailing empty strings to avoid extra bottom padding inside the frame.
+	for len(sections) > 0 && sections[len(sections)-1] == "" {
+		sections = sections[:len(sections)-1]
+	}
+
 	content := strings.Join(sections, "\n")
 	frame := frameStyle.Render(content)
 


### PR DESCRIPTION
This PR adds support for customization of UI frame padding via two new optional properties in `config.toml`
- `padding_horizontal` (integer, default `3`)
- `padding_vertical` (integer, default `1`)

**Changes** 
- Replaced hard-coded padding values
- Updated the layout (re)calculation
- Stripped trailing empty lines within the frame to prevent extra space at bottom (open to other approaches if there’s a better way to handle this)

**Example `config.toml`**

For a gapless look
```toml
padding_horizontal = 0
padding_vertical = 0
```

For the current/default look (or omit these, since they are optional)
```toml
padding_horizontal = 3
padding_vertical = 1
```