### PR TITLE
Improve file browser

### DIFF
--- a/ui/filebrowser.go
+++ b/ui/filebrowser.go
@@ -30,11 +30,12 @@ type fbTracksResolvedMsg struct {
 
 // openFileBrowser initialises and shows the file browser overlay.
 func (m *Model) openFileBrowser() {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		home = "/"
+	if m.fileBrowser.dir == "" {
+		m.fileBrowser.dir, _ = os.UserHomeDir()
+		if m.fileBrowser.dir == "" {
+			m.fileBrowser.dir = "/"
+		}
 	}
-	m.fileBrowser.dir = home
 	m.fileBrowser.cursor = 0
 	m.fileBrowser.selected = make(map[string]bool)
 	m.fileBrowser.err = ""
@@ -45,7 +46,14 @@ func (m *Model) openFileBrowser() {
 // loadFBDir reads the current directory and populates fbEntries.
 func (m *Model) loadFBDir() {
 	m.fileBrowser.err = ""
-	m.fileBrowser.entries = nil
+	m.fileBrowser.cursor = 0
+
+	// Reuse internal memory buffer of m.fileBrowser.entries.
+	m.fileBrowser.entries = m.fileBrowser.entries[:0]
+	if cap(m.fileBrowser.entries) > 512 {
+		// Previous directory list was too large, do not retain memory, re-allocate buffer.
+		m.fileBrowser.entries = nil
+	}
 
 	// Always provide a parent entry for navigating up.
 	m.fileBrowser.entries = append(m.fileBrowser.entries, fbEntry{
@@ -55,40 +63,55 @@ func (m *Model) loadFBDir() {
 		isParent: true,
 	})
 
+	// Get entries sorted by name, dirs and files mixed
 	entries, err := os.ReadDir(m.fileBrowser.dir)
 	if err != nil {
 		m.fileBrowser.err = err.Error()
-		m.fileBrowser.cursor = 0
 		return
 	}
 
-	// Separate dirs and files, skip dotfiles.
-	var dirs, files []fbEntry
+	// Add directories to m.fileBrowser.entries (reuse internal memory),
+	// add files to files, then append all files to m.fileBrowser.entries, skip dotfiles.
+	var files []fbEntry
 	for _, e := range entries {
 		name := e.Name()
 		if strings.HasPrefix(name, ".") {
 			continue
 		}
-		full := filepath.Join(m.fileBrowser.dir, name)
+		// Detect directories and directory-like entries.
+		dirType := "" // Name suffix for directories and some non-regular file types.
 		if e.IsDir() {
-			dirs = append(dirs, fbEntry{
-				name:  name + "/",
-				path:  full,
+			dirType = "/"
+		} else if !e.Type().IsRegular() {
+			if e.Type()&os.ModeSymlink != 0 && !player.SupportedExts[strings.ToLower(filepath.Ext(name))] {
+				// Treat symlink as a directory unless it points to media file.
+				// os.DirEntry has no option to test the type of object symlink points to.
+				dirType = "@"
+			} else if os.PathSeparator == '\\' && e.Type()&os.ModeIrregular != 0 {
+				// Try to support directory junctions on Windows (mklink /J).
+				// Go do not support such files, it treats them as os.ModeIrregular (?---------).
+				dirType = "?"
+			}
+		}
+		// Add entry to m.fileBrowser.entries or to files slice
+		if dirType != "" {
+			m.fileBrowser.entries = append(m.fileBrowser.entries, fbEntry{
+				name:  name + dirType,
+				path:  filepath.Join(m.fileBrowser.dir, name),
 				isDir: true,
 			})
 		} else {
-			ext := strings.ToLower(filepath.Ext(name))
+			if files == nil {
+				files = make([]fbEntry, 0, 16) // Avoid reallocations
+			}
 			files = append(files, fbEntry{
 				name:    name,
-				path:    full,
-				isAudio: player.SupportedExts[ext],
+				path:    filepath.Join(m.fileBrowser.dir, name),
+				isAudio: player.SupportedExts[strings.ToLower(filepath.Ext(name))],
 			})
 		}
 	}
-
-	m.fileBrowser.entries = append(m.fileBrowser.entries, dirs...)
 	m.fileBrowser.entries = append(m.fileBrowser.entries, files...)
-	m.fileBrowser.cursor = 0
 }
 
 // handleFileBrowserKey processes key presses while the file browser is open.
@@ -98,9 +121,8 @@ func (m *Model) handleFileBrowserKey(msg tea.KeyMsg) tea.Cmd {
 		m.fileBrowser.visible = false
 		return m.quit()
 
-	case "esc", "o":
+	case "esc", "o", "q":
 		m.fileBrowser.visible = false
-		return nil
 
 	case "up", "k":
 		if m.fileBrowser.cursor > 0 {
@@ -145,6 +167,20 @@ func (m *Model) handleFileBrowserKey(msg tea.KeyMsg) tea.Cmd {
 		m.fileBrowser.dir = filepath.Dir(m.fileBrowser.dir)
 		m.loadFBDir()
 
+	case "~":
+		cd, _ := os.UserHomeDir()
+		if cd != "" && m.fileBrowser.dir != cd {
+			m.fileBrowser.dir = cd
+			m.loadFBDir()
+		}
+
+	case ".":
+		cd, _ := os.Getwd()
+		if cd != "" && m.fileBrowser.dir != cd {
+			m.fileBrowser.dir = cd
+			m.loadFBDir()
+		}
+
 	case " ":
 		if m.fileBrowser.cursor < len(m.fileBrowser.entries) {
 			e := m.fileBrowser.entries[m.fileBrowser.cursor]
@@ -154,6 +190,9 @@ func (m *Model) handleFileBrowserKey(msg tea.KeyMsg) tea.Cmd {
 				} else {
 					m.fileBrowser.selected[e.path] = true
 				}
+			}
+			if m.fileBrowser.cursor < len(m.fileBrowser.entries)-1 {
+				m.fileBrowser.cursor++
 			}
 		}
 
@@ -284,7 +323,9 @@ func (m Model) renderFileBrowser() string {
 		lines = append(lines, "")
 	}
 
-	help := helpKey("↑↓", "Navigate ") + helpKey("Enter", "Open ") + helpKey("Spc", "Select ") + helpKey("a", "All ") + helpKey("←", "Back ")
+	help := helpKey("↑↓", "Scroll ") + helpKey("Enter", "Open ") + 
+		helpKey("Spc", "Select ") + helpKey("a", "All ") +
+		helpKey("←", "Back ") + helpKey("~.", "Home/Cwd ")
 	if len(m.fileBrowser.selected) > 0 {
 		help += helpKey("R", "Replace ")
 	}


### PR DESCRIPTION
## Some improvements of built-in file browser.

### Navigation

1. Preserve last opened directory on close. Next time the browser will be opened in same directory.
2. Quickly navigate to home directory by `~` (`shift+tilde`) hotkey (go to `os.UserHomeDir()`).
3. Quickly navigate to current working directory by `.` hotkey (go to `os.Getwd()`).
4. Close browser by `q` hotkey (in addition to `Esc` and `o`).
5. Move cursor down on select: `space` selects current entry and moves cursor down.

### Internals

7. Reuse internal memory buffer of `Model.fileBrowser.entries` while changing directory. Use less intermediate buffers for file list entries (`[]fbEntry`), less memory allocations/copyings.
8. Support symlinks: treat symlink as a directory unless it's name has one of audio extensions (`os.DirEntry` has no option to test the type of object symlink really points to). Append "@" to symlink names in list.
9. Support directory junctions on Windows (symlink created with `mklink /J`). Go treats such files as `os.ModeIrregular` but technically they are symlinks. Append "?" name suffix to such symlinks in list.