### PR TITLE
File browser: improve navigation, fixes

### DIFF
--- a/ui/filebrowser.go
+++ b/ui/filebrowser.go
@@ -246,6 +246,15 @@ func (m *Model) handleFileBrowserKey(msg tea.KeyMsg) tea.Cmd {
 		}
 	}
 
+	// Change drive letter on Windows by pressing alt+[c..z]
+	if os.PathSeparator == '\\' {
+		if cd = msg.String(); len(cd) == 5 && strings.HasPrefix(cd, "alt+") && 'c' <= cd[4] && cd[4] <= 'z' {
+			cd = strings.ToUpper(cd[4:]) + ":\\"
+			m.fileBrowser.dir = cd
+			m.loadFBDir()
+		}
+	}
+
 	return nil
 }
 
@@ -346,6 +355,9 @@ func (m Model) renderFileBrowser() string {
 	help := helpKey("↑↓", "Scroll ") + helpKey("Enter", "Open ") + 
 		helpKey("Spc", "Select ") + helpKey("a", "All ") +
 		helpKey("←", "Back ") + helpKey("~.", "Home/Cwd ")
+	if os.PathSeparator == '\\' {
+		help += helpKey("AltCZ", "Drive ")
+	}
 	if len(m.fileBrowser.selected) > 0 {
 		help += helpKey("R", "Replace ")
 	}


### PR DESCRIPTION
## There are new features in file browser.

1. CD to parent directory: place cursor on previous directory name in list. It's a common behavior of file managers.

2. On Windows, allow to change current drive letter by pressing any of `alt-C-Z` keys. There were no other ways to open files on other drives via file browser.

3. Reimplemented "toggle select all files" action (key `a`). Now it works in one pass over `Model.fileBrowser.entries`. Once it encounters first unselected file in cycle, it selects all remaining files in same cycle, skipping any checks. UX does not change.

## Fixes:

1. Clear current selection on directory change. This fixes the following problem: if we select some files and then open parent directory with `backspace` then we can't anymore change directories by pressing `enter`, because pressing `enter` causes previoulsy selected files to be added to playlist.

2. Window height changes on errors and on selection toggle. Now it always has constant size. `Model.renderFileBrowser()` now preallocates a buffer sufficient for all output lines once at start. Local variable `maxVisible = 12` moved to global constant `fbMaxVisible` (it also used by `PgUp`/`PgDown` handler). For consistency I suggest to use another constant `maxPlVisible = 12` already defined in `model.go`, it has same value and same meaning (I thik so).