### PR TITLE
feat: add dracula, ember, and neon-blade-runner themes

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -1,6 +1,6 @@
 # Themes
 
-cliamp ships with 17 built-in color themes and supports custom themes via simple TOML files.
+cliamp ships with 20 built-in color themes and supports custom themes via simple TOML files.
 
 Press `t` during playback to open the theme picker. Navigate with `↑`/`↓`, preview live as you move, confirm with `Enter`, or cancel with `Esc`.
 
@@ -8,7 +8,7 @@ Your selection is saved automatically and restored on next launch.
 
 ## Built-in themes
 
-ayu-mirage-dark, catppuccin, catppuccin-latte, ethereal, everforest, flexoki-light, gruvbox, hackerman, kanagawa, matte-black, miasma, nord, osaka-jade, ristretto, rose-pine, tokyo-night, vantablack
+ayu-mirage-dark, catppuccin, catppuccin-latte, dracula, ember, ethereal, everforest, flexoki-light, gruvbox, hackerman, kanagawa, matte-black, miasma, neon-blade-runner, nord, osaka-jade, ristretto, rose-pine, tokyo-night, vantablack
 
 ## Creating a custom theme
 
@@ -20,15 +20,15 @@ mkdir -p ~/.config/cliamp/themes
 
 Each file needs 6 hex color values. The filename (minus `.toml`) becomes the theme name.
 
-### Example: `~/.config/cliamp/themes/dracula.toml`
+### Example: `~/.config/cliamp/themes/solarized.toml`
 
 ```toml
-accent = "#bd93f9"
-bright_fg = "#f8f8f2"
-fg = "#6272a4"
-green = "#50fa7b"
-yellow = "#f1fa8c"
-red = "#ff5555"
+accent = "#268bd2"
+bright_fg = "#eee8d5"
+fg = "#839496"
+green = "#859900"
+yellow = "#b58900"
+red = "#dc322f"
 ```
 
 That's it. Press `t` and your theme appears in the list immediately.

--- a/theme/themes/dracula.toml
+++ b/theme/themes/dracula.toml
@@ -1,0 +1,8 @@
+# Dracula — gothic purple with vivid spectrum.
+# The most popular terminal theme. draculatheme.com
+accent = "#bd93f9"
+bright_fg = "#f8f8f2"
+fg = "#6272a4"
+green = "#50fa7b"
+yellow = "#f1fa8c"
+red = "#ff5555"

--- a/theme/themes/ember.toml
+++ b/theme/themes/ember.toml
@@ -1,0 +1,8 @@
+# Ember — deep warm hearth.
+# Campfire coals, darkroom safelight, analog warmth.
+accent = "#e07040"
+bright_fg = "#e8d0b8"
+fg = "#907868"
+green = "#a08858"
+yellow = "#d8a050"
+red = "#c04848"

--- a/theme/themes/neon-blade-runner.toml
+++ b/theme/themes/neon-blade-runner.toml
@@ -1,0 +1,9 @@
+# Blade Runner 1982 — Neon noir.
+# Hot pink neon signs, cyan rain reflections, amber instrument readouts.
+# Cronenweth's Los Angeles: perpetual night, wet streets, practical light.
+accent = "#e8609a"
+bright_fg = "#b8c4d0"
+fg = "#758494"
+green = "#4eb8a8"
+yellow = "#d4a040"
+red = "#c85070"


### PR DESCRIPTION
Hey @bjarneo, followed up on #158 with something simpler. Three theme files, no code.

**neon-blade-runner** was basically matte-black with a different name last time. Rebuilt it around Cronenweth's actual palette—pink neon, teal rain, amber readouts. Only pink accent in the collection.

**dracula**, the canonical colors from draculatheme.com. Noticed you already had it as the example in `docs/themes.md`, figured it should just be built-in.

**ember**, warm monochrome. Campfire coals, darkroom safelight.

All pass WCAG contrast minimums on dark terminals. Just TOML files and a docs update from 17 to 20.