### PR TITLE
Align playlist track number, artist name, track title

### DIFF
--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -605,6 +605,7 @@ func (m Model) renderPlaylist() string {
 	// The loop below counts every appended line against this budget
 	// so the playlist never overflows its area.
 	lines := make([]string, 0, budget) // tracks
+	numWidth := len(fmt.Sprintf("%d", len(tracks)))
 	for i := scroll; i < len(tracks) && len(lines) < budget; i++ {
 		prefix := "  "
 		style := playlistItemStyle
@@ -631,19 +632,22 @@ func (m Model) renderPlaylist() string {
 			queueSuffix = fmt.Sprintf(" [Q%d]", qp)
 		}
 		queueLen := utf8.RuneCountInString(queueSuffix)
+
+		linePrefixWidth := utf8.RuneCountInString(prefix) + numWidth + 2 // 2 for ". "
+
 		// Truncate the track name only against queue/fav overhead, never album.
-		name = truncate(name, ui.PanelWidth-6-queueLen-favBudget)
+		name = truncate(name, ui.PanelWidth-linePrefixWidth-queueLen-favBudget)
 		// Truncate the album to fit whatever space remains after the track name.
 		albumSuffix := ""
 		if album := tracks[i].Album; album != "" {
 			nameLen := utf8.RuneCountInString(name)
-			remaining := ui.PanelWidth - 6 - favBudget - nameLen - queueLen - 3 // 3 = " · "
+			remaining := ui.PanelWidth - linePrefixWidth - favBudget - nameLen - queueLen - 3 // 3 = " · "
 			if remaining >= 4 {
 				albumSuffix = " · " + truncate(album, remaining)
 			}
 		}
 
-		numStr := fmt.Sprintf("%s%d. ", prefix, i+1)
+		numStr := fmt.Sprintf("%s%*d. ", prefix, numWidth, i+1)
 		line := style.Render(numStr)
 		if isFav {
 			line += activeToggle.Render("★ ")

--- a/ui/model/view_state_test.go
+++ b/ui/model/view_state_test.go
@@ -2,10 +2,12 @@ package model
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
 	"charm.land/lipgloss/v2"
+
 	"cliamp/playlist"
 	"cliamp/ui"
 )
@@ -183,5 +185,60 @@ func TestFullVisualizerViewFitsTerminalWidth(t *testing.T) {
 
 	if got := lipgloss.Width(m.View().Content); got > m.width {
 		t.Fatalf("View() width = %d, want <= %d in full visualizer mode", got, m.width)
+	}
+}
+
+var ansi = regexp.MustCompile(`\x1b\[[0-9;]*[mK]`)
+
+func stripAnsi(str string) string {
+	return ansi.ReplaceAllString(str, "")
+}
+
+func TestRenderPlaylistAddsPaddingToTrackNumber(t *testing.T) {
+	if sharedPlayer == nil {
+		t.Skip("audio hardware unavailable")
+	}
+	withFrameWidth(t, 80)
+
+	sharedPlayer.Stop()
+
+	pl := playlist.New()
+	for i := 0; i < 120; i++ {
+		pl.Add(playlist.Track{
+			Path:  fmt.Sprintf("/tmp/track-%d.mp3", i),
+			Title: fmt.Sprintf("Track %d", i+1),
+		})
+	}
+
+	m := Model{
+		player:    sharedPlayer,
+		playlist:  pl,
+		vis:       ui.NewVisualizer(float64(sharedPlayer.SampleRate())),
+		width:     80,
+		plVisible: 120,
+	}
+	m.vis.Mode = ui.VisNone
+	m.height = m.mainFrameFixedLines(false) + 120
+
+	out := m.renderPlaylist()
+	lines := strings.Split(out, "\n")
+
+	if len(lines) < 120 {
+		t.Fatalf("renderPlaylist() returned %d lines, want 120", len(lines))
+	}
+
+	line9 := stripAnsi(lines[8])
+	line99 := stripAnsi(lines[98])
+	line119 := stripAnsi(lines[118])
+
+	ninthLineTrackIndex := strings.Index(line9, "Track")
+	ninetyNinthLineTrackIndex := strings.Index(line99, "Track")
+	oneHundredNineteenthLineTrackIndex := strings.Index(line119, "Track")
+
+	if ninthLineTrackIndex != ninetyNinthLineTrackIndex || ninthLineTrackIndex != oneHundredNineteenthLineTrackIndex {
+		t.Errorf(`Track name alignment is off for 3-digit numbers.
+Line 9: %q (index %d)
+Line 99: %q (index %d)
+Line 119: %q (index %d)`, line9, ninthLineTrackIndex, line99, ninetyNinthLineTrackIndex, line119, oneHundredNineteenthLineTrackIndex)
 	}
 }


### PR DESCRIPTION
Small thing that was bugging me is that when the track number goes from 1 digit to 2 digits, the playlist no longer aligns. See track number 9 and 10 below.

Before:
<img width="610" height="481" alt="Screenshot 2026-04-03 at 19 24 49" src="https://github.com/user-attachments/assets/4f1d508d-fa01-4ea0-a6e6-0b2e8d1394c7" />


After:
<img width="612" height="469" alt="Screenshot 2026-04-03 at 19 25 51" src="https://github.com/user-attachments/assets/ef933c39-4b8a-4986-b563-93a28a5a3012" />
