### PR TITLE
Correct keymap scrolling, refactor keymap for consistency

### DIFF
--- a/ui/model/filebrowser.go
+++ b/ui/model/filebrowser.go
@@ -92,11 +92,12 @@ func (m *Model) fbMaybeAdjustScroll(visible int) {
 	if visible <= 0 {
 		return
 	}
+	count := len(m.fileBrowser.entries)
 	if m.fileBrowser.cursor < 0 {
 		m.fileBrowser.cursor = 0
 	}
-	if m.fileBrowser.cursor >= len(m.fileBrowser.entries) && len(m.fileBrowser.entries) > 0 {
-		m.fileBrowser.cursor = len(m.fileBrowser.entries) - 1
+	if m.fileBrowser.cursor >= count && count > 0 {
+		m.fileBrowser.cursor = count - 1
 	}
 
 	if m.fileBrowser.cursor < m.fileBrowser.scroll {
@@ -105,8 +106,8 @@ func (m *Model) fbMaybeAdjustScroll(visible int) {
 		m.fileBrowser.scroll = m.fileBrowser.cursor - visible + 1
 	}
 
-	if m.fileBrowser.scroll+visible > len(m.fileBrowser.entries) {
-		m.fileBrowser.scroll = max(0, len(m.fileBrowser.entries)-visible)
+	if m.fileBrowser.scroll+visible > count {
+		m.fileBrowser.scroll = max(0, count-visible)
 	}
 }
 

--- a/ui/model/keymap.go
+++ b/ui/model/keymap.go
@@ -1,9 +1,13 @@
 package model
 
 import (
+	"fmt"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"cliamp/ui"
 )
 
 // keymapEntry is a key-action pair for the keymap overlay.
@@ -61,11 +65,52 @@ var keymapEntries = []keymapEntry{
 	{"q", "Quit"},
 }
 
-func (m Model) keymapCount() int {
+func (m *Model) keymapCount() int {
 	if m.keymap.search != "" {
 		return len(m.keymap.filtered)
 	}
 	return len(keymapEntries)
+}
+
+func (m *Model) keymapHelpLine() string {
+	return helpKey("↑↓", "Navigate ") + helpKey("PgUp/Dn", "Page ") +
+		helpKey("Home/End", "Jump ") + helpKey("Type", "Filter ") + helpKey("Esc", "Close")
+}
+
+func (m *Model) keymapHeaderLines() []string {
+	header := []string{
+		titleStyle.Render("K E Y M A P"),
+		"",
+	}
+	if m.keymap.search != "" {
+		header = append(header, playlistSelectedStyle.Render("  / "+m.keymap.search+"_"), "")
+	} else {
+		header = append(header, dimStyle.Render("  Type to filter…"), "")
+	}
+	return header
+}
+
+func (m *Model) keymapVisible() int {
+	probeSections := append([]string{}, m.keymapHeaderLines()...)
+
+	// 1-line list placeholder.
+	probeSections = append(probeSections, "x", "")
+
+	// Footer area must mirror renderKeymapOverlay().
+	probeSections = append(probeSections,
+		dimStyle.Render("  0/0 keys"),
+		"",
+		m.keymapHelpLine(),
+	)
+
+	probeFrame := ui.FrameStyle.Render(strings.Join(probeSections, "\n"))
+	fixedHeight := lipgloss.Height(probeFrame) - 1
+
+	limit := maxPlVisible
+	if m.heightExpanded {
+		limit = m.height
+	}
+	return max(3, min(limit, m.height-fixedHeight))
 }
 
 // keymapMaybeAdjustScroll keeps the cursor visible in the current keymap window.
@@ -92,23 +137,28 @@ func (m *Model) keymapMaybeAdjustScroll(visible int) {
 	}
 }
 
+// openKeymap resets the keymap state and shows it.
+func (m *Model) openKeymap() {
+	m.keymap.search = ""
+	m.keymap.filtered = nil
+	m.keymap.cursor = 0
+	m.keymap.scroll = 0
+	m.keymap.visible = true
+}
+
 // handleKeymapKey processes key presses while the keymap overlay is open.
 func (m *Model) handleKeymapKey(msg tea.KeyPressMsg) tea.Cmd {
 	key := msg.String()
 
-	switch {
-	case key == "ctrl+c":
+	switch key {
+	case "ctrl+c":
 		m.keymap.visible = false
 		return m.quit()
 
-	case msg.Code == tea.KeyEscape:
+	case "esc", "ctrl+k":
 		m.keymap.visible = false
-		m.keymap.search = ""
-		m.keymap.filtered = nil
-		m.keymap.cursor = 0
-		m.keymap.scroll = 0
 
-	case msg.Code == tea.KeyUp:
+	case "up", "k":
 		count := m.keymapCount()
 		if m.keymap.cursor > 0 {
 			m.keymap.cursor--
@@ -117,7 +167,7 @@ func (m *Model) handleKeymapKey(msg tea.KeyPressMsg) tea.Cmd {
 		}
 		m.keymapMaybeAdjustScroll(m.keymapVisible())
 
-	case msg.Code == tea.KeyDown:
+	case "down", "j":
 		count := m.keymapCount()
 		if m.keymap.cursor < count-1 {
 			m.keymap.cursor++
@@ -126,18 +176,18 @@ func (m *Model) handleKeymapKey(msg tea.KeyPressMsg) tea.Cmd {
 		}
 		m.keymapMaybeAdjustScroll(m.keymapVisible())
 
-	case key == "ctrl+x":
+	case "ctrl+x":
 		m.toggleExpandPlaylist()
 		m.keymapMaybeAdjustScroll(m.keymapVisible())
 
-	case key == "pgup" || key == "ctrl+u":
+	case "pgup", "ctrl+u":
 		if m.keymap.cursor > 0 {
 			visible := m.keymapVisible()
 			m.keymap.cursor -= min(m.keymap.cursor, visible)
 			m.keymapMaybeAdjustScroll(visible)
 		}
 
-	case key == "pgdown" || key == "ctrl+d":
+	case "pgdown", "ctrl+d":
 		count := m.keymapCount()
 		if m.keymap.cursor < count-1 {
 			visible := m.keymapVisible()
@@ -145,24 +195,24 @@ func (m *Model) handleKeymapKey(msg tea.KeyPressMsg) tea.Cmd {
 			m.keymapMaybeAdjustScroll(visible)
 		}
 
-	case msg.Code == tea.KeyHome:
+	case "home", "g":
 		m.keymap.cursor = 0
 		m.keymapMaybeAdjustScroll(m.keymapVisible())
 
-	case msg.Code == tea.KeyEnd:
+	case "end", "G":
 		count := m.keymapCount()
 		if count > 0 {
 			m.keymap.cursor = count - 1
 		}
 		m.keymapMaybeAdjustScroll(m.keymapVisible())
 
-	case msg.Code == tea.KeyBackspace:
+	case "backspace":
 		if m.keymap.search != "" {
 			m.keymap.search = removeLastRune(m.keymap.search)
 			m.updateKeymapFilter()
 		}
 
-	case msg.Code == tea.KeySpace:
+	case "space":
 		m.keymap.search += " "
 		m.updateKeymapFilter()
 
@@ -191,4 +241,40 @@ func (m *Model) updateKeymapFilter() {
 			m.keymap.filtered = append(m.keymap.filtered, i)
 		}
 	}
+}
+
+// renderKeymapOverlay renders the keymap overlay.
+func (m Model) renderKeymapOverlay() string {
+	lines := append(make([]string, 0, 16), m.keymapHeaderLines()...)
+
+	entries := keymapEntries
+	var visible []keymapEntry
+	if m.keymap.search != "" {
+		for _, i := range m.keymap.filtered {
+			visible = append(visible, entries[i])
+		}
+	} else {
+		visible = entries
+	}
+
+	maxVisible := m.keymapVisible()
+	rendered := 0
+
+	if len(visible) == 0 {
+		lines = append(lines, dimStyle.Render("  No matches"))
+		rendered = 1
+	} else {
+		scroll := m.keymap.scroll
+		for i := scroll; i < len(visible) && i < scroll+maxVisible; i++ {
+			line := fmt.Sprintf("%-10s %s", visible[i].key, visible[i].action)
+			lines = append(lines, cursorLine(line, i == m.keymap.cursor))
+			rendered++
+		}
+	}
+
+	lines = padLines(lines, maxVisible, rendered)
+	lines = append(lines, "", dimStyle.Render(fmt.Sprintf("  %d/%d keys", len(visible), len(entries))))
+	lines = append(lines, "", m.keymapHelpLine())
+
+	return m.centerOverlay(strings.Join(lines, "\n"))
 }

--- a/ui/model/keymap.go
+++ b/ui/model/keymap.go
@@ -115,7 +115,7 @@ func (m *Model) handleKeymapKey(msg tea.KeyPressMsg) tea.Cmd {
 		} else if count > 0 {
 			m.keymap.cursor = count - 1
 		}
-		m.keymapMaybeAdjustScroll(m.keymapVisibleRows())
+		m.keymapMaybeAdjustScroll(m.keymapVisible())
 
 	case msg.Code == tea.KeyDown:
 		count := m.keymapCount()
@@ -124,15 +124,15 @@ func (m *Model) handleKeymapKey(msg tea.KeyPressMsg) tea.Cmd {
 		} else if count > 0 {
 			m.keymap.cursor = 0
 		}
-		m.keymapMaybeAdjustScroll(m.keymapVisibleRows())
+		m.keymapMaybeAdjustScroll(m.keymapVisible())
 
 	case key == "ctrl+x":
 		m.toggleExpandPlaylist()
-		m.keymapMaybeAdjustScroll(m.keymapVisibleRows())
+		m.keymapMaybeAdjustScroll(m.keymapVisible())
 
 	case key == "pgup" || key == "ctrl+u":
 		if m.keymap.cursor > 0 {
-			visible := m.keymapVisibleRows()
+			visible := m.keymapVisible()
 			m.keymap.cursor -= min(m.keymap.cursor, visible)
 			m.keymapMaybeAdjustScroll(visible)
 		}
@@ -140,21 +140,21 @@ func (m *Model) handleKeymapKey(msg tea.KeyPressMsg) tea.Cmd {
 	case key == "pgdown" || key == "ctrl+d":
 		count := m.keymapCount()
 		if m.keymap.cursor < count-1 {
-			visible := m.keymapVisibleRows()
+			visible := m.keymapVisible()
 			m.keymap.cursor = min(count-1, m.keymap.cursor+visible)
 			m.keymapMaybeAdjustScroll(visible)
 		}
 
 	case msg.Code == tea.KeyHome:
 		m.keymap.cursor = 0
-		m.keymapMaybeAdjustScroll(m.keymapVisibleRows())
+		m.keymapMaybeAdjustScroll(m.keymapVisible())
 
 	case msg.Code == tea.KeyEnd:
 		count := m.keymapCount()
 		if count > 0 {
 			m.keymap.cursor = count - 1
 		}
-		m.keymapMaybeAdjustScroll(m.keymapVisibleRows())
+		m.keymapMaybeAdjustScroll(m.keymapVisible())
 
 	case msg.Code == tea.KeyBackspace:
 		if m.keymap.search != "" {

--- a/ui/model/keymap.go
+++ b/ui/model/keymap.go
@@ -68,6 +68,30 @@ func (m Model) keymapCount() int {
 	return len(keymapEntries)
 }
 
+// keymapMaybeAdjustScroll keeps the cursor visible in the current keymap window.
+func (m *Model) keymapMaybeAdjustScroll(visible int) {
+	if visible <= 0 {
+		return
+	}
+	count := m.keymapCount()
+	if m.keymap.cursor < 0 {
+		m.keymap.cursor = 0
+	}
+	if m.keymap.cursor >= count && count > 0 {
+		m.keymap.cursor = count - 1
+	}
+
+	if m.keymap.cursor < m.keymap.scroll {
+		m.keymap.scroll = m.keymap.cursor
+	} else if m.keymap.cursor >= m.keymap.scroll+visible {
+		m.keymap.scroll = m.keymap.cursor - visible + 1
+	}
+
+	if m.keymap.scroll+visible > count {
+		m.keymap.scroll = max(0, count-visible)
+	}
+}
+
 // handleKeymapKey processes key presses while the keymap overlay is open.
 func (m *Model) handleKeymapKey(msg tea.KeyPressMsg) tea.Cmd {
 	key := msg.String()
@@ -82,6 +106,7 @@ func (m *Model) handleKeymapKey(msg tea.KeyPressMsg) tea.Cmd {
 		m.keymap.search = ""
 		m.keymap.filtered = nil
 		m.keymap.cursor = 0
+		m.keymap.scroll = 0
 
 	case msg.Code == tea.KeyUp:
 		count := m.keymapCount()
@@ -90,6 +115,7 @@ func (m *Model) handleKeymapKey(msg tea.KeyPressMsg) tea.Cmd {
 		} else if count > 0 {
 			m.keymap.cursor = count - 1
 		}
+		m.keymapMaybeAdjustScroll(m.keymapVisibleRows())
 
 	case msg.Code == tea.KeyDown:
 		count := m.keymapCount()
@@ -98,31 +124,37 @@ func (m *Model) handleKeymapKey(msg tea.KeyPressMsg) tea.Cmd {
 		} else if count > 0 {
 			m.keymap.cursor = 0
 		}
+		m.keymapMaybeAdjustScroll(m.keymapVisibleRows())
 
 	case key == "ctrl+x":
 		m.toggleExpandPlaylist()
+		m.keymapMaybeAdjustScroll(m.keymapVisibleRows())
 
 	case key == "pgup" || key == "ctrl+u":
 		if m.keymap.cursor > 0 {
-			step := max(1, m.keymapVisibleRows())
-			m.keymap.cursor -= min(m.keymap.cursor, step)
+			visible := m.keymapVisibleRows()
+			m.keymap.cursor -= min(m.keymap.cursor, visible)
+			m.keymapMaybeAdjustScroll(visible)
 		}
 
 	case key == "pgdown" || key == "ctrl+d":
 		count := m.keymapCount()
 		if m.keymap.cursor < count-1 {
-			step := max(1, m.keymapVisibleRows())
-			m.keymap.cursor = min(count-1, m.keymap.cursor+step)
+			visible := m.keymapVisibleRows()
+			m.keymap.cursor = min(count-1, m.keymap.cursor+visible)
+			m.keymapMaybeAdjustScroll(visible)
 		}
 
 	case msg.Code == tea.KeyHome:
 		m.keymap.cursor = 0
+		m.keymapMaybeAdjustScroll(m.keymapVisibleRows())
 
 	case msg.Code == tea.KeyEnd:
 		count := m.keymapCount()
 		if count > 0 {
 			m.keymap.cursor = count - 1
 		}
+		m.keymapMaybeAdjustScroll(m.keymapVisibleRows())
 
 	case msg.Code == tea.KeyBackspace:
 		if m.keymap.search != "" {
@@ -148,6 +180,7 @@ func (m *Model) handleKeymapKey(msg tea.KeyPressMsg) tea.Cmd {
 func (m *Model) updateKeymapFilter() {
 	m.keymap.filtered = nil
 	m.keymap.cursor = 0
+	m.keymap.scroll = 0
 	if m.keymap.search == "" {
 		return
 	}

--- a/ui/model/keymap.go
+++ b/ui/model/keymap.go
@@ -148,9 +148,7 @@ func (m *Model) openKeymap() {
 
 // handleKeymapKey processes key presses while the keymap overlay is open.
 func (m *Model) handleKeymapKey(msg tea.KeyPressMsg) tea.Cmd {
-	key := msg.String()
-
-	switch key {
+	switch msg.String() {
 	case "ctrl+c":
 		m.keymap.visible = false
 		return m.quit()

--- a/ui/model/keymap.go
+++ b/ui/model/keymap.go
@@ -156,7 +156,7 @@ func (m *Model) handleKeymapKey(msg tea.KeyPressMsg) tea.Cmd {
 	case "esc", "ctrl+k":
 		m.keymap.visible = false
 
-	case "up", "k":
+	case "up":
 		count := m.keymapCount()
 		if m.keymap.cursor > 0 {
 			m.keymap.cursor--
@@ -165,7 +165,7 @@ func (m *Model) handleKeymapKey(msg tea.KeyPressMsg) tea.Cmd {
 		}
 		m.keymapMaybeAdjustScroll(m.keymapVisible())
 
-	case "down", "j":
+	case "down":
 		count := m.keymapCount()
 		if m.keymap.cursor < count-1 {
 			m.keymap.cursor++
@@ -193,11 +193,11 @@ func (m *Model) handleKeymapKey(msg tea.KeyPressMsg) tea.Cmd {
 			m.keymapMaybeAdjustScroll(visible)
 		}
 
-	case "home", "g":
+	case "home":
 		m.keymap.cursor = 0
 		m.keymapMaybeAdjustScroll(m.keymapVisible())
 
-	case "end", "G":
+	case "end":
 		count := m.keymapCount()
 		if count > 0 {
 			m.keymap.cursor = count - 1

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -735,6 +735,10 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 
 	case "ctrl+k":
 		m.keymap.visible = true
+		m.keymap.cursor = 0
+		m.keymap.scroll = 0
+		m.keymap.search = ""
+		m.keymap.filtered = nil
 	}
 
 	return nil

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -734,11 +734,7 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 		m.changeSpeed(-0.25)
 
 	case "ctrl+k":
-		m.keymap.visible = true
-		m.keymap.cursor = 0
-		m.keymap.scroll = 0
-		m.keymap.search = ""
-		m.keymap.filtered = nil
+		m.openKeymap()
 	}
 
 	return nil
@@ -969,7 +965,7 @@ func (m *Model) handleSearchKey(msg tea.KeyPressMsg) tea.Cmd {
 	// Allow opening overlays during search (ctrl combos don't conflict with text input).
 	switch msg.String() {
 	case "ctrl+k":
-		m.keymap.visible = true
+		m.openKeymap()
 		return nil
 	}
 
@@ -1035,7 +1031,7 @@ func (m *Model) handleSearchKey(msg tea.KeyPressMsg) tea.Cmd {
 func (m *Model) handleNetSearchKey(msg tea.KeyPressMsg) tea.Cmd {
 	switch msg.String() {
 	case "ctrl+k":
-		m.keymap.visible = true
+		m.openKeymap()
 		return nil
 	}
 
@@ -1339,7 +1335,7 @@ func (m *Model) handleQueueKey(msg tea.KeyPressMsg) tea.Cmd {
 		m.queue.visible = false
 		return m.quit()
 	case "ctrl+k":
-		m.keymap.visible = true
+		m.openKeymap()
 	case "up", "k":
 		if m.queue.cursor > 0 {
 			m.queue.cursor--

--- a/ui/model/state.go
+++ b/ui/model/state.go
@@ -69,6 +69,7 @@ type lyricsState struct {
 type keymapOverlay struct {
 	visible  bool
 	cursor   int
+	scroll   int
 	search   string
 	filtered []int // indices into keymapEntries
 }

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -73,7 +73,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.fbMaybeAdjustScroll(m.fbVisible())
 		}
 		if m.keymap.visible {
-			m.keymapMaybeAdjustScroll(m.keymapVisibleRows())
+			m.keymapMaybeAdjustScroll(m.keymapVisible())
 		}
 		return m, nil
 

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -72,6 +72,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.fileBrowser.visible {
 			m.fbMaybeAdjustScroll(m.fbVisible())
 		}
+		if m.keymap.visible {
+			m.keymapMaybeAdjustScroll(m.keymapVisibleRows())
+		}
 		return m, nil
 
 	case seekTickMsg:

--- a/ui/model/view_overlays.go
+++ b/ui/model/view_overlays.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"charm.land/lipgloss/v2"
-
 	"cliamp/lyrics"
 	"cliamp/theme"
 	"cliamp/ui"
@@ -62,82 +60,7 @@ func (m Model) renderDeviceOverlay() string {
 	return m.centerOverlay(strings.Join(lines, "\n"))
 }
 
-func (m Model) keymapHelpLine() string {
-	return helpKey("↑↓", "Navigate ") + helpKey("PgUp/Dn", "Page ") +
-		helpKey("Home/End", "Jump ") + helpKey("Type", "Filter ") + helpKey("Esc", "Close")
-}
 
-func (m Model) keymapVisible() int {
-	probeSearch := dimStyle.Render("  Type to filter…")
-	if m.keymap.search != "" {
-		probeSearch = playlistSelectedStyle.Render("  / " + m.keymap.search + "_")
-	}
-
-	probeSections := []string{
-		titleStyle.Render("K E Y M A P"),
-		"",
-		probeSearch,
-		"",
-		"x", // list placeholder (1 row)
-		"",
-		dimStyle.Render("  0/0 keys"),
-		"",
-		m.keymapHelpLine(),
-	}
-
-	probeFrame := ui.FrameStyle.Render(strings.Join(probeSections, "\n"))
-	fixedHeight := lipgloss.Height(probeFrame) - 1
-
-	limit := maxPlVisible
-	if m.heightExpanded {
-		limit = m.height
-	}
-	return max(3, min(limit, m.height-fixedHeight))
-}
-
-func (m Model) renderKeymapOverlay() string {
-	lines := []string{
-		titleStyle.Render("K E Y M A P"),
-		"",
-	}
-
-	if m.keymap.search != "" {
-		lines = append(lines, playlistSelectedStyle.Render("  / "+m.keymap.search+"_"), "")
-	} else {
-		lines = append(lines, dimStyle.Render("  Type to filter…"), "")
-	}
-
-	entries := keymapEntries
-	var visible []keymapEntry
-	if m.keymap.search != "" {
-		for _, i := range m.keymap.filtered {
-			visible = append(visible, entries[i])
-		}
-	} else {
-		visible = entries
-	}
-
-	maxVisible := m.keymapVisible()
-	rendered := 0
-
-	if len(visible) == 0 {
-		lines = append(lines, dimStyle.Render("  No matches"))
-		rendered = 1
-	} else {
-		scroll := m.keymap.scroll
-		for i := scroll; i < len(visible) && i < scroll+maxVisible; i++ {
-			line := fmt.Sprintf("%-10s %s", visible[i].key, visible[i].action)
-			lines = append(lines, cursorLine(line, i == m.keymap.cursor))
-			rendered++
-		}
-	}
-
-	lines = padLines(lines, maxVisible, rendered)
-	lines = append(lines, "", dimStyle.Render(fmt.Sprintf("  %d/%d keys", len(visible), len(entries))))
-	lines = append(lines, "", m.keymapHelpLine())
-
-	return m.centerOverlay(strings.Join(lines, "\n"))
-}
 
 func (m Model) renderThemePicker() string {
 	lines := []string{

--- a/ui/model/view_overlays.go
+++ b/ui/model/view_overlays.go
@@ -67,7 +67,7 @@ func (m Model) keymapHelpLine() string {
 		helpKey("Home/End", "Jump ") + helpKey("Type", "Filter ") + helpKey("Esc", "Close")
 }
 
-func (m Model) keymapVisibleRows() int {
+func (m Model) keymapVisible() int {
 	probeSearch := dimStyle.Render("  Type to filter…")
 	if m.keymap.search != "" {
 		probeSearch = playlistSelectedStyle.Render("  / " + m.keymap.search + "_")
@@ -117,7 +117,7 @@ func (m Model) renderKeymapOverlay() string {
 		visible = entries
 	}
 
-	maxVisible := m.keymapVisibleRows()
+	maxVisible := m.keymapVisible()
 	rendered := 0
 
 	if len(visible) == 0 {

--- a/ui/model/view_overlays.go
+++ b/ui/model/view_overlays.go
@@ -124,7 +124,7 @@ func (m Model) renderKeymapOverlay() string {
 		lines = append(lines, dimStyle.Render("  No matches"))
 		rendered = 1
 	} else {
-		scroll := scrollStart(m.keymap.cursor, maxVisible)
+		scroll := m.keymap.scroll
 		for i := scroll; i < len(visible) && i < scroll+maxVisible; i++ {
 			line := fmt.Sprintf("%-10s %s", visible[i].key, visible[i].action)
 			lines = append(lines, cursorLine(line, i == m.keymap.cursor))


### PR DESCRIPTION
Corrects the scrolling behavior in the keymap view so it matches the persistent scrolling used in the playlist and file browser. Introduces a dedicated `scroll` state for the keymap view, ensuring the view only scrolls when the cursor moves outside the visible region. Additionally, there is some refactoring for style consistency with analogous functions of the file browser view.