### PR TITLE
fix(ui): handle paste events in text input fields

### DIFF
--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -961,6 +961,77 @@ func (m *Model) toggleExpandPlaylist() {
 	m.adjustScroll()
 }
 
+// handlePaste routes pasted text to the active text input field.
+// The priority order mirrors handleKey so the correct input receives the content.
+func (m *Model) handlePaste(content string) tea.Cmd {
+	if content == "" {
+		return nil
+	}
+
+	// Keymap overlay search
+	if m.keymap.visible {
+		m.keymap.search += content
+		m.updateKeymapFilter()
+		return nil
+	}
+
+	// Nav browser search
+	if m.navBrowser.visible && m.navBrowser.mode != navBrowseModeMenu && m.navBrowser.searching {
+		m.navBrowser.search += content
+		m.navBrowser.cursor = 0
+		m.navBrowser.scroll = 0
+		m.navUpdateSearch()
+		return nil
+	}
+
+	// Playlist manager new-name input
+	if m.plManager.visible && m.plManager.screen == plMgrScreenNewName {
+		m.plManager.newName += content
+		return nil
+	}
+
+	if m.jumping {
+		m.jumpInput += content
+		return nil
+	}
+
+	if m.urlInputting {
+		m.urlInput += content
+		return nil
+	}
+
+	if m.search.active {
+		m.search.query += content
+		m.updateSearch()
+		return nil
+	}
+
+	if m.netSearch.active {
+		m.netSearch.query += content
+		return nil
+	}
+
+	if m.spotSearch.visible {
+		switch m.spotSearch.screen {
+		case spotSearchInput:
+			m.spotSearch.query += content
+		case spotSearchNewName:
+			m.spotSearch.newName += content
+		}
+		return nil
+	}
+
+	if m.provSearch.active {
+		m.provSearch.query += content
+		if _, ok := m.provider.(provider.CatalogSearcher); !ok {
+			m.updateProvSearch()
+		}
+		return nil
+	}
+
+	return nil
+}
+
 func (m *Model) handleSearchKey(msg tea.KeyPressMsg) tea.Cmd {
 	// Allow opening overlays during search (ctrl combos don't conflict with text input).
 	switch msg.String() {

--- a/ui/model/paste_test.go
+++ b/ui/model/paste_test.go
@@ -1,0 +1,197 @@
+package model
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"cliamp/playlist"
+)
+
+func TestHandlePasteRoutesToActiveInput(t *testing.T) {
+	tests := []struct {
+		name    string
+		model   Model
+		content string
+		check   func(t *testing.T, m *Model)
+	}{
+		{
+			name:    "keymap search",
+			model:   Model{keymap: keymapOverlay{visible: true}},
+			content: "ctrl",
+			check: func(t *testing.T, m *Model) {
+				if m.keymap.search != "ctrl" {
+					t.Fatalf("keymap.search = %q, want %q", m.keymap.search, "ctrl")
+				}
+			},
+		},
+		{
+			name:    "net search",
+			model:   Model{netSearch: netSearchState{active: true, query: "hello "}},
+			content: "world",
+			check: func(t *testing.T, m *Model) {
+				if m.netSearch.query != "hello world" {
+					t.Fatalf("netSearch.query = %q, want %q", m.netSearch.query, "hello world")
+				}
+			},
+		},
+		{
+			name:    "search appends and filters",
+			model:   Model{search: searchState{active: true, query: "ja"}, playlist: playlist.New()},
+			content: "zz",
+			check: func(t *testing.T, m *Model) {
+				if m.search.query != "jazz" {
+					t.Fatalf("search.query = %q, want %q", m.search.query, "jazz")
+				}
+			},
+		},
+		{
+			name:    "jump input",
+			model:   Model{jumping: true, jumpInput: "1:"},
+			content: "30",
+			check: func(t *testing.T, m *Model) {
+				if m.jumpInput != "1:30" {
+					t.Fatalf("jumpInput = %q, want %q", m.jumpInput, "1:30")
+				}
+			},
+		},
+		{
+			name:    "url input",
+			model:   Model{urlInputting: true},
+			content: "https://example.com/song.mp3",
+			check: func(t *testing.T, m *Model) {
+				if m.urlInput != "https://example.com/song.mp3" {
+					t.Fatalf("urlInput = %q, want %q", m.urlInput, "https://example.com/song.mp3")
+				}
+			},
+		},
+		{
+			name: "playlist manager new name",
+			model: Model{plManager: plManagerState{
+				visible: true,
+				screen:  plMgrScreenNewName,
+			}},
+			content: "My Playlist",
+			check: func(t *testing.T, m *Model) {
+				if m.plManager.newName != "My Playlist" {
+					t.Fatalf("plManager.newName = %q, want %q", m.plManager.newName, "My Playlist")
+				}
+			},
+		},
+		{
+			name: "spotify search input",
+			model: Model{spotSearch: spotSearchState{
+				visible: true,
+				screen:  spotSearchInput,
+			}},
+			content: "arctic monkeys",
+			check: func(t *testing.T, m *Model) {
+				if m.spotSearch.query != "arctic monkeys" {
+					t.Fatalf("spotSearch.query = %q, want %q", m.spotSearch.query, "arctic monkeys")
+				}
+			},
+		},
+		{
+			name: "spotify new name",
+			model: Model{spotSearch: spotSearchState{
+				visible: true,
+				screen:  spotSearchNewName,
+			}},
+			content: "New Playlist",
+			check: func(t *testing.T, m *Model) {
+				if m.spotSearch.newName != "New Playlist" {
+					t.Fatalf("spotSearch.newName = %q, want %q", m.spotSearch.newName, "New Playlist")
+				}
+			},
+		},
+		{
+			name:    "provider search (non-catalog)",
+			model:   Model{provSearch: provSearchState{active: true, query: "rock"}},
+			content: " ballads",
+			check: func(t *testing.T, m *Model) {
+				if m.provSearch.query != "rock ballads" {
+					t.Fatalf("provSearch.query = %q, want %q", m.provSearch.query, "rock ballads")
+				}
+			},
+		},
+		{
+			name: "nav browser search",
+			model: Model{navBrowser: navBrowserState{
+				visible:   true,
+				mode:      navBrowseModeByAlbum,
+				searching: true,
+			}},
+			content: "album",
+			check: func(t *testing.T, m *Model) {
+				if m.navBrowser.search != "album" {
+					t.Fatalf("navBrowser.search = %q, want %q", m.navBrowser.search, "album")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := tt.model
+			if cmd := m.handlePaste(tt.content); cmd != nil {
+				t.Fatalf("handlePaste returned non-nil cmd")
+			}
+			tt.check(t, &m)
+		})
+	}
+}
+
+func TestHandlePasteEmptyContentIsNoop(t *testing.T) {
+	m := Model{netSearch: netSearchState{active: true, query: "before"}}
+
+	if cmd := m.handlePaste(""); cmd != nil {
+		t.Fatalf("handlePaste(\"\") returned non-nil cmd")
+	}
+	if m.netSearch.query != "before" {
+		t.Fatalf("query changed on empty paste: got %q", m.netSearch.query)
+	}
+}
+
+func TestHandlePasteNoInputActiveIsNoop(t *testing.T) {
+	m := Model{focus: focusPlaylist}
+
+	if cmd := m.handlePaste("ignored text"); cmd != nil {
+		t.Fatalf("handlePaste returned non-nil cmd when no input active")
+	}
+}
+
+func TestHandlePastePriorityOrder(t *testing.T) {
+	// When multiple input states are active, the highest-priority one wins.
+	// Nav browser search has higher priority than net search.
+	m := Model{
+		navBrowser: navBrowserState{
+			visible:   true,
+			mode:      navBrowseModeByAlbum,
+			searching: true,
+		},
+		netSearch: netSearchState{active: true},
+	}
+
+	m.handlePaste("test")
+
+	if m.navBrowser.search != "test" {
+		t.Fatalf("navBrowser.search = %q, want %q", m.navBrowser.search, "test")
+	}
+	if m.netSearch.query != "" {
+		t.Fatalf("netSearch.query = %q, want empty (lower priority)", m.netSearch.query)
+	}
+}
+
+func TestUpdateRoutesPasteMsg(t *testing.T) {
+	m := Model{netSearch: netSearchState{active: true}}
+
+	next, cmd := m.Update(tea.PasteMsg{Content: "pasted"})
+	got := next.(Model)
+
+	if cmd != nil {
+		t.Fatalf("Update(PasteMsg) cmd = %v, want nil", cmd)
+	}
+	if got.netSearch.query != "pasted" {
+		t.Fatalf("netSearch.query = %q, want %q", got.netSearch.query, "pasted")
+	}
+}

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -35,6 +35,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}()
 
 	switch msg := msg.(type) {
+	case tea.PasteMsg:
+		cmd := m.handlePaste(msg.Content)
+		return m, cmd
+
 	case tea.KeyPressMsg:
 		cmd := m.handleKey(msg)
 		if m.quitting {


### PR DESCRIPTION
## Summary

- After the bubbletea v2 migration (#161), clipboard paste events (`tea.PasteMsg`) were not handled in `Update()`, causing paste to silently fail in all text input fields.
- Add `handlePaste` method that routes pasted text to the active input, following the same priority order as `handleKey`.
- Covers all 11 text inputs: keymap search, nav browser search, playlist manager name, jump, URL, local search, net search, Spotify search/new name, provider search, and catalog search.

Closes #166