### PR TITLE
fix: races

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,8 +39,8 @@ require (
 	github.com/devgianlu/shannon v0.0.0-20230613115856-82ec90b7fa7e // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/dop251/goja v0.0.0-20260311135729-065cd970411c // indirect
-	github.com/ebitengine/oto/v3 v3.3.2 // indirect
-	github.com/ebitengine/purego v0.8.0 // indirect
+	github.com/ebitengine/oto/v3 v3.4.0 // indirect
+	github.com/ebitengine/purego v0.9.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,10 +53,10 @@ github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZ
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dop251/goja v0.0.0-20260311135729-065cd970411c h1:OcLmPfx1T1RmZVHHFwWMPaZDdRf0DBMZOFMVWJa7Pdk=
 github.com/dop251/goja v0.0.0-20260311135729-065cd970411c/go.mod h1:MxLav0peU43GgvwVgNbLAj1s/bSGboKkhuULvq/7hx4=
-github.com/ebitengine/oto/v3 v3.3.2 h1:VTWBsKX9eb+dXzaF4jEwQbs4yWIdXukJ0K40KgkpYlg=
-github.com/ebitengine/oto/v3 v3.3.2/go.mod h1:MZeb/lwoC4DCOdiTIxYezrURTw7EvK/yF863+tmBI+U=
-github.com/ebitengine/purego v0.8.0 h1:JbqvnEzRvPpxhCJzJJ2y0RbiZ8nyjccVUrSM3q+GvvE=
-github.com/ebitengine/purego v0.8.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/ebitengine/oto/v3 v3.4.0 h1:br0PgASsEWaoWn38b2Goe7m1GKFYfNgnsjSd5Gg+/bQ=
+github.com/ebitengine/oto/v3 v3.4.0/go.mod h1:IOleLVD0m+CMak3mRVwsYY8vTctQgOM0iiL6S7Ar7eI=
+github.com/ebitengine/purego v0.9.0 h1:mh0zpKBIXDceC63hpvPuGLiJ8ZAa3DfrFTudmfi8A4k=
+github.com/ebitengine/purego v0.9.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/luaplugin/api_timer.go
+++ b/luaplugin/api_timer.go
@@ -65,6 +65,41 @@ func (tm *timerManager) stopAll() {
 	tm.mu.Unlock()
 }
 
+func (tm *timerManager) stopPlugin(p *Plugin) {
+	tm.mu.Lock()
+	for id, e := range tm.timers {
+		if e.plugin != p {
+			continue
+		}
+		close(e.done)
+		if e.ticker != nil {
+			e.ticker.Stop()
+		}
+		if e.timer != nil {
+			e.timer.Stop()
+		}
+		delete(tm.timers, id)
+	}
+	tm.mu.Unlock()
+}
+
+func (tm *timerManager) take(id int64) bool {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	if _, ok := tm.timers[id]; !ok {
+		return false
+	}
+	delete(tm.timers, id)
+	return true
+}
+
+func (tm *timerManager) active(id int64) bool {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	_, ok := tm.timers[id]
+	return ok
+}
+
 // registerTimerAPI adds cliamp.timer.{after,every,cancel} to the cliamp table.
 // p is the owning plugin whose mutex protects all LState calls.
 func registerTimerAPI(L *lua.LState, cliamp *lua.LTable, tm *timerManager, p *Plugin) {
@@ -84,15 +119,16 @@ func registerTimerAPI(L *lua.LState, cliamp *lua.LTable, tm *timerManager, p *Pl
 			select {
 			case <-t.C:
 				p.mu.Lock()
+				if !tm.take(id) {
+					p.mu.Unlock()
+					return
+				}
 				_ = L.CallByParam(lua.P{
 					Fn:      fn,
 					NRet:    0,
 					Protect: true,
 				})
 				p.mu.Unlock()
-				tm.mu.Lock()
-				delete(tm.timers, id)
-				tm.mu.Unlock()
 			case <-e.done:
 			}
 		}()
@@ -116,6 +152,10 @@ func registerTimerAPI(L *lua.LState, cliamp *lua.LTable, tm *timerManager, p *Pl
 				select {
 				case <-ticker.C:
 					p.mu.Lock()
+					if !tm.active(id) {
+						p.mu.Unlock()
+						return
+					}
 					_ = L.CallByParam(lua.P{
 						Fn:      fn,
 						NRet:    0,

--- a/luaplugin/luaplugin.go
+++ b/luaplugin/luaplugin.go
@@ -194,31 +194,55 @@ func (m *Manager) loadPlugin(path, name string, cfg map[string]string) (*Plugin,
 	// Register all cliamp.* API tables.
 	m.registerCliampAPI(L, p)
 
-	if err := L.DoFile(path); err != nil {
+	p.mu.Lock()
+	err := L.DoFile(path)
+	if err != nil {
+		m.cleanupPlugin(p)
+		p.mu.Unlock()
 		L.Close()
 		return nil, err
 	}
 
 	// If plugin.register() was never called, skip this file.
-	// Remove any hooks that may have been registered during DoFile
-	// before closing the LState to prevent dangling references.
 	if p.Type == "" {
-		m.mu.Lock()
-		for event, hooks := range m.hooks {
-			filtered := hooks[:0]
-			for _, h := range hooks {
-				if h.plugin != p {
-					filtered = append(filtered, h)
-				}
-			}
-			m.hooks[event] = filtered
-		}
-		m.mu.Unlock()
+		m.cleanupPlugin(p)
+		p.mu.Unlock()
 		L.Close()
 		return nil, nil
 	}
+	p.mu.Unlock()
 
 	return p, nil
+}
+
+func (m *Manager) cleanupPlugin(p *Plugin) {
+	m.mu.Lock()
+	for event, hooks := range m.hooks {
+		filtered := hooks[:0]
+		for _, h := range hooks {
+			if h.plugin != p {
+				filtered = append(filtered, h)
+			}
+		}
+		m.hooks[event] = filtered
+	}
+
+	filteredVis := m.visPlugs[:0]
+	for _, vis := range m.visPlugs {
+		if vis.plugin != p {
+			filteredVis = append(filteredVis, vis)
+		}
+	}
+	m.visPlugs = filteredVis
+
+	for name, vis := range m.visMap {
+		if vis.plugin == p {
+			delete(m.visMap, name)
+		}
+	}
+	m.mu.Unlock()
+
+	m.timers.stopPlugin(p)
 }
 
 // registerPluginAPI sets up the global "plugin" table with register() and

--- a/luaplugin/luaplugin.go
+++ b/luaplugin/luaplugin.go
@@ -224,6 +224,9 @@ func (m *Manager) cleanupPlugin(p *Plugin) {
 				filtered = append(filtered, h)
 			}
 		}
+		for i := len(filtered); i < len(hooks); i++ {
+			hooks[i] = nil
+		}
 		m.hooks[event] = filtered
 	}
 
@@ -232,6 +235,9 @@ func (m *Manager) cleanupPlugin(p *Plugin) {
 		if vis.plugin != p {
 			filteredVis = append(filteredVis, vis)
 		}
+	}
+	for i := len(filteredVis); i < len(m.visPlugs); i++ {
+		m.visPlugs[i] = nil
 	}
 	m.visPlugs = filteredVis
 

--- a/luaplugin/luaplugin_test.go
+++ b/luaplugin/luaplugin_test.go
@@ -121,6 +121,15 @@ func TestLoadPluginCleanupStopsPendingTimers(t *testing.T) {
 			`,
 		},
 		{
+			name: "every",
+			code: `
+				cliamp.timer.every(0.01, function()
+					cliamp.fs.write(%q, "fired")
+				end)
+				cliamp.sleep(0.05)
+			`,
+		},
+		{
 			name:      "on load error",
 			expectErr: true,
 			code: `

--- a/luaplugin/luaplugin_test.go
+++ b/luaplugin/luaplugin_test.go
@@ -1,6 +1,7 @@
 package luaplugin
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -40,6 +41,18 @@ func loadTestPluginWithConfig(t *testing.T, m *Manager, name, code string, cfg m
 		m.plugins = append(m.plugins, p)
 	}
 	return p
+}
+
+func loadTestPluginExpectError(t *testing.T, m *Manager, name, code string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, name+".lua")
+	if err := os.WriteFile(path, []byte(code), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.loadPlugin(path, name, nil); err == nil {
+		t.Fatalf("expected error for %s", name)
+	}
 }
 
 func TestLoadPluginRegistersHookPlugin(t *testing.T) {
@@ -89,6 +102,85 @@ func TestLoadPluginSyntaxError(t *testing.T) {
 	_, err := m.loadPlugin(path, "bad", nil)
 	if err == nil {
 		t.Fatal("expected error for invalid Lua syntax")
+	}
+}
+
+func TestLoadPluginCleanupStopsPendingTimers(t *testing.T) {
+	cases := []struct {
+		name      string
+		expectErr bool
+		code      string
+	}{
+		{
+			name: "without register",
+			code: `
+				cliamp.timer.after(0.01, function()
+					cliamp.fs.write(%q, "fired")
+				end)
+				cliamp.sleep(0.05)
+			`,
+		},
+		{
+			name:      "on load error",
+			expectErr: true,
+			code: `
+				local p = plugin.register({name = "bad", type = "hook"})
+				cliamp.timer.after(0.01, function()
+					cliamp.fs.write(%q, "fired")
+				end)
+				cliamp.sleep(0.05)
+				error("boom")
+			`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestManager()
+			path := filepath.Join(t.TempDir(), "fired")
+			code := fmt.Sprintf(tc.code, path)
+
+			if tc.expectErr {
+				loadTestPluginExpectError(t, m, "bad", code)
+			} else {
+				p := loadTestPlugin(t, m, "no-register-expired-timer", code)
+				if p != nil {
+					t.Fatalf("expected nil plugin for script without register, got %+v", p)
+				}
+			}
+
+			time.Sleep(50 * time.Millisecond)
+
+			if _, err := os.Stat(path); !os.IsNotExist(err) {
+				t.Fatalf("timer callback wrote %q after cleanup, err=%v", path, err)
+			}
+		})
+	}
+}
+
+func TestLoadPluginErrorRemovesHooks(t *testing.T) {
+	m := newTestManager()
+	loadTestPluginExpectError(t, m, "bad", `
+		local p = plugin.register({name = "bad", type = "hook"})
+		p:on("track.change", function() end)
+		error("boom")
+	`)
+	if len(m.hooks["track.change"]) != 0 {
+		t.Fatalf("hooks[track.change] = %d, want 0", len(m.hooks["track.change"]))
+	}
+}
+
+func TestLoadVisualizerErrorRemovesVisualizer(t *testing.T) {
+	m := newTestManager()
+	loadTestPluginExpectError(t, m, "bad", `
+		plugin.register({name = "bad", type = "visualizer"})
+		error("boom")
+	`)
+	if len(m.visPlugs) != 0 {
+		t.Fatalf("visualizer count = %d, want 0", len(m.visPlugs))
+	}
+	if _, ok := m.visMap["bad"]; ok {
+		t.Fatal("expected visualizer to be removed from visMap")
 	}
 }
 


### PR DESCRIPTION
Fixes two races found by running `go test -race`

1st: `luaplugin`: timer callbacks can enter the same Lua VM concurrently with plugin loading, so `gopher-lua` sees unsynchronized access to one `*lua.LState`. Fixed by plugin loading now holding the same mutex that timer callbacks use, so the Lua VM can’t be entered concurrently during startup. Cleanup also stops a plugin’s timers so callbacks can’t fire after failed or skipped loads.

Test output:
```text
cliamp/luaplugin.registerTimerAPI.func1.1()
    /Users/gg/code/wannabe-worktrees/cliamp/herpderp/luaplugin/api_timer.go:87 +0x12c

Previous write at ... by goroutine 55:
github.com/yuin/gopher-lua.(*LState).DoFile()
    /Users/gg/go/pkg/mod/github.com/yuin/gopher-lua@v1.1.2/auxlib.go:401 +0xa0
cliamp/luaplugin.(*Manager).loadPlugin()
    /Users/gg/code/wannabe-worktrees/cliamp/herpderp/luaplugin/luaplugin.go:197 +0x194

--- FAIL: TestTimerAfter (0.15s)
    testing.go:1712: race detected during execution of test
```

2nd: `ui/model`: there is a race in the oto v3.3.x (coming from beep). oto v3.4.0 does not have this issue. So, fix was just a bump. I have also opened a PR to beep to bump oto https://github.com/gopxl/beep/pull/222

Test output:
```text
Write at ... by goroutine 10:
github.com/ebitengine/oto/v3.newContext.func1()
    /Users/gg/go/pkg/mod/github.com/ebitengine/oto/v3@v3.3.2/driver_darwin.go:161 +0x2e0

Previous read at ... by main goroutine:
github.com/ebitengine/oto/v3.newContext()
    /Users/gg/go/pkg/mod/github.com/ebitengine/oto/v3@v3.3.2/driver_darwin.go:166 +0x318
cliamp/ui/model.TestMain()
    /Users/gg/code/wannabe-worktrees/cliamp/herpderp/ui/model/tick_test.go:22 +0x50

testing: race detected outside of test execution
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Go module dependencies for improved stability.

* **Bug Fixes**
  * Improved plugin cleanup to reliably remove timers, hooks, and visualizers when plugins fail to load or don't register.
  * Enhanced timer management to prevent callbacks from running after a plugin is removed.

* **Tests**
  * Added tests verifying plugin cleanup and that timers/hooks/visualizers are removed on load errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->