### PR TITLE
Add Shift+0-9 percentage seeking (#183)

### DIFF
--- a/ui/model/keymap.go
+++ b/ui/model/keymap.go
@@ -22,6 +22,7 @@ var keymapEntries = []keymapEntry{
 	{"< ,", "Previous track"},
 	{"← →", "Seek ±5s"},
 	{"Shift+← →", "Seek ±large step"},
+	{"Shift+0-9", "Seek to % of track (0%=start)"},
 	{"+ -", "Volume up/down"},
 	{"] [", "Speed up/down (±0.25x)"},
 	{"z", "Toggle shuffle"},

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -370,6 +370,21 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 		return nil
 	}
 
+	// Shift+0-9: percentage seeking. Matches the shifted symbol produced by
+	// Shift+digit on any keyboard layout (US, Nordic, etc.) since terminals
+	// translate the key before Bubbletea sees it.
+	shiftedDigits := map[string]int{
+		")": 0, "!": 1, "@": 2, "#": 3, "$": 4,
+		"%": 5, "^": 6, "&": 7, "*": 8, "(": 9,
+	}
+	if digit, ok := shiftedDigits[msg.Text]; ok {
+		dur := m.player.Duration()
+		if dur > 0 {
+			target := dur * time.Duration(digit) / 10
+			return m.seekAbsolute(target)
+		}
+	}
+
 	switch msg.String() {
 	case "q", "ctrl+c":
 		return m.quit()

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -370,9 +370,7 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 		return nil
 	}
 
-	// Shift+0-9: percentage seeking. Matches the shifted symbol produced by
-	// Shift+digit on any keyboard layout (US, Nordic, etc.) since terminals
-	// translate the key before Bubbletea sees it.
+	// Shift+0-9: percentage seeking.
 	shiftedDigits := map[string]int{
 		")": 0, "!": 1, "@": 2, "#": 3, "$": 4,
 		"%": 5, "^": 6, "&": 7, "*": 8, "(": 9,


### PR DESCRIPTION
Closes #183
Implements YouTube-style percentage seeking via Shift+0-9.
- Shift+0 seeks to 0% (start), Shift+5 to 50%, Shift+9 to 90%
- Uses shifted symbol matching to work across keyboard layouts
  (US, Nordic, etc.) since terminals translate modifier keys before
  Bubbletea sees them
- Added keymap entry for discoverability
- No conflict with existing keybindings - text overlays (search,
  jump mode, URL input) intercept keys first

## Development notes
### Approach 1: `msg.Mod` + `msg.Code` (didn't work)
Tried checking `msg.Mod&tea.ModShift != 0` and `msg.Code >= '0' && msg.Code <= '9'`. This assumed the terminal would set the Shift modifier flag and report the unshifted digit in Code. On Windows, `Mod` is always 0 - terminals translate Shift+5 into `%` before Bubbletea sees it.
### Approach 2: `msg.BaseCode` + `msg.ShiftedCode` (didn't work)
Bubbletea v2 provides `BaseCode` (physical US-PC101 key) and `ShiftedCode` fields for layout-independent detection. Tested by printing all key fields to the status bar. Both `BaseCode` and `ShiftedCode` are always `\x00` on this terminal - not populated.
### Debug output revealed:
Bare 5:      Code='5' Mod=0 Text="5" Base='\x00' Shifted='\x00'
Shift+5:     Code='%' Mod=0 Text="%" Base='\x00' Shifted='\x00'
The terminal handles Shift entirely - it sends the shifted character with no modifier flags.
### Approach 3: Shifted symbol matching (final solution)
Since the terminal sends the shifted symbol directly, match `msg.Text` against a map of shifted-digit symbols (`)`, `!`, `@`, `#`, `$`, `%`, `^`, `&`, `*`, `(`) and map back to digits 0–9. Uses US keyboard layout as reference. Works on any keyboard where Shift+digit produces these symbols.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts (Shift+0-9) to seek to specific percentages of the current track (0% at start, 90% near end).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->