### PR TITLE
feat: split YouTube videos by chapters into individual audio files

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -354,6 +354,8 @@ func playlistCommand() *cli.Command {
 	}
 }
 
+// splitChaptersCommand returns the CLI subcommand for splitting a YouTube
+// video by chapters into individual MP3 files saved to ~/Music/cliamp/.
 func splitChaptersCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "split-chapters",

--- a/commands.go
+++ b/commands.go
@@ -377,7 +377,7 @@ func splitChaptersCommand() *cli.Command {
 					fmt.Fprintln(os.Stderr, "No chapters found. Use Ctrl+S to save the whole track.")
 					return cli.Exit("", 1)
 				}
-				return err
+				return fmt.Errorf("splitting chapters: %w", err)
 			}
 			fmt.Printf("Split into %d files in %s\n", count, outDir)
 			return nil

--- a/commands.go
+++ b/commands.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -15,6 +16,7 @@ import (
 	"cliamp/ipc"
 	"cliamp/player"
 	"cliamp/pluginmgr"
+	"cliamp/resolve"
 	"cliamp/theme"
 	"cliamp/ui"
 	"cliamp/upgrade"
@@ -60,6 +62,7 @@ func buildApp() *cli.Command {
 			upgradeCommand(),
 			pluginsCommand(),
 			playlistCommand(),
+			splitChaptersCommand(),
 			ipcSimpleCommand("play", "resume playback"),
 			ipcSimpleCommand("pause", "pause playback"),
 			ipcSimpleCommand("toggle", "play/pause toggle"),
@@ -346,6 +349,35 @@ func playlistCommand() *cli.Command {
 					return cmd.PlaylistEnrich(c.Args().First())
 				},
 			},
+		},
+	}
+}
+
+func splitChaptersCommand() *cli.Command {
+	return &cli.Command{
+		Name:      "split-chapters",
+		Usage:     "Split a video by chapters into audio files",
+		ArgsUsage: "<url>",
+		Action: func(ctx context.Context, c *cli.Command) error {
+			if c.Args().Len() == 0 {
+				return fmt.Errorf("usage: cliamp split-chapters <url>")
+			}
+			url := c.Args().First()
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("getting home directory: %w", err)
+			}
+			saveDir := filepath.Join(home, "Music", "cliamp")
+			outDir, count, err := resolve.SplitChaptersYTDL(url, saveDir, os.Stdout)
+			if err != nil {
+				if err == resolve.ErrNoChapters {
+					fmt.Fprintln(os.Stderr, "No chapters found. Use Ctrl+S to save the whole track.")
+					return cli.Exit("", 1)
+				}
+				return err
+			}
+			fmt.Printf("Split into %d files in %s\n", count, outDir)
+			return nil
 		},
 	}
 }

--- a/commands.go
+++ b/commands.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -368,9 +369,9 @@ func splitChaptersCommand() *cli.Command {
 				return fmt.Errorf("getting home directory: %w", err)
 			}
 			saveDir := filepath.Join(home, "Music", "cliamp")
-			outDir, count, err := resolve.SplitChaptersYTDL(url, saveDir, os.Stdout)
+			outDir, count, err := resolve.SplitChaptersYTDL(ctx, url, saveDir)
 			if err != nil {
-				if err == resolve.ErrNoChapters {
+				if errors.Is(err, resolve.ErrNoChapters) {
 					fmt.Fprintln(os.Stderr, "No chapters found. Use Ctrl+S to save the whole track.")
 					return cli.Exit("", 1)
 				}

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -53,6 +53,7 @@ Press `Ctrl+K` in the player to see all keybindings.
 | `u` | Load URL (stream/playlist) |
 | `y` | Show lyrics |
 | `Ctrl+S` | Save track to ~/Music |
+| `x` | Split chapters — save current track split by chapters to ~/Music |
 | `N` | Navidrome browser |
 | `L` | Browse local playlists (with cliamp radio) |
 | `R` | Open radio provider |

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -53,7 +53,7 @@ Press `Ctrl+K` in the player to see all keybindings.
 | `u` | Load URL (stream/playlist) |
 | `y` | Show lyrics |
 | `Ctrl+S` | Save track to ~/Music |
-| `x` | Split chapters — save current track split by chapters to ~/Music |
+| `x` | Split chapters — save current track split by chapters to ~/Music (press again to cancel) |
 | `N` | Navidrome browser |
 | `L` | Browse local playlists (with cliamp radio) |
 | `R` | Open radio provider |

--- a/resolve/kill_unix.go
+++ b/resolve/kill_unix.go
@@ -2,12 +2,18 @@
 
 package resolve
 
-import "syscall"
+import (
+	"fmt"
+	"syscall"
+)
 
 // killProcessTree terminates a process and all of its children on Unix
 // by sending SIGKILL to the process group. The negative PID targets the
 // entire group, which requires the child to have been started with
 // SysProcAttr{Setpgid: true}.
 func killProcessTree(pid int) error {
-	return syscall.Kill(-pid, syscall.SIGKILL)
+	if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil {
+		return fmt.Errorf("kill process group -%d: %w", pid, err)
+	}
+	return nil
 }

--- a/resolve/kill_unix.go
+++ b/resolve/kill_unix.go
@@ -12,8 +12,11 @@ import (
 // entire group, which requires the child to have been started with
 // SysProcAttr{Setpgid: true}.
 func killProcessTree(pid int) error {
+	if pid <= 0 {
+		return fmt.Errorf("killProcessTree: invalid pid %d", pid)
+	}
 	if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil {
-		return fmt.Errorf("kill process group -%d: %w", pid, err)
+		return fmt.Errorf("killProcessTree(%d): %w", pid, err)
 	}
 	return nil
 }

--- a/resolve/kill_unix.go
+++ b/resolve/kill_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package resolve
+
+import "syscall"
+
+// killProcessTree terminates a process and all of its children on Unix
+// by sending SIGKILL to the process group. The negative PID targets the
+// entire group, which requires the child to have been started with
+// SysProcAttr{Setpgid: true}.
+func killProcessTree(pid int) error {
+	return syscall.Kill(-pid, syscall.SIGKILL)
+}

--- a/resolve/kill_windows.go
+++ b/resolve/kill_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package resolve
+
+import (
+	"os/exec"
+	"strconv"
+)
+
+// killProcessTree terminates a process and all of its children on Windows
+// using taskkill. This is needed because exec.CommandContext only kills the
+// direct process, leaving child processes (e.g. ffmpeg spawned by yt-dlp)
+// running and holding file handles open.
+func killProcessTree(pid int) error {
+	return exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(pid)).Run()
+}

--- a/resolve/kill_windows.go
+++ b/resolve/kill_windows.go
@@ -3,6 +3,7 @@
 package resolve
 
 import (
+	"fmt"
 	"os/exec"
 	"strconv"
 )
@@ -12,5 +13,11 @@ import (
 // direct process, leaving child processes (e.g. ffmpeg spawned by yt-dlp)
 // running and holding file handles open.
 func killProcessTree(pid int) error {
-	return exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(pid)).Run()
+	if pid <= 0 {
+		return fmt.Errorf("killProcessTree: invalid pid %d", pid)
+	}
+	if err := exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(pid)).Run(); err != nil {
+		return fmt.Errorf("killProcessTree(%d): %w", pid, err)
+	}
+	return nil
 }

--- a/resolve/proc_unix.go
+++ b/resolve/proc_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package resolve
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setProcAttr configures the child process to start in its own process group
+// so that killProcessTree can target the entire group via negative PID.
+func setProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}

--- a/resolve/proc_windows.go
+++ b/resolve/proc_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package resolve
+
+import "os/exec"
+
+// setProcAttr is a no-op on Windows. Process tree cleanup is handled by
+// taskkill /T which targets the child and all descendants directly.
+func setProcAttr(_ *exec.Cmd) {}

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"mime"
 	"net/http"
@@ -30,7 +30,7 @@ import (
 
 // ErrNoChapters is returned by SplitChaptersYTDL when the video has no
 // chapter markers.
-var ErrNoChapters = fmt.Errorf("no chapters found")
+var ErrNoChapters = errors.New("no chapters found")
 
 // httpClient is used for feed and M3U resolution. It has a generous but
 // finite timeout to prevent hanging on unresponsive servers.
@@ -616,45 +616,57 @@ func sanitizeFilename(name string) string {
 		">", "-",
 		"|", "-",
 	)
-	return strings.TrimSpace(replacer.Replace(name))
+	cleaned := strings.TrimSpace(replacer.Replace(name))
+	cleaned = strings.TrimLeft(cleaned, ".")
+	if cleaned == "" || cleaned == "." || cleaned == ".." {
+		return "untitled"
+	}
+	return cleaned
 }
 
 // uniqueDir returns a directory path that does not already exist.
 // If dir exists, it appends " (1)", " (2)", etc. (Windows-download style).
+// Returns the original dir if stat fails for a reason other than "not exist".
 func uniqueDir(dir string) string {
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		return dir
 	}
 	base := dir
-	for i := 1; ; i++ {
+	for i := 1; i < 1000; i++ {
 		candidate := fmt.Sprintf("%s (%d)", base, i)
-		if _, err := os.Stat(candidate); os.IsNotExist(err) {
+		_, err := os.Stat(candidate)
+		if os.IsNotExist(err) {
+			return candidate
+		}
+		if err != nil {
+			// Stat failed for a reason other than "not exist" (e.g. permission
+			// denied). Return the candidate as-is to avoid an infinite loop.
 			return candidate
 		}
 	}
+	return base
 }
 
-// SplitChaptersYTDL downloads a video via yt-dlp, splits it by chapters,
-// and saves the resulting audio files into a subdirectory of baseSaveDir.
-// The subdirectory name is derived from the video title.
-// If progress is non-nil, yt-dlp stdout/stderr are copied to it.
+// SplitChaptersYTDL downloads a YouTube track, splits it by chapters, and saves
+// the resulting MP3s to a subdirectory of baseSaveDir named after the video title.
+// The provided context can be used to cancel both the probe and download phases.
 // Returns the output directory, the number of files created, and any error.
-func SplitChaptersYTDL(pageURL, baseSaveDir string, progress io.Writer) (string, int, error) {
+func SplitChaptersYTDL(ctx context.Context, pageURL, baseSaveDir string) (string, int, error) {
 	if _, err := exec.LookPath("yt-dlp"); err != nil {
 		return "", 0, fmt.Errorf("yt-dlp not found in PATH")
 	}
 
 	// 1. Probe metadata to get title and check for chapters.
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+	probeCtx, probeCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer probeCancel()
 
-	probeCmd := exec.CommandContext(ctx, "yt-dlp",
+	probeCmd := exec.CommandContext(probeCtx, "yt-dlp",
 		"--no-download", "--dump-json", "--socket-timeout", "15", pageURL)
 	var probeStderr strings.Builder
 	probeCmd.Stderr = &probeStderr
 	probeOut, err := probeCmd.Output()
 	if err != nil {
-		if ctx.Err() == context.DeadlineExceeded {
+		if probeCtx.Err() == context.DeadlineExceeded {
 			return "", 0, fmt.Errorf("yt-dlp: timed out probing %s (30s)", pageURL)
 		}
 		msg := strings.TrimSpace(probeStderr.String())
@@ -684,12 +696,22 @@ func SplitChaptersYTDL(pageURL, baseSaveDir string, progress io.Writer) (string,
 		return "", 0, fmt.Errorf("creating output directory: %w", err)
 	}
 
+	// cleanDir removes the output directory if it is empty or contains only
+	// partial files left over from a cancelled or failed download.
+	cleanDir := func() {
+		entries, _ := os.ReadDir(outDir)
+		for _, e := range entries {
+			_ = os.Remove(filepath.Join(outDir, e.Name()))
+		}
+		os.Remove(outDir) // remove the now-empty directory
+	}
+
 	// 3. Download, extract to mp3, and split by chapters.
 	// The base -o template sends the full file into outDir so cleanup can
 	// remove it. The "chapter:" prefix is required for --split-chapters to
 	// name the individual chapter files.
 	chapterTemplate := filepath.Join(outDir, "%(section_number)03d - %(section_title)s.%(ext)s")
-	dlCmd := exec.Command("yt-dlp",
+	dlCmd := exec.CommandContext(ctx, "yt-dlp",
 		"-f", "bestaudio",
 		"-x",
 		"--audio-format", "mp3",
@@ -698,19 +720,30 @@ func SplitChaptersYTDL(pageURL, baseSaveDir string, progress io.Writer) (string,
 		"-o", filepath.Join(outDir, "%(title)s.%(ext)s"),
 		"-o", "chapter:"+chapterTemplate,
 		pageURL)
-	if progress != nil {
-		dlCmd.Stdout = progress
-		dlCmd.Stderr = progress
-	}
 	if err := dlCmd.Run(); err != nil {
+		if ctx.Err() == context.Canceled {
+			cleanDir()
+			return "", 0, context.Canceled
+		}
+		cleanDir()
 		return "", 0, fmt.Errorf("yt-dlp split download failed: %w", err)
 	}
 
 	// 4. Clean up: remove the full file that yt-dlp leaves behind.
-	// Chapter files match the pattern "NNN - Title.ext"; the full file does not.
+	count, err := cleanupNonChapterFiles(outDir)
+	if err != nil {
+		return outDir, 0, err
+	}
+
+	return outDir, count, nil
+}
+
+// cleanupNonChapterFiles removes files in outDir that don't match the chapter
+// naming pattern and returns the count of remaining chapter files.
+func cleanupNonChapterFiles(outDir string) (int, error) {
 	entries, err := os.ReadDir(outDir)
 	if err != nil {
-		return outDir, 0, fmt.Errorf("reading output directory: %w", err)
+		return 0, fmt.Errorf("reading output directory: %w", err)
 	}
 	count := 0
 	for _, e := range entries {
@@ -723,8 +756,7 @@ func SplitChaptersYTDL(pageURL, baseSaveDir string, progress io.Writer) (string,
 			_ = os.Remove(filepath.Join(outDir, e.Name()))
 		}
 	}
-
-	return outDir, count, nil
+	return count, nil
 }
 
 // isChapterFile reports whether the filename matches the yt-dlp chapter
@@ -741,6 +773,11 @@ func isChapterFile(name string) bool {
 	if i == 0 || i >= len(name) {
 		return false
 	}
-	// After digits, expect " - " then at least one character before the extension.
-	return strings.HasPrefix(name[i:], " - ") && len(name[i+3:]) > 0
+	// After digits, expect " - " then at least one non-dot character (the title).
+	rest := name[i:]
+	if !strings.HasPrefix(rest, " - ") {
+		return false
+	}
+	title := rest[3:]
+	return len(title) > 0 && title[0] != '.'
 }

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"io"
 	"io/fs"
 	"mime"
 	"net/http"
@@ -26,6 +27,10 @@ import (
 
 	"github.com/kkdai/youtube/v2"
 )
+
+// ErrNoChapters is returned by SplitChaptersYTDL when the video has no
+// chapter markers.
+var ErrNoChapters = fmt.Errorf("no chapters found")
 
 // httpClient is used for feed and M3U resolution. It has a generous but
 // finite timeout to prevent hanging on unresponsive servers.
@@ -595,4 +600,145 @@ func parseItunesDuration(s string) int {
 // humanizeBasename converts a URL basename like "clr-podcast-467" into "clr podcast 467".
 func humanizeBasename(s string) string {
 	return strings.ReplaceAll(s, "-", " ")
+}
+
+// sanitizeFilename removes or replaces characters that are illegal in file
+// and directory names on common filesystems.
+func sanitizeFilename(name string) string {
+	replacer := strings.NewReplacer(
+		"/", "-",
+		"\\", "-",
+		":", "-",
+		"*", "-",
+		"?", "-",
+		"\"", "-",
+		"<", "-",
+		">", "-",
+		"|", "-",
+	)
+	return strings.TrimSpace(replacer.Replace(name))
+}
+
+// uniqueDir returns a directory path that does not already exist.
+// If dir exists, it appends " (1)", " (2)", etc. (Windows-download style).
+func uniqueDir(dir string) string {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return dir
+	}
+	base := dir
+	for i := 1; ; i++ {
+		candidate := fmt.Sprintf("%s (%d)", base, i)
+		if _, err := os.Stat(candidate); os.IsNotExist(err) {
+			return candidate
+		}
+	}
+}
+
+// SplitChaptersYTDL downloads a video via yt-dlp, splits it by chapters,
+// and saves the resulting audio files into a subdirectory of baseSaveDir.
+// The subdirectory name is derived from the video title.
+// If progress is non-nil, yt-dlp stdout/stderr are copied to it.
+// Returns the output directory, the number of files created, and any error.
+func SplitChaptersYTDL(pageURL, baseSaveDir string, progress io.Writer) (string, int, error) {
+	if _, err := exec.LookPath("yt-dlp"); err != nil {
+		return "", 0, fmt.Errorf("yt-dlp not found in PATH")
+	}
+
+	// 1. Probe metadata to get title and check for chapters.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	probeCmd := exec.CommandContext(ctx, "yt-dlp",
+		"--no-download", "--dump-json", "--socket-timeout", "15", pageURL)
+	var probeStderr strings.Builder
+	probeCmd.Stderr = &probeStderr
+	probeOut, err := probeCmd.Output()
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", 0, fmt.Errorf("yt-dlp: timed out probing %s (30s)", pageURL)
+		}
+		msg := strings.TrimSpace(probeStderr.String())
+		if msg != "" {
+			return "", 0, fmt.Errorf("yt-dlp: %s", msg)
+		}
+		return "", 0, fmt.Errorf("yt-dlp: %w", err)
+	}
+
+	var info struct {
+		Title    string `json:"title"`
+		Chapters []struct {
+			Title string `json:"title"`
+		} `json:"chapters"`
+	}
+	if err := json.Unmarshal(probeOut, &info); err != nil {
+		return "", 0, fmt.Errorf("parsing yt-dlp probe output: %w", err)
+	}
+
+	if len(info.Chapters) == 0 {
+		return "", 0, ErrNoChapters
+	}
+
+	// 2. Prepare output directory.
+	outDir := uniqueDir(filepath.Join(baseSaveDir, sanitizeFilename(info.Title)))
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return "", 0, fmt.Errorf("creating output directory: %w", err)
+	}
+
+	// 3. Download, extract to mp3, and split by chapters.
+	// The "chapter:" prefix in the -o template is required by yt-dlp's
+	// --split-chapters flag to name the individual chapter files.
+	chapterTemplate := filepath.Join(outDir, "%(section_number)03d - %(section_title)s.%(ext)s")
+	dlCmd := exec.Command("yt-dlp",
+		"-f", "bestaudio",
+		"-x",
+		"--audio-format", "mp3",
+		"--no-playlist",
+		"--split-chapters",
+		"-o", "chapter:"+chapterTemplate,
+		pageURL)
+	if progress != nil {
+		dlCmd.Stdout = progress
+		dlCmd.Stderr = progress
+	}
+	if err := dlCmd.Run(); err != nil {
+		return "", 0, fmt.Errorf("yt-dlp split download failed: %w", err)
+	}
+
+	// 4. Clean up: remove the full file that yt-dlp leaves behind.
+	// Chapter files match the pattern "NNN - Title.ext"; the full file does not.
+	entries, err := os.ReadDir(outDir)
+	if err != nil {
+		return outDir, 0, fmt.Errorf("reading output directory: %w", err)
+	}
+	count := 0
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if isChapterFile(e.Name()) {
+			count++
+		} else {
+			_ = os.Remove(filepath.Join(outDir, e.Name()))
+		}
+	}
+
+	return outDir, count, nil
+}
+
+// isChapterFile reports whether the filename matches the yt-dlp chapter
+// naming pattern "NNN - Chapter Title.ext" (digits, space, hyphen, space).
+func isChapterFile(name string) bool {
+	// Chapter files look like "001 - Intro.mp3"
+	if len(name) < 8 { // minimum: "1 - X.mp3"
+		return false
+	}
+	i := 0
+	for i < len(name) && name[i] >= '0' && name[i] <= '9' {
+		i++
+	}
+	if i == 0 || i >= len(name) {
+		return false
+	}
+	// After digits, expect " - " then at least one character before the extension.
+	return strings.HasPrefix(name[i:], " - ") && len(name[i+3:]) > 0
 }

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -685,8 +685,9 @@ func SplitChaptersYTDL(pageURL, baseSaveDir string, progress io.Writer) (string,
 	}
 
 	// 3. Download, extract to mp3, and split by chapters.
-	// The "chapter:" prefix in the -o template is required by yt-dlp's
-	// --split-chapters flag to name the individual chapter files.
+	// The base -o template sends the full file into outDir so cleanup can
+	// remove it. The "chapter:" prefix is required for --split-chapters to
+	// name the individual chapter files.
 	chapterTemplate := filepath.Join(outDir, "%(section_number)03d - %(section_title)s.%(ext)s")
 	dlCmd := exec.Command("yt-dlp",
 		"-f", "bestaudio",
@@ -694,6 +695,7 @@ func SplitChaptersYTDL(pageURL, baseSaveDir string, progress io.Writer) (string,
 		"--audio-format", "mp3",
 		"--no-playlist",
 		"--split-chapters",
+		"-o", filepath.Join(outDir, "%(title)s.%(ext)s"),
 		"-o", "chapter:"+chapterTemplate,
 		pageURL)
 	if progress != nil {

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -711,7 +711,7 @@ func SplitChaptersYTDL(ctx context.Context, pageURL, baseSaveDir string) (string
 	// remove it. The "chapter:" prefix is required for --split-chapters to
 	// name the individual chapter files.
 	chapterTemplate := filepath.Join(outDir, "%(section_number)03d - %(section_title)s.%(ext)s")
-	dlCmd := exec.CommandContext(ctx, "yt-dlp",
+	dlCmd := exec.Command("yt-dlp",
 		"-f", "bestaudio",
 		"-x",
 		"--audio-format", "mp3",
@@ -720,14 +720,33 @@ func SplitChaptersYTDL(ctx context.Context, pageURL, baseSaveDir string) (string
 		"-o", filepath.Join(outDir, "%(title)s.%(ext)s"),
 		"-o", "chapter:"+chapterTemplate,
 		pageURL)
-	if err := dlCmd.Run(); err != nil {
+	if err := dlCmd.Start(); err != nil {
+		return "", 0, fmt.Errorf("yt-dlp split download failed: %w", err)
+	}
+	pid := dlCmd.Process.Pid
+
+	// Watch for context cancellation and kill the entire process tree
+	// (yt-dlp + ffmpeg + any children) so file handles are released.
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			killProcessTree(pid)
+		case <-done:
+		}
+	}()
+
+	if err := dlCmd.Wait(); err != nil {
+		close(done)
 		if ctx.Err() == context.Canceled {
+			time.Sleep(300 * time.Millisecond) // let OS release file handles
 			cleanDir()
 			return "", 0, context.Canceled
 		}
 		cleanDir()
 		return "", 0, fmt.Errorf("yt-dlp split download failed: %w", err)
 	}
+	close(done)
 
 	// 4. Clean up: remove the full file that yt-dlp leaves behind.
 	count, err := cleanupNonChapterFiles(outDir)

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -462,12 +462,12 @@ func resolveYTDLRange(pageURL string, start, end int) ([]playlist.Track, error) 
 	cmd.Stderr = &stderr
 	stdout, err := cmd.Output()
 	if err != nil {
-		if ctx.Err() == context.DeadlineExceeded {
-			return nil, fmt.Errorf("yt-dlp: timed out resolving %s (30s)", pageURL)
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, fmt.Errorf("resolving yt-dlp metadata: %w", ctxErr)
 		}
 		msg := strings.TrimSpace(stderr.String())
 		if msg != "" {
-			return nil, fmt.Errorf("yt-dlp: %s", msg)
+			return nil, fmt.Errorf("yt-dlp: %s: %w", msg, err)
 		}
 		return nil, fmt.Errorf("yt-dlp: %w", err)
 	}
@@ -624,27 +624,24 @@ func sanitizeFilename(name string) string {
 	return cleaned
 }
 
-// uniqueDir returns a directory path that does not already exist.
-// If dir exists, it appends " (1)", " (2)", etc. (Windows-download style).
-// Returns the original dir if stat fails for a reason other than "not exist".
-func uniqueDir(dir string) string {
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		return dir
-	}
-	base := dir
-	for i := 1; i < 1000; i++ {
-		candidate := fmt.Sprintf("%s (%d)", base, i)
-		_, err := os.Stat(candidate)
-		if os.IsNotExist(err) {
-			return candidate
+// createUniqueDir creates and returns a directory path that did not already
+// exist. If dir exists, it appends " (1)", " (2)", etc. (Windows-download
+// style). Uses os.Mkdir atomically to avoid race conditions.
+func createUniqueDir(dir string) (string, error) {
+	for i := 0; i < 1000; i++ {
+		candidate := dir
+		if i > 0 {
+			candidate = fmt.Sprintf("%s (%d)", dir, i)
 		}
-		if err != nil {
-			// Stat failed for a reason other than "not exist" (e.g. permission
-			// denied). Return the candidate as-is to avoid an infinite loop.
-			return candidate
+		if err := os.Mkdir(candidate, 0o755); err == nil {
+			return candidate, nil
+		} else if errors.Is(err, fs.ErrExist) {
+			continue
+		} else {
+			return "", fmt.Errorf("creating output directory %s: %w", candidate, err)
 		}
 	}
-	return base
+	return "", fmt.Errorf("creating unique output directory for %s: exhausted suffixes", dir)
 }
 
 // SplitChaptersYTDL downloads a YouTube track, splits it by chapters, and saves
@@ -661,19 +658,19 @@ func SplitChaptersYTDL(ctx context.Context, pageURL, baseSaveDir string) (string
 	defer probeCancel()
 
 	probeCmd := exec.CommandContext(probeCtx, "yt-dlp",
-		"--no-download", "--dump-json", "--socket-timeout", "15", pageURL)
+		"--no-download", "--dump-json", "--no-playlist", "--socket-timeout", "15", pageURL)
 	var probeStderr strings.Builder
 	probeCmd.Stderr = &probeStderr
 	probeOut, err := probeCmd.Output()
 	if err != nil {
-		if probeCtx.Err() == context.DeadlineExceeded {
-			return "", 0, fmt.Errorf("yt-dlp: timed out probing %s (30s)", pageURL)
+		if ctxErr := probeCtx.Err(); ctxErr != nil {
+			return "", 0, fmt.Errorf("probing yt-dlp metadata: %w", ctxErr)
 		}
 		msg := strings.TrimSpace(probeStderr.String())
 		if msg != "" {
-			return "", 0, fmt.Errorf("yt-dlp: %s", msg)
+			return "", 0, fmt.Errorf("probing yt-dlp metadata: %s: %w", msg, err)
 		}
-		return "", 0, fmt.Errorf("yt-dlp: %w", err)
+		return "", 0, fmt.Errorf("probing yt-dlp metadata: %w", err)
 	}
 
 	var info struct {
@@ -691,9 +688,12 @@ func SplitChaptersYTDL(ctx context.Context, pageURL, baseSaveDir string) (string
 	}
 
 	// 2. Prepare output directory.
-	outDir := uniqueDir(filepath.Join(baseSaveDir, sanitizeFilename(info.Title)))
-	if err := os.MkdirAll(outDir, 0o755); err != nil {
-		return "", 0, fmt.Errorf("creating output directory: %w", err)
+	if err := os.MkdirAll(baseSaveDir, 0o755); err != nil {
+		return "", 0, fmt.Errorf("creating base output directory: %w", err)
+	}
+	outDir, err := createUniqueDir(filepath.Join(baseSaveDir, sanitizeFilename(info.Title)))
+	if err != nil {
+		return "", 0, err
 	}
 
 	// cleanDir removes the output directory if it is empty or contains only
@@ -711,7 +711,7 @@ func SplitChaptersYTDL(ctx context.Context, pageURL, baseSaveDir string) (string
 	// remove it. The "chapter:" prefix is required for --split-chapters to
 	// name the individual chapter files.
 	chapterTemplate := filepath.Join(outDir, "%(section_number)03d - %(section_title)s.%(ext)s")
-	dlCmd := exec.Command("yt-dlp",
+	dlCmd := exec.CommandContext(ctx, "yt-dlp",
 		"-f", "bestaudio",
 		"-x",
 		"--audio-format", "mp3",
@@ -720,6 +720,7 @@ func SplitChaptersYTDL(ctx context.Context, pageURL, baseSaveDir string) (string
 		"-o", filepath.Join(outDir, "%(title)s.%(ext)s"),
 		"-o", "chapter:"+chapterTemplate,
 		pageURL)
+	setProcAttr(dlCmd)
 	if err := dlCmd.Start(); err != nil {
 		return "", 0, fmt.Errorf("yt-dlp split download failed: %w", err)
 	}
@@ -738,10 +739,10 @@ func SplitChaptersYTDL(ctx context.Context, pageURL, baseSaveDir string) (string
 
 	if err := dlCmd.Wait(); err != nil {
 		close(done)
-		if ctx.Err() == context.Canceled {
+		if ctxErr := ctx.Err(); ctxErr != nil {
 			time.Sleep(300 * time.Millisecond) // let OS release file handles
 			cleanDir()
-			return "", 0, context.Canceled
+			return "", 0, fmt.Errorf("running yt-dlp split download: %w", ctxErr)
 		}
 		cleanDir()
 		return "", 0, fmt.Errorf("yt-dlp split download failed: %w", err)
@@ -772,7 +773,10 @@ func cleanupNonChapterFiles(outDir string) (int, error) {
 		if isChapterFile(e.Name()) {
 			count++
 		} else {
-			_ = os.Remove(filepath.Join(outDir, e.Name()))
+			path := filepath.Join(outDir, e.Name())
+			if err := os.Remove(path); err != nil {
+				return count, fmt.Errorf("removing non-chapter file %s: %w", path, err)
+			}
 		}
 	}
 	return count, nil

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -650,7 +650,7 @@ func createUniqueDir(dir string) (string, error) {
 // Returns the output directory, the number of files created, and any error.
 func SplitChaptersYTDL(ctx context.Context, pageURL, baseSaveDir string) (string, int, error) {
 	if _, err := exec.LookPath("yt-dlp"); err != nil {
-		return "", 0, fmt.Errorf("yt-dlp not found in PATH")
+		return "", 0, fmt.Errorf("looking up yt-dlp: %w", err)
 	}
 
 	// 1. Probe metadata to get title and check for chapters.
@@ -711,13 +711,16 @@ func SplitChaptersYTDL(ctx context.Context, pageURL, baseSaveDir string) (string
 	// remove it. The "chapter:" prefix is required for --split-chapters to
 	// name the individual chapter files.
 	chapterTemplate := filepath.Join(outDir, "%(section_number)03d - %(section_title)s.%(ext)s")
+	// Use a sentinel name for the unsplit file so it cannot be mistaken for a
+	// chapter file by cleanupNonChapterFiles (chapter files match "NNN - Title.ext").
+	sentinelTemplate := filepath.Join(outDir, "_unsplit_audio.%(ext)s")
 	dlCmd := exec.CommandContext(ctx, "yt-dlp",
 		"-f", "bestaudio",
 		"-x",
 		"--audio-format", "mp3",
 		"--no-playlist",
 		"--split-chapters",
-		"-o", filepath.Join(outDir, "%(title)s.%(ext)s"),
+		"-o", sentinelTemplate,
 		"-o", "chapter:"+chapterTemplate,
 		pageURL)
 	setProcAttr(dlCmd)

--- a/resolve/resolve_test.go
+++ b/resolve/resolve_test.go
@@ -183,38 +183,45 @@ func TestSanitizeFilename(t *testing.T) {
 	}
 }
 
-func TestUniqueDir(t *testing.T) {
-	tmp := t.TempDir()
-	base := filepath.Join(tmp, "testdir")
-
-	// First call: dir does not exist yet.
-	got := uniqueDir(base)
-	if got != base {
-		t.Fatalf("uniqueDir(base) = %q, want %q", got, base)
+func TestCreateUniqueDir(t *testing.T) {
+	tests := []struct {
+		name         string
+		precreateDir string
+		wantSuffix   string
+	}{
+		{name: "dir does not exist", wantSuffix: ""},
+		{name: "base exists", precreateDir: "", wantSuffix: " (1)"},
+		{name: "base and (1) exist", precreateDir: " (1)", wantSuffix: " (2)"},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			base := filepath.Join(tmp, "testdir")
 
-	// Create the directory.
-	if err := os.MkdirAll(base, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
+			if tt.precreateDir == "" && tt.wantSuffix != "" {
+				// Pre-create the base directory.
+				if err := os.MkdirAll(base, 0o755); err != nil {
+					t.Fatalf("setup: %v", err)
+				}
+			} else if tt.precreateDir != "" {
+				// Pre-create base and the suffix directory.
+				if err := os.MkdirAll(base, 0o755); err != nil {
+					t.Fatalf("setup base: %v", err)
+				}
+				if err := os.MkdirAll(base+tt.precreateDir, 0o755); err != nil {
+					t.Fatalf("setup suffix: %v", err)
+				}
+			}
 
-	// Second call: dir exists, should get " (1)".
-	got = uniqueDir(base)
-	want := base + " (1)"
-	if got != want {
-		t.Fatalf("uniqueDir(base) = %q, want %q", got, want)
-	}
-
-	// Create the " (1)" directory.
-	if err := os.MkdirAll(want, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-
-	// Third call: should get " (2)".
-	got = uniqueDir(base)
-	want2 := base + " (2)"
-	if got != want2 {
-		t.Fatalf("uniqueDir(base) = %q, want %q", got, want2)
+			got, err := createUniqueDir(base)
+			if err != nil {
+				t.Fatalf("createUniqueDir() error: %v", err)
+			}
+			want := base + tt.wantSuffix
+			if got != want {
+				t.Errorf("createUniqueDir() = %q, want %q", got, want)
+			}
+		})
 	}
 }
 
@@ -260,49 +267,60 @@ func TestIsChapterFile(t *testing.T) {
 	}
 }
 
-func TestSplitChaptersYTDLCleanupRemovesFullFile(t *testing.T) {
-	// Simulate the directory cleanup step: create a directory with a full
-	// file and several chapter files, then call the cleanup logic.
-	// This tests the filter behavior without requiring yt-dlp on the path.
-	tmp := t.TempDir()
-	outDir := filepath.Join(tmp, "splits")
-	if err := os.MkdirAll(outDir, 0o755); err != nil {
-		t.Fatal(err)
+func TestCleanupNonChapterFiles(t *testing.T) {
+	tests := []struct {
+		name      string
+		files     []string
+		wantCount int
+		wantGone  string // file expected to be deleted
+	}{
+		{
+			name: "removes full file, keeps chapters",
+			files: []string{
+				"Pushpa 2 The Rule - Full Audio Jukebox.mp3",
+				"001 - Intro.mp3",
+				"002 - Versio.mp3",
+				"003 - Salaar Remix.mp3",
+			},
+			wantCount: 3,
+			wantGone:  "Pushpa 2 The Rule - Full Audio Jukebox.mp3",
+		},
+		{
+			name: "only chapter files",
+			files: []string{
+				"001 - Intro.mp3",
+				"002 - Outro.mp3",
+			},
+			wantCount: 2,
+		},
+		{
+			name:      "empty directory",
+			files:     nil,
+			wantCount: 0,
+		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			for _, f := range tt.files {
+				if err := os.WriteFile(filepath.Join(tmp, f), []byte("audio"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
 
-	// Simulate what yt-dlp produces: one full file + chapter files.
-	files := []string{
-		"Pushpa 2 The Rule - Full Audio Jukebox.mp3",
-		"001 - Intro.mp3",
-		"002 - Versio.mp3",
-		"003 - Salaar Remix.mp3",
-	}
-	for _, f := range files {
-		if err := os.WriteFile(filepath.Join(outDir, f), []byte("audio"), 0o644); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	// Run the production cleanup helper.
-	count, err := cleanupNonChapterFiles(outDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if count != 3 {
-		t.Fatalf("expected 3 chapter files, got %d", count)
-	}
-
-	// Verify the full file was deleted.
-	if _, err := os.Stat(filepath.Join(outDir, "Pushpa 2 The Rule - Full Audio Jukebox.mp3")); !os.IsNotExist(err) {
-		t.Fatal("expected full file to be deleted")
-	}
-
-	// Verify chapter files still exist.
-	for _, f := range files[1:] {
-		if _, err := os.Stat(filepath.Join(outDir, f)); err != nil {
-			t.Fatalf("chapter file %q was deleted: %v", f, err)
-		}
+			count, err := cleanupNonChapterFiles(tmp)
+			if err != nil {
+				t.Fatalf("cleanupNonChapterFiles() error: %v", err)
+			}
+			if count != tt.wantCount {
+				t.Errorf("count = %d, want %d", count, tt.wantCount)
+			}
+			if tt.wantGone != "" {
+				if _, err := os.Stat(filepath.Join(tmp, tt.wantGone)); !os.IsNotExist(err) {
+					t.Errorf("expected %q to be deleted", tt.wantGone)
+				}
+			}
+		})
 	}
 }
 

--- a/resolve/resolve_test.go
+++ b/resolve/resolve_test.go
@@ -164,6 +164,14 @@ func TestSanitizeFilename(t *testing.T) {
 		{"a:b*c?d\"e<f>g|h", "a-b-c-d-e-f-g-h"},
 		{"  trim me  ", "trim me"},
 		{"normal name", "normal name"},
+		// Path traversal and edge cases.
+		{"..", "untitled"},
+		{".", "untitled"},
+		{"", "untitled"},
+		{"...", "untitled"},
+		{".hidden", "hidden"},
+		{"..hidden", "hidden"},
+		{"  ..  ", "untitled"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
@@ -238,6 +246,9 @@ func TestIsChapterFile(t *testing.T) {
 		// Invalid — full file name (no chapter pattern)
 		{"Pushpa 2 The Rule Telugu Audio Jukebox.mp3", false},
 		{"Some Full Song.m4a", false},
+		// Invalid — no title, just extension after separator
+		{"1 - .mp3", false},
+		{"001 - .m4a", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
@@ -272,21 +283,10 @@ func TestSplitChaptersYTDLCleanupRemovesFullFile(t *testing.T) {
 		}
 	}
 
-	// Run the cleanup logic (same logic as SplitChaptersYTDL step 4).
-	entries, err := os.ReadDir(outDir)
+	// Run the production cleanup helper.
+	count, err := cleanupNonChapterFiles(outDir)
 	if err != nil {
 		t.Fatal(err)
-	}
-	count := 0
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		if isChapterFile(e.Name()) {
-			count++
-		} else {
-			_ = os.Remove(filepath.Join(outDir, e.Name()))
-		}
 	}
 
 	if count != 3 {

--- a/resolve/resolve_test.go
+++ b/resolve/resolve_test.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -149,6 +151,158 @@ func TestParseItunesDuration(t *testing.T) {
 				t.Errorf("parseItunesDuration(%q) = %d, want %d", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSanitizeFilename(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"hello/world", "hello-world"},
+		{"foo\\bar", "foo-bar"},
+		{"a:b*c?d\"e<f>g|h", "a-b-c-d-e-f-g-h"},
+		{"  trim me  ", "trim me"},
+		{"normal name", "normal name"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := sanitizeFilename(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeFilename(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUniqueDir(t *testing.T) {
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, "testdir")
+
+	// First call: dir does not exist yet.
+	got := uniqueDir(base)
+	if got != base {
+		t.Fatalf("uniqueDir(base) = %q, want %q", got, base)
+	}
+
+	// Create the directory.
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Second call: dir exists, should get " (1)".
+	got = uniqueDir(base)
+	want := base + " (1)"
+	if got != want {
+		t.Fatalf("uniqueDir(base) = %q, want %q", got, want)
+	}
+
+	// Create the " (1)" directory.
+	if err := os.MkdirAll(want, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Third call: should get " (2)".
+	got = uniqueDir(base)
+	want2 := base + " (2)"
+	if got != want2 {
+		t.Fatalf("uniqueDir(base) = %q, want %q", got, want2)
+	}
+}
+
+func TestIsChapterFile(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		// Valid chapter files
+		{"001 - Intro.mp3", true},
+		{"12 - Verse Two.m4a", true},
+		{"1 - A.mp3", true},
+		{"999 - Last Track.webm", true},
+		// Invalid — too short
+		{"1.mp3", false},
+		{"1 - ", false},
+		// Invalid — no separator
+		{"001_Intro.mp3", false},
+		{"001 -Intro.mp3", false},
+		{"001  -  Intro.mp3", false}, // two spaces before hyphen
+		// Invalid — no digits at start
+		{"Intro - 001.mp3", false},
+		{"A - 001.mp3", false},
+		// Invalid — empty
+		{"", false},
+		// Invalid — digits but no separator or extension
+		{"001", false},
+		{"001 ", false},
+		// Invalid — full file name (no chapter pattern)
+		{"Pushpa 2 The Rule Telugu Audio Jukebox.mp3", false},
+		{"Some Full Song.m4a", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := isChapterFile(tt.input)
+			if got != tt.want {
+				t.Errorf("isChapterFile(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSplitChaptersYTDLCleanupRemovesFullFile(t *testing.T) {
+	// Simulate the directory cleanup step: create a directory with a full
+	// file and several chapter files, then call the cleanup logic.
+	// This tests the filter behavior without requiring yt-dlp on the path.
+	tmp := t.TempDir()
+	outDir := filepath.Join(tmp, "splits")
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate what yt-dlp produces: one full file + chapter files.
+	files := []string{
+		"Pushpa 2 The Rule - Full Audio Jukebox.mp3",
+		"001 - Intro.mp3",
+		"002 - Versio.mp3",
+		"003 - Salaar Remix.mp3",
+	}
+	for _, f := range files {
+		if err := os.WriteFile(filepath.Join(outDir, f), []byte("audio"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Run the cleanup logic (same logic as SplitChaptersYTDL step 4).
+	entries, err := os.ReadDir(outDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := 0
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if isChapterFile(e.Name()) {
+			count++
+		} else {
+			_ = os.Remove(filepath.Join(outDir, e.Name()))
+		}
+	}
+
+	if count != 3 {
+		t.Fatalf("expected 3 chapter files, got %d", count)
+	}
+
+	// Verify the full file was deleted.
+	if _, err := os.Stat(filepath.Join(outDir, "Pushpa 2 The Rule - Full Audio Jukebox.mp3")); !os.IsNotExist(err) {
+		t.Fatal("expected full file to be deleted")
+	}
+
+	// Verify chapter files still exist.
+	for _, f := range files[1:] {
+		if _, err := os.Stat(filepath.Join(outDir, f)); err != nil {
+			t.Fatalf("chapter file %q was deleted: %v", f, err)
+		}
 	}
 }
 

--- a/site/index.html
+++ b/site/index.html
@@ -1884,7 +1884,7 @@
           <div class="key-row"><kbd>V</kbd><span>Full-screen visualizer</span></div>
           <div class="key-row"><kbd>y / i</kbd><span>Lyrics / Track info</span></div>
           <div class="key-row"><kbd>Ctrl+S</kbd><span>Save to ~/Music</span></div>
-          <div class="key-row"><kbd>x</kbd><span>Split chapters to ~/Music</span></div>
+          <div class="key-row"><kbd>x</kbd><span>Split chapters to ~/Music (press again to cancel)</span></div>
           <div class="key-row"><kbd>Ctrl+K</kbd><span>Show keymap</span></div>
           <div class="key-row"><kbd>q</kbd><span>Quit</span></div>
         </div>

--- a/site/index.html
+++ b/site/index.html
@@ -1884,6 +1884,7 @@
           <div class="key-row"><kbd>V</kbd><span>Full-screen visualizer</span></div>
           <div class="key-row"><kbd>y / i</kbd><span>Lyrics / Track info</span></div>
           <div class="key-row"><kbd>Ctrl+S</kbd><span>Save to ~/Music</span></div>
+          <div class="key-row"><kbd>x</kbd><span>Split chapters to ~/Music</span></div>
           <div class="key-row"><kbd>Ctrl+K</kbd><span>Show keymap</span></div>
           <div class="key-row"><kbd>q</kbd><span>Quit</span></div>
         </div>

--- a/ui/model/commands.go
+++ b/ui/model/commands.go
@@ -243,6 +243,8 @@ func saveYTDLCmd(pageURL string, saveDir string) tea.Cmd {
 	}
 }
 
+// splitChaptersYTDLCmd returns a tea.Cmd that downloads and splits a YouTube
+// video by chapters in the background, posting a ytdlSplitMsg on completion.
 func splitChaptersYTDLCmd(ctx context.Context, pageURL, saveDir string) tea.Cmd {
 	return func() tea.Msg {
 		outDir, count, err := resolve.SplitChaptersYTDL(ctx, pageURL, saveDir)

--- a/ui/model/commands.go
+++ b/ui/model/commands.go
@@ -97,6 +97,13 @@ type ytdlSavedMsg struct {
 	err  error
 }
 
+// ytdlSplitMsg signals that an async yt-dlp chapter split completed.
+type ytdlSplitMsg struct {
+	outDir string
+	count  int
+	err    error
+}
+
 // — Navidrome browser message types —
 
 // navArtistsLoadedMsg carries the full artist list from a provider browser.
@@ -233,6 +240,13 @@ func saveYTDLCmd(pageURL string, saveDir string) tea.Cmd {
 	return func() tea.Msg {
 		path, err := resolve.DownloadYTDL(pageURL, saveDir)
 		return ytdlSavedMsg{path: path, err: err}
+	}
+}
+
+func splitChaptersYTDLCmd(pageURL, saveDir string) tea.Cmd {
+	return func() tea.Msg {
+		outDir, count, err := resolve.SplitChaptersYTDL(pageURL, saveDir, nil)
+		return ytdlSplitMsg{outDir: outDir, count: count, err: err}
 	}
 }
 

--- a/ui/model/commands.go
+++ b/ui/model/commands.go
@@ -243,9 +243,9 @@ func saveYTDLCmd(pageURL string, saveDir string) tea.Cmd {
 	}
 }
 
-func splitChaptersYTDLCmd(pageURL, saveDir string) tea.Cmd {
+func splitChaptersYTDLCmd(ctx context.Context, pageURL, saveDir string) tea.Cmd {
 	return func() tea.Msg {
-		outDir, count, err := resolve.SplitChaptersYTDL(pageURL, saveDir, nil)
+		outDir, count, err := resolve.SplitChaptersYTDL(ctx, pageURL, saveDir)
 		return ytdlSplitMsg{outDir: outDir, count: count, err: err}
 	}
 }

--- a/ui/model/keymap.go
+++ b/ui/model/keymap.go
@@ -52,7 +52,7 @@ var keymapEntries = []keymapEntry{
 	{"p", "Playlist manager"},
 	{"i", "Track info / metadata"},
 	{"Ctrl+S", "Save/download track to ~/Music"},
-	{"x", "Split chapters (save to ~/Music)"},
+	{"x", "Split chapters (save to ~/Music; press again to cancel)"},
 	{"Ctrl+X", "Expand/collapse view"},
 	{"/", "Filter/search list"},
 	{"f", "Toggle bookmark ★ (or favorite station in radio)"},

--- a/ui/model/keymap.go
+++ b/ui/model/keymap.go
@@ -52,6 +52,7 @@ var keymapEntries = []keymapEntry{
 	{"p", "Playlist manager"},
 	{"i", "Track info / metadata"},
 	{"Ctrl+S", "Save/download track to ~/Music"},
+	{"x", "Split chapters (save to ~/Music)"},
 	{"Ctrl+X", "Expand/collapse view"},
 	{"/", "Filter/search list"},
 	{"f", "Toggle bookmark ★ (or favorite station in radio)"},

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -828,6 +828,13 @@ func (m *Model) splitTrack() tea.Cmd {
 		return nil
 	}
 
+	// If a split is already running, cancel it.
+	if m.split.active {
+		m.split.cancelSplit()
+		m.status.Show("Split cancelled.", statusTTLShort)
+		return nil
+	}
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		m.status.Showf(statusTTLShort, "Split failed: %s", err)
@@ -840,8 +847,9 @@ func (m *Model) splitTrack() tea.Cmd {
 		return nil
 	}
 
-	m.split.start()
-	return splitChaptersYTDLCmd(track.Path, saveDir)
+	ctx, cancel := context.WithCancel(context.Background())
+	m.split.start(cancel)
+	return splitChaptersYTDLCmd(ctx, track.Path, saveDir)
 }
 
 func (m *Model) resetJumpInput() {

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -816,6 +816,9 @@ func (m *Model) saveTrack() tea.Cmd {
 	return nil
 }
 
+// splitTrack initiates a chapter split for the current track, or cancels
+// a split that is already in progress. It guards against non-streaming tracks
+// and empty playlists.
 func (m *Model) splitTrack() tea.Cmd {
 	track, idx := m.playlist.Current()
 	if idx < 0 {

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -820,6 +820,13 @@ func (m *Model) saveTrack() tea.Cmd {
 // a split that is already in progress. It guards against non-streaming tracks
 // and empty playlists.
 func (m *Model) splitTrack() tea.Cmd {
+	// If a split is already running, cancel it regardless of playlist state.
+	if m.split.active {
+		m.split.cancelSplit()
+		m.status.Show("Split cancelled.", statusTTLShort)
+		return nil
+	}
+
 	track, idx := m.playlist.Current()
 	if idx < 0 {
 		m.status.Show("Nothing to split", statusTTLShort)
@@ -828,13 +835,6 @@ func (m *Model) splitTrack() tea.Cmd {
 
 	if !playlist.IsYouTubeURL(track.Path) && !playlist.IsYTDL(track.Path) {
 		m.status.Show("Only streaming tracks can be split by chapters", statusTTLShort)
-		return nil
-	}
-
-	// If a split is already running, cancel it.
-	if m.split.active {
-		m.split.cancelSplit()
-		m.status.Show("Split cancelled.", statusTTLShort)
 		return nil
 	}
 

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -628,6 +628,8 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 
 	case "ctrl+s":
 		return m.saveTrack()
+	case "x":
+		return m.splitTrack()
 	case "S":
 		return m.switchToProvider("spotify")
 
@@ -812,6 +814,34 @@ func (m *Model) saveTrack() tea.Cmd {
 
 	m.status.Showf(statusTTLDefault, "Saved to ~/Music/cliamp/%s", name+ext)
 	return nil
+}
+
+func (m *Model) splitTrack() tea.Cmd {
+	track, idx := m.playlist.Current()
+	if idx < 0 {
+		m.status.Show("Nothing to split", statusTTLShort)
+		return nil
+	}
+
+	if !playlist.IsYouTubeURL(track.Path) && !playlist.IsYTDL(track.Path) {
+		m.status.Show("Only streaming tracks can be split by chapters", statusTTLShort)
+		return nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		m.status.Showf(statusTTLShort, "Split failed: %s", err)
+		return nil
+	}
+
+	saveDir := filepath.Join(home, "Music", "cliamp")
+	if err := os.MkdirAll(saveDir, 0o755); err != nil {
+		m.status.Showf(statusTTLShort, "Split failed: %s", err)
+		return nil
+	}
+
+	m.split.start()
+	return splitChaptersYTDLCmd(track.Path, saveDir)
 }
 
 func (m *Model) resetJumpInput() {

--- a/ui/model/model.go
+++ b/ui/model/model.go
@@ -77,7 +77,7 @@ func (s topLevelScreen) hidesVisualizer() bool {
 }
 
 // maxPlVisible caps the playlist at a readable height even on tall terminals.
-// maxPlExpandVisible is the higher cap used when the user expands with 'x'.
+// maxPlExpandVisible is the higher cap used when the user expands with Ctrl+X.
 const (
 	maxPlVisible       = 12
 	maxPlExpandVisible = 24

--- a/ui/model/model.go
+++ b/ui/model/model.go
@@ -183,6 +183,7 @@ type Model struct {
 	ytdlBatch      ytdlBatchState
 	reconnect      reconnectState
 	save           saveState
+	split          splitState
 	status         statusMsg
 	logLines       []logLine
 	network        networkStats

--- a/ui/model/split_state_test.go
+++ b/ui/model/split_state_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"cliamp/playlist"
@@ -10,20 +11,26 @@ import (
 )
 
 func TestSplitStateActivityText(t *testing.T) {
-	var split splitState
-
-	if got := split.activityText(); got != "" {
-		t.Fatalf("activityText() = %q, want empty", got)
+	tests := []struct {
+		name string
+		run  func(*splitState)
+		want string
+	}{
+		{"inactive", func(*splitState) {}, ""},
+		{"active", func(s *splitState) { s.start(func() {}) }, "Splitting chapters... [press x to cancel]"},
+		{"finished", func(s *splitState) {
+			s.start(func() {})
+			s.finish()
+		}, ""},
 	}
-
-	split.start(func() {})
-	if got := split.activityText(); got != "Splitting chapters... [press x to cancel]" {
-		t.Fatalf("activityText() after start = %q, want %q", got, "Splitting chapters... [press x to cancel]")
-	}
-
-	split.finish()
-	if got := split.activityText(); got != "" {
-		t.Fatalf("activityText() after finish = %q, want empty", got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var split splitState
+			tt.run(&split)
+			if got := split.activityText(); got != tt.want {
+				t.Errorf("activityText() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -102,6 +109,12 @@ func TestYTDLSplitMsg(t *testing.T) {
 		{
 			name:       "no chapters",
 			msg:        ytdlSplitMsg{err: resolve.ErrNoChapters},
+			wantStatus: "No chapters found. Use Ctrl+S to save the whole track.",
+			wantActive: false,
+		},
+		{
+			name:       "wrapped no chapters",
+			msg:        ytdlSplitMsg{err: fmt.Errorf("probing chapters: %w", resolve.ErrNoChapters)},
 			wantStatus: "No chapters found. Use Ctrl+S to save the whole track.",
 			wantActive: false,
 		},

--- a/ui/model/split_state_test.go
+++ b/ui/model/split_state_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -8,97 +9,159 @@ import (
 	"cliamp/resolve"
 )
 
-func TestSplitStateActivityTextTracksPending(t *testing.T) {
+func TestSplitStateActivityText(t *testing.T) {
 	var split splitState
 
 	if got := split.activityText(); got != "" {
 		t.Fatalf("activityText() = %q, want empty", got)
 	}
 
-	split.start()
-	if got := split.activityText(); got != "Splitting chapters..." {
-		t.Fatalf("activityText() after first start = %q, want %q", got, "Splitting chapters...")
-	}
-
-	split.start()
-	if got := split.activityText(); got != "Splitting chapters... (2)" {
-		t.Fatalf("activityText() after second start = %q, want %q", got, "Splitting chapters... (2)")
-	}
-
-	split.finish()
-	if got := split.activityText(); got != "Splitting chapters..." {
-		t.Fatalf("activityText() after first finish = %q, want %q", got, "Splitting chapters...")
+	split.start(func() {})
+	if got := split.activityText(); got != "Splitting chapters... [press x to cancel]" {
+		t.Fatalf("activityText() after start = %q, want %q", got, "Splitting chapters... [press x to cancel]")
 	}
 
 	split.finish()
 	if got := split.activityText(); got != "" {
-		t.Fatalf("activityText() after second finish = %q, want empty", got)
+		t.Fatalf("activityText() after finish = %q, want empty", got)
 	}
 }
 
-func TestYTDLSplitMsgUpdatesStatus(t *testing.T) {
-	m := Model{
-		split: splitState{pending: 1},
+func TestSplitStateLifecycle(t *testing.T) {
+	tests := []struct {
+		name            string
+		action          string
+		wantActive      bool
+		wantNilCancel   bool
+		wantCancelCalls int
+	}{
+		{
+			name:            "finish clears active",
+			action:          "finish",
+			wantActive:      false,
+			wantNilCancel:   true,
+			wantCancelCalls: 0,
+		},
+		{
+			name:            "cancel clears active and calls cancel func",
+			action:          "cancel",
+			wantActive:      false,
+			wantNilCancel:   true,
+			wantCancelCalls: 1,
+		},
+		{
+			name:            "cancel is idempotent",
+			action:          "cancel-cancel",
+			wantActive:      false,
+			wantNilCancel:   true,
+			wantCancelCalls: 1,
+		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var s splitState
+			cancelCalls := 0
+			s.start(func() { cancelCalls++ })
 
-	nextModel, cmd := m.Update(ytdlSplitMsg{outDir: "/tmp/album", count: 5, err: nil})
-	if cmd != nil {
-		t.Fatalf("Update() cmd = %v, want nil", cmd)
-	}
+			switch tt.action {
+			case "finish":
+				s.finish()
+			case "cancel":
+				s.cancelSplit()
+			case "cancel-cancel":
+				s.cancelSplit()
+				s.cancelSplit()
+			}
 
-	next, ok := nextModel.(Model)
-	if !ok {
-		t.Fatalf("Update() model = %T, want ui.Model", nextModel)
-	}
-	if next.split.pending != 0 {
-		t.Fatalf("pending after ytdlSplitMsg = %d, want 0", next.split.pending)
-	}
-	want := "Split into 5 files in /tmp/album"
-	if next.status.text != want {
-		t.Fatalf("status.text = %q, want %q", next.status.text, want)
+			if s.active != tt.wantActive {
+				t.Errorf("active = %v, want %v", s.active, tt.wantActive)
+			}
+			if (s.cancel == nil) != tt.wantNilCancel {
+				t.Errorf("cancel is nil = %v, want %v", s.cancel == nil, tt.wantNilCancel)
+			}
+			if cancelCalls != tt.wantCancelCalls {
+				t.Errorf("cancel calls = %d, want %d", cancelCalls, tt.wantCancelCalls)
+			}
+		})
 	}
 }
 
-func TestYTDLSplitMsgNoChaptersShowsFallback(t *testing.T) {
-	m := Model{
-		split: splitState{pending: 1},
+func TestYTDLSplitMsg(t *testing.T) {
+	tests := []struct {
+		name       string
+		msg        ytdlSplitMsg
+		wantStatus string
+		wantActive bool
+	}{
+		{
+			name:       "success",
+			msg:        ytdlSplitMsg{outDir: "/tmp/album", count: 5, err: nil},
+			wantStatus: "Split into 5 files in /tmp/album",
+			wantActive: false,
+		},
+		{
+			name:       "no chapters",
+			msg:        ytdlSplitMsg{err: resolve.ErrNoChapters},
+			wantStatus: "No chapters found. Use Ctrl+S to save the whole track.",
+			wantActive: false,
+		},
+		{
+			name:       "generic error",
+			msg:        ytdlSplitMsg{err: errors.New("network timeout")},
+			wantStatus: "Split failed: network timeout",
+			wantActive: false,
+		},
+		{
+			name:       "cancelled",
+			msg:        ytdlSplitMsg{err: context.Canceled},
+			wantStatus: "",
+			wantActive: false,
+		},
 	}
-
-	nextModel, _ := m.Update(ytdlSplitMsg{err: resolve.ErrNoChapters})
-	next := nextModel.(Model)
-
-	want := "No chapters found. Use Ctrl+S to save the whole track."
-	if next.status.text != want {
-		t.Fatalf("status.text = %q, want %q", next.status.text, want)
-	}
-}
-
-func TestYTDLSplitMsgGenericErrorShowsFailure(t *testing.T) {
-	m := Model{
-		split: splitState{pending: 1},
-	}
-
-	nextModel, _ := m.Update(ytdlSplitMsg{err: errors.New("network timeout")})
-	next := nextModel.(Model)
-
-	want := "Split failed: network timeout"
-	if next.status.text != want {
-		t.Fatalf("status.text = %q, want %q", next.status.text, want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := Model{split: splitState{active: true}}
+			nextModel, cmd := m.Update(tt.msg)
+			if cmd != nil {
+				t.Errorf("Update() cmd = %v, want nil", cmd)
+			}
+			next := nextModel.(Model)
+			if next.split.active != tt.wantActive {
+				t.Errorf("active = %v, want %v", next.split.active, tt.wantActive)
+			}
+			if next.status.text != tt.wantStatus {
+				t.Errorf("status.text = %q, want %q", next.status.text, tt.wantStatus)
+			}
+		})
 	}
 }
 
 func TestSplitTrackGuards(t *testing.T) {
-	// No track in playlist.
-	pl := playlist.New()
-	m := Model{playlist: pl}
-	if cmd := m.splitTrack(); cmd != nil {
-		t.Fatalf("splitTrack() with empty playlist returned cmd, want nil")
+	tests := []struct {
+		name  string
+		setup func() Model
+	}{
+		{
+			name: "empty playlist",
+			setup: func() Model {
+				return Model{playlist: playlist.New()}
+			},
+		},
+		{
+			name: "non-streaming track",
+			setup: func() Model {
+				pl := playlist.New()
+				pl.Add(playlist.Track{Path: "/local/file.mp3"})
+				return Model{playlist: pl}
+			},
+		},
 	}
-
-	// Non-streaming track.
-	pl.Add(playlist.Track{Path: "/local/file.mp3"})
-	m = Model{playlist: pl}
-	if cmd := m.splitTrack(); cmd != nil {
-		t.Fatalf("splitTrack() with local track returned cmd, want nil")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := tt.setup()
+			if cmd := m.splitTrack(); cmd != nil {
+				t.Errorf("splitTrack() returned cmd, want nil")
+			}
+		})
 	}
 }

--- a/ui/model/split_state_test.go
+++ b/ui/model/split_state_test.go
@@ -1,0 +1,104 @@
+package model
+
+import (
+	"errors"
+	"testing"
+
+	"cliamp/playlist"
+	"cliamp/resolve"
+)
+
+func TestSplitStateActivityTextTracksPending(t *testing.T) {
+	var split splitState
+
+	if got := split.activityText(); got != "" {
+		t.Fatalf("activityText() = %q, want empty", got)
+	}
+
+	split.start()
+	if got := split.activityText(); got != "Splitting chapters..." {
+		t.Fatalf("activityText() after first start = %q, want %q", got, "Splitting chapters...")
+	}
+
+	split.start()
+	if got := split.activityText(); got != "Splitting chapters... (2)" {
+		t.Fatalf("activityText() after second start = %q, want %q", got, "Splitting chapters... (2)")
+	}
+
+	split.finish()
+	if got := split.activityText(); got != "Splitting chapters..." {
+		t.Fatalf("activityText() after first finish = %q, want %q", got, "Splitting chapters...")
+	}
+
+	split.finish()
+	if got := split.activityText(); got != "" {
+		t.Fatalf("activityText() after second finish = %q, want empty", got)
+	}
+}
+
+func TestYTDLSplitMsgUpdatesStatus(t *testing.T) {
+	m := Model{
+		split: splitState{pending: 1},
+	}
+
+	nextModel, cmd := m.Update(ytdlSplitMsg{outDir: "/tmp/album", count: 5, err: nil})
+	if cmd != nil {
+		t.Fatalf("Update() cmd = %v, want nil", cmd)
+	}
+
+	next, ok := nextModel.(Model)
+	if !ok {
+		t.Fatalf("Update() model = %T, want ui.Model", nextModel)
+	}
+	if next.split.pending != 0 {
+		t.Fatalf("pending after ytdlSplitMsg = %d, want 0", next.split.pending)
+	}
+	want := "Split into 5 files in /tmp/album"
+	if next.status.text != want {
+		t.Fatalf("status.text = %q, want %q", next.status.text, want)
+	}
+}
+
+func TestYTDLSplitMsgNoChaptersShowsFallback(t *testing.T) {
+	m := Model{
+		split: splitState{pending: 1},
+	}
+
+	nextModel, _ := m.Update(ytdlSplitMsg{err: resolve.ErrNoChapters})
+	next := nextModel.(Model)
+
+	want := "No chapters found. Use Ctrl+S to save the whole track."
+	if next.status.text != want {
+		t.Fatalf("status.text = %q, want %q", next.status.text, want)
+	}
+}
+
+func TestYTDLSplitMsgGenericErrorShowsFailure(t *testing.T) {
+	m := Model{
+		split: splitState{pending: 1},
+	}
+
+	nextModel, _ := m.Update(ytdlSplitMsg{err: errors.New("network timeout")})
+	next := nextModel.(Model)
+
+	want := "Split failed: network timeout"
+	if next.status.text != want {
+		t.Fatalf("status.text = %q, want %q", next.status.text, want)
+	}
+}
+
+func TestSplitTrackGuards(t *testing.T) {
+	// No track in playlist.
+	pl := playlist.New()
+	m := Model{playlist: pl}
+	if cmd := m.splitTrack(); cmd != nil {
+		t.Fatalf("splitTrack() with empty playlist returned cmd, want nil")
+	}
+
+	// Non-streaming track.
+	pl.Add(playlist.Track{Path: "/local/file.mp3"})
+	m = Model{playlist: pl}
+	if cmd := m.splitTrack(); cmd != nil {
+		t.Fatalf("splitTrack() with local track returned cmd, want nil")
+	}
+}

--- a/ui/model/state.go
+++ b/ui/model/state.go
@@ -4,6 +4,7 @@
 package model
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -214,28 +215,33 @@ func (s *saveState) finishDownload() {
 }
 
 type splitState struct {
-	pending int
+	active bool
+	cancel context.CancelFunc
 }
 
 func (s splitState) activityText() string {
-	switch s.pending {
-	case 0:
+	if !s.active {
 		return ""
-	case 1:
-		return "Splitting chapters..."
-	default:
-		return fmt.Sprintf("Splitting chapters... (%d)", s.pending)
 	}
+	return "Splitting chapters... [press x to cancel]"
 }
 
-func (s *splitState) start() {
-	s.pending++
+func (s *splitState) start(cancel context.CancelFunc) {
+	s.active = true
+	s.cancel = cancel
+}
+
+func (s *splitState) cancelSplit() {
+	if s.cancel != nil {
+		s.cancel()
+		s.cancel = nil
+	}
+	s.active = false
 }
 
 func (s *splitState) finish() {
-	if s.pending > 0 {
-		s.pending--
-	}
+	s.active = false
+	s.cancel = nil
 }
 
 // statusTTL is how long a status line stays visible.

--- a/ui/model/state.go
+++ b/ui/model/state.go
@@ -214,11 +214,15 @@ func (s *saveState) finishDownload() {
 	}
 }
 
+// splitState tracks the lifecycle of an in-progress chapter split operation.
+// It holds a cancel function so the TUI can abort the split by pressing x.
 type splitState struct {
 	active bool
 	cancel context.CancelFunc
 }
 
+// activityText returns a status string while a split is in progress,
+// or an empty string if no split is running.
 func (s splitState) activityText() string {
 	if !s.active {
 		return ""
@@ -226,11 +230,14 @@ func (s splitState) activityText() string {
 	return "Splitting chapters... [press x to cancel]"
 }
 
+// start marks the split as active and stores the cancel function for later use.
 func (s *splitState) start(cancel context.CancelFunc) {
 	s.active = true
 	s.cancel = cancel
 }
 
+// cancelSplit aborts the in-progress split by calling the stored cancel
+// function and resetting the state. It is safe to call multiple times.
 func (s *splitState) cancelSplit() {
 	if s.cancel != nil {
 		s.cancel()
@@ -239,6 +246,7 @@ func (s *splitState) cancelSplit() {
 	s.active = false
 }
 
+// finish marks the split as complete and clears the cancel function.
 func (s *splitState) finish() {
 	s.active = false
 	s.cancel = nil

--- a/ui/model/state.go
+++ b/ui/model/state.go
@@ -213,6 +213,31 @@ func (s *saveState) finishDownload() {
 	}
 }
 
+type splitState struct {
+	pending int
+}
+
+func (s splitState) activityText() string {
+	switch s.pending {
+	case 0:
+		return ""
+	case 1:
+		return "Splitting chapters..."
+	default:
+		return fmt.Sprintf("Splitting chapters... (%d)", s.pending)
+	}
+}
+
+func (s *splitState) start() {
+	s.pending++
+}
+
+func (s *splitState) finish() {
+	if s.pending > 0 {
+		s.pending--
+	}
+}
+
 // statusTTL is how long a status line stays visible.
 type statusTTL time.Duration
 

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -526,6 +527,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ytdlSplitMsg:
 		m.split.finish()
 		if msg.err != nil {
+			if errors.Is(msg.err, context.Canceled) {
+				// User already saw "Split cancelled." when they pressed x.
+				return m, nil
+			}
 			if errors.Is(msg.err, resolve.ErrNoChapters) {
 				m.status.Show("No chapters found. Use Ctrl+S to save the whole track.", statusTTLMedium)
 			} else {

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -13,6 +13,7 @@ import (
 	"cliamp/player"
 	"cliamp/playlist"
 	"cliamp/provider"
+	"cliamp/resolve"
 	"cliamp/theme"
 	"cliamp/ui"
 )
@@ -519,6 +520,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.status.Showf(statusTTLMedium, "Download failed: %s", msg.err)
 		} else {
 			m.status.Showf(statusTTLMedium, "Saved to %s", msg.path)
+		}
+		return m, nil
+
+	case ytdlSplitMsg:
+		m.split.finish()
+		if msg.err != nil {
+			if errors.Is(msg.err, resolve.ErrNoChapters) {
+				m.status.Show("No chapters found. Use Ctrl+S to save the whole track.", statusTTLMedium)
+			} else {
+				m.status.Showf(statusTTLMedium, "Split failed: %s", msg.err)
+			}
+		} else {
+			m.status.Showf(statusTTLMedium, "Split into %d files in %s", msg.count, msg.outDir)
 		}
 		return m, nil
 

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -152,6 +152,9 @@ func (m Model) mainSections(playlist string, includeTransient bool) []string {
 
 func (m Model) footerMessages() []string {
 	var lines []string
+	if text := m.split.activityText(); text != "" {
+		lines = append(lines, statusStyle.Render(text))
+	}
 	if text := m.save.activityText(); text != "" {
 		lines = append(lines, statusStyle.Render(text))
 	}


### PR DESCRIPTION
Closes #188

What this does
Adds a "Split by Chapters" feature that downloads a YouTube video with chapter markers and splits it into separate .mp3 files ,useful for full albums, compilations, and jukeboxes uploaded as single videos.

Interfaces
- TUI: Press x on a playing YouTube/YTDL track to split it by chapters.
- CLI: cliamp split-chapters <url> for headless use.
 
Output
Files are saved to ~/Music/cliamp/<Video Title>/ with names like:
001 - Intro.mp3
002 - Main Theme.mp3
003 - Outro.mp3
If the directory already exists, a (1), (2) suffix is appended.

Key implementation details
- Probes metadata first via yt-dlp --dump-json to check for chapters before downloading.
- Uses yt-dlp --split-chapters with the chapter: output template prefix (required for yt-dlp to actually split files).
- Adds a base -o template so the full unsplit file also lands in the output directory, then cleans it up after splitting.
- Audio format is mp3 only (-x --audio-format mp3), requires ffmpeg.
- No-chapters fallback: shows "No chapters found. Use Ctrl+S to save the whole track." in the TUI status bar or CLI stderr.

Testing
- go build ./... — clean
- go vet ./resolve ./ui/model . — clean
- New tests added for all helper functions and TUI state transitions
- Manually tested with YouTube album uploads
---

Design notes for review
- The x keybinding was chosen as "eXtract chapters" (vim-friendly, single keystroke).
- The saveState/ytdlSavedMsg pattern was mirrored for splitState/ytdlSplitMsg to keep the async flow consistent with existing code.
- isChapterFile() uses a simple heuristic (digits + " - " prefix) to distinguish chapter files from the full file during cleanup. This matches yt-dlp's default chapter naming.
---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Split chapters" action: CLI subcommand and in-app "x" key to split a track into per‑chapter MP3s saved under ~/Music/cliamp; supports canceling and reports file count and output directory.

* **UI**
  * Footer and status show split activity and distinct messages for success, cancellation, no chapters found, and failures.

* **Documentation**
  * Keybindings docs and site updated with the new "x" shortcut and cancel behavior.

* **Tests**
  * Added tests for filename sanitization, chapter-file detection, cleanup, and split-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->