### PR TITLE
Album separators in playlist views

### DIFF
--- a/docs/playlists.md
+++ b/docs/playlists.md
@@ -141,6 +141,8 @@ Press `p` from any view to open the playlist manager:
 6. **Play all**: press `Enter` on the track list to load all tracks into the player
 7. **New playlist**: select "+ New Playlist...", type a name, and press Enter
 
+Tracks with an `album` field are grouped by album with visual separator headers in both the playlist manager and the main player view.
+
 The directory `~/.config/cliamp/playlists/` is created automatically on first use. Removing the last track from a playlist auto-deletes the file.
 
 ### Creating Playlists Manually

--- a/site/index.html
+++ b/site/index.html
@@ -1522,7 +1522,7 @@
       <div class="feature">
         <div class="feature-icon">☰</div>
         <div class="feature-name">Playlists</div>
-        <p>TOML playlists, M3U/M3U8/PLS support, built-in playlist manager.</p>
+        <p>TOML playlists, M3U/M3U8/PLS support, playlist manager with album grouping.</p>
       </div>
       <div class="feature">
         <div class="feature-icon">→</div>

--- a/ui/model/scroll.go
+++ b/ui/model/scroll.go
@@ -83,7 +83,7 @@ func (m Model) playlistRowsFromScroll(scroll, cursor int) int {
 		prevAlbum = tracks[scroll-1].Album
 	}
 	for i := scroll; i <= cursor && i < len(tracks); i++ {
-		if album := tracks[i].Album; album != "" && album != prevAlbum {
+		if album := tracks[i].Album; album != "" && album != prevAlbum && !isStreamingPlaylistTrack(tracks[i].Path) {
 			rows++
 		}
 		prevAlbum = tracks[i].Album

--- a/ui/model/scroll.go
+++ b/ui/model/scroll.go
@@ -66,30 +66,10 @@ func (m Model) playlistScroll(visible int) int {
 	if m.plCursor < scroll {
 		return m.plCursor
 	}
-	for scroll < m.plCursor && m.playlistRowsFromScroll(scroll, m.plCursor) > visible {
+	for scroll < m.plCursor && albumSeparatorRows(tracks, scroll, m.plCursor) > visible {
 		scroll++
 	}
 	return scroll
-}
-
-func (m Model) playlistRowsFromScroll(scroll, cursor int) int {
-	tracks := m.playlist.Tracks()
-	if len(tracks) == 0 || cursor < scroll || scroll < 0 || cursor >= len(tracks) {
-		return 0
-	}
-	rows := 0
-	prevAlbum := ""
-	if scroll > 0 {
-		prevAlbum = tracks[scroll-1].Album
-	}
-	for i := scroll; i <= cursor && i < len(tracks); i++ {
-		if album := tracks[i].Album; album != "" && album != prevAlbum && !isStreamingPlaylistTrack(tracks[i].Path) {
-			rows++
-		}
-		prevAlbum = tracks[i].Album
-		rows++
-	}
-	return rows
 }
 
 func (m Model) mainFrameFixedLines(includeTransient bool) int {

--- a/ui/model/scroll.go
+++ b/ui/model/scroll.go
@@ -66,10 +66,30 @@ func (m Model) playlistScroll(visible int) int {
 	if m.plCursor < scroll {
 		return m.plCursor
 	}
-	if m.plCursor-scroll+1 <= visible {
-		return scroll
+	for scroll < m.plCursor && m.playlistRowsFromScroll(scroll, m.plCursor) > visible {
+		scroll++
 	}
-	return m.plCursor - visible + 1
+	return scroll
+}
+
+func (m Model) playlistRowsFromScroll(scroll, cursor int) int {
+	tracks := m.playlist.Tracks()
+	if len(tracks) == 0 || cursor < scroll || scroll < 0 || cursor >= len(tracks) {
+		return 0
+	}
+	rows := 0
+	prevAlbum := ""
+	if scroll > 0 {
+		prevAlbum = tracks[scroll-1].Album
+	}
+	for i := scroll; i <= cursor && i < len(tracks); i++ {
+		if album := tracks[i].Album; album != "" && album != prevAlbum {
+			rows++
+		}
+		prevAlbum = tracks[i].Album
+		rows++
+	}
+	return rows
 }
 
 func (m Model) mainFrameFixedLines(includeTransient bool) int {

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -620,12 +620,24 @@ func (m Model) renderPlaylist() string {
 	currentIdx := m.playlist.Index()
 	scroll := m.playlistScroll(budget)
 
-	// budget is the number of rendered lines available for tracks.
-	// The loop below counts every appended line against this budget
-	// so the playlist never overflows its area.
-	lines := make([]string, 0, budget) // tracks
+	lines := make([]string, 0, budget)
 	numWidth := len(fmt.Sprintf("%d", len(tracks)))
+	prevAlbum := ""
+	if scroll > 0 {
+		prevAlbum = tracks[scroll-1].Album
+	}
 	for i := scroll; i < len(tracks) && len(lines) < budget; i++ {
+		if album := tracks[i].Album; album != "" && album != prevAlbum {
+			if len(lines)+1 >= budget {
+				break
+			}
+			lines = append(lines, m.albumSeparator(album, tracks[i].Year))
+		}
+		prevAlbum = tracks[i].Album
+		if len(lines) >= budget {
+			break
+		}
+
 		prefix := "  "
 		style := playlistItemStyle
 

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -627,7 +627,7 @@ func (m Model) renderPlaylist() string {
 		prevAlbum = tracks[scroll-1].Album
 	}
 	for i := scroll; i < len(tracks) && len(lines) < budget; i++ {
-		if album := tracks[i].Album; album != "" && album != prevAlbum {
+		if album := tracks[i].Album; album != "" && album != prevAlbum && !isStreamingPlaylistTrack(tracks[i].Path) {
 			if len(lines)+1 >= budget {
 				break
 			}

--- a/ui/model/view_helpers.go
+++ b/ui/model/view_helpers.go
@@ -55,6 +55,10 @@ func helpKey(key, label string) string {
 	return helpKeyStyle.Render(" "+key+" ") + helpStyle.Render(" "+label)
 }
 
+func isStreamingPlaylistTrack(path string) bool {
+	return strings.HasPrefix(path, "spotify:track:")
+}
+
 // albumSeparator builds a full-width album divider line.
 func (m Model) albumSeparator(album string, year int) string {
 	prefix := "── "

--- a/ui/model/view_helpers.go
+++ b/ui/model/view_helpers.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"cliamp/playlist"
 	"cliamp/ui"
 )
 
@@ -55,8 +56,34 @@ func helpKey(key, label string) string {
 	return helpKeyStyle.Render(" "+key+" ") + helpStyle.Render(" "+label)
 }
 
+// isStreamingPlaylistTrack reports whether path is a streaming-provider URI
+// whose Album metadata may not represent a real album grouping (so separators
+// would be misleading).
 func isStreamingPlaylistTrack(path string) bool {
 	return strings.HasPrefix(path, "spotify:track:")
+}
+
+// albumSeparatorRows counts rendered rows between scroll and cursor (inclusive)
+// in a playlist view that emits an album-separator row whenever the album
+// changes. Streaming tracks are treated as not contributing a separator,
+// matching the renderer.
+func albumSeparatorRows(tracks []playlist.Track, scroll, cursor int) int {
+	if len(tracks) == 0 || scroll < 0 || cursor < scroll || cursor >= len(tracks) {
+		return 0
+	}
+	rows := 0
+	prevAlbum := ""
+	if scroll > 0 {
+		prevAlbum = tracks[scroll-1].Album
+	}
+	for i := scroll; i <= cursor; i++ {
+		if album := tracks[i].Album; album != "" && album != prevAlbum && !isStreamingPlaylistTrack(tracks[i].Path) {
+			rows++
+		}
+		prevAlbum = tracks[i].Album
+		rows++
+	}
+	return rows
 }
 
 // albumSeparator builds a full-width album divider line.

--- a/ui/model/view_nav.go
+++ b/ui/model/view_nav.go
@@ -197,7 +197,7 @@ func (m Model) renderNavTrackList() []string {
 		for i := scroll; i < len(m.navBrowser.tracks) && rendered < maxVisible; i++ {
 			t := m.navBrowser.tracks[i]
 
-			if album := t.Album; album != "" && album != prevAlbum {
+			if album := t.Album; album != "" && album != prevAlbum && !isStreamingPlaylistTrack(t.Path) {
 				lines = append(lines, m.albumSeparator(album, t.Year))
 				if rendered >= maxVisible {
 					break

--- a/ui/model/view_overlays.go
+++ b/ui/model/view_overlays.go
@@ -157,22 +157,7 @@ func (m Model) renderPlMgrTracks() []string {
 	maxVisible := 12
 	tracks := m.plManager.tracks
 	scroll := scrollStart(m.plManager.cursor, maxVisible)
-	for scroll < m.plManager.cursor {
-		rows := 0
-		pa := ""
-		if scroll > 0 {
-			pa = tracks[scroll-1].Album
-		}
-		for j := scroll; j <= m.plManager.cursor && j < len(tracks); j++ {
-			if a := tracks[j].Album; a != "" && a != pa {
-				rows++
-			}
-			pa = tracks[j].Album
-			rows++
-		}
-		if rows <= maxVisible {
-			break
-		}
+	for scroll < m.plManager.cursor && albumSeparatorRows(tracks, scroll, m.plManager.cursor) > maxVisible {
 		scroll++
 	}
 
@@ -200,8 +185,8 @@ func (m Model) renderPlMgrTracks() []string {
 		rendered++
 	}
 
-	if len(m.plManager.tracks) > maxVisible {
-		lines = append(lines, "", dimStyle.Render(fmt.Sprintf("  %d/%d tracks", m.plManager.cursor+1, len(m.plManager.tracks))))
+	if len(tracks) > maxVisible {
+		lines = append(lines, "", dimStyle.Render(fmt.Sprintf("  %d/%d tracks", m.plManager.cursor+1, len(tracks))))
 	}
 
 	lines = append(lines, "", helpKey("↑↓", "Navigate ")+helpKey("Enter", "Play all ")+helpKey("a", "Add track ")+helpKey("d", "Remove ")+helpKey("Esc", "Back"))

--- a/ui/model/view_overlays.go
+++ b/ui/model/view_overlays.go
@@ -155,12 +155,49 @@ func (m Model) renderPlMgrTracks() []string {
 	}
 
 	maxVisible := 12
+	tracks := m.plManager.tracks
 	scroll := scrollStart(m.plManager.cursor, maxVisible)
+	for scroll < m.plManager.cursor {
+		rows := 0
+		pa := ""
+		if scroll > 0 {
+			pa = tracks[scroll-1].Album
+		}
+		for j := scroll; j <= m.plManager.cursor && j < len(tracks); j++ {
+			if a := tracks[j].Album; a != "" && a != pa {
+				rows++
+			}
+			pa = tracks[j].Album
+			rows++
+		}
+		if rows <= maxVisible {
+			break
+		}
+		scroll++
+	}
 
-	for i := scroll; i < len(m.plManager.tracks) && i < scroll+maxVisible; i++ {
-		name := truncate(m.plManager.tracks[i].DisplayName(), ui.PanelWidth-8)
+	rendered := 0
+	prevAlbum := ""
+	if scroll > 0 {
+		prevAlbum = tracks[scroll-1].Album
+	}
+
+	for i := scroll; i < len(tracks) && rendered < maxVisible; i++ {
+		if album := tracks[i].Album; album != "" && album != prevAlbum {
+			if rendered+1 >= maxVisible {
+				break
+			}
+			lines = append(lines, m.albumSeparator(album, tracks[i].Year))
+			rendered++
+		}
+		prevAlbum = tracks[i].Album
+		if rendered >= maxVisible {
+			break
+		}
+		name := truncate(tracks[i].DisplayName(), ui.PanelWidth-8)
 		label := fmt.Sprintf("%d. %s", i+1, name)
 		lines = append(lines, cursorLine(label, i == m.plManager.cursor))
+		rendered++
 	}
 
 	if len(m.plManager.tracks) > maxVisible {

--- a/ui/model/view_overlays.go
+++ b/ui/model/view_overlays.go
@@ -183,7 +183,7 @@ func (m Model) renderPlMgrTracks() []string {
 	}
 
 	for i := scroll; i < len(tracks) && rendered < maxVisible; i++ {
-		if album := tracks[i].Album; album != "" && album != prevAlbum {
+		if album := tracks[i].Album; album != "" && album != prevAlbum && !isStreamingPlaylistTrack(tracks[i].Path) {
 			if rendered+1 >= maxVisible {
 				break
 			}


### PR DESCRIPTION
I use playlist view constantly and it was disorienting not seeing where one album ended and another began. This adds visual grouping so multi-album playlists actually read like multi-album playlists.

## Summary

- Album separator lines between album groups in the main playlist view and playlist manager overlay
- Separator-aware scroll calculation—mirrors the existing `providerRowsFromScroll` pattern from the radio list
- Trailing-separator guard: separators only render when there's room for at least one track below
- Docs and site updated

## What changed

3 code files, 2 docs:

| File | Change |
|------|--------|
| `ui/model/scroll.go` | `playlistRowsFromScroll` helper + separator-aware `playlistScroll` |
| `ui/model/view.go` | Separator insertion in `renderPlaylist()` |
| `ui/model/view_overlays.go` | Separator insertion + separator-aware scroll in `renderPlMgrTracks()` |
| `docs/playlists.md` | Note on album grouping |
| `site/index.html` | Playlist feature card updated |

## Test plan
- [x] `make check` passes (IPC socket failures are pre-existing—path length on macOS)
- [ ] `./cliamp --playlist nolan`—separators between Batman Begins, Dark Knight Rises, Inception
- [ ] Scroll through album boundaries—no jitter, cursor stays visible
- [ ] Single-album playlist—one separator at top, none when scrolled
- [ ] Playlist manager (`p`)—separators visible in track list view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Playlists now group tracks by album and display separator headers in the playlist manager and main player.

* **Bug Fixes**
  * Scrolling and rendering adjusted so the cursor remains visible when album separators are present.
  * Album separators suppressed for streaming tracks to avoid misleading grouping.

* **Documentation**
  * Docs and website copy updated to describe album grouping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->