### PR TITLE
File-based logging with intent-based applog facade

### DIFF
--- a/applog/applog.go
+++ b/applog/applog.go
@@ -1,46 +1,187 @@
-// Package applog provides a thread-safe in-app log buffer for messages that
-// would otherwise be written to stderr (which corrupts the TUI).
+// Package applog provides logging for cliamp.
+//
+// Two sinks are layered behind one API:
+//
+//   - A file sink, written through log/slog, for diagnostic logs the user
+//     reads after the fact (~/.config/cliamp/cliamp.log).
+//   - An in-memory ring buffer drained by the TUI footer for short-lived,
+//     user-facing messages. The buffer exists because writing to stderr
+//     would corrupt the TUI.
+//
+// Callers pick by intent, not sink:
+//
+//   - Debug/Info/Warn/Error    write only to the file.
+//   - Status                   writes only to the footer (transient UI
+//     feedback that wouldn't help post-mortem debugging).
+//   - UserWarn/UserError       write to both.
+//
+// Init must be called once at startup. Calls before Init are silently
+// dropped on the file side; the footer buffer always works.
 package applog
 
 import (
+	"context"
 	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
-// Entry is a single log message with a timestamp.
+// Entry is a single footer message with a timestamp.
 type Entry struct {
 	Text string
 	At   time.Time
 }
 
+// Level is an alias for slog.Level so callers don't need a second import.
+type Level = slog.Level
+
+const (
+	LevelDebug = slog.LevelDebug
+	LevelInfo  = slog.LevelInfo
+	LevelWarn  = slog.LevelWarn
+	LevelError = slog.LevelError
+)
+
 const maxEntries = 4
 
 var (
-	mu      sync.Mutex
-	entries []Entry
+	logger atomic.Pointer[slog.Logger]
+
+	mu          sync.Mutex
+	entries     []Entry
+	currentFile io.Closer
 )
 
-// Printf writes a formatted log message to the buffer.
-func Printf(format string, args ...any) {
+func init() {
+	logger.Store(slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+// Init opens path for append, installs a slog text handler at the given
+// level, and returns a close func. Calling Init twice closes the previous
+// file before swapping handlers.
+func Init(path string, level Level) (func() error, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("create log dir: %w", err)
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("open log file: %w", err)
+	}
+
+	h := slog.NewTextHandler(f, &slog.HandlerOptions{Level: level})
+	logger.Store(slog.New(h))
+
+	mu.Lock()
+	prev := currentFile
+	currentFile = f
+	mu.Unlock()
+	if prev != nil {
+		_ = prev.Close()
+	}
+
+	return func() error {
+		mu.Lock()
+		defer mu.Unlock()
+		if currentFile == nil {
+			return nil
+		}
+		err := currentFile.Close()
+		currentFile = nil
+		logger.Store(slog.New(slog.NewTextHandler(io.Discard, nil)))
+		return err
+	}, nil
+}
+
+// ParseLevel maps a string to a Level. Empty input maps to LevelInfo.
+// "warning" is accepted as an alias for "warn".
+func ParseLevel(s string) (Level, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return LevelInfo, nil
+	}
+	if strings.EqualFold(s, "warning") {
+		return LevelWarn, nil
+	}
+	var lvl Level
+	if err := lvl.UnmarshalText([]byte(strings.ToUpper(s))); err != nil {
+		return LevelInfo, fmt.Errorf("invalid log level %q (want debug|info|warn|error)", s)
+	}
+	return lvl, nil
+}
+
+// Debug, Info, Warn, Error log only to the file. Format follows fmt.Sprintf.
+// The level guard avoids paying the Sprintf cost when the level is filtered out.
+func Debug(format string, args ...any) { logf(slog.LevelDebug, format, args...) }
+func Info(format string, args ...any)  { logf(slog.LevelInfo, format, args...) }
+func Warn(format string, args ...any)  { logf(slog.LevelWarn, format, args...) }
+func Error(format string, args ...any) { logf(slog.LevelError, format, args...) }
+
+// Status pushes a message into the footer buffer without writing to the
+// log file. Use for ephemeral, user-facing notifications that wouldn't help
+// post-mortem debugging.
+func Status(format string, args ...any) {
+	pushFooter(fmt.Sprintf(format, args...))
+}
+
+// UserWarn logs at warn level and pushes the same message into the footer.
+func UserWarn(format string, args ...any) {
+	lg := logger.Load()
+	if !lg.Enabled(context.Background(), slog.LevelWarn) {
+		pushFooter(fmt.Sprintf(format, args...))
+		return
+	}
 	msg := fmt.Sprintf(format, args...)
+	lg.Warn(msg)
+	pushFooter(msg)
+}
+
+// UserError logs at error level and pushes the same message into the footer.
+func UserError(format string, args ...any) {
+	lg := logger.Load()
+	if !lg.Enabled(context.Background(), slog.LevelError) {
+		pushFooter(fmt.Sprintf(format, args...))
+		return
+	}
+	msg := fmt.Sprintf(format, args...)
+	lg.Error(msg)
+	pushFooter(msg)
+}
+
+// Drain returns and clears all buffered footer entries.
+func Drain() []Entry {
+	mu.Lock()
+	defer mu.Unlock()
+	if len(entries) == 0 {
+		return nil
+	}
+	out := entries
+	entries = nil
+	return out
+}
+
+func logf(level slog.Level, format string, args ...any) {
+	lg := logger.Load()
+	if !lg.Enabled(context.Background(), level) {
+		return
+	}
+	lg.Log(context.Background(), level, fmt.Sprintf(format, args...))
+}
+
+func pushFooter(msg string) {
+	msg = strings.TrimRight(msg, "\n")
+	if msg == "" {
+		return
+	}
 	mu.Lock()
 	entries = append(entries, Entry{Text: msg, At: time.Now()})
 	if len(entries) > maxEntries {
 		entries = entries[len(entries)-maxEntries:]
 	}
 	mu.Unlock()
-}
-
-// Drain returns all buffered entries and clears the buffer.
-func Drain() []Entry {
-	mu.Lock()
-	if len(entries) == 0 {
-		mu.Unlock()
-		return nil
-	}
-	out := entries
-	entries = nil
-	mu.Unlock()
-	return out
 }

--- a/applog/applog.go
+++ b/applog/applog.go
@@ -130,26 +130,18 @@ func Status(format string, args ...any) {
 }
 
 // UserWarn logs at warn level and pushes the same message into the footer.
+// The Sprintf cost is paid unconditionally because the footer needs the
+// formatted string, so no Enabled gate here.
 func UserWarn(format string, args ...any) {
-	lg := logger.Load()
-	if !lg.Enabled(context.Background(), slog.LevelWarn) {
-		pushFooter(fmt.Sprintf(format, args...))
-		return
-	}
 	msg := fmt.Sprintf(format, args...)
-	lg.Warn(msg)
+	logger.Load().Warn(msg)
 	pushFooter(msg)
 }
 
 // UserError logs at error level and pushes the same message into the footer.
 func UserError(format string, args ...any) {
-	lg := logger.Load()
-	if !lg.Enabled(context.Background(), slog.LevelError) {
-		pushFooter(fmt.Sprintf(format, args...))
-		return
-	}
 	msg := fmt.Sprintf(format, args...)
-	lg.Error(msg)
+	logger.Load().Error(msg)
 	pushFooter(msg)
 }
 

--- a/applog/applog_test.go
+++ b/applog/applog_test.go
@@ -1,24 +1,33 @@
 package applog
 
 import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 )
 
-// reset clears the package-level state so tests don't leak into each other.
+// reset clears package-level state so tests don't leak into each other.
 func reset(t *testing.T) {
 	t.Helper()
 	mu.Lock()
+	defer mu.Unlock()
 	entries = nil
-	mu.Unlock()
+	if currentFile != nil {
+		_ = currentFile.Close()
+		currentFile = nil
+	}
+	logger.Store(slog.New(slog.NewTextHandler(io.Discard, nil)))
 }
 
-func TestPrintfAndDrain(t *testing.T) {
+func TestUserWarnAndDrain(t *testing.T) {
 	reset(t)
 
-	Printf("hello %s", "world")
-	Printf("n=%d", 42)
+	UserWarn("hello %s", "world")
+	UserWarn("n=%d", 42)
 
 	got := Drain()
 	if len(got) != 2 {
@@ -38,7 +47,7 @@ func TestPrintfAndDrain(t *testing.T) {
 func TestDrainClearsBuffer(t *testing.T) {
 	reset(t)
 
-	Printf("first")
+	UserWarn("first")
 	_ = Drain()
 
 	got := Drain()
@@ -56,18 +65,16 @@ func TestDrainEmpty(t *testing.T) {
 	}
 }
 
-func TestPrintfRingBufferCap(t *testing.T) {
+func TestFooterRingBufferCap(t *testing.T) {
 	reset(t)
 
-	// maxEntries = 4; write 6 entries and assert we keep the last 4.
 	for i := 0; i < 6; i++ {
-		Printf("msg-%d", i)
+		UserWarn("msg-%d", i)
 	}
 	got := Drain()
 	if len(got) != maxEntries {
 		t.Fatalf("len(entries) = %d, want %d", len(got), maxEntries)
 	}
-	// Oldest two messages (msg-0, msg-1) should be dropped.
 	for i, e := range got {
 		want := "msg-" + string(rune('2'+i))
 		if e.Text != want {
@@ -76,7 +83,7 @@ func TestPrintfRingBufferCap(t *testing.T) {
 	}
 }
 
-func TestPrintfConcurrent(t *testing.T) {
+func TestFooterConcurrent(t *testing.T) {
 	reset(t)
 
 	const goroutines = 20
@@ -84,18 +91,17 @@ func TestPrintfConcurrent(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(goroutines)
-	for g := 0; g < goroutines; g++ {
+	for range goroutines {
 		go func() {
 			defer wg.Done()
-			for i := 0; i < perGoroutine; i++ {
-				Printf("g-log")
+			for range perGoroutine {
+				UserWarn("g-log")
 			}
 		}()
 	}
 	wg.Wait()
 
 	got := Drain()
-	// Ring buffer caps at maxEntries regardless of concurrent writers.
 	if len(got) > maxEntries {
 		t.Errorf("len(entries) = %d, exceeds cap %d", len(got), maxEntries)
 	}
@@ -103,5 +109,195 @@ func TestPrintfConcurrent(t *testing.T) {
 		if !strings.HasPrefix(e.Text, "g-log") {
 			t.Errorf("unexpected entry text %q", e.Text)
 		}
+	}
+}
+
+func TestParseLevel(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    Level
+		wantErr bool
+	}{
+		{"", LevelInfo, false},
+		{"info", LevelInfo, false},
+		{"INFO", LevelInfo, false},
+		{" debug ", LevelDebug, false},
+		{"warn", LevelWarn, false},
+		{"warning", LevelWarn, false},
+		{"error", LevelError, false},
+		{"trace", LevelInfo, true},
+		{"verbose", LevelInfo, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, err := ParseLevel(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("level = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStatusFootersOnly(t *testing.T) {
+	reset(t)
+	path := filepath.Join(t.TempDir(), "cliamp.log")
+	closeFn, err := Init(path, LevelDebug)
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	defer closeFn()
+
+	Status("nothing-on-disk")
+
+	if got := Drain(); len(got) != 1 || got[0].Text != "nothing-on-disk" {
+		t.Errorf("footer = %v, want one entry 'nothing-on-disk'", got)
+	}
+	data, _ := os.ReadFile(path)
+	if strings.Contains(string(data), "nothing-on-disk") {
+		t.Errorf("Status leaked to log file: %s", data)
+	}
+}
+
+func TestDiagnosticLogsSkipFooter(t *testing.T) {
+	reset(t)
+	path := filepath.Join(t.TempDir(), "cliamp.log")
+	closeFn, err := Init(path, LevelDebug)
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	defer closeFn()
+
+	Debug("dbg-msg")
+	Info("info-msg")
+	Warn("warn-msg")
+	Error("err-msg")
+
+	if got := Drain(); got != nil {
+		t.Errorf("footer = %v, want nil (diagnostic logs must not push to footer)", got)
+	}
+	if err := closeFn(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	for _, want := range []string{"dbg-msg", "info-msg", "warn-msg", "err-msg"} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("log file missing %q\nfile contents:\n%s", want, data)
+		}
+	}
+}
+
+func TestUserLogsHitBothSinks(t *testing.T) {
+	reset(t)
+	path := filepath.Join(t.TempDir(), "cliamp.log")
+	closeFn, err := Init(path, LevelDebug)
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	UserWarn("careful: %s", "oops")
+	UserError("boom: %d", 7)
+
+	got := Drain()
+	if len(got) != 2 {
+		t.Fatalf("footer entries = %d, want 2", len(got))
+	}
+	if got[0].Text != "careful: oops" || got[1].Text != "boom: 7" {
+		t.Errorf("unexpected footer texts: %+v", got)
+	}
+	if err := closeFn(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	for _, want := range []string{"careful: oops", "boom: 7", "level=WARN", "level=ERROR"} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("log file missing %q\nfile contents:\n%s", want, data)
+		}
+	}
+}
+
+func TestLevelFilteringSuppressesBelowThreshold(t *testing.T) {
+	reset(t)
+	path := filepath.Join(t.TempDir(), "cliamp.log")
+	closeFn, err := Init(path, LevelWarn)
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	Debug("hidden-debug")
+	Info("hidden-info")
+	Warn("visible-warn")
+
+	if err := closeFn(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if strings.Contains(string(data), "hidden-debug") || strings.Contains(string(data), "hidden-info") {
+		t.Errorf("entries below threshold leaked:\n%s", data)
+	}
+	if !strings.Contains(string(data), "visible-warn") {
+		t.Errorf("warn entry missing:\n%s", data)
+	}
+}
+
+func TestInitTwiceClosesPreviousFile(t *testing.T) {
+	reset(t)
+	dir := t.TempDir()
+	first := filepath.Join(dir, "first.log")
+	second := filepath.Join(dir, "second.log")
+
+	close1, err := Init(first, LevelInfo)
+	if err != nil {
+		t.Fatalf("Init first: %v", err)
+	}
+	Info("to-first")
+
+	close2, err := Init(second, LevelInfo)
+	if err != nil {
+		t.Fatalf("Init second: %v", err)
+	}
+	Info("to-second")
+
+	// close1 should be a no-op now (the second Init closed the file already).
+	_ = close1()
+
+	if err := close2(); err != nil {
+		t.Fatalf("close2: %v", err)
+	}
+
+	firstData, _ := os.ReadFile(first)
+	if !strings.Contains(string(firstData), "to-first") {
+		t.Errorf("first log missing entry:\n%s", firstData)
+	}
+	secondData, _ := os.ReadFile(second)
+	if !strings.Contains(string(secondData), "to-second") {
+		t.Errorf("second log missing entry:\n%s", secondData)
+	}
+	if strings.Contains(string(firstData), "to-second") {
+		t.Errorf("first log received post-rotation entry:\n%s", firstData)
+	}
+}
+
+func TestInitMissingDirCreatesIt(t *testing.T) {
+	reset(t)
+	nested := filepath.Join(t.TempDir(), "a", "b", "c", "cliamp.log")
+	closeFn, err := Init(nested, LevelInfo)
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	defer closeFn()
+	if _, err := os.Stat(nested); err != nil {
+		t.Errorf("log file not created: %v", err)
 	}
 }

--- a/applog/applog_test.go
+++ b/applog/applog_test.go
@@ -148,7 +148,7 @@ func TestStatusFootersOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Init: %v", err)
 	}
-	defer closeFn()
+	t.Cleanup(func() { _ = closeFn() })
 
 	Status("nothing-on-disk")
 
@@ -168,7 +168,7 @@ func TestDiagnosticLogsSkipFooter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Init: %v", err)
 	}
-	defer closeFn()
+	t.Cleanup(func() { _ = closeFn() })
 
 	Debug("dbg-msg")
 	Info("info-msg")
@@ -296,7 +296,7 @@ func TestInitMissingDirCreatesIt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Init: %v", err)
 	}
-	defer closeFn()
+	t.Cleanup(func() { _ = closeFn() })
 	if _, err := os.Stat(nested); err != nil {
 		t.Errorf("log file not created: %v", err)
 	}

--- a/commands.go
+++ b/commands.go
@@ -11,6 +11,7 @@ import (
 
 	cli "github.com/urfave/cli/v3"
 
+	"cliamp/applog"
 	"cliamp/cmd"
 	"cliamp/config"
 	"cliamp/ipc"
@@ -40,6 +41,7 @@ func buildApp() *cli.Command {
 		&cli.IntFlag{Name: "bit-depth", Usage: "PCM bit depth: 16 or 32", HideDefault: true},
 		&cli.StringFlag{Name: "audio-device", Usage: "audio output device (use 'list' to show)"},
 		&cli.StringFlag{Name: "playlist", Usage: "load a local TOML playlist by name and start playing"},
+		&cli.StringFlag{Name: "log-level", Usage: "log level: debug, info, warn, error"},
 	}
 
 	return &cli.Command{
@@ -182,6 +184,13 @@ func overridesFromFlags(c *cli.Command) (config.Overrides, error) {
 	if c.IsSet("playlist") {
 		v := c.String("playlist")
 		ov.Playlist = &v
+	}
+	if c.IsSet("log-level") {
+		v := c.String("log-level")
+		if _, err := applog.ParseLevel(v); err != nil {
+			return ov, fmt.Errorf("--log-level: %w", err)
+		}
+		ov.LogLevel = &v
 	}
 	return ov, nil
 }

--- a/config.toml.example
+++ b/config.toml.example
@@ -44,6 +44,10 @@ eq = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 # Visualizer mode: Bars, BarsDot, Rain, BarsOutline, Bricks, Columns, ClassicPeak, Wave, Scatter, Flame, Retro, Pulse, Matrix, Binary, Sakura, Firework, Logo, Terrain, Glitch, Scope, Heartbeat, Butterfly, Lightning, or None
 # visualizer = "Bars"
 
+# Log level: "debug", "info", "warn", or "error" (default "info")
+# Logs are written to ~/.config/cliamp/cliamp.log
+# log_level = "info"
+
 # ---
 # Spotify (optional)
 # A Spotify Premium account and a registered app at

--- a/config/config.go
+++ b/config/config.go
@@ -151,6 +151,7 @@ type Config struct {
 	Plex            PlexConfig                   // optional Plex Media Server credentials
 	Jellyfin        JellyfinConfig               // optional Jellyfin server credentials
 	Plugins         map[string]map[string]string // per-plugin config from [plugins.*] sections
+	LogLevel        string                       // log level: debug, info, warn, error (default "info")
 }
 
 // defaultConfig returns a Config with sensible defaults.
@@ -170,6 +171,7 @@ func defaultConfig() Config {
 		PaddingH:        3,
 		PaddingV:        1,
 		Spotify:         SpotifyConfig{Bitrate: 320},
+		LogLevel:        "info",
 	}
 }
 
@@ -367,6 +369,8 @@ func Load() (Config, error) {
 				if v, err := strconv.Atoi(val); err == nil {
 					cfg.PaddingV = v
 				}
+			case "log_level":
+				cfg.LogLevel = strings.ToLower(strings.Trim(val, `"'`))
 			}
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -370,7 +370,11 @@ func Load() (Config, error) {
 					cfg.PaddingV = v
 				}
 			case "log_level":
-				cfg.LogLevel = strings.ToLower(strings.Trim(val, `"'`))
+				lvl := strings.ToLower(strings.Trim(val, `"'`))
+				switch lvl {
+				case "debug", "info", "warn", "warning", "error":
+					cfg.LogLevel = lvl
+				}
 			}
 		}
 	}

--- a/config/flags.go
+++ b/config/flags.go
@@ -18,6 +18,7 @@ type Overrides struct {
 	Compact         *bool
 	AudioDevice     *string
 	Playlist        *string
+	LogLevel        *string
 }
 
 // Apply merges non-nil overrides into cfg and clamps the result.
@@ -69,6 +70,9 @@ func (o Overrides) Apply(cfg *Config) {
 	}
 	if o.Playlist != nil {
 		cfg.Playlist = *o.Playlist
+	}
+	if o.LogLevel != nil {
+		cfg.LogLevel = *o.LogLevel
 	}
 	cfg.clamp()
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -30,6 +30,14 @@ cliamp --compact ~/Music                     # cap width at 80 columns
 cliamp --eq-preset "Bass Boost" ~/Music
 ```
 
+## Diagnostics
+
+```sh
+cliamp --log-level debug                     # raise log verbosity for one session
+```
+
+Logs are written to `~/.config/cliamp/cliamp.log`. Levels: `debug`, `info` (default), `warn`, `error`.
+
 ## Search
 
 Search and play a track directly from the command line (requires [yt-dlp](https://github.com/yt-dlp/yt-dlp)):
@@ -75,6 +83,7 @@ cliamp track.mp3 --repeat all --mono ~/Music
 | `--resample-quality` | int | 4 | 1–4 |
 | `--bit-depth` | int | 16 | 16, 32 |
 | `--playlist` | string | | local TOML playlist name |
+| `--log-level` | string | info | debug, info, warn, error |
 
 CLI flags override config file values for the current session only. They are not persisted.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,6 +45,10 @@ compact = false
 # UI theme name (see available themes in ~/.config/cliamp/themes/)
 theme = "Tokyo Night"
 
+# Log level: "debug", "info", "warn", or "error" (default "info")
+# Logs are written to ~/.config/cliamp/cliamp.log
+log_level = "info"
+
 ```
 
 ## Default Provider

--- a/external/spotify/provider.go
+++ b/external/spotify/provider.go
@@ -512,7 +512,7 @@ func (p *SpotifyProvider) NewStreamer(uri string) (beep.StreamSeekCloser, beep.F
 	}
 
 	// Auth error — try silent reconnect first.
-	applog.Printf("spotify: stream auth error (%v), attempting silent reconnect...\n", err)
+	applog.UserWarn("spotify: stream auth error (%v), attempting silent reconnect...", err)
 
 	reconnCtx, reconnCancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	reconnErr := p.session.Reconnect(reconnCtx)
@@ -526,9 +526,9 @@ func (p *SpotifyProvider) NewStreamer(uri string) (beep.StreamSeekCloser, beep.F
 		if !isAuthError(err) {
 			return nil, beep.Format{}, 0, fmt.Errorf("spotify: new stream after silent reconnect: %w", err)
 		}
-		applog.Printf("spotify: stream still failing after silent reconnect (%v), falling back to interactive...\n", err)
+		applog.UserWarn("spotify: stream still failing after silent reconnect (%v), falling back to interactive...", err)
 	} else {
-		applog.Printf("spotify: silent reconnect failed (%v), falling back to interactive...\n", reconnErr)
+		applog.UserWarn("spotify: silent reconnect failed (%v), falling back to interactive...", reconnErr)
 	}
 
 	interactiveCtx, interactiveCancel := context.WithTimeout(context.Background(), 2*time.Minute)
@@ -584,7 +584,7 @@ func (p *SpotifyProvider) webAPIWithBody(ctx context.Context, method, path strin
 					wait = time.Duration(secs) * time.Second
 				}
 			}
-			applog.Printf("spotify: rate limited on %s, retrying in %v (attempt %d/%d)\n", path, wait, attempt+1, maxRetries)
+			applog.UserWarn("spotify: rate limited on %s, retrying in %v (attempt %d/%d)", path, wait, attempt+1, maxRetries)
 			select {
 			case <-ctx.Done():
 				return nil, ctx.Err()

--- a/external/spotify/session.go
+++ b/external/spotify/session.go
@@ -112,7 +112,7 @@ func newSessionFromStored(ctx context.Context, clientID string, creds *storedCre
 		if silentOnly {
 			// Web API token refresh failed, but the spclient session is valid.
 			// Continue without a token source — webApiWithBody falls back to spclient token.
-			applog.Printf("spotify: silent token refresh failed, continuing with spclient token\n")
+			applog.UserWarn("spotify: silent token refresh failed, continuing with spclient token")
 			s := &Session{sess: sess, devID: devID, clientID: clientID}
 			if err := saveCreds(&storedCreds{
 				Username:     sess.Username(),
@@ -120,7 +120,7 @@ func newSessionFromStored(ctx context.Context, clientID string, creds *storedCre
 				DeviceID:     devID,
 				RefreshToken: creds.RefreshToken, // preserve for next attempt
 			}); err != nil {
-				applog.Printf("spotify: failed to save credentials: %v\n", err)
+				applog.UserError("spotify: failed to save credentials: %v", err)
 			}
 			if err := s.initPlayer(); err != nil {
 				sess.Close()
@@ -149,7 +149,7 @@ func newSessionFromStored(ctx context.Context, clientID string, creds *storedCre
 		DeviceID:     devID,
 		RefreshToken: oauthToken.RefreshToken,
 	}); err != nil {
-		applog.Printf("spotify: failed to save credentials: %v\n", err)
+		applog.UserError("spotify: failed to save credentials: %v", err)
 	}
 
 	if err := s.initPlayer(); err != nil {
@@ -239,7 +239,7 @@ func performOAuth2PKCE(ctx context.Context, clientID string) (*oauth2.Token, err
 			w.Header().Set("Content-Type", "text/html")
 			_, _ = w.Write([]byte(oauthCallbackHTML))
 		})); err != nil && !errors.Is(err, net.ErrClosed) {
-			applog.Printf("spotify: auth callback server error: %v\n", err)
+			applog.UserError("spotify: auth callback server error: %v", err)
 		}
 	}()
 
@@ -303,7 +303,7 @@ func newInteractiveSession(ctx context.Context, clientID string) (*Session, erro
 		DeviceID:     devID,
 		RefreshToken: token.RefreshToken,
 	}); err != nil {
-		applog.Printf("spotify: failed to save credentials: %v\n", err)
+		applog.UserError("spotify: failed to save credentials: %v", err)
 	}
 
 	// Create an auto-refreshing token source for Web API calls.
@@ -453,7 +453,8 @@ func (s *Session) reconnect(ctx context.Context, build func(context.Context, str
 	newSess.player = nil
 	newSess.mu.Unlock()
 
-	applog.Printf("spotify: re-authenticated successfully\n")
+	applog.Info("spotify: re-authenticated successfully")
+	applog.Status("spotify: re-authenticated successfully")
 	return nil
 }
 

--- a/external/spotify/session.go
+++ b/external/spotify/session.go
@@ -453,8 +453,9 @@ func (s *Session) reconnect(ctx context.Context, build func(context.Context, str
 	newSess.player = nil
 	newSess.mu.Unlock()
 
-	applog.Info("spotify: re-authenticated successfully")
-	applog.Status("spotify: re-authenticated successfully")
+	const reauthMsg = "spotify: re-authenticated successfully"
+	applog.Info(reauthMsg)
+	applog.Status(reauthMsg)
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
 
+	"cliamp/applog"
 	"cliamp/config"
 	"cliamp/external/jellyfin"
 	"cliamp/external/local"
@@ -17,6 +19,7 @@ import (
 	"cliamp/external/radio"
 	"cliamp/external/spotify"
 	"cliamp/external/ytmusic"
+	"cliamp/internal/appdir"
 	"cliamp/internal/appmeta"
 	"cliamp/internal/playback"
 	"cliamp/internal/resume"
@@ -40,6 +43,15 @@ func run(overrides config.Overrides, positional []string) error {
 		return fmt.Errorf("config: %w", err)
 	}
 	overrides.Apply(&cfg)
+
+	closeLog, logErr := initLogging(cfg.LogLevel)
+	defer closeLog()
+	if logErr != nil {
+		fmt.Fprintf(os.Stderr, "logging: %v (continuing without file log)\n", logErr)
+		applog.Status("logging: %v", logErr)
+	} else {
+		applog.Info("cliamp starting (version=%s level=%s)", appmeta.Version(), cfg.LogLevel)
+	}
 
 	// Build provider list: Radio is always available, Navidrome and Spotify if configured.
 	radioProv := radio.New()
@@ -338,6 +350,26 @@ func run(overrides config.Overrides, positional []string) error {
 	}
 
 	return nil
+}
+
+// initLogging always returns a non-nil close func so the caller can defer
+// it unconditionally. Errors come back as the second return value and the
+// close func is a no-op in that case.
+func initLogging(levelStr string) (func() error, error) {
+	noop := func() error { return nil }
+	level, err := applog.ParseLevel(levelStr)
+	if err != nil {
+		return noop, err
+	}
+	dir, err := appdir.Dir()
+	if err != nil {
+		return noop, fmt.Errorf("resolve config dir: %w", err)
+	}
+	closeFn, err := applog.Init(filepath.Join(dir, "cliamp.log"), level)
+	if err != nil {
+		return noop, err
+	}
+	return closeFn, nil
 }
 
 func wireMediaCtl(prog *tea.Program) (*mediactl.Service, error) {

--- a/main.go
+++ b/main.go
@@ -44,13 +44,13 @@ func run(overrides config.Overrides, positional []string) error {
 	}
 	overrides.Apply(&cfg)
 
-	closeLog, logErr := initLogging(cfg.LogLevel)
+	closeLog, appliedLevel, logErr := initLogging(cfg.LogLevel)
 	defer closeLog()
 	if logErr != nil {
 		fmt.Fprintf(os.Stderr, "logging: %v (continuing without file log)\n", logErr)
 		applog.Status("logging: %v", logErr)
 	} else {
-		applog.Info("cliamp starting (version=%s level=%s)", appmeta.Version(), cfg.LogLevel)
+		applog.Info("cliamp starting (version=%s level=%s)", appmeta.Version(), appliedLevel)
 	}
 
 	// Build provider list: Radio is always available, Navidrome and Spotify if configured.
@@ -353,23 +353,24 @@ func run(overrides config.Overrides, positional []string) error {
 }
 
 // initLogging always returns a non-nil close func so the caller can defer
-// it unconditionally. Errors come back as the second return value and the
-// close func is a no-op in that case.
-func initLogging(levelStr string) (func() error, error) {
+// it unconditionally, plus the applied level as a string for diagnostics.
+// Errors come back as the third return value; the close func is a no-op
+// and the level string is empty in that case.
+func initLogging(levelStr string) (func() error, string, error) {
 	noop := func() error { return nil }
 	level, err := applog.ParseLevel(levelStr)
 	if err != nil {
-		return noop, err
+		return noop, "", err
 	}
 	dir, err := appdir.Dir()
 	if err != nil {
-		return noop, fmt.Errorf("resolve config dir: %w", err)
+		return noop, "", fmt.Errorf("resolve config dir: %w", err)
 	}
 	closeFn, err := applog.Init(filepath.Join(dir, "cliamp.log"), level)
 	if err != nil {
-		return noop, err
+		return noop, "", err
 	}
-	return closeFn, nil
+	return closeFn, level.String(), nil
 }
 
 func wireMediaCtl(prog *tea.Program) (*mediactl.Service, error) {

--- a/site/index.html
+++ b/site/index.html
@@ -1565,6 +1565,11 @@
         <p>Override volume, shuffle, repeat, theme, EQ, sample rate per-session.</p>
       </div>
       <div class="feature">
+        <div class="feature-icon">≡</div>
+        <div class="feature-name">Diagnostic Logging</div>
+        <p>File logs at <span class="path">~/.config/cliamp/cliamp.log</span>. Set <code>log_level</code> in config or <code>--log-level</code> on the CLI: <code>debug</code>, <code>info</code>, <code>warn</code>, <code>error</code>.</p>
+      </div>
+      <div class="feature">
         <div class="feature-icon">↑</div>
         <div class="feature-name">Self-Update</div>
         <p>Run <code>--upgrade</code> to update to the latest release in-terminal.</p>


### PR DESCRIPTION
Closes #176.

Adds a slog-backed file logger at ~/.config/cliamp/cliamp.log with a configurable level (log_level config key, --log-level CLI flag) and refactors applog into an intent-based facade with three tiers:

- Debug/Info/Warn/Error: file only
- Status: footer only (transient UI feedback)
- UserWarn/UserError: both file and footer

The footer ring buffer is preserved unchanged; the file sink is layered behind an atomic.Pointer[*slog.Logger] so log calls stay lock-free.

Migrated all 11 spotify call sites: failures saving credentials and the auth-callback server error to UserError, reconnect/rate-limit warnings to UserWarn, 're-authenticated successfully' to Info+Status.

Plugin-side logging and log rotation deferred to follow-ups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File-backed diagnostic logging with configurable verbosity (debug/info/warn/error), a per-session CLI flag and persistent config option (default: info). Short-lived user messages remain in the UI footer.

* **Bug Fixes**
  * Clearer separation: diagnostics to file, status to footer, user warnings/errors to both. Safer init, level parsing/validation, and log rotation/cleanup.

* **Documentation**
  * CLI, config, and site docs updated to describe logging options and log file location.

* **Tests**
  * Expanded tests covering level parsing, footer behavior, multi-sink logging, and init/cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->