### PR TITLE
Restore scroll position on <enter> with empty filter in keymap & file browser

### DIFF
--- a/ui/model/filebrowser.go
+++ b/ui/model/filebrowser.go
@@ -268,6 +268,10 @@ func (m *Model) handleFileBrowserSearchKey(msg tea.KeyPressMsg) tea.Cmd {
 		return nil
 	case "enter":
 		m.fileBrowser.searching = false
+		if m.fileBrowser.search == "" {
+			m.fileBrowser.cursor = m.fileBrowser.savedCursor
+			m.fileBrowser.scroll = m.fileBrowser.savedScroll
+		}
 		return nil
 	case "down":
 		m.fileBrowser.searching = false

--- a/ui/model/keymap.go
+++ b/ui/model/keymap.go
@@ -245,6 +245,10 @@ func (m *Model) handleKeymapSearchKey(msg tea.KeyPressMsg) tea.Cmd {
 		return nil
 	case "enter":
 		m.keymap.searching = false
+		if m.keymap.search == "" {
+			m.keymap.cursor = m.keymap.savedCursor
+			m.keymap.scroll = m.keymap.savedScroll
+		}
 		return nil
 	case "down":
 		m.keymap.searching = false


### PR DESCRIPTION
Current behavior on <enter> with empty filter in keymap & file browser is that scroll position is reset to the top of the list. This can be annoying since no useful filtering is performed (since the filter is empty), and scroll position is lost.

This small fix treats <enter> with an empty filter the same as <escape>, exiting the filter and restoring the scroll position.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed cursor and scroll position restoration when exiting search mode with an empty search query using the Enter key
* Search navigation state now properly restores across the interface when confirming search with no query text
* Improved consistency in search mode exit behavior when pressing Enter

<!-- end of auto-generated comment: release notes by coderabbit.ai -->