### PR TITLE
Arrow-related help hint corrections

### DIFF
--- a/ui/model/filebrowser.go
+++ b/ui/model/filebrowser.go
@@ -71,7 +71,7 @@ func (m Model) fbHelpLine() string {
 	if m.fileBrowser.searching {
 		return helpKey("Enter", "Confirm ") + helpKey("Esc", "Cancel ") + helpKey("Type", "Filter")
 	}
-	help := helpKey("←↑↓→", "Navigate ") + helpKey("Enter", "Open ") + helpKey("/", "Filter ") +
+	help := helpKey("←↓↑→", "Navigate ") + helpKey("Enter", "Open ") + helpKey("/", "Filter ") +
 		helpKey("Spc", "Select ") + helpKey("a", "All ") +
 		helpKey("←", "Back ") + helpKey("~.", "Home/Cwd ")
 	if os.PathSeparator == '\\' {

--- a/ui/model/keymap.go
+++ b/ui/model/keymap.go
@@ -77,7 +77,7 @@ func (m *Model) keymapHelpLine() string {
 	if m.keymap.searching {
 		return helpKey("Enter", "Confirm ") + helpKey("Esc", "Cancel ") + helpKey("Type", "Filter")
 	}
-	return helpKey("↓↑", "Navigate ") + helpKey("PgUp/Dn", "Page ") +
+	return helpKey("↓↑", "Scroll ") + helpKey("PgUp/Dn", "Page ") +
 		helpKey("Home/End", "Jump ") + helpKey("/", "Filter ") + helpKey("Esc", "Close")
 }
 

--- a/ui/model/keymap.go
+++ b/ui/model/keymap.go
@@ -77,7 +77,7 @@ func (m *Model) keymapHelpLine() string {
 	if m.keymap.searching {
 		return helpKey("Enter", "Confirm ") + helpKey("Esc", "Cancel ") + helpKey("Type", "Filter")
 	}
-	return helpKey("↑↓", "Navigate ") + helpKey("PgUp/Dn", "Page ") +
+	return helpKey("↓↑", "Navigate ") + helpKey("PgUp/Dn", "Page ") +
 		helpKey("Home/End", "Jump ") + helpKey("/", "Filter ") + helpKey("Esc", "Close")
 }
 

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -723,7 +723,7 @@ func (m Model) renderJumpOverlay() string {
 
 func (m Model) renderHelp() string {
 	if m.focus == focusProvider {
-		help := helpKey("↓↑", "Navigate ") + helpKey("Enter", "Load ") + helpKey("/", "Search ")
+		help := helpKey("↓↑", "Scroll ") + helpKey("Enter", "Load ") + helpKey("/", "Search ")
 		if _, ok := m.provider.(provider.FavoriteToggler); ok {
 			help += helpKey("f", "Fav ")
 		}

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -723,7 +723,7 @@ func (m Model) renderJumpOverlay() string {
 
 func (m Model) renderHelp() string {
 	if m.focus == focusProvider {
-		help := helpKey("↑↓", "Navigate ") + helpKey("Enter", "Load ") + helpKey("/", "Search ")
+		help := helpKey("↓↑", "Navigate ") + helpKey("Enter", "Load ") + helpKey("/", "Search ")
 		if _, ok := m.provider.(provider.FavoriteToggler); ok {
 			help += helpKey("f", "Fav ")
 		}
@@ -747,7 +747,7 @@ func (m Model) renderHelp() string {
 	} else if m.focus == focusEQ {
 		hints = append(hints,
 			helpHint{helpKey("←→", "Band "), 100},
-			helpHint{helpKey("↑↓", "Gain "), 100},
+			helpHint{helpKey("↓↑", "Gain "), 100},
 			helpHint{helpKey("e", "Preset "), 90},
 			helpHint{helpKey("Spc", "▶❚❚ "), 80},
 			helpHint{helpKey("Tab", "Focus "), 70},
@@ -756,7 +756,7 @@ func (m Model) renderHelp() string {
 	} else {
 		// focusPlaylist (default)
 		hints = append(hints,
-			helpHint{helpKey("↑↓", "Scroll "), 100},
+			helpHint{helpKey("↓↑", "Scroll "), 100},
 			helpHint{helpKey("Enter", "Play "), 100},
 			helpHint{helpKey("Spc", "▶❚❚ "), 90},
 		)

--- a/ui/model/view_nav.go
+++ b/ui/model/view_nav.go
@@ -60,7 +60,7 @@ func (m Model) renderNavMenu() []string {
 	}
 
 	lines = append(lines, "",
-		helpKey("↓↑", "Navigate ")+helpKey("Enter", "Select ")+helpKey("Esc", "Close"))
+		helpKey("↓↑", "Scroll ")+helpKey("Enter", "Select ")+helpKey("Esc", "Close"))
 
 	return lines
 }

--- a/ui/model/view_nav.go
+++ b/ui/model/view_nav.go
@@ -60,7 +60,7 @@ func (m Model) renderNavMenu() []string {
 	}
 
 	lines = append(lines, "",
-		helpKey("↑↓", "Navigate ")+helpKey("Enter", "Select ")+helpKey("Esc", "Close"))
+		helpKey("↓↑", "Navigate ")+helpKey("Enter", "Select ")+helpKey("Esc", "Close"))
 
 	return lines
 }
@@ -86,7 +86,7 @@ func (m Model) renderNavArtistList() []string {
 
 	lines = append(lines, "", m.navCountLine("artists", len(m.navBrowser.artists)))
 	lines = append(lines, m.navSearchBar(
-		helpKey("←↑↓→", "Navigate ")+helpKey("Enter", "Open ")+helpKey("/", "Search"))...)
+		helpKey("←↓↑→", "Navigate ")+helpKey("Enter", "Open ")+helpKey("/", "Search"))...)
 
 	return lines
 }
@@ -144,7 +144,7 @@ func (m Model) renderNavAlbumList(artistAlbums bool) []string {
 		lines = append(lines, m.navCountLine("albums", len(m.navBrowser.albums)))
 	}
 
-	defaultHelp := helpKey("←↑↓→", "Navigate ") + helpKey("Enter", "Open ")
+	defaultHelp := helpKey("←↓↑→", "Navigate ") + helpKey("Enter", "Open ")
 	if !artistAlbums {
 		defaultHelp += helpKey("s", "Sort ")
 	}
@@ -215,7 +215,7 @@ func (m Model) renderNavTrackList() []string {
 
 	lines = append(lines, "", m.navCountLine("tracks", len(m.navBrowser.tracks)))
 	lines = append(lines, m.navSearchBar(
-		helpKey("←↑↓→", "Navigate ")+
+		helpKey("←↓↑→", "Navigate ")+
 			helpKey("Enter", "Play ")+
 			helpKey("q", "Queue ")+
 			helpKey("R", "Replace ")+

--- a/ui/model/view_overlays.go
+++ b/ui/model/view_overlays.go
@@ -56,7 +56,7 @@ func (m Model) renderDeviceOverlay() string {
 		lines = append(lines, "", dimStyle.Render(fmt.Sprintf("  %d/%d devices", m.devicePicker.cursor+1, len(m.devicePicker.devices))))
 	}
 
-	lines = append(lines, "", helpKey("↓↑", "Navigate ")+helpKey("Enter", "Select ")+helpKey("Esc", "Cancel"))
+	lines = append(lines, "", helpKey("↓↑", "Scroll ")+helpKey("Enter", "Select ")+helpKey("Esc", "Cancel"))
 	return m.centerOverlay(strings.Join(lines, "\n"))
 }
 
@@ -86,7 +86,7 @@ func (m Model) renderThemePicker() string {
 		lines = append(lines, "", dimStyle.Render(fmt.Sprintf("  %d/%d themes", m.themePicker.cursor+1, count)))
 	}
 
-	lines = append(lines, "", helpKey("↓↑", "Navigate ")+helpKey("Enter", "Select ")+helpKey("Esc", "Cancel"))
+	lines = append(lines, "", helpKey("↓↑", "Scroll ")+helpKey("Enter", "Select ")+helpKey("Esc", "Cancel"))
 
 	return m.centerOverlay(strings.Join(lines, "\n"))
 }
@@ -138,7 +138,7 @@ func (m Model) renderPlMgrList() []string {
 		lines = append(lines, "", dimStyle.Render(fmt.Sprintf("  %d/%d playlists", m.plManager.cursor+1, count)))
 	}
 
-	lines = append(lines, "", helpKey("↓↑", "Navigate ")+helpKey("Enter/→", "Open ")+helpKey("a", "Add track ")+helpKey("d", "Delete ")+helpKey("Esc", "Close"))
+	lines = append(lines, "", helpKey("↓↑", "Scroll ")+helpKey("Enter/→", "Open ")+helpKey("a", "Add track ")+helpKey("d", "Delete ")+helpKey("Esc", "Close"))
 
 	return lines
 }
@@ -169,7 +169,7 @@ func (m Model) renderPlMgrTracks() []string {
 		lines = append(lines, "", dimStyle.Render(fmt.Sprintf("  %d/%d tracks", m.plManager.cursor+1, len(m.plManager.tracks))))
 	}
 
-	lines = append(lines, "", helpKey("↓↑", "Navigate ")+helpKey("Enter", "Play all ")+helpKey("a", "Add track ")+helpKey("d", "Remove ")+helpKey("Esc", "Back"))
+	lines = append(lines, "", helpKey("↓↑", "Scroll ")+helpKey("Enter", "Play all ")+helpKey("a", "Add track ")+helpKey("d", "Remove ")+helpKey("Esc", "Back"))
 
 	return lines
 }
@@ -211,7 +211,7 @@ func (m Model) renderQueueOverlay() string {
 
 	lines = padLines(lines, maxVisible, rendered)
 	lines = append(lines, "", dimStyle.Render(fmt.Sprintf("  %d queued", len(tracks))))
-	lines = append(lines, "", helpKey("↓↑", "Navigate ")+helpKey("Shift+↓↑", "Reorder ")+helpKey("d", "Remove ")+helpKey("c", "Clear ")+helpKey("Esc", "Close"))
+	lines = append(lines, "", helpKey("↓↑", "Scroll ")+helpKey("Shift+↓↑", "Reorder ")+helpKey("d", "Remove ")+helpKey("c", "Clear ")+helpKey("Esc", "Close"))
 
 	return m.centerOverlay(strings.Join(lines, "\n"))
 }
@@ -303,7 +303,7 @@ func (m Model) renderSearchOverlay() string {
 
 	lines = padLines(lines, maxVisible, rendered)
 	lines = append(lines, "", dimStyle.Render(fmt.Sprintf("  %d found", len(m.search.results))))
-	lines = append(lines, "", helpKey("↓↑", "Navigate ")+helpKey("Enter", "Play ")+helpKey("Tab", "Queue ")+helpKey("Ctrl+K", "Keymap ")+helpKey("Esc", "Close"))
+	lines = append(lines, "", helpKey("↓↑", "Scroll ")+helpKey("Enter", "Play ")+helpKey("Tab", "Queue ")+helpKey("Ctrl+K", "Keymap ")+helpKey("Esc", "Close"))
 
 	return m.centerOverlay(strings.Join(lines, "\n"))
 }
@@ -473,7 +473,7 @@ func (m Model) renderSpotSearchResults() []string {
 
 	lines = padLines(lines, maxVisible, rendered)
 	lines = append(lines, "", dimStyle.Render(fmt.Sprintf("  %d results", len(m.spotSearch.results))))
-	lines = append(lines, "", helpKey("↓↑", "Navigate ")+helpKey("Enter", "Add to playlist ")+helpKey("Esc", "Back"))
+	lines = append(lines, "", helpKey("↓↑", "Scroll ")+helpKey("Enter", "Add to playlist ")+helpKey("Esc", "Back"))
 	return lines
 }
 
@@ -511,7 +511,7 @@ func (m Model) renderSpotSearchPlaylist() []string {
 		lines = append(lines, "", dimStyle.Render(fmt.Sprintf("  %d/%d playlists", m.spotSearch.cursor+1, count)))
 	}
 
-	lines = append(lines, "", helpKey("↓↑", "Navigate ")+helpKey("Enter", "Add ")+helpKey("Esc", "Back"))
+	lines = append(lines, "", helpKey("↓↑", "Scroll ")+helpKey("Enter", "Add ")+helpKey("Esc", "Back"))
 	return lines
 }
 

--- a/ui/model/view_overlays.go
+++ b/ui/model/view_overlays.go
@@ -56,7 +56,7 @@ func (m Model) renderDeviceOverlay() string {
 		lines = append(lines, "", dimStyle.Render(fmt.Sprintf("  %d/%d devices", m.devicePicker.cursor+1, len(m.devicePicker.devices))))
 	}
 
-	lines = append(lines, "", helpKey("↑↓", "Navigate ")+helpKey("Enter", "Select ")+helpKey("Esc", "Cancel"))
+	lines = append(lines, "", helpKey("↓↑", "Navigate ")+helpKey("Enter", "Select ")+helpKey("Esc", "Cancel"))
 	return m.centerOverlay(strings.Join(lines, "\n"))
 }
 
@@ -86,7 +86,7 @@ func (m Model) renderThemePicker() string {
 		lines = append(lines, "", dimStyle.Render(fmt.Sprintf("  %d/%d themes", m.themePicker.cursor+1, count)))
 	}
 
-	lines = append(lines, "", helpKey("↑↓", "Navigate ")+helpKey("Enter", "Select ")+helpKey("Esc", "Cancel"))
+	lines = append(lines, "", helpKey("↓↑", "Navigate ")+helpKey("Enter", "Select ")+helpKey("Esc", "Cancel"))
 
 	return m.centerOverlay(strings.Join(lines, "\n"))
 }
@@ -138,7 +138,7 @@ func (m Model) renderPlMgrList() []string {
 		lines = append(lines, "", dimStyle.Render(fmt.Sprintf("  %d/%d playlists", m.plManager.cursor+1, count)))
 	}
 
-	lines = append(lines, "", helpKey("↑↓", "Navigate ")+helpKey("Enter/→", "Open ")+helpKey("a", "Add track ")+helpKey("d", "Delete ")+helpKey("Esc", "Close"))
+	lines = append(lines, "", helpKey("↓↑", "Navigate ")+helpKey("Enter/→", "Open ")+helpKey("a", "Add track ")+helpKey("d", "Delete ")+helpKey("Esc", "Close"))
 
 	return lines
 }
@@ -169,7 +169,7 @@ func (m Model) renderPlMgrTracks() []string {
 		lines = append(lines, "", dimStyle.Render(fmt.Sprintf("  %d/%d tracks", m.plManager.cursor+1, len(m.plManager.tracks))))
 	}
 
-	lines = append(lines, "", helpKey("↑↓", "Navigate ")+helpKey("Enter", "Play all ")+helpKey("a", "Add track ")+helpKey("d", "Remove ")+helpKey("Esc", "Back"))
+	lines = append(lines, "", helpKey("↓↑", "Navigate ")+helpKey("Enter", "Play all ")+helpKey("a", "Add track ")+helpKey("d", "Remove ")+helpKey("Esc", "Back"))
 
 	return lines
 }
@@ -211,7 +211,7 @@ func (m Model) renderQueueOverlay() string {
 
 	lines = padLines(lines, maxVisible, rendered)
 	lines = append(lines, "", dimStyle.Render(fmt.Sprintf("  %d queued", len(tracks))))
-	lines = append(lines, "", helpKey("↑↓", "Navigate ")+helpKey("Shift+↑↓", "Reorder ")+helpKey("d", "Remove ")+helpKey("c", "Clear ")+helpKey("Esc", "Close"))
+	lines = append(lines, "", helpKey("↓↑", "Navigate ")+helpKey("Shift+↓↑", "Reorder ")+helpKey("d", "Remove ")+helpKey("c", "Clear ")+helpKey("Esc", "Close"))
 
 	return m.centerOverlay(strings.Join(lines, "\n"))
 }
@@ -303,7 +303,7 @@ func (m Model) renderSearchOverlay() string {
 
 	lines = padLines(lines, maxVisible, rendered)
 	lines = append(lines, "", dimStyle.Render(fmt.Sprintf("  %d found", len(m.search.results))))
-	lines = append(lines, "", helpKey("↑↓", "Navigate ")+helpKey("Enter", "Play ")+helpKey("Tab", "Queue ")+helpKey("Ctrl+K", "Keymap ")+helpKey("Esc", "Close"))
+	lines = append(lines, "", helpKey("↓↑", "Navigate ")+helpKey("Enter", "Play ")+helpKey("Tab", "Queue ")+helpKey("Ctrl+K", "Keymap ")+helpKey("Esc", "Close"))
 
 	return m.centerOverlay(strings.Join(lines, "\n"))
 }
@@ -408,7 +408,7 @@ func (m Model) renderLyricsOverlay() string {
 	if m.lyricsSyncable() && m.lyricsHaveTimestamps() {
 		lines = append(lines, "", helpKey("y/Esc", "Close"))
 	} else {
-		lines = append(lines, "", helpKey("↑↓/jk", "Scroll")+" "+helpKey("y/Esc", "Close"))
+		lines = append(lines, "", helpKey("↓↑/jk", "Scroll")+" "+helpKey("y/Esc", "Close"))
 	}
 	return m.centerOverlay(strings.Join(lines, "\n"))
 }
@@ -473,7 +473,7 @@ func (m Model) renderSpotSearchResults() []string {
 
 	lines = padLines(lines, maxVisible, rendered)
 	lines = append(lines, "", dimStyle.Render(fmt.Sprintf("  %d results", len(m.spotSearch.results))))
-	lines = append(lines, "", helpKey("↑↓", "Navigate ")+helpKey("Enter", "Add to playlist ")+helpKey("Esc", "Back"))
+	lines = append(lines, "", helpKey("↓↑", "Navigate ")+helpKey("Enter", "Add to playlist ")+helpKey("Esc", "Back"))
 	return lines
 }
 
@@ -511,7 +511,7 @@ func (m Model) renderSpotSearchPlaylist() []string {
 		lines = append(lines, "", dimStyle.Render(fmt.Sprintf("  %d/%d playlists", m.spotSearch.cursor+1, count)))
 	}
 
-	lines = append(lines, "", helpKey("↑↓", "Navigate ")+helpKey("Enter", "Add ")+helpKey("Esc", "Back"))
+	lines = append(lines, "", helpKey("↓↑", "Navigate ")+helpKey("Enter", "Add ")+helpKey("Esc", "Back"))
 	return lines
 }
 

--- a/ui/model/view_overlays.go
+++ b/ui/model/view_overlays.go
@@ -262,7 +262,7 @@ func (m Model) renderInfoOverlay() string {
 	}
 	field("Path", track.Path)
 
-	lines = append(lines, "", helpKey("Esc/i", "Close"))
+	lines = append(lines, "", helpKey("Esc", "Close"))
 
 	return m.centerOverlay(strings.Join(lines, "\n"))
 }
@@ -426,9 +426,9 @@ func (m Model) renderLyricsOverlay() string {
 	}
 
 	if m.lyricsSyncable() && m.lyricsHaveTimestamps() {
-		lines = append(lines, "", helpKey("y/Esc", "Close"))
+		lines = append(lines, "", helpKey("Esc", "Close"))
 	} else {
-		lines = append(lines, "", helpKey("↓↑/jk", "Scroll")+" "+helpKey("y/Esc", "Close"))
+		lines = append(lines, "", helpKey("↓↑", "Scroll")+" "+helpKey("Esc", "Close"))
 	}
 	return m.centerOverlay(strings.Join(lines, "\n"))
 }


### PR DESCRIPTION
This PR corrects arrow-related help hints two ways:
1. The order of the arrows are corrected to match Vi-style navigation: ↓↑ instead of ↑↓ and ←↓↑→ instead of ←↑↓→
2. "Navigate" and "Scroll" are used consistently where "Navigate" is used in views that have four directions of movement, and "Scroll" is used in views that have two directions of movement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated on-screen keyboard help across navigation menus, search bars, overlays and footers: swapped directional arrow order and relabeled some hints (e.g., “Navigate” → “Scroll”).
  * Simplified certain close hints (removed redundant keys) and adjusted reorder/scroll modifier displays for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->