### PR TITLE
bind with omarchy-launch-or-focus-tui replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ sudo apt install pipewire-alsa
 Add this keybind to launch cliamp with `Super+Shift+M`:
 
 ```
-bindd = SUPER SHIFT, M, Music, exec, omarchy-launch-tui cliamp
+bindd = SUPER SHIFT, M, Music, exec, omarchy-launch-or-forcus-tui cliamp
 ```
 
 ## Author


### PR DESCRIPTION
Use modern dhh's omarchy-launch-or-focus-tui script for key binding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the keybinding configuration example in the README to reflect the current executable reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->