### PR TITLE
fix(spotify): cap track page size at 50 to match API limit

### DIFF
--- a/external/spotify/provider.go
+++ b/external/spotify/provider.go
@@ -41,7 +41,10 @@ const maxResponseBody = 10 << 20
 // Pagination limits for the Spotify Web API.
 const (
 	spotifyPlaylistPageSize = 50
-	spotifyTrackPageSize    = 100
+	// spotifyTrackPageSize is capped at 50 because /v1/playlists/{id}/items
+	// silently truncates larger limits; requesting more would cause the loop
+	// to skip items when offset advances by the requested limit.
+	spotifyTrackPageSize = 50
 )
 
 // spotifyPlaylistItem is the raw playlist object returned by /v1/me/playlists.

--- a/external/spotify/provider.go
+++ b/external/spotify/provider.go
@@ -379,7 +379,7 @@ func (p *SpotifyProvider) Tracks(playlistID string) ([]playlist.Track, error) {
 
 		if playlistID == "YOUR MUSIC" {
 			query := url.Values{
-				"limit":  {fmt.Sprintf("%d", min(50, limit))},
+				"limit":  {fmt.Sprintf("%d", limit)},
 				"offset": {fmt.Sprintf("%d", offset)},
 			}
 			resp, err = p.webAPI(ctx, "GET", "/v1/me/tracks", query)

--- a/external/spotify/provider_test.go
+++ b/external/spotify/provider_test.go
@@ -2,11 +2,9 @@ package spotify
 
 import "testing"
 
-// TestSpotifyTrackPageSizeRespectsAPILimit guards against re-introducing the
-// [1/904]-instead-of-[1/1804] bug. The /v1/playlists/{id}/items endpoint
-// silently caps `limit` at 50; if this constant exceeds that, the Tracks()
-// loop advances offset by the requested limit while the server returned only
-// 50, causing every other 50-item window to be skipped.
+// Asserts spotifyTrackPageSize stays within the Spotify Web API's silent
+// 50-item cap; see the constant's comment in provider.go for why exceeding
+// it silently drops tracks.
 func TestSpotifyTrackPageSizeRespectsAPILimit(t *testing.T) {
 	const spotifyAPIPlaylistItemsMaxLimit = 50
 	if spotifyTrackPageSize > spotifyAPIPlaylistItemsMaxLimit {

--- a/external/spotify/provider_test.go
+++ b/external/spotify/provider_test.go
@@ -2,9 +2,9 @@ package spotify
 
 import "testing"
 
-// Asserts spotifyTrackPageSize stays within the Spotify Web API's silent
-// 50-item cap; see the constant's comment in provider.go for why exceeding
-// it silently drops tracks.
+// TestSpotifyTrackPageSizeRespectsAPILimit asserts spotifyTrackPageSize stays
+// within the Spotify Web API's silent 50-item cap; see the constant's comment
+// in provider.go for why exceeding it silently drops tracks.
 func TestSpotifyTrackPageSizeRespectsAPILimit(t *testing.T) {
 	const spotifyAPIPlaylistItemsMaxLimit = 50
 	if spotifyTrackPageSize > spotifyAPIPlaylistItemsMaxLimit {
@@ -13,6 +13,8 @@ func TestSpotifyTrackPageSizeRespectsAPILimit(t *testing.T) {
 	}
 }
 
+// TestPlaylistAccessible verifies the visibility filter that hides playlists
+// the current Spotify user can't list tracks for (would otherwise return 403).
 func TestPlaylistAccessible(t *testing.T) {
 	const me = "user123"
 

--- a/external/spotify/provider_test.go
+++ b/external/spotify/provider_test.go
@@ -2,6 +2,19 @@ package spotify
 
 import "testing"
 
+// TestSpotifyTrackPageSizeRespectsAPILimit guards against re-introducing the
+// [1/904]-instead-of-[1/1804] bug. The /v1/playlists/{id}/items endpoint
+// silently caps `limit` at 50; if this constant exceeds that, the Tracks()
+// loop advances offset by the requested limit while the server returned only
+// 50, causing every other 50-item window to be skipped.
+func TestSpotifyTrackPageSizeRespectsAPILimit(t *testing.T) {
+	const spotifyAPIPlaylistItemsMaxLimit = 50
+	if spotifyTrackPageSize > spotifyAPIPlaylistItemsMaxLimit {
+		t.Fatalf("spotifyTrackPageSize = %d, want <= %d (Spotify Web API cap)",
+			spotifyTrackPageSize, spotifyAPIPlaylistItemsMaxLimit)
+	}
+}
+
 func TestPlaylistAccessible(t *testing.T) {
 	const me = "user123"
 

--- a/external/spotify/provider_test.go
+++ b/external/spotify/provider_test.go
@@ -6,10 +6,19 @@ import "testing"
 // within the Spotify Web API's silent 50-item cap; see the constant's comment
 // in provider.go for why exceeding it silently drops tracks.
 func TestSpotifyTrackPageSizeRespectsAPILimit(t *testing.T) {
-	const spotifyAPIPlaylistItemsMaxLimit = 50
-	if spotifyTrackPageSize > spotifyAPIPlaylistItemsMaxLimit {
-		t.Fatalf("spotifyTrackPageSize = %d, want <= %d (Spotify Web API cap)",
-			spotifyTrackPageSize, spotifyAPIPlaylistItemsMaxLimit)
+	tests := []struct {
+		name string
+		got  int
+		max  int
+	}{
+		{"spotifyTrackPageSize within /v1/playlists/{id}/items cap", spotifyTrackPageSize, 50},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got > tt.max {
+				t.Fatalf("page size = %d, want <= %d (Spotify Web API cap)", tt.got, tt.max)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Spotify Web API `/v1/playlists/{id}/items` silently caps the `limit`
query parameter at 50. The pagination loop in `Tracks()` was using
`spotifyTrackPageSize = 100` and advancing `offset += limit`, so the
server returned only the first 50 items of each requested 100-item
window — every other 50-item block was skipped.

For an 1804-track playlist this fetched `18 * 50 + 4 = 904` tracks
instead of the full 1804, presenting as `[1/904]` in the TUI.

## What changed

- `external/spotify/provider.go`: `spotifyTrackPageSize` 100 → 50,
  with a comment documenting the API cap and the offset-skip
  failure mode.
- `external/spotify/provider.go`: dropped the now-redundant
  `min(50, limit)` clamp on the `/v1/me/tracks` branch (the
  constant fix makes it dead code).
- `external/spotify/provider_test.go`: regression test
  `TestSpotifyTrackPageSizeRespectsAPILimit` to lock the constant
  within the API cap.

## Verification

- `make check` passes locally for the Spotify package (21 tests).
- Manually loaded a 1804-track playlist; title bar now shows
  `[N/1804]` instead of `[N/904]`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Spotify track pagination reduced to the service's 50-item page cap, preventing truncated results and offset issues when fetching tracks (including "Your Music").

* **Tests**
  * Added a test to ensure track pagination continues to honor the API's 50-item limit and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->