### PR TITLE
Sticky album headers with auto-toggle heuristic and manual toggle keybind

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -43,6 +43,7 @@ Press `Ctrl+K` in the player to see all keybindings.
 | `t` | Choose theme |
 | `v` | Cycle visualizer |
 | `V` | Full screen visualizer |
+| `Ctrl+H` | Toggle album headers |
 
 ## Features
 

--- a/site/index.html
+++ b/site/index.html
@@ -1979,6 +1979,7 @@
           <div class="key-row"><kbd>e / t / v</kbd><span>EQ preset / Theme / Visualizer</span></div>
           <div class="key-row"><kbd>V</kbd><span>Full-screen visualizer</span></div>
           <div class="key-row"><kbd>y / i</kbd><span>Lyrics / Track info</span></div>
+          <div class="key-row"><kbd>Ctrl+H</kbd><span>Toggle album headers</span></div>
           <div class="key-row"><kbd>Ctrl+S</kbd><span>Save to ~/Music</span></div>
           <div class="key-row"><kbd>Ctrl+K</kbd><span>Show keymap</span></div>
           <div class="key-row"><kbd>q</kbd><span>Quit</span></div>

--- a/ui/model/init.go
+++ b/ui/model/init.go
@@ -25,19 +25,20 @@ func applyThemeAll(t theme.Theme) {
 // localProv is an optional direct reference to the local provider for write ops.
 func New(p player.Engine, pl *playlist.Playlist, providers []ProviderEntry, defaultProvider string, localProv playlist.Provider, themes []theme.Theme, luaMgr *luaplugin.Manager, cs ConfigSaver) Model {
 	m := Model{
-		player:        p,
-		playlist:      pl,
-		configSaver:   cs,
-		vis:           ui.NewVisualizer(float64(p.SampleRate())),
-		seekStepLarge: 30 * time.Second,
-		plVisible:     5,
-		eqPresetIdx:   -1, // custom until a preset is selected
-		themes:        themes,
-		themeIdx:      -1, // Default (ANSI)
-		localProvider: localProv,
-		providers:     providers,
-		navBrowser:    navBrowserState{},
-		luaMgr:        luaMgr,
+		player:           p,
+		playlist:         pl,
+		configSaver:      cs,
+		vis:              ui.NewVisualizer(float64(p.SampleRate())),
+		seekStepLarge:    30 * time.Second,
+		plVisible:        5,
+		eqPresetIdx:      -1, // custom until a preset is selected
+		themes:           themes,
+		themeIdx:         -1, // Default (ANSI)
+		localProvider:    localProv,
+		providers:        providers,
+		navBrowser:       navBrowserState{},
+		luaMgr:           luaMgr,
+		showAlbumHeaders: true,
 	}
 	m.termTitle = initialTerminalTitleState()
 	// Select the default provider pill.

--- a/ui/model/init.go
+++ b/ui/model/init.go
@@ -140,6 +140,7 @@ func (m *Model) SetResume(path string, secs int) {
 // ResumePlaylist loads a playlist into the model for session resume.
 func (m *Model) ResumePlaylist(name string, tracks []playlist.Track) {
 	m.playlist.Replace(tracks)
+	m.setInitialHeaderState(tracks)
 	m.loadedPlaylist = name
 }
 

--- a/ui/model/keymap.go
+++ b/ui/model/keymap.go
@@ -54,7 +54,7 @@ var keymapEntries = []keymapEntry{
 	{key: "J", action: "Open Jellyfin provider"},
 	{key: "Ctrl+J", action: "Jump to time"},
 	{key: "p", action: "Playlist manager"},
-	{key: "H", action: "Toggle album headers"},
+	{key: "Ctrl+H", action: "Toggle album headers"},
 	{key: "i", action: "Track info / metadata"},
 	{key: "Ctrl+S", action: "Save/download track to ~/Music"},
 	{key: "Ctrl+X", action: "Expand/collapse view"},
@@ -99,7 +99,7 @@ var coreReservedKeys = []string{
 	"enter", "tab", "h", "l",
 
 	// Features.
-	"r", "z", "m", "e", "a", "A", "H",
+	"r", "z", "m", "e", "a", "A", "ctrl+h",
 	"ctrl+s", "S", "/", "ctrl+f",
 	"ctrl+j", "J", "p", "t", "i", "y", "o", "u",
 	"N", "L", "R", "P", "Y",

--- a/ui/model/keymap.go
+++ b/ui/model/keymap.go
@@ -54,6 +54,7 @@ var keymapEntries = []keymapEntry{
 	{key: "J", action: "Open Jellyfin provider"},
 	{key: "Ctrl+J", action: "Jump to time"},
 	{key: "p", action: "Playlist manager"},
+	{key: "H", action: "Toggle album headers"},
 	{key: "i", action: "Track info / metadata"},
 	{key: "Ctrl+S", action: "Save/download track to ~/Music"},
 	{key: "Ctrl+X", action: "Expand/collapse view"},
@@ -98,7 +99,7 @@ var coreReservedKeys = []string{
 	"enter", "tab", "h", "l",
 
 	// Features.
-	"r", "z", "m", "e", "a", "A",
+	"r", "z", "m", "e", "a", "A", "H",
 	"ctrl+s", "S", "/", "ctrl+f",
 	"ctrl+j", "J", "p", "t", "i", "y", "o", "u",
 	"N", "L", "R", "P", "Y",

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -1443,6 +1443,9 @@ func (m *Model) handlePlMgrTracksKey(msg tea.KeyPressMsg) tea.Cmd {
 
 	count := m.plMgrTracksViewCount()
 	switch msg.String() {
+	case "ctrl+h":
+		m.showAlbumHeaders = !m.showAlbumHeaders
+		return nil
 	case "ctrl+c":
 		m.plManager.visible = false
 		return m.quit()

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -716,6 +716,10 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 	case "Y":
 		return m.switchToProvider("yt")
 
+	case "H":
+		m.showAlbumHeaders = !m.showAlbumHeaders
+		m.adjustScroll()
+
 	case "v":
 		m.vis.CycleMode()
 		m.applyHeightMode()

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -1550,6 +1550,7 @@ func (m *Model) plMgrLoadAndPlay(startIdx int) tea.Cmd {
 	m.player.ClearPreload()
 	m.resetYTDLBatch()
 	m.playlist.Replace(m.plManager.tracks)
+	m.setInitialHeaderState(m.plManager.tracks)
 	m.loadedPlaylist = m.plManager.selPlaylist
 	if startIdx < 0 || startIdx >= m.playlist.Len() {
 		startIdx = 0

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -716,7 +716,7 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 	case "Y":
 		return m.switchToProvider("yt")
 
-	case "H":
+	case "ctrl+h":
 		m.showAlbumHeaders = !m.showAlbumHeaders
 		m.adjustScroll()
 

--- a/ui/model/keys_nav.go
+++ b/ui/model/keys_nav.go
@@ -314,6 +314,10 @@ func (m *Model) handleNavTrackListKey(msg tea.KeyPressMsg) tea.Cmd {
 	}
 
 	switch msg.String() {
+	case "ctrl+h":
+		m.showAlbumHeaders = !m.showAlbumHeaders
+		m.navMaybeAdjustScroll()
+		return nil
 	case "ctrl+c":
 		m.navBrowser.visible = false
 		return m.quit()

--- a/ui/model/keys_nav.go
+++ b/ui/model/keys_nav.go
@@ -362,6 +362,7 @@ func (m *Model) handleNavTrackListKey(msg tea.KeyPressMsg) tea.Cmd {
 			}
 
 			m.playlist.Add(toAdd...)
+			m.setInitialHeaderState(m.playlist.Tracks())
 			newIdx := m.playlist.Len() - len(toAdd)
 			m.playlist.SetIndex(newIdx)
 			m.plCursor = newIdx
@@ -390,6 +391,7 @@ func (m *Model) handleNavTrackListKey(msg tea.KeyPressMsg) tea.Cmd {
 			m.player.ClearPreload()
 			m.resetYTDLBatch()
 			m.playlist.Replace(tracks)
+			m.setInitialHeaderState(tracks)
 			m.plCursor = 0
 			m.plScroll = 0
 			m.playlist.SetIndex(0)
@@ -412,6 +414,7 @@ func (m *Model) handleNavTrackListKey(msg tea.KeyPressMsg) tea.Cmd {
 		if len(tracks) > 0 {
 			wasEmpty := m.playlist.Len() == 0
 			m.playlist.Add(tracks...)
+			m.setInitialHeaderState(m.playlist.Tracks())
 			m.status.Showf(statusTTLMedium, "Added %d tracks", len(tracks))
 			if wasEmpty || !m.player.IsPlaying() {
 				m.playlist.SetIndex(0)
@@ -432,6 +435,7 @@ func (m *Model) handleNavTrackListKey(msg tea.KeyPressMsg) tea.Cmd {
 		if rawIdx < len(m.navBrowser.tracks) {
 			t := m.navBrowser.tracks[rawIdx]
 			m.playlist.Add(t)
+			m.setInitialHeaderState(m.playlist.Tracks())
 			newIdx := m.playlist.Len() - 1
 			m.playlist.Queue(newIdx)
 			m.status.Showf(statusTTLMedium, "Queued: %s", t.DisplayName())

--- a/ui/model/model.go
+++ b/ui/model/model.go
@@ -245,6 +245,8 @@ type Model struct {
 	// Track info overlay (metadata details)
 	showInfo bool
 
+	showAlbumHeaders bool
+
 	// Audio device picker overlay
 	devicePicker devicePickerState
 

--- a/ui/model/overlays.go
+++ b/ui/model/overlays.go
@@ -63,6 +63,7 @@ func (m *Model) plMgrEnterTrackList(name string) {
 	}
 	m.plManager.selPlaylist = name
 	m.plManager.tracks = tracks
+	m.setInitialHeaderState(tracks)
 	m.plManager.screen = plMgrScreenTracks
 	m.plManager.cursor = 0
 	m.plManager.confirmDel = false

--- a/ui/model/playback.go
+++ b/ui/model/playback.go
@@ -85,6 +85,7 @@ func (m *Model) playTrackImmediate(track playlist.Track) tea.Cmd {
 	m.player.Stop()
 	m.player.ClearPreload()
 	m.playlist.Add(track)
+	m.setInitialHeaderState(m.playlist.Tracks())
 	idx := m.playlist.Len() - 1
 	m.playlist.SetIndex(idx)
 	m.plCursor = idx
@@ -99,6 +100,7 @@ func (m *Model) playTrackImmediate(track playlist.Track) tea.Cmd {
 func (m *Model) appendTrack(track playlist.Track) tea.Cmd {
 	wasEmpty := m.playlist.Len() == 0
 	m.playlist.Add(track)
+	m.setInitialHeaderState(m.playlist.Tracks())
 	idx := m.playlist.Len() - 1
 	m.status.Showf(statusTTLMedium, "Added: %s", track.DisplayName())
 	if wasEmpty || !m.player.IsPlaying() {
@@ -128,6 +130,7 @@ func (m *Model) closeSpotSearch() {
 // queueTrackNext adds a track to the playlist and queues it to play next.
 func (m *Model) queueTrackNext(track playlist.Track) tea.Cmd {
 	m.playlist.Add(track)
+	m.setInitialHeaderState(m.playlist.Tracks())
 	idx := m.playlist.Len() - 1
 	m.playlist.Queue(idx)
 	m.status.Showf(statusTTLMedium, "Queued: %s", track.DisplayName())

--- a/ui/model/scroll.go
+++ b/ui/model/scroll.go
@@ -66,7 +66,7 @@ func (m Model) playlistScroll(visible int) int {
 	if m.plCursor < scroll {
 		return m.plCursor
 	}
-	for scroll < m.plCursor && albumSeparatorRows(tracks, scroll, m.plCursor, m.showAlbumHeaders) > visible {
+	for scroll < m.plCursor && m.albumSeparatorRows(tracks, scroll, m.plCursor, m.showAlbumHeaders) > visible {
 		scroll++
 	}
 	return scroll

--- a/ui/model/scroll.go
+++ b/ui/model/scroll.go
@@ -66,7 +66,7 @@ func (m Model) playlistScroll(visible int) int {
 	if m.plCursor < scroll {
 		return m.plCursor
 	}
-	for scroll < m.plCursor && albumSeparatorRows(tracks, scroll, m.plCursor) > visible {
+	for scroll < m.plCursor && albumSeparatorRows(tracks, scroll, m.plCursor, m.showAlbumHeaders) > visible {
 		scroll++
 	}
 	return scroll

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -292,6 +292,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.resetYTDLBatch()
 		m.playlist.Replace(msg)
+		m.setInitialHeaderState(msg)
 		m.plCursor = 0
 		m.plScroll = 0
 		m.focus = focusPlaylist
@@ -334,6 +335,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case navTracksLoadedMsg:
 		m.navBrowser.tracks = []playlist.Track(msg)
+		m.setInitialHeaderState(m.navBrowser.tracks)
 		m.navBrowser.loading = false
 		m.navBrowser.cursor = 0
 		m.navBrowser.scroll = 0
@@ -392,6 +394,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.playlist.Add(msg.tracks...)
+		m.setInitialHeaderState(m.playlist.Tracks())
 		m.ytdlBatch.offset += len(msg.tracks)
 		if len(msg.tracks) < ytdlBatchSize {
 			m.ytdlBatch.done = true
@@ -408,6 +411,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.playlist.Replace(msg.tracks)
+		m.setInitialHeaderState(msg.tracks)
 		m.plCursor = 0
 		m.plScroll = 0
 		m.status.Showf(statusTTLDefault, "Loaded %d episode(s)", len(msg.tracks))
@@ -419,6 +423,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.feedLoading = false
 		if len(msg.tracks) > 0 {
 			m.playlist.Add(msg.tracks...)
+			m.setInitialHeaderState(m.playlist.Tracks())
 			m.status.Showf(statusTTLDefault, "Loaded %d track(s)", len(msg.tracks))
 		} else {
 			m.status.Show("No tracks found at URL.", statusTTLDefault)
@@ -475,10 +480,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.player.ClearPreload()
 			m.resetYTDLBatch()
 			m.playlist.Replace(msg.tracks)
+			m.setInitialHeaderState(msg.tracks)
 			m.plCursor = 0
 			m.plScroll = 0
 		} else {
 			m.playlist.Add(msg.tracks...)
+			m.setInitialHeaderState(m.playlist.Tracks())
 		}
 		m.focus = focusPlaylist
 		m.status.Showf(statusTTLDefault, "Added %d track(s)", len(msg.tracks))
@@ -725,6 +732,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.playlist.Replace(tracks)
+		m.setInitialHeaderState(tracks)
 		m.loadedPlaylist = msg.Playlist
 		cmd := m.playCurrentTrack()
 		m.notifyAll()
@@ -735,6 +743,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ipc.QueueMsg:
 		t := playlist.Track{Path: msg.Path, Title: msg.Path}
 		m.playlist.Add(t)
+		m.setInitialHeaderState(m.playlist.Tracks())
 		m.notifyAll()
 		return m, nil
 	case ipc.ThemeMsg:

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -707,7 +707,12 @@ func (m Model) renderPlaylist() string {
 	numWidth := len(fmt.Sprintf("%d", len(tracks)))
 	prevAlbum := ""
 	if scroll > 0 {
-		prevAlbum = tracks[scroll-1].Album
+		if !isStreamingPlaylistTrack(tracks[scroll-1].Path) {
+			prevAlbum = tracks[scroll-1].Album
+		}
+		if album := tracks[scroll].Album; album != "" && album == prevAlbum && !isStreamingPlaylistTrack(tracks[scroll].Path) {
+			lines = append(lines, m.albumSeparator(album, tracks[scroll].Year))
+		}
 	}
 	for i := scroll; i < len(tracks) && len(lines) < budget; i++ {
 		if album := tracks[i].Album; album != "" && album != prevAlbum && !isStreamingPlaylistTrack(tracks[i].Path) {
@@ -767,7 +772,7 @@ func (m Model) renderPlaylist() string {
 			if remaining >= 4 {
 				albumSuffix = truncate(" (unavailable)", remaining)
 			}
-		} else if album := tracks[i].Album; album != "" {
+		} else if album := tracks[i].Album; album != "" && isStreamingPlaylistTrack(tracks[i].Path) {
 			remaining := ui.PanelWidth - linePrefixWidth - bookmarkBudget - nameLen - queueLen - 3 // 3 = " · "
 			if remaining >= 4 {
 				albumSuffix = " · " + truncate(album, remaining)

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -705,32 +705,16 @@ func (m Model) renderPlaylist() string {
 
 	lines := make([]string, 0, budget)
 	numWidth := len(fmt.Sprintf("%d", len(tracks)))
-	prevAlbum := ""
-	if m.showAlbumHeaders && scroll > 0 {
-		if !isStreamingPlaylistTrack(tracks[scroll-1].Path) {
-			prevAlbum = tracks[scroll-1].Album
-		}
-		if album := tracks[scroll].Album; album != "" && album == prevAlbum && !isStreamingPlaylistTrack(tracks[scroll].Path) {
-			lines = append(lines, m.albumSeparator(album, tracks[scroll].Year))
-		}
-	}
-	for i := scroll; i < len(tracks) && len(lines) < budget; i++ {
-		album := tracks[i].Album
-		isStreaming := isStreamingPlaylistTrack(tracks[i].Path)
-		if m.showAlbumHeaders && album != prevAlbum && !isStreaming && (album != "" || len(lines) > 0) {
-			if len(lines)+1 >= budget {
-				break
-			}
-			lines = append(lines, m.albumSeparator(album, tracks[i].Year))
-		}
 
-		if isStreaming {
-			prevAlbum = ""
-		} else {
-			prevAlbum = album
+	m.walkTracksWithHeaders(tracks, scroll, m.showAlbumHeaders, func(album string, year int) bool {
+		if len(lines)+1 >= budget {
+			return false
 		}
+		lines = append(lines, m.albumSeparator(album, year))
+		return true
+	}, func(i int, t playlist.Track) bool {
 		if len(lines) >= budget {
-			break
+			return false
 		}
 
 		prefix := "  "
@@ -799,7 +783,8 @@ func (m Model) renderPlaylist() string {
 			line += activeToggle.Render(queueSuffix)
 		}
 		lines = append(lines, line)
-	}
+		return true
+	})
 
 	for len(lines) < budget {
 		lines = append(lines, "")

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -706,7 +706,7 @@ func (m Model) renderPlaylist() string {
 	lines := make([]string, 0, budget)
 	numWidth := len(fmt.Sprintf("%d", len(tracks)))
 	prevAlbum := ""
-	if scroll > 0 {
+	if m.showAlbumHeaders && scroll > 0 {
 		if !isStreamingPlaylistTrack(tracks[scroll-1].Path) {
 			prevAlbum = tracks[scroll-1].Album
 		}
@@ -717,7 +717,7 @@ func (m Model) renderPlaylist() string {
 	for i := scroll; i < len(tracks) && len(lines) < budget; i++ {
 		album := tracks[i].Album
 		isStreaming := isStreamingPlaylistTrack(tracks[i].Path)
-		if album != prevAlbum && !isStreaming && (album != "" || len(lines) > 0) {
+		if m.showAlbumHeaders && album != prevAlbum && !isStreaming && (album != "" || len(lines) > 0) {
 			if len(lines)+1 >= budget {
 				break
 			}
@@ -779,7 +779,7 @@ func (m Model) renderPlaylist() string {
 			if remaining >= 4 {
 				albumSuffix = truncate(" (unavailable)", remaining)
 			}
-		} else if album := tracks[i].Album; album != "" && isStreamingPlaylistTrack(tracks[i].Path) {
+		} else if album := tracks[i].Album; album != "" && (isStreamingPlaylistTrack(tracks[i].Path) || !m.showAlbumHeaders) {
 			remaining := ui.PanelWidth - linePrefixWidth - bookmarkBudget - nameLen - queueLen - 3 // 3 = " · "
 			if remaining >= 4 {
 				albumSuffix = " · " + truncate(album, remaining)

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -715,13 +715,20 @@ func (m Model) renderPlaylist() string {
 		}
 	}
 	for i := scroll; i < len(tracks) && len(lines) < budget; i++ {
-		if album := tracks[i].Album; album != "" && album != prevAlbum && !isStreamingPlaylistTrack(tracks[i].Path) {
+		album := tracks[i].Album
+		isStreaming := isStreamingPlaylistTrack(tracks[i].Path)
+		if album != prevAlbum && !isStreaming && (album != "" || len(lines) > 0) {
 			if len(lines)+1 >= budget {
 				break
 			}
 			lines = append(lines, m.albumSeparator(album, tracks[i].Year))
 		}
-		prevAlbum = tracks[i].Album
+
+		if isStreaming {
+			prevAlbum = ""
+		} else {
+			prevAlbum = album
+		}
 		if len(lines) >= budget {
 			break
 		}

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -706,24 +706,27 @@ func (m Model) renderPlaylist() string {
 	lines := make([]string, 0, budget)
 	numWidth := len(fmt.Sprintf("%d", len(tracks)))
 
-	m.walkTracksWithHeaders(tracks, scroll, m.showAlbumHeaders, func(album string, year int) bool {
-		if len(lines)+1 >= budget {
-			return false
-		}
-		lines = append(lines, m.albumSeparator(album, year))
-		return true
-	}, func(i int, t playlist.Track) bool {
-		if len(lines) >= budget {
-			return false
+	for row := range m.playlistRows(tracks, scroll, m.showAlbumHeaders) {
+		if row.Index < 0 {
+			if len(lines)+1 >= budget {
+				break
+			}
+			lines = append(lines, m.albumSeparator(row.Album, row.Year))
+			continue
 		}
 
+		if len(lines) >= budget {
+			break
+		}
+
+		i, t := row.Index, row.Track
 		prefix := "  "
 		style := playlistItemStyle
 
 		if i == currentIdx && m.player.IsPlaying() {
 			prefix = "▶ "
 			style = playlistActiveStyle
-		} else if strings.HasPrefix(tracks[i].Path, "ssh://") {
+		} else if strings.HasPrefix(t.Path, "ssh://") {
 			prefix = "↗ "
 		}
 
@@ -731,7 +734,7 @@ func (m Model) renderPlaylist() string {
 			style = playlistSelectedStyle
 		}
 
-		if tracks[i].Unplayable {
+		if t.Unplayable {
 			if m.focus == focusPlaylist && i == m.plCursor {
 				style = dimStyle
 			} else {
@@ -739,8 +742,8 @@ func (m Model) renderPlaylist() string {
 			}
 		}
 
-		name := tracks[i].DisplayName()
-		isBookmark := tracks[i].Bookmark
+		name := t.DisplayName()
+		isBookmark := t.Bookmark
 		bookmarkBudget := 0
 		if isBookmark {
 			bookmarkBudget = 2 // "★ "
@@ -758,12 +761,12 @@ func (m Model) renderPlaylist() string {
 		// Truncate the album to fit whatever space remains after the track name.
 		albumSuffix := ""
 		nameLen := utf8.RuneCountInString(name)
-		if tracks[i].Unplayable {
+		if t.Unplayable {
 			remaining := ui.PanelWidth - linePrefixWidth - bookmarkBudget - nameLen - queueLen
 			if remaining >= 4 {
 				albumSuffix = truncate(" (unavailable)", remaining)
 			}
-		} else if album := tracks[i].Album; album != "" && (isStreamingPlaylistTrack(tracks[i].Path) || !m.showAlbumHeaders) {
+		} else if album := t.Album; album != "" && (isStreamingPlaylistTrack(t.Path) || !m.showAlbumHeaders) {
 			remaining := ui.PanelWidth - linePrefixWidth - bookmarkBudget - nameLen - queueLen - 3 // 3 = " · "
 			if remaining >= 4 {
 				albumSuffix = " · " + truncate(album, remaining)
@@ -783,8 +786,7 @@ func (m Model) renderPlaylist() string {
 			line += activeToggle.Render(queueSuffix)
 		}
 		lines = append(lines, line)
-		return true
-	})
+	}
 
 	for len(lines) < budget {
 		lines = append(lines, "")

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -766,7 +766,7 @@ func (m Model) renderPlaylist() string {
 			if remaining >= 4 {
 				albumSuffix = truncate(" (unavailable)", remaining)
 			}
-		} else if album := t.Album; album != "" && (isStreamingPlaylistTrack(t.Path) || !m.showAlbumHeaders) {
+		} else if album := t.Album; album != "" && !m.showAlbumHeaders {
 			remaining := ui.PanelWidth - linePrefixWidth - bookmarkBudget - nameLen - queueLen - 3 // 3 = " · "
 			if remaining >= 4 {
 				albumSuffix = " · " + truncate(album, remaining)

--- a/ui/model/view_helpers.go
+++ b/ui/model/view_helpers.go
@@ -174,6 +174,9 @@ func albumSeparatorRows(tracks []playlist.Track, scroll, cursor int) int {
 	prevAlbum := ""
 	if scroll > 0 {
 		prevAlbum = tracks[scroll-1].Album
+		if album := tracks[scroll].Album; album != "" && album == prevAlbum && !isStreamingPlaylistTrack(tracks[scroll].Path) {
+			rows++
+		}
 	}
 	for i := scroll; i <= cursor; i++ {
 		if album := tracks[i].Album; album != "" && album != prevAlbum && !isStreamingPlaylistTrack(tracks[i].Path) {

--- a/ui/model/view_helpers.go
+++ b/ui/model/view_helpers.go
@@ -166,9 +166,12 @@ func isStreamingPlaylistTrack(path string) bool {
 // in a playlist view that emits an album-separator row whenever the album
 // changes. Streaming tracks are treated as not contributing a separator,
 // matching the renderer.
-func albumSeparatorRows(tracks []playlist.Track, scroll, cursor int) int {
+func albumSeparatorRows(tracks []playlist.Track, scroll, cursor int, showHeaders bool) int {
 	if len(tracks) == 0 || scroll < 0 || cursor < scroll || cursor >= len(tracks) {
 		return 0
+	}
+	if !showHeaders {
+		return cursor - scroll + 1
 	}
 	rows := 0
 	prevAlbum := ""

--- a/ui/model/view_helpers.go
+++ b/ui/model/view_helpers.go
@@ -162,6 +162,62 @@ func isStreamingPlaylistTrack(path string) bool {
 	return strings.HasPrefix(path, "spotify:track:")
 }
 
+// walkTracksWithHeaders iterates through tracks starting at scroll and invokes
+// callbacks for each album separator and track according to grouping and
+// sticky-header rules.
+func (m Model) walkTracksWithHeaders(
+	tracks []playlist.Track,
+	scroll int,
+	showHeaders bool,
+	onSep func(album string, year int) bool,
+	onTrack func(i int, t playlist.Track) bool,
+) {
+	if len(tracks) == 0 || scroll < 0 || scroll >= len(tracks) {
+		return
+	}
+
+	rows := 0
+	prevAlbum := ""
+	if scroll > 0 {
+		if !isStreamingPlaylistTrack(tracks[scroll-1].Path) {
+			prevAlbum = tracks[scroll-1].Album
+		}
+		if showHeaders {
+			t := tracks[scroll]
+			if album := t.Album; album != "" && album == prevAlbum && !isStreamingPlaylistTrack(t.Path) {
+				if !onSep(album, t.Year) {
+					return
+				}
+				rows++
+			}
+		}
+	}
+
+	for i := scroll; i < len(tracks); i++ {
+		t := tracks[i]
+		album := t.Album
+		isStreaming := isStreamingPlaylistTrack(t.Path)
+
+		if showHeaders && album != prevAlbum && !isStreaming && (album != "" || rows > 0) {
+			if !onSep(album, t.Year) {
+				return
+			}
+			rows++
+		}
+
+		if !onTrack(i, t) {
+			return
+		}
+		rows++
+
+		if isStreaming {
+			prevAlbum = ""
+		} else {
+			prevAlbum = album
+		}
+	}
+}
+
 // albumSeparatorRows counts rendered rows between scroll and cursor (inclusive)
 // in a playlist view that emits an album-separator row whenever the album
 // changes. Streaming tracks are treated as not contributing a separator,
@@ -173,29 +229,15 @@ func albumSeparatorRows(tracks []playlist.Track, scroll, cursor int, showHeaders
 	if !showHeaders {
 		return cursor - scroll + 1
 	}
+
 	rows := 0
-	prevAlbum := ""
-	if scroll > 0 {
-		if !isStreamingPlaylistTrack(tracks[scroll-1].Path) {
-			prevAlbum = tracks[scroll-1].Album
-		}
-		if album := tracks[scroll].Album; album != "" && album == prevAlbum && !isStreamingPlaylistTrack(tracks[scroll].Path) {
-			rows++
-		}
-	}
-	for i := scroll; i <= cursor; i++ {
-		album := tracks[i].Album
-		isStreaming := isStreamingPlaylistTrack(tracks[i].Path)
-		if album != prevAlbum && !isStreaming && (album != "" || rows > 0) {
-			rows++
-		}
-		if isStreaming {
-			prevAlbum = ""
-		} else {
-			prevAlbum = album
-		}
+	Model{}.walkTracksWithHeaders(tracks, scroll, showHeaders, func(string, int) bool {
 		rows++
-	}
+		return true
+	}, func(i int, t playlist.Track) bool {
+		rows++
+		return i < cursor
+	})
 	return rows
 }
 

--- a/ui/model/view_helpers.go
+++ b/ui/model/view_helpers.go
@@ -173,16 +173,24 @@ func albumSeparatorRows(tracks []playlist.Track, scroll, cursor int) int {
 	rows := 0
 	prevAlbum := ""
 	if scroll > 0 {
-		prevAlbum = tracks[scroll-1].Album
+		if !isStreamingPlaylistTrack(tracks[scroll-1].Path) {
+			prevAlbum = tracks[scroll-1].Album
+		}
 		if album := tracks[scroll].Album; album != "" && album == prevAlbum && !isStreamingPlaylistTrack(tracks[scroll].Path) {
 			rows++
 		}
 	}
 	for i := scroll; i <= cursor; i++ {
-		if album := tracks[i].Album; album != "" && album != prevAlbum && !isStreamingPlaylistTrack(tracks[i].Path) {
+		album := tracks[i].Album
+		isStreaming := isStreamingPlaylistTrack(tracks[i].Path)
+		if album != prevAlbum && !isStreaming && (album != "" || rows > 0) {
 			rows++
 		}
-		prevAlbum = tracks[i].Album
+		if isStreaming {
+			prevAlbum = ""
+		} else {
+			prevAlbum = album
+		}
 		rows++
 	}
 	return rows
@@ -190,6 +198,9 @@ func albumSeparatorRows(tracks []playlist.Track, scroll, cursor int) int {
 
 // albumSeparator builds a full-width album divider line.
 func (m Model) albumSeparator(album string, year int) string {
+	if album == "" {
+		return dimStyle.Render(strings.Repeat("─", ui.PanelWidth))
+	}
 	prefix := "── "
 	suffix := " "
 	label := prefix + album

--- a/ui/model/view_helpers.go
+++ b/ui/model/view_helpers.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"iter"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -162,58 +163,64 @@ func isStreamingPlaylistTrack(path string) bool {
 	return strings.HasPrefix(path, "spotify:track:")
 }
 
-// walkTracksWithHeaders iterates through tracks starting at scroll and invokes
-// callbacks for each album separator and track according to grouping and
-// sticky-header rules.
-func (m Model) walkTracksWithHeaders(
-	tracks []playlist.Track,
-	scroll int,
-	showHeaders bool,
-	onSep func(album string, year int) bool,
-	onTrack func(i int, t playlist.Track) bool,
-) {
-	if len(tracks) == 0 || scroll < 0 || scroll >= len(tracks) {
-		return
-	}
+// playlistRow represents a single line in a track list, which can be either
+// an album separator header or an actual track.
+type playlistRow struct {
+	Index int            // index into the original track list; -1 for headers
+	Track playlist.Track // only populated if Index >= 0
+	Album string         // only populated for headers (Index == -1)
+	Year  int            // only populated for headers (Index == -1)
+}
 
-	rows := 0
-	prevAlbum := ""
-	if scroll > 0 {
-		if !isStreamingPlaylistTrack(tracks[scroll-1].Path) {
-			prevAlbum = tracks[scroll-1].Album
-		}
-		if showHeaders {
-			t := tracks[scroll]
-			if album := t.Album; album != "" && album == prevAlbum && !isStreamingPlaylistTrack(t.Path) {
-				if !onSep(album, t.Year) {
-					return
-				}
-				rows++
-			}
-		}
-	}
-
-	for i := scroll; i < len(tracks); i++ {
-		t := tracks[i]
-		album := t.Album
-		isStreaming := isStreamingPlaylistTrack(t.Path)
-
-		if showHeaders && album != prevAlbum && !isStreaming && (album != "" || rows > 0) {
-			if !onSep(album, t.Year) {
-				return
-			}
-			rows++
-		}
-
-		if !onTrack(i, t) {
+// playlistRows returns an iterator over tracks and their injected album headers,
+// starting from the given scroll position. It accounts for "sticky" headers
+// (showing the header for an album even if we scrolled into the middle of it).
+func (m Model) playlistRows(tracks []playlist.Track, scroll int, showHeaders bool) iter.Seq[playlistRow] {
+	return func(yield func(playlistRow) bool) {
+		if len(tracks) == 0 || scroll < 0 || scroll >= len(tracks) {
 			return
 		}
-		rows++
 
-		if isStreaming {
-			prevAlbum = ""
-		} else {
-			prevAlbum = album
+		// Initialize the album context from the track just above the scroll window.
+		prevAlbum := ""
+		if scroll > 0 && !isStreamingPlaylistTrack(tracks[scroll-1].Path) {
+			prevAlbum = tracks[scroll-1].Album
+		}
+
+		for i := scroll; i < len(tracks); i++ {
+			t := tracks[i]
+			isStreaming := isStreamingPlaylistTrack(t.Path)
+
+			if showHeaders && !isStreaming {
+				// Sticky Header: we scrolled into the middle of a named album.
+				if i == scroll && t.Album != "" && t.Album == prevAlbum {
+					if !yield(playlistRow{Index: -1, Album: t.Album, Year: t.Year}) {
+						return
+					}
+				}
+
+				// Transition Header: the album changed.
+				if t.Album != prevAlbum {
+					// Suppress blank headers (separators) if they would be the first row of the view.
+					// Named headers are always allowed.
+					if t.Album != "" || i > scroll {
+						if !yield(playlistRow{Index: -1, Album: t.Album, Year: t.Year}) {
+							return
+						}
+					}
+				}
+			}
+
+			// The Track itself.
+			if !yield(playlistRow{Index: i, Track: t}) {
+				return
+			}
+
+			// Update context for the next iteration.
+			prevAlbum = t.Album
+			if isStreaming {
+				prevAlbum = ""
+			}
 		}
 	}
 }
@@ -222,7 +229,7 @@ func (m Model) walkTracksWithHeaders(
 // in a playlist view that emits an album-separator row whenever the album
 // changes. Streaming tracks are treated as not contributing a separator,
 // matching the renderer.
-func albumSeparatorRows(tracks []playlist.Track, scroll, cursor int, showHeaders bool) int {
+func (m Model) albumSeparatorRows(tracks []playlist.Track, scroll, cursor int, showHeaders bool) int {
 	if len(tracks) == 0 || scroll < 0 || cursor < scroll || cursor >= len(tracks) {
 		return 0
 	}
@@ -231,13 +238,12 @@ func albumSeparatorRows(tracks []playlist.Track, scroll, cursor int, showHeaders
 	}
 
 	rows := 0
-	Model{}.walkTracksWithHeaders(tracks, scroll, showHeaders, func(string, int) bool {
+	for row := range m.playlistRows(tracks, scroll, showHeaders) {
 		rows++
-		return true
-	}, func(i int, t playlist.Track) bool {
-		rows++
-		return i < cursor
-	})
+		if row.Index == cursor {
+			break
+		}
+	}
 	return rows
 }
 

--- a/ui/model/view_helpers.go
+++ b/ui/model/view_helpers.go
@@ -156,11 +156,34 @@ func helpKey(key, label string) string {
 	return helpKeyStyle.Render(" "+key+" ") + helpStyle.Render(" "+label)
 }
 
-// isStreamingPlaylistTrack reports whether path is a streaming-provider URI
-// whose Album metadata may not represent a real album grouping (so separators
-// would be misleading).
-func isStreamingPlaylistTrack(path string) bool {
-	return strings.HasPrefix(path, "spotify:track:")
+// isListCohesive returns true if the track list appears to be organized into
+// distinct albums (e.g. an artist's discography or a full album) rather than
+// a fragmented mixtape. It uses a threshold of average tracks per album.
+func isListCohesive(tracks []playlist.Track) bool {
+	headers := 0
+	prev := ""
+	first := true
+	for _, t := range tracks {
+		if first || t.Album != prev {
+			headers++
+			prev = t.Album
+			first = false
+		}
+	}
+
+	if headers == 0 {
+		return false
+	}
+
+	// If average tracks per album is < 3.0, the list is considered fragmented.
+	ratio := float64(len(tracks)) / float64(headers)
+	return ratio >= 3.0
+}
+
+// setInitialHeaderState evaluates the track list's cohesion to decide whether
+// to show album headers by default.
+func (m *Model) setInitialHeaderState(tracks []playlist.Track) {
+	m.showAlbumHeaders = isListCohesive(tracks)
 }
 
 // playlistRow represents a single line in a track list, which can be either
@@ -183,15 +206,14 @@ func (m Model) playlistRows(tracks []playlist.Track, scroll int, showHeaders boo
 
 		// Initialize the album context from the track just above the scroll window.
 		prevAlbum := ""
-		if scroll > 0 && !isStreamingPlaylistTrack(tracks[scroll-1].Path) {
+		if scroll > 0 {
 			prevAlbum = tracks[scroll-1].Album
 		}
 
 		for i := scroll; i < len(tracks); i++ {
 			t := tracks[i]
-			isStreaming := isStreamingPlaylistTrack(t.Path)
 
-			if showHeaders && !isStreaming {
+			if showHeaders {
 				// Sticky Header: we scrolled into the middle of a named album.
 				if i == scroll && t.Album != "" && t.Album == prevAlbum {
 					if !yield(playlistRow{Index: -1, Album: t.Album, Year: t.Year}) {
@@ -218,9 +240,6 @@ func (m Model) playlistRows(tracks []playlist.Track, scroll int, showHeaders boo
 
 			// Update context for the next iteration.
 			prevAlbum = t.Album
-			if isStreaming {
-				prevAlbum = ""
-			}
 		}
 	}
 }

--- a/ui/model/view_nav.go
+++ b/ui/model/view_nav.go
@@ -190,14 +190,18 @@ func (m Model) renderNavTrackList() []string {
 	if useFilter {
 		items := m.navScrollItems(len(m.navBrowser.tracks), func(i int) string {
 			t := m.navBrowser.tracks[i]
-			return formatTrackRow(i+1, t.DisplayName(), t.DurationSecs)
+			name := t.DisplayName()
+			if !m.showAlbumHeaders && t.Album != "" {
+				name += " · " + t.Album
+			}
+			return formatTrackRow(i+1, name, t.DurationSecs)
 		})
 		lines = append(lines, items...)
 	} else {
 		scroll := m.navBrowser.scroll
 		rendered := 0
 		prevAlbum := ""
-		if scroll > 0 {
+		if m.showAlbumHeaders && scroll > 0 {
 			if !isStreamingPlaylistTrack(m.navBrowser.tracks[scroll-1].Path) {
 				prevAlbum = m.navBrowser.tracks[scroll-1].Album
 			}
@@ -212,7 +216,7 @@ func (m Model) renderNavTrackList() []string {
 			album := t.Album
 			isStreaming := isStreamingPlaylistTrack(t.Path)
 
-			if album != prevAlbum && !isStreaming && (album != "" || rendered > 0) {
+			if m.showAlbumHeaders && album != prevAlbum && !isStreaming && (album != "" || rendered > 0) {
 				if rendered+1 >= maxVisible {
 					break
 				}
@@ -226,7 +230,11 @@ func (m Model) renderNavTrackList() []string {
 				prevAlbum = album
 			}
 
-			label := formatTrackRow(i+1, t.DisplayName(), t.DurationSecs)
+			name := t.DisplayName()
+			if !m.showAlbumHeaders && t.Album != "" {
+				name += " · " + t.Album
+			}
+			label := formatTrackRow(i+1, name, t.DurationSecs)
 			lines = append(lines, cursorLine(label, i == m.navBrowser.cursor))
 			rendered++
 		}

--- a/ui/model/view_nav.go
+++ b/ui/model/view_nav.go
@@ -198,7 +198,9 @@ func (m Model) renderNavTrackList() []string {
 		rendered := 0
 		prevAlbum := ""
 		if scroll > 0 {
-			prevAlbum = m.navBrowser.tracks[scroll-1].Album
+			if !isStreamingPlaylistTrack(m.navBrowser.tracks[scroll-1].Path) {
+				prevAlbum = m.navBrowser.tracks[scroll-1].Album
+			}
 			if album := m.navBrowser.tracks[scroll].Album; album != "" && album == prevAlbum && !isStreamingPlaylistTrack(m.navBrowser.tracks[scroll].Path) {
 				lines = append(lines, m.albumSeparator(album, m.navBrowser.tracks[scroll].Year))
 				rendered++
@@ -207,15 +209,22 @@ func (m Model) renderNavTrackList() []string {
 
 		for i := scroll; i < len(m.navBrowser.tracks) && rendered < maxVisible; i++ {
 			t := m.navBrowser.tracks[i]
+			album := t.Album
+			isStreaming := isStreamingPlaylistTrack(t.Path)
 
-			if album := t.Album; album != "" && album != prevAlbum && !isStreamingPlaylistTrack(t.Path) {
+			if album != prevAlbum && !isStreaming && (album != "" || rendered > 0) {
 				if rendered+1 >= maxVisible {
 					break
 				}
 				lines = append(lines, m.albumSeparator(album, t.Year))
 				rendered++
 			}
-			prevAlbum = t.Album
+
+			if isStreaming {
+				prevAlbum = ""
+			} else {
+				prevAlbum = album
+			}
 
 			label := formatTrackRow(i+1, t.DisplayName(), t.DurationSecs)
 			lines = append(lines, cursorLine(label, i == m.navBrowser.cursor))

--- a/ui/model/view_nav.go
+++ b/ui/model/view_nav.go
@@ -199,16 +199,21 @@ func (m Model) renderNavTrackList() []string {
 		prevAlbum := ""
 		if scroll > 0 {
 			prevAlbum = m.navBrowser.tracks[scroll-1].Album
+			if album := m.navBrowser.tracks[scroll].Album; album != "" && album == prevAlbum && !isStreamingPlaylistTrack(m.navBrowser.tracks[scroll].Path) {
+				lines = append(lines, m.albumSeparator(album, m.navBrowser.tracks[scroll].Year))
+				rendered++
+			}
 		}
 
 		for i := scroll; i < len(m.navBrowser.tracks) && rendered < maxVisible; i++ {
 			t := m.navBrowser.tracks[i]
 
 			if album := t.Album; album != "" && album != prevAlbum && !isStreamingPlaylistTrack(t.Path) {
-				lines = append(lines, m.albumSeparator(album, t.Year))
-				if rendered >= maxVisible {
+				if rendered+1 >= maxVisible {
 					break
 				}
+				lines = append(lines, m.albumSeparator(album, t.Year))
+				rendered++
 			}
 			prevAlbum = t.Album
 

--- a/ui/model/view_nav.go
+++ b/ui/model/view_nav.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"cliamp/playlist"
 	"cliamp/provider"
 	"cliamp/ui"
 )
@@ -200,34 +201,17 @@ func (m Model) renderNavTrackList() []string {
 	} else {
 		scroll := m.navBrowser.scroll
 		rendered := 0
-		prevAlbum := ""
-		if m.showAlbumHeaders && scroll > 0 {
-			if !isStreamingPlaylistTrack(m.navBrowser.tracks[scroll-1].Path) {
-				prevAlbum = m.navBrowser.tracks[scroll-1].Album
-			}
-			if album := m.navBrowser.tracks[scroll].Album; album != "" && album == prevAlbum && !isStreamingPlaylistTrack(m.navBrowser.tracks[scroll].Path) {
-				lines = append(lines, m.albumSeparator(album, m.navBrowser.tracks[scroll].Year))
-				rendered++
-			}
-		}
 
-		for i := scroll; i < len(m.navBrowser.tracks) && rendered < maxVisible; i++ {
-			t := m.navBrowser.tracks[i]
-			album := t.Album
-			isStreaming := isStreamingPlaylistTrack(t.Path)
-
-			if m.showAlbumHeaders && album != prevAlbum && !isStreaming && (album != "" || rendered > 0) {
-				if rendered+1 >= maxVisible {
-					break
-				}
-				lines = append(lines, m.albumSeparator(album, t.Year))
-				rendered++
+		m.walkTracksWithHeaders(m.navBrowser.tracks, scroll, m.showAlbumHeaders, func(album string, year int) bool {
+			if rendered+1 >= maxVisible {
+				return false
 			}
-
-			if isStreaming {
-				prevAlbum = ""
-			} else {
-				prevAlbum = album
+			lines = append(lines, m.albumSeparator(album, year))
+			rendered++
+			return true
+		}, func(i int, t playlist.Track) bool {
+			if rendered >= maxVisible {
+				return false
 			}
 
 			name := t.DisplayName()
@@ -237,7 +221,8 @@ func (m Model) renderNavTrackList() []string {
 			label := formatTrackRow(i+1, name, t.DurationSecs)
 			lines = append(lines, cursorLine(label, i == m.navBrowser.cursor))
 			rendered++
-		}
+			return true
+		})
 
 		lines = padLines(lines, maxVisible, rendered)
 	}

--- a/ui/model/view_nav.go
+++ b/ui/model/view_nav.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"cliamp/playlist"
 	"cliamp/provider"
 	"cliamp/ui"
 )
@@ -202,18 +201,21 @@ func (m Model) renderNavTrackList() []string {
 		scroll := m.navBrowser.scroll
 		rendered := 0
 
-		m.walkTracksWithHeaders(m.navBrowser.tracks, scroll, m.showAlbumHeaders, func(album string, year int) bool {
-			if rendered+1 >= maxVisible {
-				return false
-			}
-			lines = append(lines, m.albumSeparator(album, year))
-			rendered++
-			return true
-		}, func(i int, t playlist.Track) bool {
-			if rendered >= maxVisible {
-				return false
+		for row := range m.playlistRows(m.navBrowser.tracks, scroll, m.showAlbumHeaders) {
+			if row.Index < 0 {
+				if rendered+1 >= maxVisible {
+					break
+				}
+				lines = append(lines, m.albumSeparator(row.Album, row.Year))
+				rendered++
+				continue
 			}
 
+			if rendered >= maxVisible {
+				break
+			}
+
+			i, t := row.Index, row.Track
 			name := t.DisplayName()
 			if !m.showAlbumHeaders && t.Album != "" {
 				name += " · " + t.Album
@@ -221,8 +223,7 @@ func (m Model) renderNavTrackList() []string {
 			label := formatTrackRow(i+1, name, t.DurationSecs)
 			lines = append(lines, cursorLine(label, i == m.navBrowser.cursor))
 			rendered++
-			return true
-		})
+		}
 
 		lines = padLines(lines, maxVisible, rendered)
 	}

--- a/ui/model/view_overlays.go
+++ b/ui/model/view_overlays.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"cliamp/lyrics"
-	"cliamp/playlist"
 	"cliamp/theme"
 	"cliamp/ui"
 )
@@ -249,22 +248,26 @@ func (m Model) renderPlMgrTracks() []string {
 		}
 	} else {
 		if useAlbumSep {
-			for scroll < m.plManager.cursor && albumSeparatorRows(m.plManager.tracks, scroll, m.plManager.cursor, true) > maxVisible {
+			for scroll < m.plManager.cursor && m.albumSeparatorRows(m.plManager.tracks, scroll, m.plManager.cursor, true) > maxVisible {
 				scroll++
 			}
 		}
 
-		m.walkTracksWithHeaders(m.plManager.tracks, scroll, useAlbumSep, func(album string, year int) bool {
-			if rendered+1 >= maxVisible {
-				return false
+		for row := range m.playlistRows(m.plManager.tracks, scroll, useAlbumSep) {
+			if row.Index < 0 {
+				if rendered+1 >= maxVisible {
+					break
+				}
+				lines = append(lines, m.albumSeparator(row.Album, row.Year))
+				rendered++
+				continue
 			}
-			lines = append(lines, m.albumSeparator(album, year))
-			rendered++
-			return true
-		}, func(i int, t playlist.Track) bool {
+
 			if rendered >= maxVisible {
-				return false
+				break
 			}
+
+			i, t := row.Index, row.Track
 			name := t.DisplayName()
 			if !m.showAlbumHeaders && t.Album != "" {
 				name += " · " + t.Album
@@ -272,8 +275,7 @@ func (m Model) renderPlMgrTracks() []string {
 			label := formatTrackRow(i+1, name, t.DurationSecs)
 			lines = append(lines, cursorLine(label, i == m.plManager.cursor))
 			rendered++
-			return true
-		})
+		}
 	}
 
 	if visibleN > maxVisible {

--- a/ui/model/view_overlays.go
+++ b/ui/model/view_overlays.go
@@ -242,6 +242,14 @@ func (m Model) renderPlMgrTracks() []string {
 	prevAlbum := ""
 	if useAlbumSep && scroll > 0 {
 		prevAlbum = m.plManager.tracks[scroll-1].Album
+		// Sticky header: if we're scrolled into the middle of an album, show its header at the top.
+		if scroll < visibleN {
+			t := m.plManager.tracks[scroll]
+			if album := t.Album; album != "" && album == prevAlbum && !isStreamingPlaylistTrack(t.Path) {
+				lines = append(lines, m.albumSeparator(album, t.Year))
+				rendered++
+			}
+		}
 	}
 
 	for i := scroll; i < visibleN && rendered < maxVisible; i++ {

--- a/ui/model/view_overlays.go
+++ b/ui/model/view_overlays.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"cliamp/lyrics"
+	"cliamp/playlist"
 	"cliamp/theme"
 	"cliamp/ui"
 )
@@ -232,59 +233,47 @@ func (m Model) renderPlMgrTracks() []string {
 	useAlbumSep := m.plManager.filter == "" && m.showAlbumHeaders
 
 	scroll := scrollStart(m.plManager.cursor, maxVisible)
-	if useAlbumSep {
-		for scroll < m.plManager.cursor && albumSeparatorRows(m.plManager.tracks, scroll, m.plManager.cursor, true) > maxVisible {
-			scroll++
-		}
-	}
-
 	rendered := 0
-	prevAlbum := ""
-	if useAlbumSep && scroll > 0 {
-		if !isStreamingPlaylistTrack(m.plManager.tracks[scroll-1].Path) {
-			prevAlbum = m.plManager.tracks[scroll-1].Album
-		}
-		// Sticky header: if we're scrolled into the middle of an album, show its header at the top.
-		if scroll < visibleN {
-			t := m.plManager.tracks[scroll]
-			if album := t.Album; album != "" && album == prevAlbum && !isStreamingPlaylistTrack(t.Path) {
-				lines = append(lines, m.albumSeparator(album, t.Year))
-				rendered++
+
+	if m.plManager.filter != "" {
+		for i := scroll; i < visibleN && rendered < maxVisible; i++ {
+			realIdx := m.plMgrTrackRealIndex(i)
+			t := m.plManager.tracks[realIdx]
+			name := t.DisplayName()
+			if !m.showAlbumHeaders && t.Album != "" {
+				name += " · " + t.Album
 			}
+			label := formatTrackRow(realIdx+1, name, t.DurationSecs)
+			lines = append(lines, cursorLine(label, i == m.plManager.cursor))
+			rendered++
 		}
-	}
-
-	for i := scroll; i < visibleN && rendered < maxVisible; i++ {
-		realIdx := m.plMgrTrackRealIndex(i)
-		t := m.plManager.tracks[realIdx]
-
+	} else {
 		if useAlbumSep {
-			album := t.Album
-			isStreaming := isStreamingPlaylistTrack(t.Path)
-			if album != prevAlbum && !isStreaming && (album != "" || rendered > 0) {
-				if rendered+1 >= maxVisible {
-					break
-				}
-				lines = append(lines, m.albumSeparator(album, t.Year))
-				rendered++
-			}
-			if isStreaming {
-				prevAlbum = ""
-			} else {
-				prevAlbum = album
-			}
-			if rendered >= maxVisible {
-				break
+			for scroll < m.plManager.cursor && albumSeparatorRows(m.plManager.tracks, scroll, m.plManager.cursor, true) > maxVisible {
+				scroll++
 			}
 		}
 
-		name := t.DisplayName()
-		if !m.showAlbumHeaders && t.Album != "" {
-			name += " · " + t.Album
-		}
-		label := formatTrackRow(realIdx+1, name, t.DurationSecs)
-		lines = append(lines, cursorLine(label, i == m.plManager.cursor))
-		rendered++
+		m.walkTracksWithHeaders(m.plManager.tracks, scroll, useAlbumSep, func(album string, year int) bool {
+			if rendered+1 >= maxVisible {
+				return false
+			}
+			lines = append(lines, m.albumSeparator(album, year))
+			rendered++
+			return true
+		}, func(i int, t playlist.Track) bool {
+			if rendered >= maxVisible {
+				return false
+			}
+			name := t.DisplayName()
+			if !m.showAlbumHeaders && t.Album != "" {
+				name += " · " + t.Album
+			}
+			label := formatTrackRow(i+1, name, t.DurationSecs)
+			lines = append(lines, cursorLine(label, i == m.plManager.cursor))
+			rendered++
+			return true
+		})
 	}
 
 	if visibleN > maxVisible {

--- a/ui/model/view_overlays.go
+++ b/ui/model/view_overlays.go
@@ -241,7 +241,9 @@ func (m Model) renderPlMgrTracks() []string {
 	rendered := 0
 	prevAlbum := ""
 	if useAlbumSep && scroll > 0 {
-		prevAlbum = m.plManager.tracks[scroll-1].Album
+		if !isStreamingPlaylistTrack(m.plManager.tracks[scroll-1].Path) {
+			prevAlbum = m.plManager.tracks[scroll-1].Album
+		}
 		// Sticky header: if we're scrolled into the middle of an album, show its header at the top.
 		if scroll < visibleN {
 			t := m.plManager.tracks[scroll]
@@ -257,14 +259,20 @@ func (m Model) renderPlMgrTracks() []string {
 		t := m.plManager.tracks[realIdx]
 
 		if useAlbumSep {
-			if album := t.Album; album != "" && album != prevAlbum && !isStreamingPlaylistTrack(t.Path) {
+			album := t.Album
+			isStreaming := isStreamingPlaylistTrack(t.Path)
+			if album != prevAlbum && !isStreaming && (album != "" || rendered > 0) {
 				if rendered+1 >= maxVisible {
 					break
 				}
 				lines = append(lines, m.albumSeparator(album, t.Year))
 				rendered++
 			}
-			prevAlbum = t.Album
+			if isStreaming {
+				prevAlbum = ""
+			} else {
+				prevAlbum = album
+			}
 			if rendered >= maxVisible {
 				break
 			}

--- a/ui/model/view_overlays.go
+++ b/ui/model/view_overlays.go
@@ -229,11 +229,11 @@ func (m Model) renderPlMgrTracks() []string {
 	}
 
 	maxVisible := 12
-	useAlbumSep := m.plManager.filter == ""
+	useAlbumSep := m.plManager.filter == "" && m.showAlbumHeaders
 
 	scroll := scrollStart(m.plManager.cursor, maxVisible)
 	if useAlbumSep {
-		for scroll < m.plManager.cursor && albumSeparatorRows(m.plManager.tracks, scroll, m.plManager.cursor) > maxVisible {
+		for scroll < m.plManager.cursor && albumSeparatorRows(m.plManager.tracks, scroll, m.plManager.cursor, true) > maxVisible {
 			scroll++
 		}
 	}
@@ -278,7 +278,11 @@ func (m Model) renderPlMgrTracks() []string {
 			}
 		}
 
-		label := formatTrackRow(realIdx+1, t.DisplayName(), t.DurationSecs)
+		name := t.DisplayName()
+		if !m.showAlbumHeaders && t.Album != "" {
+			name += " · " + t.Album
+		}
+		label := formatTrackRow(realIdx+1, name, t.DurationSecs)
 		lines = append(lines, cursorLine(label, i == m.plManager.cursor))
 		rendered++
 	}


### PR DESCRIPTION
This PR makes album headers sticky so they remain visible as the album is scrolled in the view. This removes the need to display the album name as a suffix on every track.

Album headers are now able to be toggled; when album headers are hidden the album name is instead displayed in the suffix. This helps the list be cleaner in scenarios where there is a loose set of tracks is in the playlist, or in other situations where there are too many album headers.

**Changes**

*   **Sticky Album Headers**: When you’re scrolling through an album, the header (Album Name + Year) now stays pinned to the top of the scrollable area. With album headers enabled, the redundant `· Album Name` suffix is no longer displayed.
*   **Smart "Closing" Lines**: Solid "blank" separators now appear whenever an album grouping ends before any track that lacks album metadata. This provides a clear visual break between albums and tracks that don't have any album tag.
*   **New Toggle (Shift+H)**: In some cases, the album headers clutter the view. Pressing `H` toggles headers on/off and brings back the album suffixes accordingly.

Streaming tracks (like Spotify) are handled differently, they’ll keep their suffixes and won't trigger headers.

---

**Before & after comparison showing sticky headers and end-of-album blank separator**

<img width="1921" height="1657" alt="Screenshot 2026-05-05 at 14 13 53" src="https://github.com/user-attachments/assets/7520140b-3821-435d-a514-93c27c09ae0a" />

---

**Comparison showing album headers toggled on and off via `H`**

<img width="1923" height="1152" alt="Screenshot 2026-05-05 at 14 12 22" src="https://github.com/user-attachments/assets/8ec43661-5f93-43ba-802c-1fc1d82bb6bf" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ctrl+H keyboard shortcut to toggle album header visibility; headers are enabled by default.
  * Sticky album headers support for track lists.

* **Changes**
  * When headers are disabled, album names appear inline with track rows.
  * Header visibility is now initialized and kept in sync across playlist updates and navigation.
  * Scrolling and viewport behavior improved when headers are shown or hidden, including during filtering and streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->