### PR TITLE
plex: add config.toml option for selecting plex libraries

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -86,6 +86,16 @@ eq = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 # cookies_from = "firefox"   # chrome, brave, edge, opera, safari, vivaldi…
 
 # ---
+# Plex Media Server (optional)
+# [plex]
+# url   = "http://192.168.1.10:32400"
+# token = "xxxxxxxxxxxxxxxxxxxx"
+#
+# Restrict to specific music libraries (comma-separated, case-insensitive).
+# When omitted or empty, all music libraries are loaded.
+# libraries = ["Music", "Jazz"]
+
+# ---
 # Jellyfin server (optional)
 # Authenticate either with a long-lived API token or with your username/password.
 # user_id is optional and is discovered automatically when omitted.

--- a/config/config.go
+++ b/config/config.go
@@ -150,8 +150,9 @@ func (s SoundCloudConfig) IsSet() bool { return s.Enabled }
 // PlexConfig holds credentials for a Plex Media Server.
 // Both URL and Token must be non-empty for a client to be constructed.
 type PlexConfig struct {
-	URL   string // e.g. "http://192.168.1.10:32400"
-	Token string // X-Plex-Token
+	URL       string   // e.g. "http://192.168.1.10:32400"
+	Token     string   // X-Plex-Token
+	Libraries []string // optional: restrict to these music library names
 }
 
 // IsSet reports whether both Plex credentials are present.
@@ -349,6 +350,8 @@ func Load() (Config, error) {
 				cfg.Plex.URL = parseString(val)
 			case "token":
 				cfg.Plex.Token = parseString(val)
+			case "libraries":
+				cfg.Plex.Libraries = parseStringSlice(val)
 			}
 		case "soundcloud":
 			switch key {
@@ -720,6 +723,23 @@ func abs(x int) int {
 		return -x
 	}
 	return x
+}
+
+// parseStringSlice parses a comma-separated list of strings, optionally
+// wrapped in square brackets (e.g. `["Music", "Jazz"]` or `Music, Jazz`).
+// Leading/trailing whitespace and surrounding quotes are stripped from each element.
+func parseStringSlice(val string) []string {
+	val = strings.Trim(val, "[]")
+	parts := strings.Split(val, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		p = strings.Trim(p, `"'`)
+		if p != "" {
+			result = append(result, p)
+		}
+	}
+	return result
 }
 
 // parseEQ parses a TOML-style array like [0, 1.5, -2, ...] into 10 bands.

--- a/docs/plex.md
+++ b/docs/plex.md
@@ -27,12 +27,14 @@ Add a `[plex]` section to `~/.config/cliamp/config.toml`:
 [plex]
 url   = "http://192.168.1.10:32400"
 token = "xxxxxxxxxxxxxxxxxxxx"
+libraries = ["Music", "Jazz"]
 ```
 
 | Key | Description |
 |-----|-------------|
 | `url` | Base URL of your Plex Media Server, including port (default `32400`) |
 | `token` | Your `X-Plex-Token` for authentication |
+| `libraries` | Optional comma-separated list of music library names to load. When omitted, all music libraries are loaded. Names are matched case-insensitively. |
 
 If you access Plex remotely via `app.plex.tv`, you can still use a direct server URL if your server has remote access enabled, or use your server's `plex.direct` URL from the Plex Web address bar.
 

--- a/external/plex/client.go
+++ b/external/plex/client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -19,13 +20,16 @@ var apiClient = &http.Client{Timeout: 30 * time.Second}
 
 // Client speaks to a Plex Media Server over its HTTP API.
 type Client struct {
-	baseURL string // e.g. "http://192.168.1.10:32400"
-	token   string // X-Plex-Token
+	baseURL   string   // e.g. "http://192.168.1.10:32400"
+	token     string   // X-Plex-Token
+	libraries []string // if non-empty, MusicSections filters to these titles (case-insensitive)
 }
 
 // NewClient returns a Client for the given server URL and authentication token.
-func NewClient(baseURL, token string) *Client {
-	return &Client{baseURL: baseURL, token: token}
+// libraries is an optional list of music library names to restrict MusicSections to.
+// When not provided, all music libraries will be loaded
+func NewClient(baseURL, token string, libraries ...string) *Client {
+	return &Client{baseURL: baseURL, token: token, libraries: libraries}
 }
 
 // Section represents a Plex library section (e.g. a music library).
@@ -104,7 +108,9 @@ func (c *Client) Ping() error {
 	return c.get("/", nil, &result)
 }
 
-// MusicSections returns all library sections of type "artist" (music libraries).
+// MusicSections returns library sections of type "artist" (music libraries).
+// When the client was constructed with a library filter, only sections whose
+// title matches one of the allowed names (case-insensitive) are returned.
 func (c *Client) MusicSections() ([]Section, error) {
 	var result struct {
 		MediaContainer struct {
@@ -121,7 +127,7 @@ func (c *Client) MusicSections() ([]Section, error) {
 
 	var sections []Section
 	for _, d := range result.MediaContainer.Directory {
-		if d.Type == "artist" {
+		if d.Type == "artist" && c.includeLibrary(d.Title) {
 			sections = append(sections, Section{
 				Key:   d.Key,
 				Title: d.Title,
@@ -130,6 +136,20 @@ func (c *Client) MusicSections() ([]Section, error) {
 		}
 	}
 	return sections, nil
+}
+
+// includeLibrary reports whether the library with the given title should be
+// included. When no filter is configured (libraries is empty) all libraries pass.
+func (c *Client) includeLibrary(title string) bool {
+	if len(c.libraries) == 0 {
+		return true
+	}
+	for _, lib := range c.libraries {
+		if strings.EqualFold(lib, title) {
+			return true
+		}
+	}
+	return false
 }
 
 // pageSize is the number of albums requested per API call.

--- a/external/plex/client_test.go
+++ b/external/plex/client_test.go
@@ -101,6 +101,68 @@ func TestMusicSections_Empty(t *testing.T) {
 	}
 }
 
+func TestMusicSections_LibraryFilter(t *testing.T) {
+	serverJSON := `{"MediaContainer":{"Directory":[
+		{"key":"1","type":"artist","title":"Music"},
+		{"key":"2","type":"artist","title":"Jazz"},
+		{"key":"3","type":"artist","title":"Classical"}
+	]}}`
+
+	tests := []struct {
+		name       string
+		libraries  []string
+		wantLen    int
+		wantTitles []string
+		wantKeys   []string
+	}{
+		{
+			name:       "filter to subset",
+			libraries:  []string{"Jazz", "Classical"},
+			wantLen:    2,
+			wantTitles: []string{"Jazz", "Classical"},
+		},
+		{
+			name:      "case-insensitive match",
+			libraries: []string{"MUSIC"},
+			wantLen:   1,
+			wantKeys:  []string{"1"},
+		},
+		{
+			name:      "no match returns empty",
+			libraries: []string{"DoesNotExist"},
+			wantLen:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(serverJSON))
+			}))
+			defer srv.Close()
+
+			sections, err := NewClient(srv.URL, "test-token", tt.libraries...).MusicSections()
+			if err != nil {
+				t.Fatalf("MusicSections() error: %v", err)
+			}
+			if len(sections) != tt.wantLen {
+				t.Fatalf("got %d sections, want %d: %v", len(sections), tt.wantLen, sections)
+			}
+			for i, title := range tt.wantTitles {
+				if sections[i].Title != title {
+					t.Errorf("sections[%d].Title = %q, want %q", i, sections[i].Title, title)
+				}
+			}
+			for i, key := range tt.wantKeys {
+				if sections[i].Key != key {
+					t.Errorf("sections[%d].Key = %q, want %q", i, sections[i].Key, key)
+				}
+			}
+		})
+	}
+}
+
 func TestAlbums_RequestsType9(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("type") != "9" {

--- a/external/plex/provider.go
+++ b/external/plex/provider.go
@@ -36,7 +36,7 @@ func NewFromConfig(cfg config.PlexConfig) *Provider {
 	if !cfg.IsSet() {
 		return nil
 	}
-	return newProvider(NewClient(cfg.URL, cfg.Token))
+	return newProvider(NewClient(cfg.URL, cfg.Token, cfg.Libraries...))
 }
 
 // Name returns the display name used in the provider selector.
@@ -59,7 +59,7 @@ func (p *Provider) Playlists() ([]playlist.PlaylistInfo, error) {
 		return nil, err
 	}
 	if len(sections) == 0 {
-		return nil, fmt.Errorf("plex: no music libraries found on this server")
+		return nil, fmt.Errorf("plex: no matching music libraries found on this server")
 	}
 
 	var lists []playlist.PlaylistInfo

--- a/external/plex/provider_test.go
+++ b/external/plex/provider_test.go
@@ -135,7 +135,7 @@ func TestProvider_Playlists_NoMusicSections(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for no music sections, got nil")
 	}
-	if !strings.Contains(err.Error(), "no music libraries") {
+	if !strings.Contains(err.Error(), "no matching music libraries") {
 		t.Errorf("unexpected error message: %q", err.Error())
 	}
 }
@@ -270,5 +270,68 @@ func TestNewFromConfig_OK(t *testing.T) {
 	cfg := config.PlexConfig{URL: "http://localhost:32400", Token: "mytoken"}
 	if p := NewFromConfig(cfg); p == nil {
 		t.Error("NewFromConfig() returned nil for valid config")
+	}
+}
+
+func TestNewFromConfig_LibrariesWired(t *testing.T) {
+	tests := []struct {
+		name      string
+		libraries []string
+		wantLen   int
+	}{
+		{"no filter returns all", nil, 2},
+		{"filter to Jazz", []string{"Jazz"}, 1},
+		{"filter to jazz case-insensitive", []string{"jazz"}, 1},
+		{"filter to both", []string{"Music", "Jazz"}, 2},
+		{"no match returns error", []string{"Classical"}, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case strings.HasSuffix(r.URL.Path, "/library/sections"):
+					w.Write([]byte(`{"MediaContainer":{"Directory":[
+						{"key":"1","type":"artist","title":"Music"},
+						{"key":"2","type":"artist","title":"Jazz"}
+					]}}`))
+				case strings.HasSuffix(r.URL.Path, "/library/sections/1/all"):
+					w.Write([]byte(`{"MediaContainer":{"totalSize":1,"Metadata":[
+						{"ratingKey":"11","title":"Bitches Brew","parentTitle":"Miles Davis","year":1970,"leafCount":4}
+					]}}`))
+				case strings.HasSuffix(r.URL.Path, "/library/sections/2/all"):
+					w.Write([]byte(`{"MediaContainer":{"totalSize":1,"Metadata":[
+						{"ratingKey":"10","title":"Kind of Blue","parentTitle":"Miles Davis","year":1959,"leafCount":5}
+					]}}`))
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer srv.Close()
+
+			cfg := config.PlexConfig{
+				URL:       srv.URL,
+				Token:     "tok",
+				Libraries: tt.libraries,
+			}
+			p := NewFromConfig(cfg)
+			if p == nil {
+				t.Fatal("NewFromConfig() returned nil for valid config")
+			}
+
+			lists, err := p.Playlists()
+			if tt.wantLen == 0 {
+				if err == nil {
+					t.Errorf("expected error for no matching libraries, got %d playlists", len(lists))
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Playlists() error: %v", err)
+			}
+			if len(lists) != tt.wantLen {
+				t.Fatalf("got %d playlists, want %d", len(lists), tt.wantLen)
+			}
+		})
 	}
 }

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -38,7 +38,7 @@ var providerEmptyStateHint = map[string]string{
 	"navidrome":       "Verify [navidrome] url/username/password in config.toml.",
 	"jellyfin":        "Verify [jellyfin] url and token in config.toml.",
 	"emby":            "Verify [emby] url and token or username/password in config.toml.",
-	"plex":            "Verify [plex] server URL and token in config.toml.",
+	"plex":            "Verify [plex] server URL and token or library filter in config.toml.",
 	"youtube music":   "Run `cliamp ytmusic-login` to authorize, then refresh.",
 	"ytmusic":         "Run `cliamp ytmusic-login` to authorize, then refresh.",
 	"soundcloud":      "Set [soundcloud] user in config.toml to browse a profile.",


### PR DESCRIPTION
## Summary

Addresses #206. Adds a `libraries` option to the `[plex]` section in `config.toml`. This is a list of libraries to include when displaying/navigating through the Plex provider. This allows users to filter libraries so something like an Audiobook library is not included in the selection

## Screenshots / video

Without filters my personal library looks like this (includes all my audiobooks at the top):

<img width="865" height="291" alt="image" src="https://github.com/user-attachments/assets/5d79c307-bc21-41f7-b44f-fdfee1c04ad0" />

Filtering to just include my "music" library ( `libraries = ["Music"]` in config.toml), Audiobooks are no longer shown:

<img width="851" height="376" alt="image" src="https://github.com/user-attachments/assets/df954f90-4955-4043-8f9e-f471485fd573" />

## How to test

1. Claude added some unit tests, but otherwise I think you would need a Plex setup with multiple audio libraries to truly test this out
2. I tested this by trying various combinations of the `libraries` option in my config.toml and verifying the expected albums were displayed
   - `libraries` omitted showed both audiobooks and music
   - `libraries = ["Music"]` showed only music
   - `libraries = ["Audiobooks"]` showed only audiobooks
   - `libraries = ["asdfasdf"]` results in an error which directs the user to check their config
   - `libraries = ["Music", "Audiobooks"]` showed both libraries

## Checklist

- [x] `make check` passes
- [x] `docs/` and `site/index.html` updated for user-facing changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional library filtering for Plex integration — specify library names in config to limit which Plex libraries are loaded.

* **Documentation**
  * Updated Plex configuration docs with examples for the new library filter.

* **Bug Fixes / Behavior**
  * Playlists and library listing now respect the configured library filter; improved messaging when no matching libraries are found.

* **UI**
  * Provider empty-state hint updated to reference library filters in config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->