### PR TITLE
Spotify: stop rapid skipping from triggering browser re-auth

### DIFF
--- a/external/spotify/auth_error_test.go
+++ b/external/spotify/auth_error_test.go
@@ -1,0 +1,49 @@
+//go:build !windows
+
+package spotify
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/devgianlu/go-librespot/audio"
+)
+
+// TestIsAuthError pins down which errors trigger Spotify re-authentication.
+// Rapid track skipping cancels in-flight stream creation, surfacing
+// context.DeadlineExceeded / context.Canceled — these MUST NOT be treated as
+// auth errors, otherwise the streamer escalates to a browser re-auth flow
+// even though the session is healthy. See the regression discussion in
+// fix/spotify-rapid-skip-reauth.
+func TestIsAuthError(t *testing.T) {
+	wrappedDeadline := fmt.Errorf("librespot: fetch chunk: %w", context.DeadlineExceeded)
+	wrappedCanceled := fmt.Errorf("librespot: fetch chunk: %w", context.Canceled)
+	keyErr := &audio.KeyProviderError{Code: 1}
+	wrappedKeyErr := fmt.Errorf("spotify: %w", keyErr)
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"context.DeadlineExceeded (skip cancellation)", context.DeadlineExceeded, false},
+		{"wrapped DeadlineExceeded", wrappedDeadline, false},
+		{"context.Canceled (skip cancellation)", context.Canceled, false},
+		{"wrapped Canceled", wrappedCanceled, false},
+		{"plain network error", errors.New("connection reset by peer"), false},
+		{"KeyProviderError (real auth signal)", keyErr, true},
+		{"wrapped KeyProviderError", wrappedKeyErr, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isAuthError(tt.err)
+			if got != tt.want {
+				t.Fatalf("isAuthError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/external/spotify/provider.go
+++ b/external/spotify/provider.go
@@ -484,12 +484,19 @@ func (p *SpotifyProvider) Tracks(playlistID string) ([]playlist.Track, error) {
 // isAuthError returns true if the error is an authentication/session-related
 // failure that can be resolved by re-authenticating.
 func isAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// context.DeadlineExceeded and context.Canceled are NOT auth errors.
+	// They commonly fire during rapid track skipping when a previous NewStream's
+	// network fetch is interrupted, and previously caused spurious re-auth
+	// attempts (which then escalated to opening a browser tab mid-skip).
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return false
+	}
 	var keyErr *audio.KeyProviderError
 	if errors.As(err, &keyErr) {
-		return true
-	}
-	// Catch wrapped context errors from a dead session.
-	if errors.Is(err, context.DeadlineExceeded) {
 		return true
 	}
 	return false
@@ -501,9 +508,13 @@ func (p *SpotifyProvider) URISchemes() []string { return []string{"spotify:"} }
 
 // NewStreamer creates a SpotifyStreamer for the given spotify:track:xxx URI.
 // If the stream fails due to an auth error (e.g. expired session, AES key
-// rejection), the player first tries a silent reconnect from cached credentials.
-// If that fails or the retry still hits an auth error, it falls back to an
-// interactive OAuth2 flow and retries once more.
+// rejection), the player tries a silent reconnect from cached credentials.
+// If that fails — or the retry still hits an auth error — the streamer
+// surfaces playlist.ErrNeedsAuth so the UI can prompt the user to sign in.
+// We deliberately do NOT auto-launch a browser-based OAuth flow from this
+// path: rapid track skipping can produce transient stream errors and a
+// browser tab popping up mid-skip.
+//
 // Implements provider.CustomStreamer.
 func (p *SpotifyProvider) NewStreamer(uri string) (beep.StreamSeekCloser, beep.Format, time.Duration, error) {
 	if err := p.ensureSession(); err != nil {
@@ -532,39 +543,30 @@ func (p *SpotifyProvider) NewStreamer(uri string) (beep.StreamSeekCloser, beep.F
 		return nil, beep.Format{}, 0, fmt.Errorf("spotify: new stream: %w", err)
 	}
 
-	// Auth error — try silent reconnect first.
+	// Auth error — try a silent reconnect from cached credentials.
 	applog.UserWarn("spotify: stream auth error (%v), attempting silent reconnect...", err)
 
-	reconnCtx, reconnCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	reconnCtx, reconnCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	reconnErr := p.session.Reconnect(reconnCtx)
 	reconnCancel()
 
-	if reconnErr == nil {
-		s, err = tryStream()
-		if err == nil {
-			return s, s.Format(), s.Duration(), nil
-		}
-		if !isAuthError(err) {
-			return nil, beep.Format{}, 0, fmt.Errorf("spotify: new stream after silent reconnect: %w", err)
-		}
-		applog.UserWarn("spotify: stream still failing after silent reconnect (%v), falling back to interactive...", err)
-	} else {
-		applog.UserWarn("spotify: silent reconnect failed (%v), falling back to interactive...", reconnErr)
-	}
-
-	interactiveCtx, interactiveCancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	interactiveErr := p.session.ReconnectInteractive(interactiveCtx)
-	interactiveCancel()
-
-	if interactiveErr != nil {
-		return nil, beep.Format{}, 0, fmt.Errorf("spotify: interactive reconnect failed: %w (original: %v)", interactiveErr, err)
+	if reconnErr != nil {
+		applog.UserWarn("spotify: silent reconnect failed (%v); sign-in required", reconnErr)
+		return nil, beep.Format{}, 0, fmt.Errorf("spotify: stream auth error, silent reconnect failed: %w", playlist.ErrNeedsAuth)
 	}
 
 	s, err = tryStream()
-	if err != nil {
-		return nil, beep.Format{}, 0, fmt.Errorf("spotify: new stream after interactive reconnect: %w", err)
+	if err == nil {
+		return s, s.Format(), s.Duration(), nil
 	}
-	return s, s.Format(), s.Duration(), nil
+	if !isAuthError(err) {
+		return nil, beep.Format{}, 0, fmt.Errorf("spotify: new stream after silent reconnect: %w", err)
+	}
+
+	// Still failing after a silent reconnect — surface ErrNeedsAuth so the
+	// UI can prompt the user to sign in. Do NOT open a browser from here.
+	applog.UserWarn("spotify: stream still failing after silent reconnect (%v); sign-in required", err)
+	return nil, beep.Format{}, 0, fmt.Errorf("spotify: stream auth error after silent reconnect: %w", playlist.ErrNeedsAuth)
 }
 
 // webAPI calls the Spotify Web API via the session with retry on 429.

--- a/external/spotify/session.go
+++ b/external/spotify/session.go
@@ -43,7 +43,7 @@ const CallbackPort = 19872
 
 // Session manages a go-librespot session and player for Spotify integration.
 type Session struct {
-	mu          sync.Mutex
+	mu          sync.RWMutex
 	sess        *session.Session
 	player      *librespotPlayer.Player
 	devID       string
@@ -367,9 +367,19 @@ func (s *Session) initPlayer() error {
 }
 
 // NewStream creates a decoded audio stream for the given Spotify track ID.
+//
+// Holds s.mu.RLock() across the librespot network call. Multiple concurrent
+// NewStream / webApi callers can run in parallel (RLock is shared), so rapid
+// track skipping does not serialize. reconnect() and Close() take the full
+// Lock and will wait for in-flight callers to finish before tearing down the
+// player — without this, the swap could call oldPlayer.Close() while we are
+// still reading from it.
 func (s *Session) NewStream(ctx context.Context, spotID librespot.SpotifyId, bitrate int) (*librespotPlayer.Stream, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.player == nil {
+		return nil, fmt.Errorf("spotify: session closed")
+	}
 	return s.player.NewStream(ctx, http.DefaultClient, spotID, bitrate, 0)
 }
 
@@ -381,9 +391,9 @@ func (s *Session) NewStream(ctx context.Context, spotID librespot.SpotifyId, bit
 // So if there is no OAuth2 token source, fail loudly with ErrNeedsAuth
 // rather than attempting the call with the wrong token.
 func (s *Session) webApiWithBody(ctx context.Context, method, path string, query url.Values, body io.Reader, contentType string) (*http.Response, error) {
-	s.mu.Lock()
+	s.mu.RLock()
 	ts := s.tokenSource
-	s.mu.Unlock()
+	s.mu.RUnlock()
 
 	if ts == nil {
 		return nil, fmt.Errorf("spotify: web api token unavailable, run 'cliamp spotify reset' and sign in again: %w", playlist.ErrNeedsAuth)
@@ -441,17 +451,24 @@ func (s *Session) ReconnectInteractive(ctx context.Context) error {
 // reconnect replaces the live session using the provided builder function.
 // The new session is established before tearing down the old one to avoid a
 // window where s.sess/s.player are nil (which would crash concurrent callers).
+//
+// The swap-and-teardown phase is done under s.mu (full Lock), which waits for
+// any in-flight NewStream / webApi RLockers to drain. This guarantees that
+// oldPlayer.Close() is never called while a NewStream is still using the
+// old player pointer.
 func (s *Session) reconnect(ctx context.Context, build func(context.Context, string) (*Session, error)) error {
-	s.mu.Lock()
+	s.mu.RLock()
 	clientID := s.clientID
-	s.mu.Unlock()
+	s.mu.RUnlock()
 
 	newSess, err := build(ctx, clientID)
 	if err != nil {
 		return fmt.Errorf("spotify: reconnect: %w", err)
 	}
 
-	// Atomically swap internals.
+	// Swap and tear down the old session under a single write lock so
+	// in-flight NewStream / webApi calls finish before oldPlayer.Close()
+	// runs. The expensive build() above happened lock-free.
 	s.mu.Lock()
 	oldPlayer := s.player
 	oldSess := s.sess
@@ -459,14 +476,13 @@ func (s *Session) reconnect(ctx context.Context, build func(context.Context, str
 	s.player = newSess.player
 	s.devID = newSess.devID
 	s.tokenSource = newSess.tokenSource
-	s.mu.Unlock()
-
 	if oldPlayer != nil {
 		oldPlayer.Close()
 	}
 	if oldSess != nil {
 		oldSess.Close()
 	}
+	s.mu.Unlock()
 
 	// Prevent newSess.Close() from tearing down the resources we just adopted.
 	newSess.mu.Lock()

--- a/ui/model/playback.go
+++ b/ui/model/playback.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"errors"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -188,7 +189,15 @@ func (m *Model) playTrack(track playlist.Track) tea.Cmd {
 		return tea.Batch(playStreamCmd(m.player, track.Path, dur), fetchCmd)
 	}
 	if err := m.player.Play(track.Path, dur); err != nil {
-		m.err = err
+		// Provider session went stale (e.g. Spotify auth expired and
+		// silent reconnect failed). Surface the standard sign-in
+		// overlay rather than the raw stream error.
+		if errors.Is(err, playlist.ErrNeedsAuth) {
+			m.provSignIn = true
+			m.err = nil
+		} else {
+			m.err = err
+		}
 	} else {
 		m.err = nil
 		m.applyResume()


### PR DESCRIPTION
Skipping tracks aggressively in a Spotify playlist would frequently pop open a browser to re-authenticate, even though the librespot session was still valid. Two issues caused this, plus a contention bug that made the first easier to hit:

1. isAuthError treated any context.DeadlineExceeded as an auth failure. When skipping fast, the per-stream 30s context (or a wrapped DeadlineExceeded surfaced from librespot's chunk fetch when it was interrupted) was misclassified, kicking off the reconnect path. Reclassify: deadline/cancellation are NOT auth signals; only KeyProviderError is.

2. NewStreamer's reconnect path ended in ReconnectInteractive on the second failure, which always opens a browser. Replace the interactive fallback with returning playlist.ErrNeedsAuth so the UI can surface a sign-in prompt rather than yanking the user into a browser tab mid-skip. Silent reconnect from cached creds is still attempted once.

3. Session.NewStream held s.mu across the librespot network call, so concurrent NewStream / webApi calls serialized and were more likely to hit the 30s timeout under rapid skipping. Snapshot s.player under the lock and call NewStream lock-free.

Tests:
- New TestIsAuthError covers nil, plain errors, deadline/cancellation (wrapped + bare), and KeyProviderError (wrapped + bare).

Docs:
- docs/spotify.md notes the new behavior: rapid skipping never opens a browser; sign-in prompts surface in the UI instead.



spotify: stop rapid skipping from triggering browser re-auth

Skipping tracks aggressively in a Spotify playlist would frequently pop open a browser to re-authenticate, even though the librespot session was still valid. Two issues caused this, plus a contention bug that made the first easier to hit:

1. isAuthError treated any context.DeadlineExceeded as an auth failure. When skipping fast, the per-stream 30s context (or a wrapped DeadlineExceeded surfaced from librespot's chunk fetch when it was interrupted) was misclassified, kicking off the reconnect path. Reclassify: deadline/cancellation are NOT auth signals; only KeyProviderError is.

2. NewStreamer's reconnect path ended in ReconnectInteractive on the second failure, which always opens a browser. Replace the interactive fallback with returning playlist.ErrNeedsAuth so the UI can surface a sign-in prompt rather than yanking the user into a browser tab mid-skip. Silent reconnect from cached creds is still attempted once.

3. Session.NewStream held s.mu across the librespot network call, so concurrent NewStream / webApi calls serialized and were more likely to hit the 30s timeout under rapid skipping. Snapshot s.player under the lock and call NewStream lock-free.

Tests:
- New TestIsAuthError covers nil, plain errors, deadline/cancellation (wrapped + bare), and KeyProviderError (wrapped + bare).

Docs:
- docs/spotify.md notes the new behavior: rapid skipping never opens a browser; sign-in prompts surface in the UI instead.



spotify: stop rapid skipping from triggering browser re-auth

Skipping tracks aggressively in a Spotify playlist would frequently pop open a browser to re-authenticate, even though the librespot session was still valid. Two issues caused this, plus a contention bug that made the first easier to hit:

1. isAuthError treated any context.DeadlineExceeded as an auth failure. When skipping fast, the per-stream 30s context (or a wrapped DeadlineExceeded surfaced from librespot's chunk fetch when it was interrupted) was misclassified, kicking off the reconnect path. Reclassify: deadline/cancellation are NOT auth signals; only KeyProviderError is.

2. NewStreamer's reconnect path ended in ReconnectInteractive on the second failure, which always opens a browser. Replace the interactive fallback with returning playlist.ErrNeedsAuth so the UI can surface a sign-in prompt rather than yanking the user into a browser tab mid-skip. Silent reconnect from cached creds is still attempted once.

3. Session.NewStream held s.mu across the librespot network call, so concurrent NewStream / webApi calls serialized and were more likely to hit the 30s timeout under rapid skipping. Snapshot s.player under the lock and call NewStream lock-free.

Tests:
- New TestIsAuthError covers nil, plain errors, deadline/cancellation (wrapped + bare), and KeyProviderError (wrapped + bare).

Docs:
- docs/spotify.md notes the new behavior: rapid skipping never opens a browser; sign-in prompts surface in the UI instead.

## Summary

<!-- What does this PR do and why? -->

## Screenshots / video

<!-- Drag-and-drop screenshots or a short screen recording for UI changes. -->

## How to test

1.

## Checklist

- [ ] `make check` passes
- [ ] `docs/` and `site/index.html` updated for user-facing changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter detection of authentication errors; reduced false positives
  * Silent reconnect now uses a 30s timeout and avoids auto-launching interactive flows; surfaces explicit sign-in requirement when needed
  * Improved handling of closed sessions to prevent invalid operations

* **Performance**
  * Reduced lock contention in session handling for better concurrent responsiveness

* **Tests**
  * Added tests covering various authentication error scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->