### PR TITLE
Add initial_directory configuration property for file browser

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -13,6 +13,10 @@ shuffle = false
 # Start with mono output (L+R downmix)
 mono = false
 
+# Initial directory for the file browser ('o' key). 
+# Supports environment variables ($HOME) and tilde expansion (~/Music).
+# initial_directory = "~/Music"
+
 # Shift+Left/Right seek jump in seconds (6-600)
 seek_large_step_sec = 30
 

--- a/config/config.go
+++ b/config/config.go
@@ -194,36 +194,37 @@ func (e EmbyConfig) IsSet() bool {
 
 // Config holds user preferences loaded from the config file.
 type Config struct {
-	Volume          float64     // dB, range [-30, +6]
-	EQ              [10]float64 // per-band gain in dB, range [-12, +12]
-	EQPreset        string      // preset name, or "" for custom
-	Repeat          string      // "off", "all", or "one"
-	Shuffle         bool
-	Mono            bool
-	Speed           float64                      // playback speed ratio: 0.25–2.0 (default 1.0)
-	AutoPlay        bool                         // start playback automatically on launch (radio streams, CLI tracks)
-	SeekStepLarge   int                          // seconds for Shift+Left/Right seek jumps
-	Provider        string                       // default provider: "radio", "navidrome", "spotify", "plex", "jellyfin", "emby", "ytmusic" (default "radio")
-	Theme           string                       // theme name, or "" for ANSI default
-	Visualizer      string                       // visualizer mode name, or "" for default (Bars)
-	SampleRate      int                          // output sample rate: 22050, 44100, 48000, 96000, 192000
-	BufferMs        int                          // speaker buffer in milliseconds (50–500)
-	ResampleQuality int                          // beep resample quality factor (1–4)
-	BitDepth        int                          // PCM bit depth for FFmpeg output: 16 or 32
-	Compact         bool                         // compact mode: cap frame width at 80 columns
-	PaddingH        int                          // horizontal padding for the UI frame (default 3)
-	PaddingV        int                          // vertical padding for the UI frame (default 1)
-	AudioDevice     string                       // preferred audio output device name (empty = system default)
-	Playlist        string                       // local TOML playlist name to load on startup
-	Navidrome       NavidromeConfig              // optional Navidrome/Subsonic server credentials
-	Spotify         SpotifyConfig                // optional Spotify provider (requires Premium)
-	YouTubeMusic    YouTubeMusicConfig           // optional YouTube Music provider
-	Plex            PlexConfig                   // optional Plex Media Server credentials
-	Jellyfin        JellyfinConfig               // optional Jellyfin server credentials
-	Emby            EmbyConfig                   // optional Emby server credentials
-	SoundCloud      SoundCloudConfig             // SoundCloud provider (opt-in via enabled = true)
-	Plugins         map[string]map[string]string // per-plugin config from [plugins.*] sections
-	LogLevel        string                       // log level: debug, info, warn, error (default "info")
+	Volume           float64     // dB, range [-30, +6]
+	EQ               [10]float64 // per-band gain in dB, range [-12, +12]
+	EQPreset         string      // preset name, or "" for custom
+	Repeat           string      // "off", "all", or "one"
+	Shuffle          bool
+	Mono             bool
+	Speed            float64                      // playback speed ratio: 0.25–2.0 (default 1.0)
+	AutoPlay         bool                         // start playback automatically on launch (radio streams, CLI tracks)
+	SeekStepLarge    int                          // seconds for Shift+Left/Right seek jumps
+	Provider         string                       // default provider: "radio", "navidrome", "spotify", "plex", "jellyfin", "emby", "ytmusic" (default "radio")
+	Theme            string                       // theme name, or "" for ANSI default
+	Visualizer       string                       // visualizer mode name, or "" for default (Bars)
+	SampleRate       int                          // output sample rate: 22050, 44100, 48000, 96000, 192000
+	BufferMs         int                          // speaker buffer in milliseconds (50–500)
+	ResampleQuality  int                          // beep resample quality factor (1–4)
+	BitDepth         int                          // PCM bit depth for FFmpeg output: 16 or 32
+	Compact          bool                         // compact mode: cap frame width at 80 columns
+	PaddingH         int                          // horizontal padding for the UI frame (default 3)
+	PaddingV         int                          // vertical padding for the UI frame (default 1)
+	AudioDevice      string                       // preferred audio output device name (empty = system default)
+	Playlist         string                       // local TOML playlist name to load on startup
+	InitialDirectory string                       // initial directory for the file browser
+	Navidrome        NavidromeConfig              // optional Navidrome/Subsonic server credentials
+	Spotify          SpotifyConfig                // optional Spotify provider (requires Premium)
+	YouTubeMusic     YouTubeMusicConfig           // optional YouTube Music provider
+	Plex             PlexConfig                   // optional Plex Media Server credentials
+	Jellyfin         JellyfinConfig               // optional Jellyfin server credentials
+	Emby             EmbyConfig                   // optional Emby server credentials
+	SoundCloud       SoundCloudConfig             // SoundCloud provider (opt-in via enabled = true)
+	Plugins          map[string]map[string]string // per-plugin config from [plugins.*] sections
+	LogLevel         string                       // log level: debug, info, warn, error (default "info")
 }
 
 // defaultConfig returns a Config with sensible defaults.
@@ -457,6 +458,8 @@ func Load() (Config, error) {
 				cfg.Compact = val == "true"
 			case "audio_device":
 				cfg.AudioDevice = parseString(val)
+			case "initial_directory":
+				cfg.InitialDirectory = parseString(val)
 			case "padding_horizontal":
 				if v, err := strconv.Atoi(val); err == nil {
 					cfg.PaddingH = v

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,6 +30,9 @@ shuffle = false
 # Start with mono output (L+R downmix)
 mono = false
 
+# Initial directory for the file browser ('o' key)
+initial_directory = "~/Music"
+
 # Shift+Left/Right seek jump in seconds
 seek_large_step_sec = 30
 

--- a/main.go
+++ b/main.go
@@ -289,6 +289,7 @@ func run(overrides config.Overrides, positional []string, daemon bool) error {
 	}
 
 	m.SetSeekStepLarge(cfg.SeekStepLargeDuration())
+	m.SetInitialDirectory(cfg.InitialDirectory)
 	m.SetPendingURLs(resolved.Pending)
 	if len(resolved.Tracks) == 0 && len(resolved.Pending) == 0 && pl.Len() == 0 {
 		m.StartInProvider()

--- a/ui/model/filebrowser.go
+++ b/ui/model/filebrowser.go
@@ -144,9 +144,22 @@ func (m *Model) fbMaybeAdjustScroll(visible int) {
 // openFileBrowser initialises and shows the file browser overlay.
 func (m *Model) openFileBrowser() {
 	if m.fileBrowser.dir == "" {
-		m.fileBrowser.dir, _ = os.UserHomeDir()
+		m.fileBrowser.dir = m.initialDir
+		if strings.HasPrefix(m.fileBrowser.dir, "~") {
+			if home, _ := os.UserHomeDir(); home != "" {
+				m.fileBrowser.dir = filepath.Join(home, m.fileBrowser.dir[1:])
+			}
+		}
+		if m.fileBrowser.dir != "" {
+			if info, err := os.Stat(m.fileBrowser.dir); err != nil || !info.IsDir() {
+				m.fileBrowser.dir = ""
+			}
+		}
 		if m.fileBrowser.dir == "" {
-			m.fileBrowser.dir = "/"
+			m.fileBrowser.dir, _ = os.UserHomeDir()
+			if m.fileBrowser.dir == "" {
+				m.fileBrowser.dir = "/"
+			}
 		}
 	}
 	m.fileBrowser.cursor = 0

--- a/ui/model/filebrowser.go
+++ b/ui/model/filebrowser.go
@@ -144,15 +144,15 @@ func (m *Model) fbMaybeAdjustScroll(visible int) {
 // openFileBrowser initialises and shows the file browser overlay.
 func (m *Model) openFileBrowser() {
 	if m.fileBrowser.dir == "" {
-		m.fileBrowser.dir = m.initialDir
-		if strings.HasPrefix(m.fileBrowser.dir, "~") {
+		dir := os.ExpandEnv(m.initialDir)
+		if strings.HasPrefix(dir, "~") {
 			if home, _ := os.UserHomeDir(); home != "" {
-				m.fileBrowser.dir = filepath.Join(home, m.fileBrowser.dir[1:])
+				dir = filepath.Join(home, dir[1:])
 			}
 		}
-		if m.fileBrowser.dir != "" {
-			if info, err := os.Stat(m.fileBrowser.dir); err != nil || !info.IsDir() {
-				m.fileBrowser.dir = ""
+		if dir != "" {
+			if info, err := os.Stat(dir); err == nil && info.IsDir() {
+				m.fileBrowser.dir = dir
 			}
 		}
 		if m.fileBrowser.dir == "" {

--- a/ui/model/init.go
+++ b/ui/model/init.go
@@ -81,6 +81,9 @@ func (m *Model) SetAutoPlay(v bool) { m.autoPlay = v }
 // SetCompact enables compact mode which caps the frame width at 80 columns.
 func (m *Model) SetCompact(v bool) { m.compact = v }
 
+// SetInitialDirectory sets the initial directory for the file browser.
+func (m *Model) SetInitialDirectory(dir string) { m.initialDir = dir }
+
 // SetSeekStepLarge configures the Shift+Left/Right seek jump amount.
 func (m *Model) SetSeekStepLarge(d time.Duration) {
 	switch {

--- a/ui/model/model.go
+++ b/ui/model/model.go
@@ -242,6 +242,9 @@ type Model struct {
 	// History recorder (nil if config dir unavailable; safe to call when nil)
 	historyStore *history.Store
 
+	// initialDir is the starting path for the file browser ('o' key).
+	initialDir string
+
 	// Theme state: -1 = Default (ANSI), 0+ = index into themes
 	themes   []theme.Theme
 	themeIdx int


### PR DESCRIPTION
This PR adds a new `initial_directory` property to the `config.toml`.

The goal is to allow for a preferred starting point for the file browser `o`, so it is no longer necessary to navigate from the home directory to a local music library whenever the application is launched.

* New configuration property `initial_directory` added to `config.toml`.
* Supports tilde expansion and environment variables
* Has validation to ensure the path exists and is a directory (falls back to ~)
* Updated `config.toml.example` and `docs/configuration.md`

Examples

Tilde
`initial_directory = "~/Music/Library"`

Path with spaces
`initial_directory = "${HOME}/Music Library"`

Unquoted path
`initial_directory = $HOME/Music/Library`

Custom environment variable
`initial_directory = ${MUSIC_PATH}`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File browser now supports a configurable initial directory. When opening the file browser with the `o` key, it will start in your configured directory. The setting supports environment variables (e.g., `$HOME`) and tilde expansion (e.g., `~/Music`). Invalid directories automatically fall back to your home directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->