### PR TITLE
plex: route stream URLs through navBuffer pipeline

### DIFF
--- a/external/plex/client.go
+++ b/external/plex/client.go
@@ -253,6 +253,17 @@ func (c *Client) StreamURL(partKey string) string {
 	return c.baseURL + partKey + "?X-Plex-Token=" + url.QueryEscape(c.token)
 }
 
+// IsStreamURL reports whether the given URL looks like a Plex library part
+// endpoint. Used by the player to route these URLs through the buffered
+// navBuffer + ffmpeg pipeline instead of native HTTP streaming.
+func IsStreamURL(path string) bool {
+	u, err := url.Parse(path)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(u.Path), "/library/parts/")
+}
+
 // trackJSON is the shared JSON structure for track responses (children and search).
 type trackJSON struct {
 	RatingKey        string `json:"ratingKey"`

--- a/external/plex/client.go
+++ b/external/plex/client.go
@@ -256,8 +256,8 @@ func (c *Client) StreamURL(partKey string) string {
 // IsStreamURL reports whether the given URL looks like a Plex library part
 // endpoint. Used by the player to route these URLs through the buffered
 // navBuffer + ffmpeg pipeline instead of native HTTP streaming.
-func IsStreamURL(path string) bool {
-	u, err := url.Parse(path)
+func IsStreamURL(urlStr string) bool {
+	u, err := url.Parse(urlStr)
 	if err != nil {
 		return false
 	}

--- a/main.go
+++ b/main.go
@@ -225,7 +225,7 @@ func run(overrides config.Overrides, positional []string, daemon bool) error {
 	}
 
 	p.RegisterBufferedURLMatcher(func(u string) bool {
-		return navidrome.IsSubsonicStreamURL(u) || jellyfin.IsStreamURL(u) || emby.IsStreamURL(u)
+		return navidrome.IsSubsonicStreamURL(u) || jellyfin.IsStreamURL(u) || emby.IsStreamURL(u) || plex.IsStreamURL(u)
 	})
 
 	cfg.ApplyPlayer(p)


### PR DESCRIPTION
## Summary

- Plex track URLs were missing from the buffered URL matcher, causing high-bitrate files (e.g. WAV at 1411 kbps) to stall and skip
- The native WAV decoder timed out waiting to buffer the entire file over HTTP before playback could start
- Adds `plex.IsStreamURL` matching `/library/parts/` URLs, routing them through the existing `navBuffer + ffmpeg` pipeline (same approach already used for Navidrome, Jellyfin, and Emby)

## Test plan

- [ ] Play a WAV album from Plex — tracks should stream without skipping
- [ ] Play a FLAC/MP3 album from Plex — verify no regression
- [ ] `make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Plex library stream support to the buffered streaming pipeline. Plex stream URLs are now recognized for buffered playback handling, improving playback stability and parity with existing Navidrome, Jellyfin, and Emby support.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bjarneo/cliamp/pull/223)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->