### PR TITLE
Fix the dependencies for building it under Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ sudo apt install libasound2-dev
 **Linux (Fedora):**
 
 ```sh
-sudo dnf install alsa-lib-devel
+sudo dnf install alsa-lib-devel libvorbis-devel flac-devel
 ```
 
 **Linux (Arch):**


### PR DESCRIPTION
Fixes might still be needed for Arch, Debian or  Ubuntu

## Summary

Building the project from source on fedora requires 2 additional packages that are not preinstalled, or inside the dependency section of the README. It will not build without them.

## Screenshots / video

Should not be necessairy. I just changed the README.

## How to test

1. Boot up a fedora environment, 
2. Copy and paste the command for installing deps
3. Check if it builds

## Checklist

- [x] `make check` passes
- [x] `docs/` and `site/index.html` updated for user-facing changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Linux (Fedora) build prerequisites documentation to include additional codec development packages required for building from source.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bjarneo/cliamp/pull/224)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->