### PR TITLE
Fix kbd elements alignment in key-row

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1942,7 +1942,7 @@ user_id = "your-account-user-id"</code></pre>
           <div class="key-row"><kbd>&gt; / &lt;</kbd><span>Next / Previous track</span></div>
           <div class="key-row"><kbd>&larr; / &rarr;</kbd><span>Seek &minus;/+5s</span></div>
           <div class="key-row"><kbd>Shift+&larr; / Shift+&rarr;</kbd><span>Seek &minus;/+30s (default)</span></div>
-          <div class="key-row"><kbd>N then J</kbd><span>Seek to N&times;10% (e.g. <kbd>7j</kbd> = 70%)</span></div>
+          <div class="key-row"><kbd>N then j</kbd><span>Seek to N&times;10% (e.g. <kbd>7j</kbd> = 70%)</span></div>
           <div class="key-row"><kbd>Ctrl+J</kbd><span>Jump to time</span></div>
           <div class="key-row"><kbd>+ / &minus;</kbd><span>Volume up / down</span></div>
           <div class="key-row"><kbd>] / [</kbd><span>Speed &plusmn;0.25x</span></div>

--- a/site/index.html
+++ b/site/index.html
@@ -789,7 +789,6 @@
   /* ═══════════ KEYBINDINGS ═══════════ */
   .keys-groups{
     display:grid;
-    grid-template-columns:repeat(2,1fr);
     gap:10px;
   }
   .keys-group{
@@ -1941,9 +1940,9 @@ user_id = "your-account-user-id"</code></pre>
           <div class="key-row"><kbd>Space</kbd><span>Play / Pause</span></div>
           <div class="key-row"><kbd>s</kbd><span>Stop</span></div>
           <div class="key-row"><kbd>&gt; / &lt;</kbd><span>Next / Previous track</span></div>
-          <div class="key-row"><kbd>&larr; &rarr;</kbd><span>Seek &minus;/+5s</span></div>
-          <div class="key-row"><kbd>Shift+&larr; Shift+&rarr;</kbd><span>Seek &minus;/+30s (default)</span></div>
-          <div class="key-row"><kbd>N</kbd> then <kbd>j</kbd><span>Seek to N&times;10% (e.g. <kbd>7j</kbd> = 70%)</span></div>
+          <div class="key-row"><kbd>&larr; / &rarr;</kbd><span>Seek &minus;/+5s</span></div>
+          <div class="key-row"><kbd>Shift+&larr; / Shift+&rarr;</kbd><span>Seek &minus;/+30s (default)</span></div>
+          <div class="key-row"><kbd>N then J</kbd><span>Seek to N&times;10% (e.g. <kbd>7j</kbd> = 70%)</span></div>
           <div class="key-row"><kbd>Ctrl+J</kbd><span>Jump to time</span></div>
           <div class="key-row"><kbd>+ / &minus;</kbd><span>Volume up / down</span></div>
           <div class="key-row"><kbd>] / [</kbd><span>Speed &plusmn;0.25x</span></div>
@@ -1963,7 +1962,7 @@ user_id = "your-account-user-id"</code></pre>
           <div class="key-row"><kbd>Home / End</kbd><span>Jump to top / end</span></div>
           <div class="key-row"><kbd>g / G</kbd><span>Vim-style top / bottom</span></div>
           <div class="key-row"><kbd>Enter</kbd><span>Play selected</span></div>
-          <div class="key-row"><kbd>Shift+&uarr; Shift+&darr;</kbd><span>Move track up / down</span></div>
+          <div class="key-row"><kbd>Shift+&uarr; / Shift+&darr;</kbd><span>Move track up / down</span></div>
           <div class="key-row"><kbd>Esc / b</kbd><span>Back to provider</span></div>
         </div>
       </div>
@@ -1992,19 +1991,19 @@ user_id = "your-account-user-id"</code></pre>
           <div class="key-row"><kbd>P</kbd><span>Play all tracks from the top</span></div>
           <div class="key-row"><kbd>a</kbd><span>Add the now-playing track (footer shows which one)</span></div>
           <div class="key-row"><kbd>d</kbd><span>Delete playlist (confirms) / remove track</span></div>
-          <div class="key-row"><kbd>Esc</kbd> / <kbd>p</kbd><span>Close (or clear active filter)</span></div>
+          <div class="key-row"><kbd>Esc / p</kbd><span>Close (or clear active filter)</span></div>
         </div>
       </div>
 
       <div class="keys-group">
         <div class="keys-group-title">Provider Playlists Pane</div>
         <div class="keys-group-body">
-          <div class="key-row"><kbd>↑</kbd> <kbd>↓</kbd> / <kbd>j</kbd> <kbd>k</kbd><span>Move cursor (wraps)</span></div>
+          <div class="key-row"><kbd>↑ / ↓&nbsp;&nbsp;&nbsp;j / k</kbd><span>Move cursor (wraps)</span></div>
           <div class="key-row"><kbd>Enter</kbd><span>Load the highlighted playlist's tracks into the queue</span></div>
           <div class="key-row"><kbd>/</kbd><span>Filter the visible playlists</span></div>
           <div class="key-row"><kbd>Ctrl+F</kbd><span>Online / server search via the provider's own search</span></div>
           <div class="key-row"><kbd>Ctrl+R</kbd><span>Refresh — re-pull playlists from the provider</span></div>
-          <div class="key-row"><kbd>S</kbd> <kbd>N</kbd> <kbd>P</kbd> <kbd>J</kbd> <kbd>E</kbd> <kbd>Y</kbd> <kbd>C</kbd> <kbd>M</kbd> <kbd>L</kbd> <kbd>R</kbd><span>Switch to Spotify / Navidrome / Plex / Jellyfin / Emby / YouTube / SoundCloud / NetEase / Local / Radio</span></div>
+          <div class="key-row"><kbd>S / N / P / J / E / Y / C / M / L / R</kbd><span>Switch to Spotify / Navidrome / Plex / Jellyfin / Emby / YouTube / SoundCloud / NetEase / Local / Radio</span></div>
           <div class="key-row"><kbd>▶</kbd><span>Marker on the row whose tracks are currently loaded</span></div>
         </div>
       </div>
@@ -2012,15 +2011,15 @@ user_id = "your-account-user-id"</code></pre>
       <div class="keys-group">
         <div class="keys-group-title">Provider Browser (<kbd>N</kbd>)</div>
         <div class="keys-group-body">
-          <div class="key-row"><kbd>↑</kbd> <kbd>↓</kbd> / <kbd>j</kbd> <kbd>k</kbd><span>Move cursor (wraps top↔bottom)</span></div>
-          <div class="key-row"><kbd>←</kbd> <kbd>→</kbd> / <kbd>h</kbd> <kbd>l</kbd><span>Back / drill in</span></div>
+          <div class="key-row"><kbd>↑ / ↓&nbsp;&nbsp;&nbsp;j / k</kbd><span>Move cursor (wraps top↔bottom)</span></div>
+          <div class="key-row"><kbd>← / →&nbsp;&nbsp;&nbsp;h / l</kbd><span>Back / drill in</span></div>
           <div class="key-row"><kbd>Enter</kbd><span>Open (artists/albums) · play the highlighted track and queue the rest</span></div>
           <div class="key-row"><kbd>R</kbd><span>Replace queue with all visible tracks (start from #1)</span></div>
           <div class="key-row"><kbd>a</kbd><span>Append all visible tracks to the queue</span></div>
           <div class="key-row"><kbd>q</kbd><span>Queue the highlighted track to play next</span></div>
           <div class="key-row"><kbd>s</kbd><span>Cycle album sort (album list only)</span></div>
           <div class="key-row"><kbd>/</kbd><span>Filter the visible list (search bar appears under the title)</span></div>
-          <div class="key-row"><kbd>S</kbd> <kbd>N</kbd> <kbd>P</kbd> <kbd>J</kbd> <kbd>E</kbd> <kbd>Y</kbd> <kbd>C</kbd> <kbd>M</kbd> <kbd>L</kbd> <kbd>R</kbd><span>Quick-switch to another provider without going back to the main pane</span></div>
+          <div class="key-row"><kbd>S / N / P / J / E / Y / C / M / L / R</kbd><span>Quick-switch to another provider without going back to the main pane</span></div>
           <div class="key-row"><kbd>Esc</kbd><span>Walk back one level / close the browser</span></div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

This is simply a site-side fix that had broken keybinding containers.

## Screenshots / video

#### Before
<img width="1255" height="933" alt="image" src="https://github.com/user-attachments/assets/c4b8c640-db41-4122-9bc9-3c3507dce03d" />

#### After
<img width="1255" height="933" alt="image" src="https://github.com/user-attachments/assets/b761f3e0-cb9b-4bc6-8dd2-aeb3bcd2d96a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized keyboard shortcut labels across Transport, Navigation, Playlist Manager, and Provider panes (consolidated multi-key labels, slash-separated alternate keys, combined seek labels) for clearer, consistent wording.

* **Style**
  * Updated keybindings layout and visual presentation to improve readability and organization of the Keybindings section.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bjarneo/cliamp/pull/231)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->