### PR TITLE
Standardize scrolling and expanded height for all overlays

### DIFF
--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -1864,12 +1864,14 @@ func (m *Model) handleQueueKey(msg tea.KeyPressMsg) tea.Cmd {
 				m.queue.cursor--
 			}
 		}
+		m.queueMaybeAdjustScroll(m.queueVisible())
 	case "shift+down":
 		if m.queue.cursor < qLen-1 {
 			if m.playlist.MoveQueue(m.queue.cursor, m.queue.cursor+1) {
 				m.queue.cursor++
 			}
 		}
+		m.queueMaybeAdjustScroll(m.queueVisible())
 	case "d":
 		if qLen > 0 {
 			m.playlist.RemoveQueueAt(m.queue.cursor)
@@ -1877,6 +1879,7 @@ func (m *Model) handleQueueKey(msg tea.KeyPressMsg) tea.Cmd {
 				m.queue.cursor--
 			}
 		}
+		m.queueMaybeAdjustScroll(m.queueVisible())
 	case "c":
 		m.playlist.ClearQueue()
 		m.queue.visible = false

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -951,6 +951,13 @@ func (m *Model) handleProvSearchKey(msg tea.KeyPressMsg) tea.Cmd {
 	if cs, ok := m.provider.(provider.CatalogSearcher); ok {
 		return m.handleCatalogSearchKey(msg, cs)
 	}
+
+	if msg.String() == "ctrl+x" {
+		m.toggleExpandedView()
+		m.provSearchMaybeAdjustScroll()
+		return nil
+	}
+
 	switch msg.Code {
 	case tea.KeyEscape:
 		m.provSearch.active = false
@@ -1151,6 +1158,10 @@ func (m *Model) handleSearchKey(msg tea.KeyPressMsg) tea.Cmd {
 	case "ctrl+k":
 		m.openKeymap()
 		return nil
+	case "ctrl+x":
+		m.toggleExpandedView()
+		m.searchMaybeAdjustScroll(m.searchVisible())
+		return nil
 	}
 
 	switch msg.Code {
@@ -1272,6 +1283,9 @@ func (m *Model) handleNetSearchResultsKey(msg tea.KeyPressMsg) tea.Cmd {
 	count := len(m.netSearch.results)
 
 	switch msg.String() {
+	case "ctrl+x":
+		m.toggleExpandedView()
+		m.netSearchResultsMaybeAdjustScroll(m.netSearchResultsVisible())
 	case "up", "k":
 		if m.netSearch.cursor > 0 {
 			m.netSearch.cursor--
@@ -1826,6 +1840,9 @@ func (m *Model) handleQueueKey(msg tea.KeyPressMsg) tea.Cmd {
 		return m.quit()
 	case "ctrl+k", "?":
 		m.openKeymap()
+	case "ctrl+x":
+		m.toggleExpandedView()
+		m.queueMaybeAdjustScroll(m.queueVisible())
 	case "up", "k":
 		if m.queue.cursor > 0 {
 			m.queue.cursor--
@@ -1879,6 +1896,9 @@ func (m *Model) handleDeviceKey(msg tea.KeyPressMsg) tea.Cmd {
 	case "ctrl+c":
 		m.devicePicker.visible = false
 		return m.quit()
+	case "ctrl+x":
+		m.toggleExpandedView()
+		m.deviceMaybeAdjustScroll(m.devicePickerVisible())
 	case "up", "k":
 		if m.devicePicker.cursor > 0 {
 			m.devicePicker.cursor--

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -1912,7 +1912,7 @@ func (m *Model) handleDeviceKey(msg tea.KeyPressMsg) tea.Cmd {
 	case "down", "j":
 		if m.devicePicker.cursor < len(m.devicePicker.devices)-1 {
 			m.devicePicker.cursor++
-		} else {
+		} else if len(m.devicePicker.devices) > 0 {
 			m.devicePicker.cursor = 0
 		}
 		m.deviceMaybeAdjustScroll(m.devicePickerVisible())

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -319,6 +319,7 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 			m.provSearch.query = ""
 			m.provSearch.results = nil
 			m.provSearch.cursor = 0
+			m.provSearch.scroll = 0
 		case "ctrl+r":
 			if m.provider != nil && !m.provLoading {
 				if r, ok := m.provider.(playlist.Refresher); ok {
@@ -654,6 +655,7 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 		if m.focus == focusPlaylist {
 			m.queue.visible = true
 			m.queue.cursor = 0
+			m.queue.scroll = 0
 		}
 
 	case "ctrl+s":
@@ -669,6 +671,7 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 		m.search.query = ""
 		m.search.results = nil
 		m.search.cursor = 0
+		m.search.scroll = 0
 		m.prevFocus = m.focus
 		m.focus = focusSearch
 
@@ -768,6 +771,7 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 	case "d":
 		m.devicePicker.visible = true
 		m.devicePicker.cursor = 0
+		m.devicePicker.scroll = 0
 		if len(m.devicePicker.devices) == 0 {
 			m.devicePicker.loading = true
 			return listDevicesCmd()
@@ -930,6 +934,15 @@ func (m *Model) handleJumpKey(msg tea.KeyPressMsg) tea.Cmd {
 	return nil
 }
 
+func (m *Model) provSearchMaybeAdjustScroll() {
+	visible := m.providerScrollStep() - 1 // -1 for query line
+	if visible < 1 {
+		visible = 1
+	}
+	count := len(m.provSearch.results)
+	clampScroll(&m.provSearch.cursor, &m.provSearch.scroll, count, visible)
+}
+
 // handleProvSearchKey processes key presses while filtering the provider playlist list.
 // For the radio provider, Enter fires an API search; for others, Enter loads the
 // selected result. Esc cancels and restores the normal catalog view.
@@ -954,11 +967,18 @@ func (m *Model) handleProvSearchKey(msg tea.KeyPressMsg) tea.Cmd {
 	case tea.KeyUp:
 		if m.provSearch.cursor > 0 {
 			m.provSearch.cursor--
+		} else if len(m.provSearch.results) > 0 {
+			m.provSearch.cursor = len(m.provSearch.results) - 1
 		}
+		m.provSearchMaybeAdjustScroll()
+
 	case tea.KeyDown:
 		if m.provSearch.cursor < len(m.provSearch.results)-1 {
 			m.provSearch.cursor++
+		} else if len(m.provSearch.results) > 0 {
+			m.provSearch.cursor = 0
 		}
+		m.provSearchMaybeAdjustScroll()
 	case tea.KeyBackspace:
 		if m.provSearch.query != "" {
 			m.provSearch.query = removeLastRune(m.provSearch.query)
@@ -1021,6 +1041,7 @@ func (m *Model) restoreCatalog(cs provider.CatalogSearcher) {
 func (m *Model) updateProvSearch() {
 	m.provSearch.results = nil
 	m.provSearch.cursor = 0
+	m.provSearch.scroll = 0
 	if m.provSearch.query == "" {
 		return
 	}
@@ -1120,6 +1141,10 @@ func (m *Model) handlePaste(content string) tea.Cmd {
 	return nil
 }
 
+func (m *Model) searchMaybeAdjustScroll(visible int) {
+	clampScroll(&m.search.cursor, &m.search.scroll, len(m.search.results), visible)
+}
+
 func (m *Model) handleSearchKey(msg tea.KeyPressMsg) tea.Cmd {
 	// Allow opening overlays during search (ctrl combos don't conflict with text input).
 	switch msg.String() {
@@ -1159,12 +1184,18 @@ func (m *Model) handleSearchKey(msg tea.KeyPressMsg) tea.Cmd {
 	case tea.KeyUp:
 		if m.search.cursor > 0 {
 			m.search.cursor--
+		} else if len(m.search.results) > 0 {
+			m.search.cursor = len(m.search.results) - 1
 		}
+		m.searchMaybeAdjustScroll(m.searchVisible())
 
 	case tea.KeyDown:
 		if m.search.cursor < len(m.search.results)-1 {
 			m.search.cursor++
+		} else if len(m.search.results) > 0 {
+			m.search.cursor = 0
 		}
+		m.searchMaybeAdjustScroll(m.searchVisible())
 
 	case tea.KeyBackspace:
 		if m.search.query != "" {
@@ -1232,6 +1263,10 @@ func (m *Model) handleNetSearchInputKey(msg tea.KeyPressMsg) tea.Cmd {
 	return nil
 }
 
+func (m *Model) netSearchResultsMaybeAdjustScroll(visible int) {
+	clampScroll(&m.netSearch.cursor, &m.netSearch.scroll, len(m.netSearch.results), visible)
+}
+
 // handleNetSearchResultsKey handles navigation through net search results.
 func (m *Model) handleNetSearchResultsKey(msg tea.KeyPressMsg) tea.Cmd {
 	count := len(m.netSearch.results)
@@ -1243,12 +1278,14 @@ func (m *Model) handleNetSearchResultsKey(msg tea.KeyPressMsg) tea.Cmd {
 		} else if count > 0 {
 			m.netSearch.cursor = count - 1
 		}
+		m.netSearchResultsMaybeAdjustScroll(m.netSearchResultsVisible())
 	case "down", "j":
 		if m.netSearch.cursor < count-1 {
 			m.netSearch.cursor++
 		} else if count > 0 {
 			m.netSearch.cursor = 0
 		}
+		m.netSearchResultsMaybeAdjustScroll(m.netSearchResultsVisible())
 	case "enter":
 		if count > 0 && !m.netSearch.loading {
 			track := m.netSearch.results[m.netSearch.cursor]
@@ -1271,6 +1308,7 @@ func (m *Model) handleNetSearchResultsKey(msg tea.KeyPressMsg) tea.Cmd {
 		m.netSearch.screen = netSearchInput
 		m.netSearch.results = nil
 		m.netSearch.cursor = 0
+		m.netSearch.scroll = 0
 		m.netSearch.err = ""
 	}
 	return nil
@@ -1775,6 +1813,10 @@ func (m *Model) handleThemeKey(msg tea.KeyPressMsg) tea.Cmd {
 }
 
 // handleQueueKey processes key presses while the queue manager overlay is open.
+func (m *Model) queueMaybeAdjustScroll(visible int) {
+	clampScroll(&m.queue.cursor, &m.queue.scroll, m.playlist.QueueLen(), visible)
+}
+
 func (m *Model) handleQueueKey(msg tea.KeyPressMsg) tea.Cmd {
 	qLen := m.playlist.QueueLen()
 
@@ -1790,12 +1832,15 @@ func (m *Model) handleQueueKey(msg tea.KeyPressMsg) tea.Cmd {
 		} else if qLen > 0 {
 			m.queue.cursor = qLen - 1
 		}
+		m.queueMaybeAdjustScroll(m.queueVisible())
+
 	case "down", "j":
 		if m.queue.cursor < qLen-1 {
 			m.queue.cursor++
 		} else if qLen > 0 {
 			m.queue.cursor = 0
 		}
+		m.queueMaybeAdjustScroll(m.queueVisible())
 	case "shift+up":
 		if m.queue.cursor > 0 {
 			if m.playlist.MoveQueue(m.queue.cursor, m.queue.cursor-1) {
@@ -1824,6 +1869,10 @@ func (m *Model) handleQueueKey(msg tea.KeyPressMsg) tea.Cmd {
 	return nil
 }
 
+func (m *Model) deviceMaybeAdjustScroll(visible int) {
+	clampScroll(&m.devicePicker.cursor, &m.devicePicker.scroll, len(m.devicePicker.devices), visible)
+}
+
 // handleDeviceKey processes key presses while the audio device picker is open.
 func (m *Model) handleDeviceKey(msg tea.KeyPressMsg) tea.Cmd {
 	switch msg.String() {
@@ -1836,12 +1885,14 @@ func (m *Model) handleDeviceKey(msg tea.KeyPressMsg) tea.Cmd {
 		} else if len(m.devicePicker.devices) > 0 {
 			m.devicePicker.cursor = len(m.devicePicker.devices) - 1
 		}
+		m.deviceMaybeAdjustScroll(m.devicePickerVisible())
 	case "down", "j":
 		if m.devicePicker.cursor < len(m.devicePicker.devices)-1 {
 			m.devicePicker.cursor++
 		} else {
 			m.devicePicker.cursor = 0
 		}
+		m.deviceMaybeAdjustScroll(m.devicePickerVisible())
 	case "enter":
 		if len(m.devicePicker.devices) > 0 && m.devicePicker.cursor < len(m.devicePicker.devices) {
 			dev := m.devicePicker.devices[m.devicePicker.cursor]

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -947,15 +947,15 @@ func (m *Model) provSearchMaybeAdjustScroll() {
 // For the radio provider, Enter fires an API search; for others, Enter loads the
 // selected result. Esc cancels and restores the normal catalog view.
 func (m *Model) handleProvSearchKey(msg tea.KeyPressMsg) tea.Cmd {
-	// Catalog search: API-based search (no live client-side filtering).
-	if cs, ok := m.provider.(provider.CatalogSearcher); ok {
-		return m.handleCatalogSearchKey(msg, cs)
-	}
-
 	if msg.String() == "ctrl+x" {
 		m.toggleExpandedView()
 		m.provSearchMaybeAdjustScroll()
 		return nil
+	}
+
+	// Catalog search: API-based search (no live client-side filtering).
+	if cs, ok := m.provider.(provider.CatalogSearcher); ok {
+		return m.handleCatalogSearchKey(msg, cs)
 	}
 
 	switch msg.Code {

--- a/ui/model/keys_nav.go
+++ b/ui/model/keys_nav.go
@@ -34,6 +34,13 @@ func (m *Model) handleNavBrowserKey(msg tea.KeyPressMsg) tea.Cmd {
 		if m.navBrowser.searching {
 			return m.handleNavSearchKey(msg)
 		}
+
+		if key == "ctrl+x" {
+			m.toggleExpandedView()
+			m.navMaybeAdjustScroll()
+			return nil
+		}
+
 		if key == "/" {
 			// Toggle: if already filtered, clear; otherwise open.
 			if m.navBrowser.search != "" {
@@ -61,6 +68,9 @@ func (m *Model) handleNavBrowserKey(msg tea.KeyPressMsg) tea.Cmd {
 func (m *Model) handleNavMenuKey(msg tea.KeyPressMsg) tea.Cmd {
 	const menuItems = 3
 	switch msg.String() {
+	case "ctrl+x":
+		m.toggleExpandedView()
+		return nil
 	case "ctrl+c":
 		m.navBrowser.visible = false
 		return m.quit()

--- a/ui/model/keys_spotify_search.go
+++ b/ui/model/keys_spotify_search.go
@@ -65,6 +65,9 @@ func (m *Model) handleSpotSearchResultsKey(msg tea.KeyPressMsg) tea.Cmd {
 	count := len(m.spotSearch.results)
 
 	switch msg.String() {
+	case "ctrl+x":
+		m.toggleExpandedView()
+		m.spotSearchResultsMaybeAdjustScroll(m.spotSearchResultsVisible())
 	case "up", "k":
 		if m.spotSearch.cursor > 0 {
 			m.spotSearch.cursor--
@@ -121,6 +124,9 @@ func (m *Model) handleSpotSearchPlaylistKey(msg tea.KeyPressMsg) tea.Cmd {
 	count := len(m.spotSearch.playlists) + 1 // +1 for "+ New Playlist..."
 
 	switch msg.String() {
+	case "ctrl+x":
+		m.toggleExpandedView()
+		m.spotSearchPlaylistMaybeAdjustScroll(m.spotSearchPlaylistVisible())
 	case "up", "k":
 		if m.spotSearch.cursor > 0 {
 			m.spotSearch.cursor--

--- a/ui/model/keys_spotify_search.go
+++ b/ui/model/keys_spotify_search.go
@@ -56,6 +56,10 @@ func (m *Model) handleSpotSearchInputKey(msg tea.KeyPressMsg) tea.Cmd {
 	return nil
 }
 
+func (m *Model) spotSearchResultsMaybeAdjustScroll(visible int) {
+	clampScroll(&m.spotSearch.cursor, &m.spotSearch.scroll, len(m.spotSearch.results), visible)
+}
+
 // handleSpotSearchResultsKey handles navigation through search results.
 func (m *Model) handleSpotSearchResultsKey(msg tea.KeyPressMsg) tea.Cmd {
 	count := len(m.spotSearch.results)
@@ -67,12 +71,14 @@ func (m *Model) handleSpotSearchResultsKey(msg tea.KeyPressMsg) tea.Cmd {
 		} else if count > 0 {
 			m.spotSearch.cursor = count - 1
 		}
+		m.spotSearchResultsMaybeAdjustScroll(m.spotSearchResultsVisible())
 	case "down", "j":
 		if m.spotSearch.cursor < count-1 {
 			m.spotSearch.cursor++
 		} else if count > 0 {
 			m.spotSearch.cursor = 0
 		}
+		m.spotSearchResultsMaybeAdjustScroll(m.spotSearchResultsVisible())
 	case "enter":
 		if count > 0 && !m.spotSearch.loading {
 			track := m.spotSearch.results[m.spotSearch.cursor]
@@ -105,6 +111,11 @@ func (m *Model) handleSpotSearchResultsKey(msg tea.KeyPressMsg) tea.Cmd {
 	return nil
 }
 
+func (m *Model) spotSearchPlaylistMaybeAdjustScroll(visible int) {
+	count := len(m.spotSearch.playlists) + 1
+	clampScroll(&m.spotSearch.cursor, &m.spotSearch.scroll, count, visible)
+}
+
 // handleSpotSearchPlaylistKey handles picking a playlist to add to.
 func (m *Model) handleSpotSearchPlaylistKey(msg tea.KeyPressMsg) tea.Cmd {
 	count := len(m.spotSearch.playlists) + 1 // +1 for "+ New Playlist..."
@@ -116,12 +127,14 @@ func (m *Model) handleSpotSearchPlaylistKey(msg tea.KeyPressMsg) tea.Cmd {
 		} else if count > 0 {
 			m.spotSearch.cursor = count - 1
 		}
+		m.spotSearchPlaylistMaybeAdjustScroll(m.spotSearchPlaylistVisible())
 	case "down", "j":
 		if m.spotSearch.cursor < count-1 {
 			m.spotSearch.cursor++
 		} else if count > 0 {
 			m.spotSearch.cursor = 0
 		}
+		m.spotSearchPlaylistMaybeAdjustScroll(m.spotSearchPlaylistVisible())
 	case "enter":
 		if m.spotSearch.loading {
 			return nil
@@ -145,9 +158,11 @@ func (m *Model) handleSpotSearchPlaylistKey(msg tea.KeyPressMsg) tea.Cmd {
 		m.spotSearch.screen = spotSearchNewName
 		m.spotSearch.newName = ""
 		m.spotSearch.cursor = 0
+		m.spotSearch.scroll = 0
 	case "esc", "backspace":
 		m.spotSearch.screen = spotSearchResults
 		m.spotSearch.cursor = 0
+		m.spotSearch.scroll = 0
 		m.spotSearch.err = ""
 	}
 	return nil
@@ -159,6 +174,7 @@ func (m *Model) handleSpotSearchNewNameKey(msg tea.KeyPressMsg) tea.Cmd {
 	case tea.KeyEscape:
 		m.spotSearch.screen = spotSearchPlaylist
 		m.spotSearch.cursor = len(m.spotSearch.playlists)
+		m.spotSearchPlaylistMaybeAdjustScroll(m.spotSearchPlaylistVisible())
 	case tea.KeyEnter:
 		if m.spotSearch.newName != "" && !m.spotSearch.loading {
 			c, cOk := m.spotSearch.prov.(provider.PlaylistCreator)

--- a/ui/model/overlays.go
+++ b/ui/model/overlays.go
@@ -91,7 +91,6 @@ func (m *Model) searchHelpLine() string {
 	return helpKey("↓↑", "Scroll ") +
 		helpKey("Enter", "Play ") +
 		helpKey("Tab", "Queue ") +
-		helpKey("Ctrl+K", "Keymap ") +
 		helpKey("Esc", "Close")
 }
 

--- a/ui/model/providers.go
+++ b/ui/model/providers.go
@@ -18,6 +18,7 @@ func (m *Model) resetProviderNav() {
 	m.provSearch.query = ""
 	m.provSearch.results = nil
 	m.provSearch.cursor = 0
+	m.provSearch.scroll = 0
 }
 
 // StartInProvider configures the model to begin in the provider browse view.

--- a/ui/model/search.go
+++ b/ui/model/search.go
@@ -8,6 +8,7 @@ import (
 func (m *Model) updateSearch() {
 	m.search.results = nil
 	m.search.cursor = 0
+	m.search.scroll = 0
 	if m.search.query == "" {
 		return
 	}

--- a/ui/model/state.go
+++ b/ui/model/state.go
@@ -21,6 +21,7 @@ type searchState struct {
 	query   string
 	results []int // indices into playlist tracks
 	cursor  int
+	scroll  int
 }
 
 // netSearchScreenType identifies which screen of the net search overlay is active.
@@ -40,6 +41,7 @@ type netSearchState struct {
 	loading    bool
 	results    []playlist.Track
 	cursor     int
+	scroll     int
 	err        string
 }
 
@@ -49,6 +51,7 @@ type provSearchState struct {
 	query   string
 	results []int // indices into providerLists
 	cursor  int
+	scroll  int
 }
 
 // seekState holds debounce state for yt-dlp seek-by-restart.
@@ -96,6 +99,7 @@ type keymapOverlay struct {
 type queueOverlay struct {
 	visible bool
 	cursor  int
+	scroll  int
 }
 
 // plManagerState holds state for the playlist manager overlay.
@@ -175,6 +179,7 @@ type spotSearchState struct {
 	query     string
 	results   []playlist.Track
 	cursor    int
+	scroll    int
 	loading   bool
 	playlists []playlist.PlaylistInfo // user's Spotify playlists for picker
 	selTrack  playlist.Track          // track selected to add
@@ -209,6 +214,7 @@ type devicePickerState struct {
 	visible bool
 	devices []player.AudioDevice
 	cursor  int
+	scroll  int
 	loading bool
 }
 

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -468,6 +468,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case netSearchResultsMsg:
 		m.netSearch.loading = false
+		m.netSearch.cursor = 0
+		m.netSearch.scroll = 0
 		if msg.err != nil {
 			m.netSearch.err = msg.err.Error()
 			return m, nil
@@ -576,6 +578,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case spotSearchResultsMsg:
 		m.spotSearch.loading = false
+		m.spotSearch.cursor = 0
+		m.spotSearch.scroll = 0
 		if msg.err != nil {
 			m.spotSearch.err = msg.err.Error()
 			return m, nil
@@ -590,6 +594,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case spotPlaylistsMsg:
 		m.spotSearch.loading = false
+		m.spotSearch.cursor = 0
+		m.spotSearch.scroll = 0
 		if msg.err != nil {
 			m.spotSearch.err = msg.err.Error()
 			return m, nil

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -610,7 +610,7 @@ func (m Model) renderProviderList() string {
 				lines = append(lines, dimStyle.Render("  No matches"))
 			} else {
 				visible := max(0, min(visibleBudget-1, len(m.provSearch.results)))
-				scroll := max(0, m.provSearch.cursor-visible+1)
+				scroll := m.provSearch.scroll
 				for j := scroll; j < scroll+visible && j < len(m.provSearch.results); j++ {
 					idx := m.provSearch.results[j]
 					p := m.providerLists[idx]

--- a/ui/model/view_helpers.go
+++ b/ui/model/view_helpers.go
@@ -156,15 +156,6 @@ func cursorLine(label string, active bool) string {
 	return dimStyle.Render("  " + label)
 }
 
-// scrollStart returns the scroll offset so that cursor remains visible
-// within a window of maxVisible items.
-func scrollStart(cursor, maxVisible int) int {
-	if cursor >= maxVisible {
-		return cursor - maxVisible + 1
-	}
-	return 0
-}
-
 // spinnerFrames is the braille-dot animation used to indicate loading. The
 // view re-renders on the model tick so the spinner advances on its own.
 var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}

--- a/ui/model/view_overlays.go
+++ b/ui/model/view_overlays.go
@@ -78,7 +78,7 @@ func (m Model) renderDeviceOverlay() string {
 	}
 
 	visible := m.devicePickerVisible()
-	scroll := scrollStart(m.devicePicker.cursor, visible)
+	scroll := m.devicePicker.scroll
 	visibleCount := max(0, min(visible, len(items)-scroll))
 	lines := m.renderSimpleList(
 		before, after,
@@ -443,7 +443,7 @@ func (m Model) renderQueueOverlay() string {
 
 	before, after := m.queueChrome()
 	visible := m.queueVisible()
-	scroll := scrollStart(m.queue.cursor, visible)
+	scroll := m.queue.scroll
 	visibleCount := max(0, min(visible, len(items)-scroll))
 	lines := m.renderSimpleList(
 		before, after,
@@ -544,7 +544,7 @@ func (m Model) renderSearchOverlay() string {
 
 	before, after := m.searchChrome()
 	visible := m.searchVisible()
-	scroll := scrollStart(m.search.cursor, visible)
+	scroll := m.search.scroll
 	lines := m.renderSimpleList(
 		before, after,
 		items,
@@ -615,7 +615,7 @@ func (m Model) renderNetSearchResults() []string {
 
 	before, after := m.netSearchResultsChrome()
 	visible := m.netSearchResultsVisible()
-	scroll := scrollStart(m.netSearch.cursor, visible)
+	scroll := m.netSearch.scroll
 	visibleCount := max(0, min(visible, len(items)-scroll))
 	return m.renderSimpleList(
 		before, after,
@@ -778,7 +778,7 @@ func (m Model) renderSpotSearchResults() []string {
 
 	before, after := m.spotSearchResultsChrome()
 	visible := m.spotSearchResultsVisible()
-	scroll := scrollStart(m.spotSearch.cursor, visible)
+	scroll := m.spotSearch.scroll
 	visibleCount := max(0, min(visible, len(items)-scroll))
 	return m.renderSimpleList(
 		before, after,
@@ -830,8 +830,8 @@ func (m Model) renderSpotSearchPlaylist() []string {
 	}
 
 	visible := m.spotSearchPlaylistVisible()
-	scroll := scrollStart(m.spotSearch.cursor, visible)
-	visibleCount := max(0, min(visible, playlistCount-scroll))
+	scroll := m.spotSearch.scroll
+	visibleCount := max(0, min(visible, count-scroll))
 	return m.renderSimpleList(
 		before, after,
 		items,


### PR DESCRIPTION
This PR improves scrolling behavior consistency across overlays, matching the behavior of the primary list views.

### Changes

* Replaced pinned-scrolling with windowed-scrolling behavior. When scrolling in the overlay views, the highlight now moves freely within the visible area, only scrolling the list when reaching the top or bottom edges.
* Added persistent scroll tracking to all overlay state structs.
* Support for ctrl+x toggle while in overlay screens. Users can now expand search results, the queue, and provider browsers to the full terminal height.

### Affected Overlays
- Playlist Search `/`
- Queue Manager `A`
- Global Search Results `Ctrl+F`
- Audio Device Picker `d`
- Provider Overlays

Another small change in this PR is the removal of the ctrl+k helpkey from the Search Overlay help line. The keybind still works, but it seemed strange to show the helpkey there since other overlays that support ctrl+k don’t display it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ctrl+X to toggle an expanded view across searches, provider/browser, Spotify results/playlists, and overlays.

* **Bug Fixes**
  * Navigation now wraps at list boundaries and keeps the active row visible by clamping cursor and scroll.
  * Overlay scroll positions are reset when opening, exiting, or when results update (searches, playlists, provider/net results).

* **Documentation**
  * Updated overlay help line to clarify closing key.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bjarneo/cliamp/pull/233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->