### PR TITLE
Improvements to album header visibility & control

### DIFF
--- a/ui/model/init.go
+++ b/ui/model/init.go
@@ -40,9 +40,8 @@ func New(p player.Engine, pl *playlist.Playlist, providers []ProviderEntry, defa
 		navBrowser:       navBrowserState{},
 		luaMgr:           luaMgr,
 		historyStore:     history.New(),
-		showAlbumHeaders: true,
+		showAlbumHeaders: false,
 	}
-	m.refreshHeaderState()
 	m.termTitle = initialTerminalTitleState()
 	// Select the default provider pill.
 	for i, pe := range providers {

--- a/ui/model/init.go
+++ b/ui/model/init.go
@@ -42,6 +42,7 @@ func New(p player.Engine, pl *playlist.Playlist, providers []ProviderEntry, defa
 		historyStore:     history.New(),
 		showAlbumHeaders: true,
 	}
+	m.refreshHeaderState()
 	m.termTitle = initialTerminalTitleState()
 	// Select the default provider pill.
 	for i, pe := range providers {
@@ -151,7 +152,7 @@ func (m *Model) SetResume(path string, secs int) {
 // ResumePlaylist loads a playlist into the model for session resume.
 func (m *Model) ResumePlaylist(name string, tracks []playlist.Track) {
 	m.playlist.Replace(tracks)
-	m.setInitialHeaderState(tracks)
+	m.refreshHeaderState()
 	m.loadedPlaylist = name
 }
 

--- a/ui/model/init.go
+++ b/ui/model/init.go
@@ -152,7 +152,7 @@ func (m *Model) SetResume(path string, secs int) {
 // ResumePlaylist loads a playlist into the model for session resume.
 func (m *Model) ResumePlaylist(name string, tracks []playlist.Track) {
 	m.playlist.Replace(tracks)
-	m.refreshHeaderState()
+	m.setHeaderStateFromTracks(tracks)
 	m.loadedPlaylist = name
 }
 

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -739,6 +739,7 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 
 	case "ctrl+h":
 		m.showAlbumHeaders = !m.showAlbumHeaders
+		m.headerManual = true
 		m.adjustScroll()
 
 	case "v":
@@ -1580,6 +1581,7 @@ func (m *Model) handlePlMgrTracksKey(msg tea.KeyPressMsg) tea.Cmd {
 	switch msg.String() {
 	case "ctrl+h":
 		m.showAlbumHeaders = !m.showAlbumHeaders
+		m.headerManual = true
 		m.plMgrTracksMaybeAdjustScroll(m.plMgrTracksVisible())
 		return nil
 	case "ctrl+c":
@@ -1713,7 +1715,7 @@ func (m *Model) plMgrLoadAndPlay(startIdx int) tea.Cmd {
 	m.player.ClearPreload()
 	m.resetYTDLBatch()
 	m.playlist.Replace(m.plManager.tracks)
-	m.refreshHeaderState()
+	m.setHeaderStateFromTracks(m.plManager.tracks)
 	m.loadedPlaylist = m.plManager.selPlaylist
 	if startIdx < 0 || startIdx >= m.playlist.Len() {
 		startIdx = 0

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -1713,7 +1713,7 @@ func (m *Model) plMgrLoadAndPlay(startIdx int) tea.Cmd {
 	m.player.ClearPreload()
 	m.resetYTDLBatch()
 	m.playlist.Replace(m.plManager.tracks)
-	m.setInitialHeaderState(m.plManager.tracks)
+	m.refreshHeaderState()
 	m.loadedPlaylist = m.plManager.selPlaylist
 	if startIdx < 0 || startIdx >= m.playlist.Len() {
 		startIdx = 0

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -738,8 +738,7 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 		return m.switchToProvider("netease")
 
 	case "ctrl+h":
-		m.showAlbumHeaders = !m.showAlbumHeaders
-		m.headerManual = true
+		m.toggleAlbumHeadersManual()
 		m.adjustScroll()
 
 	case "v":
@@ -1580,8 +1579,7 @@ func (m *Model) handlePlMgrTracksKey(msg tea.KeyPressMsg) tea.Cmd {
 	count := m.plMgrTracksViewCount()
 	switch msg.String() {
 	case "ctrl+h":
-		m.showAlbumHeaders = !m.showAlbumHeaders
-		m.headerManual = true
+		m.toggleAlbumHeadersManual()
 		m.plMgrTracksMaybeAdjustScroll(m.plMgrTracksVisible())
 		return nil
 	case "ctrl+c":

--- a/ui/model/keys_nav.go
+++ b/ui/model/keys_nav.go
@@ -325,8 +325,7 @@ func (m *Model) handleNavTrackListKey(msg tea.KeyPressMsg) tea.Cmd {
 
 	switch msg.String() {
 	case "ctrl+h":
-		m.showAlbumHeaders = !m.showAlbumHeaders
-		m.headerManual = true
+		m.toggleAlbumHeadersManual()
 		m.navMaybeAdjustScroll()
 		return nil
 	case "ctrl+c":

--- a/ui/model/keys_nav.go
+++ b/ui/model/keys_nav.go
@@ -372,6 +372,7 @@ func (m *Model) handleNavTrackListKey(msg tea.KeyPressMsg) tea.Cmd {
 			}
 
 			m.playlist.Add(toAdd...)
+			m.refreshHeaderState()
 			newIdx := m.playlist.Len() - len(toAdd)
 			m.playlist.SetIndex(newIdx)
 			m.plCursor = newIdx
@@ -400,7 +401,7 @@ func (m *Model) handleNavTrackListKey(msg tea.KeyPressMsg) tea.Cmd {
 			m.player.ClearPreload()
 			m.resetYTDLBatch()
 			m.playlist.Replace(tracks)
-			m.setInitialHeaderState(tracks)
+			m.refreshHeaderState()
 			m.plCursor = 0
 			m.plScroll = 0
 			m.playlist.SetIndex(0)
@@ -423,6 +424,7 @@ func (m *Model) handleNavTrackListKey(msg tea.KeyPressMsg) tea.Cmd {
 		if len(tracks) > 0 {
 			wasEmpty := m.playlist.Len() == 0
 			m.playlist.Add(tracks...)
+			m.refreshHeaderState()
 			m.status.Showf(statusTTLMedium, "Added %d tracks", len(tracks))
 			if wasEmpty || !m.player.IsPlaying() {
 				m.playlist.SetIndex(0)
@@ -443,6 +445,7 @@ func (m *Model) handleNavTrackListKey(msg tea.KeyPressMsg) tea.Cmd {
 		if rawIdx < len(m.navBrowser.tracks) {
 			t := m.navBrowser.tracks[rawIdx]
 			m.playlist.Add(t)
+			m.refreshHeaderState()
 			newIdx := m.playlist.Len() - 1
 			m.playlist.Queue(newIdx)
 			m.status.Showf(statusTTLMedium, "Queued: %s", t.DisplayName())

--- a/ui/model/keys_nav.go
+++ b/ui/model/keys_nav.go
@@ -326,6 +326,7 @@ func (m *Model) handleNavTrackListKey(msg tea.KeyPressMsg) tea.Cmd {
 	switch msg.String() {
 	case "ctrl+h":
 		m.showAlbumHeaders = !m.showAlbumHeaders
+		m.headerManual = true
 		m.navMaybeAdjustScroll()
 		return nil
 	case "ctrl+c":
@@ -401,7 +402,7 @@ func (m *Model) handleNavTrackListKey(msg tea.KeyPressMsg) tea.Cmd {
 			m.player.ClearPreload()
 			m.resetYTDLBatch()
 			m.playlist.Replace(tracks)
-			m.refreshHeaderState()
+			m.setHeaderStateFromTracks(tracks)
 			m.plCursor = 0
 			m.plScroll = 0
 			m.playlist.SetIndex(0)

--- a/ui/model/keys_nav.go
+++ b/ui/model/keys_nav.go
@@ -372,7 +372,7 @@ func (m *Model) handleNavTrackListKey(msg tea.KeyPressMsg) tea.Cmd {
 			}
 
 			m.playlist.Add(toAdd...)
-			m.refreshHeaderState()
+			m.addToHeaderState(toAdd)
 			newIdx := m.playlist.Len() - len(toAdd)
 			m.playlist.SetIndex(newIdx)
 			m.plCursor = newIdx
@@ -424,7 +424,7 @@ func (m *Model) handleNavTrackListKey(msg tea.KeyPressMsg) tea.Cmd {
 		if len(tracks) > 0 {
 			wasEmpty := m.playlist.Len() == 0
 			m.playlist.Add(tracks...)
-			m.refreshHeaderState()
+			m.addToHeaderState(tracks)
 			m.status.Showf(statusTTLMedium, "Added %d tracks", len(tracks))
 			if wasEmpty || !m.player.IsPlaying() {
 				m.playlist.SetIndex(0)
@@ -445,7 +445,7 @@ func (m *Model) handleNavTrackListKey(msg tea.KeyPressMsg) tea.Cmd {
 		if rawIdx < len(m.navBrowser.tracks) {
 			t := m.navBrowser.tracks[rawIdx]
 			m.playlist.Add(t)
-			m.refreshHeaderState()
+			m.addToHeaderState([]playlist.Track{t})
 			newIdx := m.playlist.Len() - 1
 			m.playlist.Queue(newIdx)
 			m.status.Showf(statusTTLMedium, "Queued: %s", t.DisplayName())

--- a/ui/model/model.go
+++ b/ui/model/model.go
@@ -257,6 +257,7 @@ type Model struct {
 	showInfo bool
 
 	showAlbumHeaders bool
+	headerManual     bool
 
 	// Audio device picker overlay
 	devicePicker devicePickerState

--- a/ui/model/model.go
+++ b/ui/model/model.go
@@ -258,6 +258,11 @@ type Model struct {
 
 	showAlbumHeaders bool
 	headerManual     bool
+	// Running counters for the cohesion heuristic so Add can update header
+	// visibility in O(k) instead of walking the whole playlist on each call.
+	headerLastAlbum string
+	headerSegments  int
+	headerTracks    int
 
 	// Audio device picker overlay
 	devicePicker devicePickerState

--- a/ui/model/overlays.go
+++ b/ui/model/overlays.go
@@ -211,7 +211,7 @@ func (m *Model) plMgrEnterTrackList(name string) {
 	}
 	m.plManager.selPlaylist = name
 	m.plManager.tracks = tracks
-	m.setInitialHeaderState(tracks)
+	m.refreshHeaderState()
 	m.plManager.screen = plMgrScreenTracks
 	m.plManager.cursor = 0
 	m.plManager.scroll = 0

--- a/ui/model/overlays.go
+++ b/ui/model/overlays.go
@@ -211,7 +211,7 @@ func (m *Model) plMgrEnterTrackList(name string) {
 	}
 	m.plManager.selPlaylist = name
 	m.plManager.tracks = tracks
-	m.refreshHeaderState()
+	m.setHeaderStateFromTracks(tracks)
 	m.plManager.screen = plMgrScreenTracks
 	m.plManager.cursor = 0
 	m.plManager.scroll = 0

--- a/ui/model/playback.go
+++ b/ui/model/playback.go
@@ -86,6 +86,7 @@ func (m *Model) playTrackImmediate(track playlist.Track) tea.Cmd {
 	m.player.Stop()
 	m.player.ClearPreload()
 	m.playlist.Add(track)
+	m.refreshHeaderState()
 	idx := m.playlist.Len() - 1
 	m.playlist.SetIndex(idx)
 	m.plCursor = idx
@@ -100,6 +101,7 @@ func (m *Model) playTrackImmediate(track playlist.Track) tea.Cmd {
 func (m *Model) appendTrack(track playlist.Track) tea.Cmd {
 	wasEmpty := m.playlist.Len() == 0
 	m.playlist.Add(track)
+	m.refreshHeaderState()
 	idx := m.playlist.Len() - 1
 	m.status.Showf(statusTTLMedium, "Added: %s", track.DisplayName())
 	if wasEmpty || !m.player.IsPlaying() {
@@ -129,6 +131,7 @@ func (m *Model) closeSpotSearch() {
 // queueTrackNext adds a track to the playlist and queues it to play next.
 func (m *Model) queueTrackNext(track playlist.Track) tea.Cmd {
 	m.playlist.Add(track)
+	m.refreshHeaderState()
 	idx := m.playlist.Len() - 1
 	m.playlist.Queue(idx)
 	m.status.Showf(statusTTLMedium, "Queued: %s", track.DisplayName())

--- a/ui/model/playback.go
+++ b/ui/model/playback.go
@@ -86,7 +86,7 @@ func (m *Model) playTrackImmediate(track playlist.Track) tea.Cmd {
 	m.player.Stop()
 	m.player.ClearPreload()
 	m.playlist.Add(track)
-	m.refreshHeaderState()
+	m.addToHeaderState([]playlist.Track{track})
 	idx := m.playlist.Len() - 1
 	m.playlist.SetIndex(idx)
 	m.plCursor = idx
@@ -101,7 +101,7 @@ func (m *Model) playTrackImmediate(track playlist.Track) tea.Cmd {
 func (m *Model) appendTrack(track playlist.Track) tea.Cmd {
 	wasEmpty := m.playlist.Len() == 0
 	m.playlist.Add(track)
-	m.refreshHeaderState()
+	m.addToHeaderState([]playlist.Track{track})
 	idx := m.playlist.Len() - 1
 	m.status.Showf(statusTTLMedium, "Added: %s", track.DisplayName())
 	if wasEmpty || !m.player.IsPlaying() {
@@ -131,7 +131,7 @@ func (m *Model) closeSpotSearch() {
 // queueTrackNext adds a track to the playlist and queues it to play next.
 func (m *Model) queueTrackNext(track playlist.Track) tea.Cmd {
 	m.playlist.Add(track)
-	m.refreshHeaderState()
+	m.addToHeaderState([]playlist.Track{track})
 	idx := m.playlist.Len() - 1
 	m.playlist.Queue(idx)
 	m.status.Showf(statusTTLMedium, "Queued: %s", track.DisplayName())

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -309,7 +309,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.resetYTDLBatch()
 		m.playlist.Replace(msg)
-		m.refreshHeaderState()
+		m.setHeaderStateFromTracks(msg)
 		m.plCursor = 0
 		m.plScroll = 0
 		m.focus = focusPlaylist
@@ -430,7 +430,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.playlist.Replace(msg.tracks)
-		m.refreshHeaderState()
+		m.setHeaderStateFromTracks(msg.tracks)
 		m.plCursor = 0
 		m.plScroll = 0
 		m.applyHeightMode()
@@ -503,7 +503,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.player.ClearPreload()
 			m.resetYTDLBatch()
 			m.playlist.Replace(msg.tracks)
-			m.refreshHeaderState()
+			m.setHeaderStateFromTracks(msg.tracks)
 			m.plCursor = 0
 			m.plScroll = 0
 		} else {
@@ -769,7 +769,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.playlist.Replace(tracks)
-		m.refreshHeaderState()
+		m.setHeaderStateFromTracks(tracks)
 		m.loadedPlaylist = msg.Playlist
 		cmd := m.playCurrentTrack()
 		m.notifyAll()

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -354,7 +354,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case navTracksLoadedMsg:
 		m.navBrowser.tracks = []playlist.Track(msg)
-		m.refreshHeaderState()
+		m.setHeaderStateFromTracks(m.navBrowser.tracks)
 		m.navBrowser.loading = false
 		m.navBrowser.cursor = 0
 		m.navBrowser.scroll = 0

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -309,7 +309,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.resetYTDLBatch()
 		m.playlist.Replace(msg)
-		m.setInitialHeaderState(msg)
+		m.refreshHeaderState()
 		m.plCursor = 0
 		m.plScroll = 0
 		m.focus = focusPlaylist
@@ -354,7 +354,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case navTracksLoadedMsg:
 		m.navBrowser.tracks = []playlist.Track(msg)
-		m.setInitialHeaderState(m.navBrowser.tracks)
+		m.refreshHeaderState()
 		m.navBrowser.loading = false
 		m.navBrowser.cursor = 0
 		m.navBrowser.scroll = 0
@@ -413,6 +413,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.playlist.Add(msg.tracks...)
+		m.refreshHeaderState()
 		m.ytdlBatch.offset += len(msg.tracks)
 		if len(msg.tracks) < ytdlBatchSize {
 			m.ytdlBatch.done = true
@@ -429,7 +430,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.playlist.Replace(msg.tracks)
-		m.setInitialHeaderState(msg.tracks)
+		m.refreshHeaderState()
 		m.plCursor = 0
 		m.plScroll = 0
 		m.applyHeightMode()
@@ -443,6 +444,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.feedLoading = false
 		if len(msg.tracks) > 0 {
 			m.playlist.Add(msg.tracks...)
+			m.refreshHeaderState()
 			m.status.Showf(statusTTLDefault, "Loaded %d track(s)", len(msg.tracks))
 		} else {
 			m.status.Show("No tracks found at URL.", statusTTLDefault)
@@ -501,11 +503,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.player.ClearPreload()
 			m.resetYTDLBatch()
 			m.playlist.Replace(msg.tracks)
-			m.setInitialHeaderState(msg.tracks)
+			m.refreshHeaderState()
 			m.plCursor = 0
 			m.plScroll = 0
 		} else {
 			m.playlist.Add(msg.tracks...)
+			m.refreshHeaderState()
 		}
 		m.focus = focusPlaylist
 		m.applyHeightMode()
@@ -766,7 +769,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.playlist.Replace(tracks)
-		m.setInitialHeaderState(tracks)
+		m.refreshHeaderState()
 		m.loadedPlaylist = msg.Playlist
 		cmd := m.playCurrentTrack()
 		m.notifyAll()
@@ -777,6 +780,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ipc.QueueMsg:
 		t := playlist.Track{Path: msg.Path, Title: msg.Path}
 		m.playlist.Add(t)
+		m.refreshHeaderState()
 		m.notifyAll()
 		return m, nil
 	case ipc.ThemeMsg:

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -413,7 +413,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.playlist.Add(msg.tracks...)
-		m.refreshHeaderState()
+		m.addToHeaderState(msg.tracks)
 		m.ytdlBatch.offset += len(msg.tracks)
 		if len(msg.tracks) < ytdlBatchSize {
 			m.ytdlBatch.done = true
@@ -444,7 +444,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.feedLoading = false
 		if len(msg.tracks) > 0 {
 			m.playlist.Add(msg.tracks...)
-			m.refreshHeaderState()
+			m.addToHeaderState(msg.tracks)
 			m.status.Showf(statusTTLDefault, "Loaded %d track(s)", len(msg.tracks))
 		} else {
 			m.status.Show("No tracks found at URL.", statusTTLDefault)
@@ -508,7 +508,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.plScroll = 0
 		} else {
 			m.playlist.Add(msg.tracks...)
-			m.refreshHeaderState()
+			m.addToHeaderState(msg.tracks)
 		}
 		m.focus = focusPlaylist
 		m.applyHeightMode()
@@ -780,7 +780,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ipc.QueueMsg:
 		t := playlist.Track{Path: msg.Path, Title: msg.Path}
 		m.playlist.Add(t)
-		m.refreshHeaderState()
+		m.addToHeaderState([]playlist.Track{t})
 		m.notifyAll()
 		return m, nil
 	case ipc.ThemeMsg:

--- a/ui/model/view_helpers.go
+++ b/ui/model/view_helpers.go
@@ -194,27 +194,11 @@ func helpKey(key, label string) string {
 	return helpKeyStyle.Render(" "+key+" ") + helpStyle.Render(" "+label)
 }
 
-// toggleAlbumHeadersManual flips the header visibility and sets the manual
-// override flag so the heuristic stops second-guessing the user.
+// toggleAlbumHeadersManual flips header visibility and pins the choice so
+// later Adds don't re-run the cohesion heuristic over the user.
 func (m *Model) toggleAlbumHeadersManual() {
 	m.showAlbumHeaders = !m.showAlbumHeaders
 	m.headerManual = true
-}
-
-// setHeaderStateFromTracks picks a sensible header default for the given slice.
-// This resets the manual override flag as a new context is being loaded.
-func (m *Model) setHeaderStateFromTracks(tracks []playlist.Track) {
-	m.headerManual = false
-	m.computeHeaderState(tracks)
-}
-
-// refreshHeaderState picks a sensible header default for the current playlist.
-// If the user has manually toggled headers (headerManual), the heuristic is skipped.
-func (m *Model) refreshHeaderState() {
-	if m.headerManual {
-		return
-	}
-	m.computeHeaderState(m.playlist.Tracks())
 }
 
 // minTracksPerAlbum is the threshold at which a list is considered cohesive
@@ -222,26 +206,35 @@ func (m *Model) refreshHeaderState() {
 // the list looks like a fragmented mixtape and headers add noise.
 const minTracksPerAlbum = 3.0
 
-// computeHeaderState runs the cohesion heuristic to decide if album headers
-// should be shown for the given tracks. Note: It does not observe manual flag.
-func (m *Model) computeHeaderState(tracks []playlist.Track) {
-	if len(tracks) == 0 {
+// setHeaderStateFromTracks resets the running counters and re-runs the
+// cohesion heuristic. A fresh load also clears any manual override.
+func (m *Model) setHeaderStateFromTracks(tracks []playlist.Track) {
+	m.headerManual = false
+	m.headerLastAlbum = ""
+	m.headerSegments = 0
+	m.headerTracks = 0
+	m.addToHeaderState(tracks)
+}
+
+// addToHeaderState advances the cohesion counters by the newly added tracks
+// (O(k)) and refreshes header visibility, unless the user has pinned it.
+func (m *Model) addToHeaderState(tracks []playlist.Track) {
+	for _, t := range tracks {
+		if m.headerTracks == 0 || t.Album != m.headerLastAlbum {
+			m.headerSegments++
+		}
+		m.headerLastAlbum = t.Album
+		m.headerTracks++
+	}
+
+	if m.headerManual {
+		return
+	}
+	if m.headerSegments == 0 {
 		m.showAlbumHeaders = false
 		return
 	}
-
-	headers := 0
-	prev := ""
-	first := true
-	for _, t := range tracks {
-		if first || t.Album != prev {
-			headers++
-			prev = t.Album
-			first = false
-		}
-	}
-
-	m.showAlbumHeaders = float64(len(tracks))/float64(headers) >= minTracksPerAlbum
+	m.showAlbumHeaders = float64(m.headerTracks)/float64(m.headerSegments) >= minTracksPerAlbum
 }
 
 // trackAlbumSuffix returns the " · Album" suffix shown after track names when

--- a/ui/model/view_helpers.go
+++ b/ui/model/view_helpers.go
@@ -199,10 +199,14 @@ func helpKey(key, label string) string {
 // the list looks like a fragmented mixtape and headers add noise.
 const minTracksPerAlbum = 3.0
 
-// isListCohesive returns true if the track list appears to be organized into
-// distinct albums (e.g. an artist's discography or a full album) rather than
-// a fragmented mixtape.
-func isListCohesive(tracks []playlist.Track) bool {
+// refreshHeaderState picks a sensible header default for the current playlist.
+func (m *Model) refreshHeaderState() {
+	tracks := m.playlist.Tracks()
+	if len(tracks) == 0 {
+		m.showAlbumHeaders = false
+		return
+	}
+
 	headers := 0
 	prev := ""
 	first := true
@@ -214,15 +218,7 @@ func isListCohesive(tracks []playlist.Track) bool {
 		}
 	}
 
-	if headers == 0 {
-		return false
-	}
-	return float64(len(tracks))/float64(headers) >= minTracksPerAlbum
-}
-
-// refreshHeaderState picks a sensible header default for the current playlist.
-func (m *Model) refreshHeaderState() {
-	m.showAlbumHeaders = isListCohesive(m.playlist.Tracks())
+	m.showAlbumHeaders = float64(len(tracks))/float64(headers) >= minTracksPerAlbum
 }
 
 // trackAlbumSuffix returns the " · Album" suffix shown after track names when

--- a/ui/model/view_helpers.go
+++ b/ui/model/view_helpers.go
@@ -199,9 +199,8 @@ func helpKey(key, label string) string {
 // the list looks like a fragmented mixtape and headers add noise.
 const minTracksPerAlbum = 3.0
 
-// refreshHeaderState picks a sensible header default for the current playlist.
-func (m *Model) refreshHeaderState() {
-	tracks := m.playlist.Tracks()
+// setHeaderStateFromTracks picks a sensible header default for the given slice.
+func (m *Model) setHeaderStateFromTracks(tracks []playlist.Track) {
 	if len(tracks) == 0 {
 		m.showAlbumHeaders = false
 		return
@@ -219,6 +218,11 @@ func (m *Model) refreshHeaderState() {
 	}
 
 	m.showAlbumHeaders = float64(len(tracks))/float64(headers) >= minTracksPerAlbum
+}
+
+// refreshHeaderState picks a sensible header default for the current playlist.
+func (m *Model) refreshHeaderState() {
+	m.setHeaderStateFromTracks(m.playlist.Tracks())
 }
 
 // trackAlbumSuffix returns the " · Album" suffix shown after track names when

--- a/ui/model/view_helpers.go
+++ b/ui/model/view_helpers.go
@@ -200,7 +200,22 @@ func helpKey(key, label string) string {
 const minTracksPerAlbum = 3.0
 
 // setHeaderStateFromTracks picks a sensible header default for the given slice.
+// This resets the manual override flag as a new context is being loaded.
 func (m *Model) setHeaderStateFromTracks(tracks []playlist.Track) {
+	m.headerManual = false
+	m.computeHeaderState(tracks)
+}
+
+// refreshHeaderState picks a sensible header default for the current playlist.
+// If the user has manually toggled headers (headerManual), the heuristic is skipped.
+func (m *Model) refreshHeaderState() {
+	if m.headerManual {
+		return
+	}
+	m.computeHeaderState(m.playlist.Tracks())
+}
+
+func (m *Model) computeHeaderState(tracks []playlist.Track) {
 	if len(tracks) == 0 {
 		m.showAlbumHeaders = false
 		return
@@ -218,11 +233,6 @@ func (m *Model) setHeaderStateFromTracks(tracks []playlist.Track) {
 	}
 
 	m.showAlbumHeaders = float64(len(tracks))/float64(headers) >= minTracksPerAlbum
-}
-
-// refreshHeaderState picks a sensible header default for the current playlist.
-func (m *Model) refreshHeaderState() {
-	m.setHeaderStateFromTracks(m.playlist.Tracks())
 }
 
 // trackAlbumSuffix returns the " · Album" suffix shown after track names when

--- a/ui/model/view_helpers.go
+++ b/ui/model/view_helpers.go
@@ -194,10 +194,12 @@ func helpKey(key, label string) string {
 	return helpKeyStyle.Render(" "+key+" ") + helpStyle.Render(" "+label)
 }
 
-// minTracksPerAlbum is the threshold at which a list is considered cohesive
-// enough to default to showing album headers; below this average tracks/album,
-// the list looks like a fragmented mixtape and headers add noise.
-const minTracksPerAlbum = 3.0
+// toggleAlbumHeadersManual flips the header visibility and sets the manual
+// override flag so the heuristic stops second-guessing the user.
+func (m *Model) toggleAlbumHeadersManual() {
+	m.showAlbumHeaders = !m.showAlbumHeaders
+	m.headerManual = true
+}
 
 // setHeaderStateFromTracks picks a sensible header default for the given slice.
 // This resets the manual override flag as a new context is being loaded.
@@ -215,6 +217,13 @@ func (m *Model) refreshHeaderState() {
 	m.computeHeaderState(m.playlist.Tracks())
 }
 
+// minTracksPerAlbum is the threshold at which a list is considered cohesive
+// enough to default to showing album headers; below this average tracks/album,
+// the list looks like a fragmented mixtape and headers add noise.
+const minTracksPerAlbum = 3.0
+
+// computeHeaderState runs the cohesion heuristic to decide if album headers
+// should be shown for the given tracks. Note: It does not observe manual flag.
 func (m *Model) computeHeaderState(tracks []playlist.Track) {
 	if len(tracks) == 0 {
 		m.showAlbumHeaders = false
@@ -233,13 +242,6 @@ func (m *Model) computeHeaderState(tracks []playlist.Track) {
 	}
 
 	m.showAlbumHeaders = float64(len(tracks))/float64(headers) >= minTracksPerAlbum
-}
-
-// toggleAlbumHeadersManual flips the header visibility and sets the manual
-// override flag so the heuristic stops second-guessing the user.
-func (m *Model) toggleAlbumHeadersManual() {
-	m.showAlbumHeaders = !m.showAlbumHeaders
-	m.headerManual = true
 }
 
 // trackAlbumSuffix returns the " · Album" suffix shown after track names when

--- a/ui/model/view_helpers.go
+++ b/ui/model/view_helpers.go
@@ -220,12 +220,9 @@ func isListCohesive(tracks []playlist.Track) bool {
 	return float64(len(tracks))/float64(headers) >= minTracksPerAlbum
 }
 
-// setInitialHeaderState picks a sensible header default for a freshly loaded
-// list. Only call this when the playlist is replaced or first populated —
-// calling it after every Add re-runs the heuristic over the whole list (O(N²)
-// during incremental loads) and silently overrides the user's Ctrl+H toggle.
-func (m *Model) setInitialHeaderState(tracks []playlist.Track) {
-	m.showAlbumHeaders = isListCohesive(tracks)
+// refreshHeaderState picks a sensible header default for the current playlist.
+func (m *Model) refreshHeaderState() {
+	m.showAlbumHeaders = isListCohesive(m.playlist.Tracks())
 }
 
 // trackAlbumSuffix returns the " · Album" suffix shown after track names when

--- a/ui/model/view_helpers.go
+++ b/ui/model/view_helpers.go
@@ -235,6 +235,13 @@ func (m *Model) computeHeaderState(tracks []playlist.Track) {
 	m.showAlbumHeaders = float64(len(tracks))/float64(headers) >= minTracksPerAlbum
 }
 
+// toggleAlbumHeadersManual flips the header visibility and sets the manual
+// override flag so the heuristic stops second-guessing the user.
+func (m *Model) toggleAlbumHeadersManual() {
+	m.showAlbumHeaders = !m.showAlbumHeaders
+	m.headerManual = true
+}
+
 // trackAlbumSuffix returns the " · Album" suffix shown after track names when
 // album headers are hidden. Empty when headers are on or the track has no album.
 func trackAlbumSuffix(t playlist.Track, showHeaders bool) string {

--- a/ui/model/view_helpers_test.go
+++ b/ui/model/view_helpers_test.go
@@ -111,6 +111,119 @@ func TestFormatTrackRow(t *testing.T) {
 	}
 }
 
+func TestHeaderStateIncremental(t *testing.T) {
+	mk := func(album string) playlist.Track { return playlist.Track{Album: album} }
+
+	tests := []struct {
+		name        string
+		batches     [][]playlist.Track
+		wantHeaders bool
+		wantTracks  int
+		wantSegs    int
+	}{
+		{
+			name:        "empty",
+			batches:     nil,
+			wantHeaders: false,
+		},
+		{
+			name: "single track is below cohesion threshold",
+			batches: [][]playlist.Track{
+				{mk("Aja")},
+			},
+			wantHeaders: false,
+			wantTracks:  1,
+			wantSegs:    1,
+		},
+		{
+			name: "full album in one shot is cohesive",
+			batches: [][]playlist.Track{
+				{mk("Aja"), mk("Aja"), mk("Aja"), mk("Aja")},
+			},
+			wantHeaders: true,
+			wantTracks:  4,
+			wantSegs:    1,
+		},
+		{
+			name: "full album split across batches stays cohesive",
+			batches: [][]playlist.Track{
+				{mk("Aja"), mk("Aja")},
+				{mk("Aja"), mk("Aja")},
+			},
+			wantHeaders: true,
+			wantTracks:  4,
+			wantSegs:    1,
+		},
+		{
+			name: "mixtape across batches is not cohesive",
+			batches: [][]playlist.Track{
+				{mk("A"), mk("B")},
+				{mk("C"), mk("D")},
+			},
+			wantHeaders: false,
+			wantTracks:  4,
+			wantSegs:    4,
+		},
+		{
+			name: "two albums of 3 tracks each meet threshold",
+			batches: [][]playlist.Track{
+				{mk("X"), mk("X"), mk("X")},
+				{mk("Y"), mk("Y"), mk("Y")},
+			},
+			wantHeaders: true,
+			wantTracks:  6,
+			wantSegs:    2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Model{}
+			m.setHeaderStateFromTracks(nil) // reset counters
+			for _, batch := range tt.batches {
+				m.addToHeaderState(batch)
+			}
+			if m.showAlbumHeaders != tt.wantHeaders {
+				t.Errorf("showAlbumHeaders = %v, want %v", m.showAlbumHeaders, tt.wantHeaders)
+			}
+			if m.headerTracks != tt.wantTracks {
+				t.Errorf("headerTracks = %d, want %d", m.headerTracks, tt.wantTracks)
+			}
+			if m.headerSegments != tt.wantSegs {
+				t.Errorf("headerSegments = %d, want %d", m.headerSegments, tt.wantSegs)
+			}
+		})
+	}
+}
+
+func TestHeaderStateManualOverride(t *testing.T) {
+	mk := func(album string) playlist.Track { return playlist.Track{Album: album} }
+
+	m := &Model{}
+	// Start with a cohesive album so the heuristic would prefer headers.
+	m.setHeaderStateFromTracks([]playlist.Track{mk("A"), mk("A"), mk("A"), mk("A")})
+	if !m.showAlbumHeaders {
+		t.Fatalf("baseline cohesive album should default to showing headers")
+	}
+
+	// User manually toggles off.
+	m.toggleAlbumHeadersManual()
+	if m.showAlbumHeaders {
+		t.Fatalf("after manual toggle showAlbumHeaders should be false")
+	}
+
+	// Adding more cohesive tracks must NOT flip back on.
+	m.addToHeaderState([]playlist.Track{mk("A"), mk("A"), mk("A")})
+	if m.showAlbumHeaders {
+		t.Fatalf("manual override should suppress heuristic after Add")
+	}
+
+	// A fresh load via setHeaderStateFromTracks clears the manual flag.
+	m.setHeaderStateFromTracks([]playlist.Track{mk("B"), mk("B"), mk("B"), mk("B")})
+	if !m.showAlbumHeaders {
+		t.Fatalf("setHeaderStateFromTracks should clear manual flag and re-run heuristic")
+	}
+}
+
 func TestProviderKeyForShortcut(t *testing.T) {
 	tests := map[string]string{
 		"S": "spotify",


### PR DESCRIPTION
Previously, whether or not to show album headers was only decided on application launch, or when the entire playlist was replaced. This PR ensures the layout stays in sync as content changes, while also respecting manual user preference.

**Changes**
- Runs the cohesion heuristic whenever tracks are added or queued so headers adapt as the playlist grows.
- Preserves user preference for headers chosen with `ctrl+h`.
- Provider browsing views now compute headers from their own results rather than the background playlist.
- Replaces hardcoded header visibility default at launch with a heuristic check of the initial tracks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Header-state logic unified: header display is now recalculated consistently whenever tracks are added, queued, replaced, loaded, or when resuming sessions.
  * Heuristic reorganized to compute album/header cohesion from contiguous album segments and track counts.

* **New Features**
  * Manual header toggle now sets a persistent manual mode so user show/hide preference is preserved.
  * Header state is derived from playlist tracks when replacing or resuming.

* **Bug Fixes**
  * Fewer stale or incorrect header displays during playback, navigation, and playlist operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bjarneo/cliamp/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->