### PR TITLE
fix(httpclient): respect HTTP_PROXY/HTTPS_PROXY for streaming client

### DIFF
--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -12,8 +12,13 @@ import (
 // live streams (Icecast/SHOUTcast) aren't killed. HTTP/2 is explicitly
 // disabled via TLSNextProto because Icecast/SHOUTcast servers don't
 // support it — Go's default ALPN negotiation causes EOF.
+//
+// Proxy is read from the environment (HTTP_PROXY, HTTPS_PROXY, NO_PROXY)
+// so users behind corporate or local proxies aren't bypassed; the rest of
+// the codebase uses http.DefaultTransport, which already honors these vars.
 var Streaming = &http.Client{
 	Transport: &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
 		ResponseHeaderTimeout: 30 * time.Second,
 		TLSNextProto:          make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
 	},


### PR DESCRIPTION
## Summary

The Streaming HTTP client in `internal/httpclient/client.go` sets a custom `http.Transport` (to disable HTTP/2 for Icecast/SHOUTcast compatibility and to extend the header timeout) but doesn't set `Proxy`, so it silently ignores the `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables.

This makes cliamp unusable for anyone behind a corporate or local proxy: the rest of the codebase relies on `http.DefaultTransport`, which already honors those vars via `http.ProxyFromEnvironment`, so playback is the only thing that breaks — which is the most visible feature, and the failure mode (silent EOF / hang) is hard to diagnose.

## The fix

One-line addition: `Proxy: http.ProxyFromEnvironment` in the streaming `http.Transport`. Brings the streaming client in line with Go's default behavior and the rest of cliamp.

```diff
 var Streaming = &http.Client{
   Transport: &http.Transport{
+    Proxy:                 http.ProxyFromEnvironment,
     ResponseHeaderTimeout: 30 * time.Second,
     TLSNextProto:          make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
   },
 }
```

## Tested

- Built locally and confirmed `strings cliamp | grep ProxyFromEnvironment` returns the symbol.
- Verified playback works through both an HTTPS proxy and a SOCKS-over-SSH tunnel (`HTTPS_PROXY=socks5://localhost:<port>`).
- No effect when the env vars are unset (Go's `ProxyFromEnvironment` returns nil → behavior identical to current code).

## Why this is safe

`http.ProxyFromEnvironment` is the same helper used by `http.DefaultTransport`. With no proxy env vars set, the call is a no-op and the transport behaves exactly as before. With proxy env vars set, the streaming client gains the behavior every other HTTP client in cliamp already has.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Network connectivity now properly respects environment proxy settings, improving access for users behind corporate or local proxies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bjarneo/cliamp/pull/238?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->