### PR TITLE
Add rename playlist to the playlist manager

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -85,6 +85,7 @@ Press `?` or `Ctrl+K` in the player to see all keybindings.
 | `Enter` / `→` | List screen: open the highlighted playlist · Tracks screen: play the **highlighted** track |
 | `P` | Tracks screen: play all from the top |
 | `a` | Add the now-playing track (footer shows which track) |
+| `r` | List: rename the playlist |
 | `d` | List: delete playlist (confirms) · Tracks: remove the highlighted track |
 | `←` `Backspace` `h` | Tracks screen: go back to the list |
 | `p` `Esc` | Close the playlist manager |

--- a/external/local/provider.go
+++ b/external/local/provider.go
@@ -25,6 +25,7 @@ import (
 var (
 	_ provider.PlaylistWriter  = (*Provider)(nil)
 	_ provider.PlaylistDeleter = (*Provider)(nil)
+	_ provider.PlaylistRenamer = (*Provider)(nil)
 	_ provider.Searcher        = (*Provider)(nil)
 )
 
@@ -343,6 +344,26 @@ func trackMatches(t playlist.Track, lowerQuery string) bool {
 		return true
 	}
 	return false
+}
+
+// RenamePlaylist renames a playlist by renaming its TOML file.
+// The reserved "Recently Played" history playlist cannot be renamed.
+func (p *Provider) RenamePlaylist(oldName, newName string) error {
+	if isHistoryName(oldName) || isHistoryName(newName) {
+		return errReservedHistoryName
+	}
+	oldPath, err := p.safePath(oldName)
+	if err != nil {
+		return fmt.Errorf("invalid playlist name %q: %w", oldName, err)
+	}
+	newPath, err := p.safePath(newName)
+	if err != nil {
+		return fmt.Errorf("invalid playlist name %q: %w", newName, err)
+	}
+	if _, err := os.Stat(newPath); err == nil {
+		return fmt.Errorf("playlist %q already exists", newName)
+	}
+	return os.Rename(oldPath, newPath)
 }
 
 // DeletePlaylist removes the TOML file for the named playlist.

--- a/external/local/provider.go
+++ b/external/local/provider.go
@@ -362,8 +362,13 @@ func (p *Provider) RenamePlaylist(oldName, newName string) error {
 	}
 	if _, err := os.Stat(newPath); err == nil {
 		return fmt.Errorf("playlist %q already exists", newName)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat destination playlist %q: %w", newName, err)
 	}
-	return os.Rename(oldPath, newPath)
+	if err := os.Rename(oldPath, newPath); err != nil {
+		return fmt.Errorf("rename playlist %q to %q: %w", oldName, newName, err)
+	}
+	return nil
 }
 
 // DeletePlaylist removes the TOML file for the named playlist.

--- a/provider/interfaces.go
+++ b/provider/interfaces.go
@@ -67,6 +67,11 @@ type PlaylistDeleter interface {
 	RemoveTrack(name string, index int) error
 }
 
+// PlaylistRenamer is implemented by providers that support renaming playlists.
+type PlaylistRenamer interface {
+	RenamePlaylist(oldName, newName string) error
+}
+
 // BookmarkSetter is implemented by providers that support toggling
 // track bookmarks and persisting them.
 type BookmarkSetter interface {

--- a/site/index.html
+++ b/site/index.html
@@ -1990,6 +1990,7 @@ user_id = "your-account-user-id"</code></pre>
           <div class="key-row"><kbd>Enter</kbd><span>Open playlist · play <em>highlighted</em> track on the tracks screen</span></div>
           <div class="key-row"><kbd>P</kbd><span>Play all tracks from the top</span></div>
           <div class="key-row"><kbd>a</kbd><span>Add the now-playing track (footer shows which one)</span></div>
+          <div class="key-row"><kbd>r</kbd><span>Rename the playlist</span></div>
           <div class="key-row"><kbd>d</kbd><span>Delete playlist (confirms) / remove track</span></div>
           <div class="key-row"><kbd>Esc / p</kbd><span>Close (or clear active filter)</span></div>
         </div>

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -1355,7 +1355,7 @@ func (m *Model) handleURLInputKey(msg tea.KeyPressMsg) tea.Cmd {
 func (m *Model) handlePlaylistManagerKey(msg tea.KeyPressMsg) tea.Cmd {
 	// Quick-switch (Shift+letter) jumps to another provider. Only honored when
 	// the manager isn't currently capturing text input (filter, new-name).
-	if m.plManager.screen != plMgrScreenNewName && !m.plManager.filtering {
+	if m.plManager.screen != plMgrScreenNewName && m.plManager.screen != plMgrScreenRename && !m.plManager.filtering {
 		if cmd := m.quickSwitchProvider(msg.String()); cmd != nil {
 			return cmd
 		}
@@ -1367,6 +1367,8 @@ func (m *Model) handlePlaylistManagerKey(msg tea.KeyPressMsg) tea.Cmd {
 		return m.handlePlMgrTracksKey(msg)
 	case plMgrScreenNewName:
 		return m.handlePlMgrNewNameKey(msg)
+	case plMgrScreenRename:
+		return m.handlePlMgrRenameKey(msg)
 	}
 	return nil
 }
@@ -1468,6 +1470,14 @@ func (m *Model) handlePlMgrListKey(msg tea.KeyPressMsg) tea.Cmd {
 		if realIdx >= 0 {
 			m.addToPlaylist(m.plManager.playlists[realIdx].Name)
 			m.plMgrRefreshList()
+		}
+	case "r":
+		realIdx := m.plMgrPlaylistRealIndex(m.plManager.cursor)
+		if realIdx >= 0 {
+			name := m.plManager.playlists[realIdx].Name
+			m.plManager.renameOldName = name
+			m.plManager.renameName = name
+			m.plManager.screen = plMgrScreenRename
 		}
 	case "d":
 		if m.plMgrPlaylistRealIndex(m.plManager.cursor) >= 0 {
@@ -1732,6 +1742,36 @@ func (m *Model) handlePlMgrNewNameKey(msg tea.KeyPressMsg) tea.Cmd {
 	default:
 		if len(msg.Text) > 0 {
 			m.plManager.newName += msg.Text
+		}
+	}
+	return nil
+}
+
+// handlePlMgrRenameKey handles keys on screen 3 (rename playlist input).
+func (m *Model) handlePlMgrRenameKey(msg tea.KeyPressMsg) tea.Cmd {
+	switch msg.Code {
+	case tea.KeyEscape:
+		m.plManager.screen = plMgrScreenList
+	case tea.KeyEnter:
+		newName := strings.TrimSpace(m.plManager.renameName)
+		if newName != "" && newName != m.plManager.renameOldName {
+			if r, ok := m.localProvider.(provider.PlaylistRenamer); ok {
+				if err := r.RenamePlaylist(m.plManager.renameOldName, newName); err != nil {
+					m.status.Showf(statusTTLDefault, "Rename failed: %s", err)
+				} else {
+					m.status.Showf(statusTTLDefault, "Renamed %q to %q", m.plManager.renameOldName, newName)
+					m.plMgrRefreshList()
+				}
+			}
+		}
+		m.plManager.screen = plMgrScreenList
+	case tea.KeyBackspace:
+		m.plManager.renameName = removeLastRune(m.plManager.renameName)
+	case tea.KeySpace:
+		m.plManager.renameName += " "
+	default:
+		if len(msg.Text) > 0 {
+			m.plManager.renameName += msg.Text
 		}
 	}
 	return nil

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -1474,16 +1474,17 @@ func (m *Model) handlePlMgrListKey(msg tea.KeyPressMsg) tea.Cmd {
 		}
 	case "r":
 		realIdx := m.plMgrPlaylistRealIndex(m.plManager.cursor)
-		if realIdx >= 0 {
-			name := m.plManager.playlists[realIdx].Name
-			if name == history.PlaylistName {
-				m.status.Show("Recently Played cannot be renamed", statusTTLDefault)
-				return nil
-			}
-			m.plManager.renameOldName = name
-			m.plManager.renameName = name
-			m.plManager.screen = plMgrScreenRename
+		if realIdx < 0 {
+			return nil
 		}
+		name := m.plManager.playlists[realIdx].Name
+		if name == history.PlaylistName {
+			m.status.Show("Recently Played cannot be renamed", statusTTLDefault)
+			return nil
+		}
+		m.plManager.renameOldName = name
+		m.plManager.renameName = name
+		m.plManager.screen = plMgrScreenRename
 	case "d":
 		if m.plMgrPlaylistRealIndex(m.plManager.cursor) >= 0 {
 			m.plManager.confirmDel = true
@@ -1758,20 +1759,7 @@ func (m *Model) handlePlMgrRenameKey(msg tea.KeyPressMsg) tea.Cmd {
 	case tea.KeyEscape:
 		m.plManager.screen = plMgrScreenList
 	case tea.KeyEnter:
-		newName := strings.TrimSpace(m.plManager.renameName)
-		if newName != "" && newName != m.plManager.renameOldName {
-			if r, ok := m.localProvider.(provider.PlaylistRenamer); ok {
-				if err := r.RenamePlaylist(m.plManager.renameOldName, newName); err != nil {
-					m.status.Showf(statusTTLDefault, "Rename failed: %s", err)
-				} else {
-					m.status.Showf(statusTTLDefault, "Renamed %q to %q", m.plManager.renameOldName, newName)
-					if m.loadedPlaylist == m.plManager.renameOldName {
-						m.loadedPlaylist = newName
-					}
-					m.plMgrRefreshList()
-				}
-			}
-		}
+		m.plMgrCommitRename()
 		m.plManager.screen = plMgrScreenList
 	case tea.KeyBackspace:
 		m.plManager.renameName = removeLastRune(m.plManager.renameName)
@@ -1783,6 +1771,29 @@ func (m *Model) handlePlMgrRenameKey(msg tea.KeyPressMsg) tea.Cmd {
 		}
 	}
 	return nil
+}
+
+// plMgrCommitRename applies the pending rename. No-op when the name is
+// empty, unchanged, or the local provider doesn't support renaming.
+func (m *Model) plMgrCommitRename() {
+	newName := strings.TrimSpace(m.plManager.renameName)
+	oldName := m.plManager.renameOldName
+	if newName == "" || newName == oldName {
+		return
+	}
+	r, ok := m.localProvider.(provider.PlaylistRenamer)
+	if !ok {
+		return
+	}
+	if err := r.RenamePlaylist(oldName, newName); err != nil {
+		m.status.Showf(statusTTLDefault, "Rename failed: %s", err)
+		return
+	}
+	m.status.Showf(statusTTLDefault, "Renamed %q to %q", oldName, newName)
+	if m.loadedPlaylist == oldName {
+		m.loadedPlaylist = newName
+	}
+	m.plMgrRefreshList()
 }
 
 // localDeleter returns the PlaylistDeleter from the local provider.

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -10,6 +10,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"cliamp/history"
 	"cliamp/internal/fileutil"
 	"cliamp/playlist"
 	"cliamp/provider"
@@ -1475,6 +1476,10 @@ func (m *Model) handlePlMgrListKey(msg tea.KeyPressMsg) tea.Cmd {
 		realIdx := m.plMgrPlaylistRealIndex(m.plManager.cursor)
 		if realIdx >= 0 {
 			name := m.plManager.playlists[realIdx].Name
+			if name == history.PlaylistName {
+				m.status.Show("Recently Played cannot be renamed", statusTTLDefault)
+				return nil
+			}
 			m.plManager.renameOldName = name
 			m.plManager.renameName = name
 			m.plManager.screen = plMgrScreenRename
@@ -1760,6 +1765,9 @@ func (m *Model) handlePlMgrRenameKey(msg tea.KeyPressMsg) tea.Cmd {
 					m.status.Showf(statusTTLDefault, "Rename failed: %s", err)
 				} else {
 					m.status.Showf(statusTTLDefault, "Renamed %q to %q", m.plManager.renameOldName, newName)
+					if m.loadedPlaylist == m.plManager.renameOldName {
+						m.loadedPlaylist = newName
+					}
 					m.plMgrRefreshList()
 				}
 			}

--- a/ui/model/model.go
+++ b/ui/model/model.go
@@ -90,6 +90,7 @@ const (
 	plMgrScreenList plMgrScreenType = iota
 	plMgrScreenTracks
 	plMgrScreenNewName
+	plMgrScreenRename
 )
 
 // navBrowseModeType identifies which Navidrome browse mode is active.

--- a/ui/model/overlays.go
+++ b/ui/model/overlays.go
@@ -139,6 +139,7 @@ func (m *Model) plMgrListHelpLine() string {
 	return helpKey("↓↑→", "Navigate ") +
 		helpKey("Enter", "Open ") +
 		helpKey("a", addLabel+" ") +
+		helpKey("r", "Rename ") +
 		helpKey("d", "Delete ") +
 		helpKey("/", "Filter ") +
 		helpKey("Esc", "Close")
@@ -195,6 +196,8 @@ func (m *Model) openPlaylistManager() {
 	m.plManager.cursor = 0
 	m.plManager.scroll = 0
 	m.plManager.confirmDel = false
+	m.plManager.renameOldName = ""
+	m.plManager.renameName = ""
 	m.plManager.visible = true
 	m.plMgrListMaybeAdjustScroll(m.plMgrListVisible())
 }

--- a/ui/model/state.go
+++ b/ui/model/state.go
@@ -104,13 +104,13 @@ type queueOverlay struct {
 
 // plManagerState holds state for the playlist manager overlay.
 type plManagerState struct {
-	visible     bool
-	screen      plMgrScreenType
-	cursor      int // view-index: offset into filtered when filter != "", else direct index
-	scroll      int
-	playlists   []playlist.PlaylistInfo
-	selPlaylist string           // playlist name open in screen 1
-	tracks      []playlist.Track // tracks in the selected playlist
+	visible       bool
+	screen        plMgrScreenType
+	cursor        int // view-index: offset into filtered when filter != "", else direct index
+	scroll        int
+	playlists     []playlist.PlaylistInfo
+	selPlaylist   string           // playlist name open in screen 1
+	tracks        []playlist.Track // tracks in the selected playlist
 	newName       string
 	confirmDel    bool
 	renameOldName string

--- a/ui/model/state.go
+++ b/ui/model/state.go
@@ -111,8 +111,10 @@ type plManagerState struct {
 	playlists   []playlist.PlaylistInfo
 	selPlaylist string           // playlist name open in screen 1
 	tracks      []playlist.Track // tracks in the selected playlist
-	newName     string
-	confirmDel  bool
+	newName       string
+	confirmDel    bool
+	renameOldName string
+	renameName    string
 
 	// Filter (`/`) state. Reset on screen change. `filtered` indexes into
 	// `playlists` (list screen) or `tracks` (tracks screen).

--- a/ui/model/view_overlays.go
+++ b/ui/model/view_overlays.go
@@ -141,6 +141,8 @@ func (m Model) renderPlaylistManager() string {
 		lines = m.renderPlMgrTracks()
 	case plMgrScreenNewName:
 		lines = m.renderPlMgrNewName()
+	case plMgrScreenRename:
+		lines = m.renderPlMgrRename()
 	}
 	return m.centerOverlay(strings.Join(m.appendFooterMessages(lines), "\n"))
 }
@@ -401,6 +403,19 @@ func (m Model) renderPlMgrTracks() []string {
 	lines = append(lines, footer...)
 
 	return lines
+}
+
+func (m Model) renderPlMgrRename() []string {
+	return []string{
+		titleStyle.Render("R E N A M E  P L A Y L I S T"),
+		"",
+		dimStyle.Render("  Current name: " + m.plManager.renameOldName),
+		"",
+		dimStyle.Render("  New name:"),
+		playlistSelectedStyle.Render("  " + m.plManager.renameName + "_"),
+		"",
+		helpKey("Enter", "Rename ") + helpKey("Esc", "Cancel"),
+	}
 }
 
 func (m Model) renderPlMgrNewName() []string {


### PR DESCRIPTION
## Summary

Adds a rename playlist action to the TUI playlist manager overlay. Press `r` on any playlist in the manager to rename it. The input is pre-populated with the current name. `Enter` commits, `Esc` cancels. The reserved "Recently Played" history playlist cannot be renamed.

## Screenshots / video

https://github.com/user-attachments/assets/2efe4a6c-bb0d-4750-ab5a-9b468666599f
<img width="1920" height="402" alt="Screenshot_20260520_160204-1" src="https://github.com/user-attachments/assets/5e57945c-2917-467e-8996-7dc324e55b81" />


## How to test

1. Launch cliamp and open the playlist manager with `p`
2. Navigate to any playlist with ↑/↓
3. Press `r`  a rename screen appears pre-filled with the current name
4. Edit the name and press Enter
5. The playlist is renamed and the list refreshes


## Checklist

- [x] `make check` passes
- [x] `docs/` and `site/index.html` updated for user-facing changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added playlist rename via the 'r' key in the playlist manager.
  * Dedicated rename input screen with text editing, Backspace/Space support, Enter to confirm, Esc to cancel.
  * Prevents renaming reserved playlists and disallows choosing an existing playlist name; updates active playlist when renamed.

* **Documentation**
  * Keybinding docs updated to include the new rename shortcut.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bjarneo/cliamp/pull/239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->