### PR TITLE
Add cliamp-plugin-block-burst to community plugins list

### DIFF
--- a/docs/community-plugins.md
+++ b/docs/community-plugins.md
@@ -6,3 +6,4 @@ Plugins built by the community. If you've built a plugin, open a PR to add it he
 |--------|-------------|--------|
 | [cliamp-lastfm](https://github.com/tetsuo76/cliamp-lastfm) | Last.fm scrobbling | [@tetsuo76](https://github.com/tetsuo76) |
 | [cliamp-plugin-led-burst](https://github.com/AlexZeitler/cliamp-plugin-led-burst) | Stereo LED matrix visualizer | [@AlexZeitler](https://github.com/AlexZeitler) |
+| [cliamp-plugin-block-burst](https://github.com/AlexZeitler/cliamp-plugin-block-burst) | Stereo LED block matrix visualizer | [@AlexZeitler](https://github.com/AlexZeitler) |


### PR DESCRIPTION
## Summary

Adds the block burst LED visualizer to the list of community plugins

## Screenshots / video

https://github.com/user-attachments/assets/79ddbce1-417e-4560-a044-572eb1d15cbd

## How to test

```bash
cliamp plugins install AlexZeitler/cliamp-plugin-block-burst
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added community plugin entry for `cliamp-plugin-block-burst`, including GitHub link, description, and author attribution to the plugins directory.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bjarneo/cliamp/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->