### PR TITLE
Add VU meter style visualizer plugin to documentation

### DIFF
--- a/docs/community-plugins.md
+++ b/docs/community-plugins.md
@@ -7,3 +7,4 @@ Plugins built by the community. If you've built a plugin, open a PR to add it he
 | [cliamp-lastfm](https://github.com/tetsuo76/cliamp-lastfm) | Last.fm scrobbling | [@tetsuo76](https://github.com/tetsuo76) |
 | [cliamp-plugin-led-burst](https://github.com/AlexZeitler/cliamp-plugin-led-burst) | Stereo LED matrix visualizer | [@AlexZeitler](https://github.com/AlexZeitler) |
 | [cliamp-plugin-block-burst](https://github.com/AlexZeitler/cliamp-plugin-block-burst) | Stereo LED block matrix visualizer | [@AlexZeitler](https://github.com/AlexZeitler) |
+| [cliamp-plugin-block-burst](https://github.com/AlexZeitler/cliamp-plugin-vu-emter) | Analog multi VU meter style visualizer | [@AlexZeitler](https://github.com/AlexZeitler) |

--- a/docs/community-plugins.md
+++ b/docs/community-plugins.md
@@ -7,4 +7,4 @@ Plugins built by the community. If you've built a plugin, open a PR to add it he
 | [cliamp-lastfm](https://github.com/tetsuo76/cliamp-lastfm) | Last.fm scrobbling | [@tetsuo76](https://github.com/tetsuo76) |
 | [cliamp-plugin-led-burst](https://github.com/AlexZeitler/cliamp-plugin-led-burst) | Stereo LED matrix visualizer | [@AlexZeitler](https://github.com/AlexZeitler) |
 | [cliamp-plugin-block-burst](https://github.com/AlexZeitler/cliamp-plugin-block-burst) | Stereo LED block matrix visualizer | [@AlexZeitler](https://github.com/AlexZeitler) |
-| [cliamp-plugin-block-burst](https://github.com/AlexZeitler/cliamp-plugin-vu-emter) | Analog multi VU meter style visualizer | [@AlexZeitler](https://github.com/AlexZeitler) |
+| [cliamp-plugin-block-burst](https://github.com/AlexZeitler/cliamp-plugin-vu-meter) | Analog multi VU meter style visualizer | [@AlexZeitler](https://github.com/AlexZeitler) |


### PR DESCRIPTION
## Summary

Adds analog multi VU meter style visualizer plugin to documentation

## Screenshots / video

https://github.com/user-attachments/assets/8234aba3-d26a-4f36-8b11-3e610135f07f

## How to test

cliamp plugins install AlexZeitler/cliamp-plugin-vu-meter


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new community plugin entry for an "Analog multi VU meter style visualizer," including repository link and author attribution — now discoverable in the community plugins listing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bjarneo/cliamp/pull/245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->