### PR TITLE
Lower app wakeup by reducing Bubbletea FPS and adding more aggressive settings with --low-power

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -252,6 +252,7 @@ type Config struct {
 	NetEase          NetEaseConfig                // NetEase Cloud Music provider (opt-in via enabled = true)
 	Plugins          map[string]map[string]string // per-plugin config from [plugins.*] sections
 	LogLevel         string                       // log level: debug, info, warn, error (default "info")
+	LowPower         bool                         // runtime-only: set by --low-power, not loaded from config
 }
 
 // defaultConfig returns a Config with sensible defaults.

--- a/config/flags.go
+++ b/config/flags.go
@@ -76,9 +76,9 @@ func (o Overrides) Apply(cfg *Config) {
 		cfg.LogLevel = *o.LogLevel
 	}
 	if o.LowPower != nil && *o.LowPower {
+		cfg.LowPower = true
 		// Low-power mode disables the visualizer entirely. With Mode = None,
-		// the tick loop falls back to TickSlow (5 FPS) for time/seek display
-		// only — the dominant CPU sink for the TUI.
+		// the model also uses lower UI cadences to reduce idle wakeups.
 		cfg.Visualizer = "none"
 	}
 	cfg.clamp()

--- a/main.go
+++ b/main.go
@@ -40,6 +40,11 @@ import (
 // version is set at build time via -ldflags "-X main.version=vX.Y.Z".
 var version string
 
+const (
+	defaultUIFPS  = 20
+	lowPowerUIFPS = 5
+)
+
 func run(overrides config.Overrides, positional []string, daemon bool) error {
 	cfg, err := config.Load()
 	if err != nil {
@@ -331,6 +336,9 @@ func run(overrides config.Overrides, positional []string, daemon bool) error {
 	if cfg.AutoPlay {
 		m.SetAutoPlay(true)
 	}
+	if cfg.LowPower {
+		m.SetLowPower(true)
+	}
 	if cfg.Compact {
 		m.SetCompact(true)
 	}
@@ -341,7 +349,11 @@ func run(overrides config.Overrides, positional []string, daemon bool) error {
 		}
 	}
 
-	prog := tea.NewProgram(m)
+	progOpts := []tea.ProgramOption{tea.WithFPS(defaultUIFPS)}
+	if cfg.LowPower {
+		progOpts[0] = tea.WithFPS(lowPowerUIFPS)
+	}
+	prog := tea.NewProgram(m, progOpts...)
 
 	if spotifyProv != nil {
 		spotify.SetAuthURLObserver(func(u string) {

--- a/player/player.go
+++ b/player/player.go
@@ -37,6 +37,8 @@ type Player struct {
 	current         *trackPipeline // active track's resources
 	nextPipeline    *trackPipeline // preloaded track's resources
 	started         bool           // true after first speaker.Play()
+	suspendMu       sync.Mutex     // guards suspended and speaker suspend/resume calls
+	suspended       bool           // true when speaker.Suspend() has been called
 	ctrl            *beep.Ctrl
 	volMin          atomic.Uint64     // dB floor stored as Float64bits, range [-90, 0]
 	volume          atomic.Uint64     // dB stored as Float64bits, range [volMin, +6]
@@ -75,6 +77,10 @@ func New(q Quality) (*Player, error) {
 	p.volMin.Store(math.Float64bits(-50))
 	p.speed.Store(math.Float64bits(1.0))
 	p.gapless = &gaplessStreamer{}
+	// Suspend the speaker immediately; the ALSA audio callback goroutine
+	// burns ~2% CPU even on silence. Resume is called on every Play().
+	_ = speaker.Suspend()
+	p.suspended = true
 	p.gapless.onSwap = func() {
 		// Called from audio thread (goroutine) when gapless transition occurs.
 		// Swap current ← nextPipeline and close the old one.
@@ -141,6 +147,8 @@ func (p *Player) PlayYTDL(pageURL string, knownDuration time.Duration) error {
 // On the first call it builds the long-lived EQ → volume → tap → ctrl chain.
 // Subsequent calls swap only the track source via the gapless streamer.
 func (p *Player) playPipeline(tp *trackPipeline) error {
+	p.resumeSpeaker()
+
 	// Collect old pipelines to close after releasing locks.
 	var oldCurrent, oldNext *trackPipeline
 
@@ -260,6 +268,8 @@ func (p *Player) GaplessAdvanced() bool {
 }
 
 // TogglePause toggles between paused and playing states.
+// When pausing, the speaker is suspended to save CPU; when unpausing
+// it is resumed so the audio callback drains the queued samples.
 func (p *Player) TogglePause() {
 	speaker.Lock()
 	if p.ctrl != nil {
@@ -267,14 +277,19 @@ func (p *Player) TogglePause() {
 		paused := p.ctrl.Paused
 		speaker.Unlock()
 		p.paused.Store(paused)
+		if paused {
+			p.suspendSpeaker()
+		} else {
+			p.resumeSpeaker()
+		}
 	} else {
 		speaker.Unlock()
 	}
 }
 
-// Stop halts playback and releases resources. The speaker continues running
-// (outputting silence via the gapless streamer) so it can be restarted without
-// rebuilding the pipeline.
+// Stop halts playback and releases resources. The speaker is suspended so
+// the ALSA audio callback goroutine blocks (zero CPU) instead of streaming
+// silence. Resume is called automatically on the next Play().
 func (p *Player) Stop() {
 	// Lock speaker to ensure the goroutine finishes any in-progress Stream()
 	// call, then clear the source and pause. After unlock, the speaker will
@@ -297,6 +312,8 @@ func (p *Player) Stop() {
 	p.mu.Unlock()
 
 	closePipelines(oldCurrent, oldNext)
+
+	p.suspendSpeaker()
 }
 
 // Seek moves the playback position by the given duration (positive or negative).
@@ -746,6 +763,40 @@ func (p *Player) RegisterBufferedURLMatcher(match func(string) bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.bufferedURLMatch = match
+}
+
+// suspendSpeaker suspends the ALSA audio callback goroutine so it blocks
+// on a condition variable instead of busy-looping. Safe to call multiple
+// times; subsequent calls are no-ops.
+func (p *Player) suspendSpeaker() {
+	p.suspendMu.Lock()
+	defer p.suspendMu.Unlock()
+
+	if p.suspended {
+		return
+	}
+	if err := speaker.Suspend(); err != nil {
+		// Non-fatal: the ALSA driver may return an error if the context
+		// has already hit a terminal error. Continue without tracking
+		// the suspended state so we don't try to resume a dead context.
+		return
+	}
+	p.suspended = true
+}
+
+// resumeSpeaker resumes the ALSA audio callback goroutine. Safe to call
+// multiple times; subsequent calls are no-ops.
+func (p *Player) resumeSpeaker() {
+	p.suspendMu.Lock()
+	defer p.suspendMu.Unlock()
+
+	if !p.suspended {
+		return
+	}
+	if err := speaker.Resume(); err != nil {
+		return
+	}
+	p.suspended = false
 }
 
 // Close fully stops the speaker and cleans up all resources.

--- a/ui/model/init.go
+++ b/ui/model/init.go
@@ -84,6 +84,9 @@ func (m *Model) findProviderWith(check func(playlist.Provider) bool) playlist.Pr
 // SetAutoPlay makes the player start playback immediately on Init.
 func (m *Model) SetAutoPlay(v bool) { m.autoPlay = v }
 
+// SetLowPower lowers UI cadences for --low-power without affecting normal mode.
+func (m *Model) SetLowPower(v bool) { m.lowPower = v }
+
 // SetCompact enables compact mode which caps the frame width at 80 columns.
 func (m *Model) SetCompact(v bool) {
 	m.compact = v

--- a/ui/model/init.go
+++ b/ui/model/init.go
@@ -85,7 +85,10 @@ func (m *Model) findProviderWith(check func(playlist.Provider) bool) playlist.Pr
 func (m *Model) SetAutoPlay(v bool) { m.autoPlay = v }
 
 // SetCompact enables compact mode which caps the frame width at 80 columns.
-func (m *Model) SetCompact(v bool) { m.compact = v }
+func (m *Model) SetCompact(v bool) {
+	m.compact = v
+	m.refreshChrome()
+}
 
 // SetInitialDirectory sets the initial directory for the file browser.
 func (m *Model) SetInitialDirectory(dir string) { m.initialDir = dir }
@@ -129,6 +132,13 @@ func (m *Model) SetVisualizer(name string) bool {
 	}
 	m.vis.Mode = mode
 	m.vis.RequestRefresh()
+	m.refreshChrome()
+	// Skip the terminal-title intro animation when the visualizer is disabled
+	// (e.g. --low-power); the user opted out of visual flair, so the 3-second
+	// TickFast intro burn (~20 FPS UI rendering) is just wasted CPU.
+	if mode == ui.VisNone {
+		m.termTitle.introActive = false
+	}
 	return true
 }
 

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -430,6 +430,7 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 			m.fullVis = false
 			m.vis.Rows = ui.DefaultVisRows
 			m.restorePanelWidth()
+			m.refreshChrome()
 		} else if m.focus == focusPlaylist {
 			// Keep current expanded/collapsed height mode when switching focus.
 			m.focus = focusProvider
@@ -743,6 +744,8 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 
 	case "v":
 		m.vis.CycleMode()
+		m.vis.RequestRefresh()
+		m.refreshChrome()
 		m.applyHeightMode()
 		m.adjustScroll()
 		if err := m.configSaver.Save("visualizer", fmt.Sprintf("%q", m.vis.ModeName())); err != nil {
@@ -758,6 +761,7 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 			m.vis.Rows = ui.DefaultVisRows
 			m.restorePanelWidth()
 		}
+		m.refreshChrome()
 
 	case "ctrl+x":
 		if m.focus == focusPlaylist {

--- a/ui/model/model.go
+++ b/ui/model/model.go
@@ -279,6 +279,13 @@ type Model struct {
 	cachedDur  time.Duration
 	lastTickAt time.Time // wall time of previous tickMsg; used for tick delta
 
+	// Cached height of the fixed chrome (title, track info, time, seek bar,
+	// controls, provider pill, playlist header, help, bottom status, no
+	// transient footer). Reused to avoid rendering all chrome sections twice
+	// per View() call. The measurement in effectivePlaylistVisible() uses
+	// this cache instead of a full render pass.
+	chromeHeight int
+	chromeOK     bool
 }
 
 func (m Model) activeScreen() topLevelScreen {

--- a/ui/model/model.go
+++ b/ui/model/model.go
@@ -271,6 +271,7 @@ type Model struct {
 	fullVis bool
 
 	autoPlay       bool // start playing immediately on launch
+	lowPower       bool // lower UI/render cadences; set only by --low-power
 	compact        bool // compact mode: cap frame width at 80 columns
 	heightExpanded bool // tracks whether manual 'x' expansion is active
 

--- a/ui/model/scroll.go
+++ b/ui/model/scroll.go
@@ -115,6 +115,17 @@ func (m Model) playlistScroll(visible int) int {
 }
 
 func (m Model) mainFrameFixedLines(includeTransient bool) int {
+	if m.chromeOK {
+		if !includeTransient {
+			return m.chromeHeight
+		}
+		transientLines := len(m.footerMessages())
+		if m.err != nil {
+			transientLines++
+		}
+		return m.chromeHeight + transientLines
+	}
+	// Fallback: render and measure (only needed until first WindowSizeMsg)
 	content := strings.Join(m.mainSections("", includeTransient), "\n")
 	return lipgloss.Height(ui.FrameStyle.Render(content))
 }
@@ -128,4 +139,26 @@ func (m Model) effectivePlaylistVisible() int {
 		return 0
 	}
 	return min(m.plVisible, available)
+}
+
+// recomputeChrome renders the fixed chrome (without playlist or transients)
+// and caches its height. Called when terminal width or compact mode changes.
+func (m *Model) recomputeChrome() {
+	content := strings.Join(m.mainSections("", false), "\n")
+	m.chromeHeight = lipgloss.Height(ui.FrameStyle.Render(content))
+	m.chromeOK = true
+}
+
+// invalidateChrome marks the chrome height dirty. Until the next recompute,
+// mainFrameFixedLines falls back to direct measurement.
+func (m *Model) invalidateChrome() {
+	m.chromeOK = false
+}
+
+func (m *Model) refreshChrome() {
+	if m.width > 0 {
+		m.recomputeChrome()
+		return
+	}
+	m.invalidateChrome()
 }

--- a/ui/model/tick.go
+++ b/ui/model/tick.go
@@ -126,6 +126,9 @@ func (m *Model) tickInterval() time.Duration {
 	// cadence to save CPU.
 	if !m.isOverlayActive() && !m.buffering && m.player != nil &&
 		m.player.IsPlaying() && !m.player.IsPaused() && d > ui.TickFast {
+		if m.lowPower {
+			return ui.TickLowPowerPlaying
+		}
 		d = ui.TickFast
 	}
 	return d

--- a/ui/model/tick.go
+++ b/ui/model/tick.go
@@ -154,7 +154,7 @@ func (m *Model) isFullyIdle() bool {
 }
 
 func (m *Model) tickVisualizer(now time.Time) {
-	if m.vis == nil {
+	if m.vis == nil || m.vis.Mode == ui.VisNone {
 		return
 	}
 	m.vis.Tick(m.visualizerTickContext(now))

--- a/ui/model/tick_test.go
+++ b/ui/model/tick_test.go
@@ -75,6 +75,35 @@ func TestTickIntervalPendingStatusUsesSlow(t *testing.T) {
 	}
 }
 
+func TestTickIntervalPlayingUsesFastCadence(t *testing.T) {
+	p := &playbackFakeEngine{playing: true}
+	m := Model{
+		player:   p,
+		vis:      ui.NewVisualizer(float64(p.SampleRate())),
+		playlist: playlist.New(),
+	}
+	m.SetVisualizer("none")
+
+	if got := m.tickInterval(); got != ui.TickFast {
+		t.Fatalf("tickInterval() = %v, want %v", got, ui.TickFast)
+	}
+}
+
+func TestTickIntervalLowPowerPlayingUsesLowPowerCadence(t *testing.T) {
+	p := &playbackFakeEngine{playing: true}
+	m := Model{
+		player:   p,
+		vis:      ui.NewVisualizer(float64(p.SampleRate())),
+		playlist: playlist.New(),
+	}
+	m.SetVisualizer("none")
+	m.SetLowPower(true)
+
+	if got := m.tickInterval(); got != ui.TickLowPowerPlaying {
+		t.Fatalf("tickInterval() = %v, want %v", got, ui.TickLowPowerPlaying)
+	}
+}
+
 func TestInitialTickUsesFastCadence(t *testing.T) {
 	prev := teaTick
 	t.Cleanup(func() {

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -70,6 +70,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.vis.Rows = max(ui.DefaultVisRows, (m.height-10)*4/5)
 			ui.PanelWidth = max(0, m.width-2*ui.PaddingH)
 		}
+		m.recomputeChrome()
 		m.applyHeightMode()
 		m.adjustScroll()
 		if m.focus == focusProvider {
@@ -191,8 +192,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.network.sampleFor += dt
 		if m.network.sampleFor >= time.Second {
-			m.notifyAll()
 			downloaded, _ := m.player.StreamBytes()
+			if downloaded > 0 || m.player.IsPlaying() {
+				m.notifyAll()
+			}
 			delta := downloaded - m.network.lastBytes
 			if delta > 0 {
 				// Exponential moving average for smooth display.
@@ -809,6 +812,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if strings.EqualFold(msg.Name, "next") {
 			m.vis.CycleMode()
 			m.vis.RequestRefresh()
+			m.refreshChrome()
 			resp = ipc.Response{OK: true, Visualizer: m.vis.ModeName()}
 		} else if m.SetVisualizer(msg.Name) {
 			resp = ipc.Response{OK: true, Visualizer: m.vis.ModeName()}

--- a/ui/tick.go
+++ b/ui/tick.go
@@ -9,6 +9,9 @@ const (
 	TickFast    = 50 * time.Millisecond  // 20 FPS — per-frame-animated spectrum modes
 	TickAnalyze = 33 * time.Millisecond  // ~30 Hz — FFT analysis cadence (independent of animation)
 	TickSlow    = 200 * time.Millisecond // 5 FPS — visualizer off or overlay
+	// TickLowPowerPlaying keeps playback bookkeeping responsive while avoiding
+	// the 20 FPS time/seek refresh cost when --low-power is explicitly enabled.
+	TickLowPowerPlaying = 500 * time.Millisecond // 2 FPS — low-power playback UI cadence
 	// TickIdle is used when the player is stopped or paused with nothing
 	// animating (no overlay, no buffering, no pending status / reconnect).
 	// Bubbletea wakes immediately on key / IPC / MPRIS / plugin messages, so


### PR DESCRIPTION
When playback stops or pauses, suspend the ALSA PCM device so the audio hardware can power down. Saves ~1.3% CPU during idle periods on slow old hardware. But this is a good battery saver. Code is AI suggested based on my prompts.

Changes in `player/player.go`:
- Add `suspendALSA` / `resumeALSA` methods
- Call `suspendALSA` on stop/pause transitions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduce CPU/audio glitches during pause/stop by suspending/resuming audio callbacks.
  * Prevent visualizer work when disabled to avoid unnecessary updates.

* **New Features**
  * Low-power mode: reduces UI framerate and visualizer cadence to save CPU.
  * UI chrome caching and immediate refresh on compact/visualizer changes; disabling visualizer stops the intro animation.

* **Tests**
  * Added tests for tick cadence behavior in normal and low-power playback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bjarneo/cliamp/pull/249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->