### PR TITLE
fix(mpris): declare properties in introspection XML

### DIFF
--- a/mediactl/service_linux.go
+++ b/mediactl/service_linux.go
@@ -36,6 +36,12 @@ const introspectXML = `
   <interface name="org.mpris.MediaPlayer2">
     <method name="Raise"/>
     <method name="Quit"/>
+    <property name="Identity" type="s" access="read"/>
+    <property name="CanQuit" type="b" access="read"/>
+    <property name="CanRaise" type="b" access="read"/>
+    <property name="HasTrackList" type="b" access="read"/>
+    <property name="SupportedUriSchemes" type="as" access="read"/>
+    <property name="SupportedMimeTypes" type="as" access="read"/>
   </interface>
   <interface name="org.mpris.MediaPlayer2.Player">
     <method name="Next"/>
@@ -47,6 +53,19 @@ const introspectXML = `
     <method name="Seek"><arg direction="in" type="x"/></method>
     <method name="SetPosition"><arg direction="in" type="o"/><arg direction="in" type="x"/></method>
     <signal name="Seeked"><arg type="x"/></signal>
+    <property name="PlaybackStatus" type="s" access="read"/>
+    <property name="Rate" type="d" access="readwrite"/>
+    <property name="Metadata" type="a{sv}" access="read"/>
+    <property name="Volume" type="d" access="readwrite"/>
+    <property name="Position" type="x" access="read"/>
+    <property name="MinimumRate" type="d" access="read"/>
+    <property name="MaximumRate" type="d" access="read"/>
+    <property name="CanGoNext" type="b" access="read"/>
+    <property name="CanGoPrevious" type="b" access="read"/>
+    <property name="CanPlay" type="b" access="read"/>
+    <property name="CanPause" type="b" access="read"/>
+    <property name="CanSeek" type="b" access="read"/>
+    <property name="CanControl" type="b" access="read"/>
   </interface>
 ` + introspect.IntrospectDataString + `</node>`
 
@@ -138,10 +157,12 @@ func New(send func(tea.Msg)) (*Service, error) {
 
 	propsSpec := map[string]map[string]*prop.Prop{
 		"org.mpris.MediaPlayer2": {
-			"Identity":     {Value: "Cliamp", Writable: false, Emit: prop.EmitTrue},
-			"CanQuit":      {Value: true, Writable: false, Emit: prop.EmitTrue},
-			"CanRaise":     {Value: false, Writable: false, Emit: prop.EmitTrue},
-			"HasTrackList": {Value: false, Writable: false, Emit: prop.EmitTrue},
+			"Identity":            {Value: "Cliamp", Writable: false, Emit: prop.EmitTrue},
+			"CanQuit":             {Value: true, Writable: false, Emit: prop.EmitTrue},
+			"CanRaise":            {Value: false, Writable: false, Emit: prop.EmitTrue},
+			"HasTrackList":        {Value: false, Writable: false, Emit: prop.EmitTrue},
+			"SupportedUriSchemes": {Value: []string{}, Writable: false, Emit: prop.EmitTrue},
+			"SupportedMimeTypes":  {Value: []string{}, Writable: false, Emit: prop.EmitTrue},
 		},
 		"org.mpris.MediaPlayer2.Player": {
 			"PlaybackStatus": {Value: string(playback.StatusStopped), Writable: false, Emit: prop.EmitTrue},

--- a/mediactl/service_linux.go
+++ b/mediactl/service_linux.go
@@ -54,7 +54,7 @@ const introspectXML = `
     <method name="SetPosition"><arg direction="in" type="o"/><arg direction="in" type="x"/></method>
     <signal name="Seeked"><arg type="x"/></signal>
     <property name="PlaybackStatus" type="s" access="read"/>
-    <property name="Rate" type="d" access="readwrite"/>
+    <property name="Rate" type="d" access="read"/>
     <property name="Metadata" type="a{sv}" access="read"/>
     <property name="Volume" type="d" access="readwrite"/>
     <property name="Position" type="x" access="read"/>


### PR DESCRIPTION
## Problem

GLib-based tools like `playerctl`, `playerctld`, and waybar rely on D-Bus introspection to discover interface properties. The current `introspectXML` only declares methods and signals — no `<property>` elements.

Without property declarations, `GDBus` does not attempt to read or cache MPRIS properties, which causes:
- `playerctl -l` to not list cliamp when `playerctld` is running
- Media keys to be unresponsive or erratic (playerctld cannot track playback state)
- waybar's MPRIS module to ignore cliamp entirely

Direct D-Bus queries (`dbus-send ... GetAll`) still work because `prop.Export` correctly implements `org.freedesktop.DBus.Properties` — but GLib won't call it without seeing the properties in introspection first.

## Fix

Add `<property>` elements to both MPRIS interfaces in `introspectXML`, matching the properties already exported via `prop.Export`. Also adds the two required-but-missing root properties: `SupportedUriSchemes` and `SupportedMimeTypes`.

## Testing

Verified on Linux with playerctl 2.4.1 and playerctld:

```
# Before fix
$ playerctl -l
chromium.instance63259   # cliamp missing

# After fix
$ playerctl -l
chromium.instance63259
cliamp                   # ✓ visible

$ playerctl --player=cliamp status
Playing                  # ✓ correct state

$ gdbus introspect --session --dest org.mpris.MediaPlayer2.cliamp \
    --object-path /org/mpris/MediaPlayer2
# Now shows properties in both interfaces
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Declares additional media control properties (playback status, rate, metadata, volume, position and related capabilities) for richer system integration.
  * Exposes explicit read-only properties for supported URI schemes and MIME types (initialized empty) to improve format/source visibility.
  * Clarifies and reformats existing identity and capability declarations while preserving prior behavior for better compatibility with system controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bjarneo/cliamp/pull/251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->