### PR TITLE
Full-width separators and separator label clean-up

### DIFF
--- a/external/local/provider.go
+++ b/external/local/provider.go
@@ -47,7 +47,7 @@ func New() *Provider {
 	}
 }
 
-func (p *Provider) Name() string { return "Local Playlists" }
+func (p *Provider) Name() string { return "Local" }
 
 // safePath validates a playlist name and returns the absolute path to its TOML
 // file, ensuring the result stays within p.dir. This prevents path traversal

--- a/external/local/provider_test.go
+++ b/external/local/provider_test.go
@@ -53,8 +53,8 @@ func TestSafePathRejectsSlash(t *testing.T) {
 
 func TestProviderName(t *testing.T) {
 	p := newTestProvider(t)
-	if got := p.Name(); got != "Local Playlists" {
-		t.Fatalf("Name() = %q, want %q", got, "Local Playlists")
+	if got := p.Name(); got != "Local" {
+		t.Fatalf("Name() = %q, want %q", got, "Local")
 	}
 }
 

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -517,7 +517,7 @@ func (m Model) renderProviderPill() string {
 
 func (m Model) renderPlaylistHeader() string {
 	if m.focus == focusProvider {
-		return dimStyle.Render(fmt.Sprintf("── %s Playlists ──", m.provider.Name()))
+		return dimStyle.Render(labeledSeparator("", fmt.Sprintf("%s Playlists", m.provider.Name())))
 	}
 
 	var shuffle string
@@ -660,11 +660,11 @@ func (m Model) renderProviderList() string {
 					var header string
 					switch pfx {
 					case "f":
-						header = "  ── favorites ──"
+						header = labeledSeparator("  ", "favorites")
 					case "c":
-						header = "  ── catalog ──"
+						header = labeledSeparator("  ", "catalog")
 					case "s":
-						header = "  ── search results ──"
+						header = labeledSeparator("  ", "search results")
 					}
 					if header != "" && len(lines) < visibleBudget {
 						lines = append(lines, dimStyle.Render(header))
@@ -672,7 +672,7 @@ func (m Model) renderProviderList() string {
 					prevPrefix = pfx
 				}
 			} else if hasSections && p.Section != prevSection {
-				header := "  ── " + strings.ToLower(p.Section) + " ──"
+				header := labeledSeparator("  ", strings.ToLower(p.Section))
 				if len(lines) < visibleBudget {
 					lines = append(lines, dimStyle.Render(header))
 				}

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -660,11 +660,11 @@ func (m Model) renderProviderList() string {
 					var header string
 					switch pfx {
 					case "f":
-						header = labeledSeparator("  ", "favorites")
+						header = labeledSeparator("  ", "Favorites")
 					case "c":
-						header = labeledSeparator("  ", "catalog")
+						header = labeledSeparator("  ", "Catalog")
 					case "s":
-						header = labeledSeparator("  ", "search results")
+						header = labeledSeparator("  ", "Search Results")
 					}
 					if header != "" && len(lines) < visibleBudget {
 						lines = append(lines, dimStyle.Render(header))
@@ -672,7 +672,7 @@ func (m Model) renderProviderList() string {
 					prevPrefix = pfx
 				}
 			} else if hasSections && p.Section != prevSection {
-				header := labeledSeparator("  ", strings.ToLower(p.Section))
+				header := labeledSeparator("  ", p.Section)
 				if len(lines) < visibleBudget {
 					lines = append(lines, dimStyle.Render(header))
 				}

--- a/ui/model/view_helpers.go
+++ b/ui/model/view_helpers.go
@@ -7,6 +7,8 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"charm.land/lipgloss/v2"
+
 	"cliamp/playlist"
 	"cliamp/ui"
 )
@@ -318,22 +320,35 @@ func (m Model) albumSeparatorRows(tracks []playlist.Track, scroll, cursor int, s
 	return rows
 }
 
-// albumSeparator builds a full-width album divider line.
+// separatorLine pads or truncates an unstyled separator to exactly fill the playlist pane width.
+func separatorLine(line string) string {
+	if ui.PanelWidth <= 0 {
+		return ""
+	}
+	if w := lipgloss.Width(line); w < ui.PanelWidth {
+		return line + strings.Repeat("─", ui.PanelWidth-w)
+	}
+	if lipgloss.Width(line) > ui.PanelWidth {
+		return truncate(line, ui.PanelWidth)
+	}
+	return line
+}
+
+// labeledSeparator builds a labeled separator line.
+func labeledSeparator(indent, label string) string {
+	return separatorLine(indent + "── " + label + " ")
+}
+
+// albumSeparator builds an album separator line.
 func (m Model) albumSeparator(album string, year int) string {
 	if album == "" {
 		return dimStyle.Render(strings.Repeat("─", ui.PanelWidth))
 	}
-	prefix := "── "
-	suffix := " "
-	label := prefix + album
+	label := album
 	if year != 0 {
 		label += fmt.Sprintf(" (%d)", year)
 	}
-	label += suffix
-	if labelLen := utf8.RuneCountInString(label); labelLen < ui.PanelWidth {
-		label += strings.Repeat("─", ui.PanelWidth-labelLen)
-	}
-	return dimStyle.Render(label)
+	return dimStyle.Render(labeledSeparator("", label))
 }
 
 // navScrollItems renders a filtered or unfiltered scrolled list for nav browsers.

--- a/ui/model/view_helpers.go
+++ b/ui/model/view_helpers.go
@@ -8,6 +8,7 @@ import (
 	"unicode/utf8"
 
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	"cliamp/playlist"
 	"cliamp/ui"
@@ -329,7 +330,7 @@ func separatorLine(line string) string {
 		return line + strings.Repeat("─", ui.PanelWidth-w)
 	}
 	if lipgloss.Width(line) > ui.PanelWidth {
-		return truncate(line, ui.PanelWidth)
+		return ansi.Truncate(line, ui.PanelWidth, "")
 	}
 	return line
 }

--- a/ui/model/view_state_test.go
+++ b/ui/model/view_state_test.go
@@ -188,10 +188,10 @@ func TestFullVisualizerViewFitsTerminalWidth(t *testing.T) {
 	}
 }
 
-var ansi = regexp.MustCompile(`\x1b\[[0-9;]*[mK]`)
+var stripAnsiRegExp = regexp.MustCompile(`\x1b\[[0-9;]*[mK]`)
 
 func stripAnsi(str string) string {
-	return ansi.ReplaceAllString(str, "")
+	return stripAnsiRegExp.ReplaceAllString(str, "")
 }
 
 func TestRenderPlaylistAddsPaddingToTrackNumber(t *testing.T) {


### PR DESCRIPTION
This PR makes two UI consistency updates regarding list separators

1. Full-width separators
   • Introduces `separatorLine(...)` for unified full-width padding/truncation
   • Replaces hard-coded separator strings like `── favorites ──` with `labeledSeparator(...)` helper

2. Separator label clean-up
   • Local `Provider.Name()` now returns simply `"Local"` instead of `"Local Playlists"` so it does not appear as `"Local Playlists Playlists"` in the playlist view
   • Other labeled separators are now title-case to match the capitalization of the rest of the UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Provider display name changed from "Local Playlists" to "Local" for clearer, more consistent labeling.
  * Playlist and provider section separators now use width-aware rendering and labeled separators for improved visual alignment and consistent headers across the app.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bjarneo/cliamp/pull/252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->