### PR TITLE
fix(player): fall back to ffmpeg for non-Vorbis OGG HTTP streams

### DIFF
--- a/player/pipeline.go
+++ b/player/pipeline.go
@@ -181,10 +181,20 @@ func (p *Player) buildPipelineAt(path string, byteOffset int64, timeOffset time.
 
 	// For OGG HTTP streams, use the chained decoder so Icecast radio
 	// continues across song boundaries instead of stopping at EOS.
+	// If Vorbis init fails (e.g. OggFLAC or OggOpus), fall back to ffmpeg.
 	if isURL(path) && ext == ".ogg" {
 		tp, err := p.buildChainedOggPipeline(rc, onMeta)
 		if err != nil {
-			return nil, err
+			rc.Close()
+			decoder, fmt2, err2 := decodeFFmpegStream(path, p.sr, p.bitDepth)
+			if err2 != nil {
+				return nil, fmt.Errorf("decode: %w", err2)
+			}
+			return &trackPipeline{
+				decoder: decoder,
+				stream:  decoder,
+				format:  fmt2,
+			}, nil
 		}
 		tp.bytesRead = byteCounter
 		tp.contentLength = src.contentLength


### PR DESCRIPTION
## Problem

OGG containers can carry FLAC or Opus codecs, not just Vorbis. When a stream's `Content-Type` is `application/ogg` or `audio/ogg` but the codec isn't Vorbis, `oggvorbis.NewReader` returns `vorbis: invalid header` and playback fails immediately with no recovery path.

Reproducer: `http://stream.radioparadise.com/rock-flac` — serves `Content-Type: application/ogg` but encodes audio as FLAC.

## Fix

When `buildChainedOggPipeline` fails, close the already-consumed `rc` and retry via `decodeFFmpegStream`, which handles OggFLAC, OggOpus, and any other OGG variant ffmpeg supports.

## Test plan

- [ ] Play `http://stream.radioparadise.com/rock-flac` — should stream without error
- [ ] Play a standard OGG/Vorbis Icecast stream — chained decoder still used, behaviour unchanged
- [ ] `make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced OGG audio playback reliability with improved fallback handling over HTTP connections. The player now automatically recovers from certain initialization errors using alternative decoding methods, improving overall playback stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bjarneo/cliamp/pull/253?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->