### PR TITLE
fix(resolve,player): play HLS (.m3u8) radio streams via ffmpeg

### DIFF
--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -22,6 +22,18 @@ PLS playlist files are supported alongside M3U:
 cliamp https://radio.cliamp.stream/lofi/stream.pls
 ```
 
+## HLS Streams
+
+HLS playlists (`.m3u8`, master or media) are supported — common for large broadcasters such as Brazilian RBS/Wowza stations:
+
+```sh
+cliamp "https://example.com/live/playlist.m3u8"
+```
+
+cliamp hands the URL to ffmpeg, which resolves the relative chunklist/segment URIs and follows the live segment window. Requires `ffmpeg` (already needed for AAC/Opus).
+
+Live HLS carries timed metadata rather than inline ICY, so the now-playing track title isn't updated for HLS streams.
+
 ## Podcasts
 
 Play any podcast by passing its RSS feed URL:

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -24,7 +24,7 @@ cliamp https://radio.cliamp.stream/lofi/stream.pls
 
 ## HLS Streams
 
-HLS playlists (`.m3u8`, master or media) are supported — common for large broadcasters such as Brazilian RBS/Wowza stations:
+HLS playlists (`.m3u8`, master or media) are supported, as used by large broadcasters such as Brazilian RBS/Wowza stations:
 
 ```sh
 cliamp "https://example.com/live/playlist.m3u8"

--- a/player/decode.go
+++ b/player/decode.go
@@ -232,6 +232,10 @@ func needsFFmpeg(ext string) bool {
 	return false
 }
 
+// isHLS reports whether the extension denotes an HLS playlist that ffmpeg must
+// open by URL (so it can fetch and demux the segments itself).
+func isHLS(ext string) bool { return ext == ".m3u8" }
+
 // isBufferedURL reports whether the given URL requires the buffered download
 // + ffmpeg pipeline. Returns true if a registered matcher matches the URL.
 func (p *Player) isBufferedURL(path string) bool {

--- a/player/decode_test.go
+++ b/player/decode_test.go
@@ -1,0 +1,14 @@
+package player
+
+import "testing"
+
+func TestIsHLS(t *testing.T) {
+	if !isHLS(".m3u8") {
+		t.Error(".m3u8 should be HLS")
+	}
+	for _, ext := range []string{".mp3", ".m3u", ".aac", ""} {
+		if isHLS(ext) {
+			t.Errorf("%q should not be HLS", ext)
+		}
+	}
+}

--- a/player/pipeline.go
+++ b/player/pipeline.go
@@ -158,6 +158,23 @@ func (p *Player) buildPipelineAt(path string, byteOffset int64, timeOffset time.
 		}, nil
 	}
 
+	// HLS playlists must be opened by ffmpeg directly from the URL so it can
+	// resolve relative chunklist/segment URIs and follow the live segment
+	// window. Feeding the playlist bytes via stdin (the needsFFmpeg path below)
+	// would strip the base URL and break relative segment resolution.
+	if isURL(path) && isHLS(formatExt(path)) {
+		decoder, format, err := decodeFFmpegStream(path, p.sr, p.bitDepth)
+		if err != nil {
+			return nil, fmt.Errorf("open hls: %w", err)
+		}
+		return &trackPipeline{
+			decoder: decoder,
+			stream:  decoder,
+			format:  format,
+			path:    path,
+		}, nil
+	}
+
 	src, err := openSourceAt(path, byteOffset, onMeta)
 	if err != nil {
 		return nil, fmt.Errorf("open source: %w", err)

--- a/player/pipeline.go
+++ b/player/pipeline.go
@@ -158,11 +158,13 @@ func (p *Player) buildPipelineAt(path string, byteOffset int64, timeOffset time.
 		}, nil
 	}
 
+	ext := formatExt(path)
+
 	// HLS playlists must be opened by ffmpeg directly from the URL so it can
 	// resolve relative chunklist/segment URIs and follow the live segment
 	// window. Feeding the playlist bytes via stdin (the needsFFmpeg path below)
 	// would strip the base URL and break relative segment resolution.
-	if isURL(path) && isHLS(formatExt(path)) {
+	if isURL(path) && isHLS(ext) {
 		decoder, format, err := decodeFFmpegStream(path, p.sr, p.bitDepth)
 		if err != nil {
 			return nil, fmt.Errorf("open hls: %w", err)
@@ -189,7 +191,6 @@ func (p *Player) buildPipelineAt(path string, byteOffset int64, timeOffset time.
 	}
 
 	// Determine format: prefer URL extension, fall back to Content-Type.
-	ext := formatExt(path)
 	if isURL(path) && ext == ".mp3" && src.contentType != "" {
 		if ctExt := extFromContentType(src.contentType); ctExt != "" {
 			ext = ctExt

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -4,6 +4,7 @@ package resolve
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"encoding/xml"
@@ -322,7 +323,14 @@ func resolveFeed(feedURL string) ([]playlist.Track, error) {
 	return tracks, nil
 }
 
-// resolveM3U fetches an M3U playlist URL and returns tracks with EXTINF metadata.
+// maxM3UBody caps how much of a remote playlist we read before classifying it.
+// HLS/M3U playlists are tiny (a few KB); 1 MB is a generous safety bound.
+const maxM3UBody = 1 << 20
+
+// resolveM3U fetches an M3U/M3U8 URL. HLS playlists (master or media) are a
+// single live/VOD stream — not a track list — so the original URL is handed to
+// the player, where ffmpeg resolves the relative chunklist/segment URIs and
+// follows the live segment window. Plain M3U files are parsed as track lists.
 func resolveM3U(m3uURL string) ([]playlist.Track, error) {
 	resp, err := httpClient.Get(m3uURL)
 	if err != nil {
@@ -334,7 +342,21 @@ func resolveM3U(m3uURL string) ([]playlist.Track, error) {
 		return nil, fmt.Errorf("http status %s", resp.Status)
 	}
 
-	entries, err := parseM3U(resp.Body, "")
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxM3UBody))
+	if err != nil {
+		return nil, err
+	}
+
+	if isHLSPlaylist(body) {
+		// Parsing an HLS playlist as a track list would extract the relative
+		// "chunklist_*.m3u8" URI as a bogus local-file track and fail with
+		// "open source: ... no such file or directory".
+		t := playlist.TrackFromPath(m3uURL) // Stream=true; title derived from URL
+		t.Realtime = !bytes.Contains(body, []byte("#EXT-X-ENDLIST"))
+		return []playlist.Track{t}, nil
+	}
+
+	entries, err := parseM3U(bytes.NewReader(body), "")
 	if err != nil {
 		return nil, err
 	}
@@ -358,6 +380,14 @@ func resolvePLS(plsURL string) ([]playlist.Track, error) {
 		return nil, err
 	}
 	return plsEntriesToTracks(entries), nil
+}
+
+// isHLSPlaylist reports whether an M3U body is an HLS playlist (master or media)
+// rather than a plain list of media URLs. HLS is identified by its #EXT-X-* tags.
+func isHLSPlaylist(body []byte) bool {
+	return bytes.Contains(body, []byte("#EXT-X-STREAM-INF")) || // master
+		bytes.Contains(body, []byte("#EXT-X-TARGETDURATION")) || // media
+		bytes.Contains(body, []byte("#EXT-X-MEDIA-SEQUENCE")) // media
 }
 
 // ytdlFlatEntry holds JSON fields from yt-dlp --flat-playlist output.

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -352,6 +352,8 @@ func resolveM3U(m3uURL string) ([]playlist.Track, error) {
 		// "chunklist_*.m3u8" URI as a bogus local-file track and fail with
 		// "open source: ... no such file or directory".
 		t := playlist.TrackFromPath(m3uURL) // Stream=true; title derived from URL
+		// #EXT-X-ENDLIST only appears in media playlists, so VOD behind a
+		// master playlist is conservatively treated as live.
 		t.Realtime = !bytes.Contains(body, []byte("#EXT-X-ENDLIST"))
 		return []playlist.Track{t}, nil
 	}

--- a/resolve/resolve_test.go
+++ b/resolve/resolve_test.go
@@ -1,6 +1,7 @@
 package resolve
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -163,4 +164,63 @@ func (t rewriteHostTransport) RoundTrip(req *http.Request) (*http.Response, erro
 	clone.URL.Host = t.target.Host
 	clone.Host = t.target.Host
 	return t.rt.RoundTrip(clone)
+}
+
+func TestIsHLSPlaylist(t *testing.T) {
+	master := "#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=1000000\nchunklist_abc.m3u8\n"
+	media := "#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-TARGETDURATION:6\n#EXT-X-MEDIA-SEQUENCE:42\n#EXTINF:6.0,\nmedia_42.ts\n"
+	simple := "#EXTM3U\n#EXTINF:-1,Radio\nhttp://radio.example.com/stream\n"
+
+	if !isHLSPlaylist([]byte(master)) {
+		t.Error("master playlist should be detected as HLS")
+	}
+	if !isHLSPlaylist([]byte(media)) {
+		t.Error("media playlist should be detected as HLS")
+	}
+	if isHLSPlaylist([]byte(simple)) {
+		t.Error("plain radio M3U must NOT be detected as HLS")
+	}
+}
+
+func TestResolveM3U_HLS_ReturnsSingleStream(t *testing.T) {
+	const master = "#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=1000000\nchunklist_abc.m3u8\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.apple.mpegurl")
+		_, _ = io.WriteString(w, master)
+	}))
+	defer srv.Close()
+
+	u := srv.URL + "/primary/gaucha_rbs.sdp/playlist.m3u8"
+	tracks, err := resolveM3U(u)
+	if err != nil {
+		t.Fatalf("resolveM3U: %v", err)
+	}
+	if len(tracks) != 1 {
+		t.Fatalf("got %d tracks, want 1 (HLS = single stream)", len(tracks))
+	}
+	if tracks[0].Path != u {
+		t.Errorf("Path = %q, want original URL %q", tracks[0].Path, u)
+	}
+	if !tracks[0].Stream {
+		t.Error("Stream should be true")
+	}
+	if !tracks[0].Realtime {
+		t.Error("Realtime should be true (no #EXT-X-ENDLIST)")
+	}
+}
+
+func TestResolveM3U_PlainPlaylist_StillParsesTracks(t *testing.T) {
+	const pl = "#EXTM3U\n#EXTINF:-1,A\nhttp://x/a.mp3\n#EXTINF:-1,B\nhttp://x/b.mp3\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, pl)
+	}))
+	defer srv.Close()
+
+	tracks, err := resolveM3U(srv.URL + "/list.m3u")
+	if err != nil {
+		t.Fatalf("resolveM3U: %v", err)
+	}
+	if len(tracks) != 2 {
+		t.Fatalf("got %d tracks, want 2 (regression guard)", len(tracks))
+	}
 }

--- a/site/index.html
+++ b/site/index.html
@@ -1623,7 +1623,7 @@ user_id = "your-account-user-id"</code></pre>
       <div class="feature">
         <div class="feature-icon">→</div>
         <div class="feature-name">HTTP Streaming</div>
-        <p>Play from URLs, internet radio, and remote M3U playlists.</p>
+        <p>Play from URLs, internet radio, remote M3U playlists, and HLS (<code>.m3u8</code>) live streams via ffmpeg.</p>
       </div>
       <div class="feature">
         <div class="feature-icon">♪</div>


### PR DESCRIPTION
## Summary

HLS radio streams (`.m3u8` playlists) failed to play. `resolveM3U` parsed the remote `.m3u8` as a track list with an empty `baseDir`, so the master playlist's **relative** variant URI (`chunklist_<uuid>.m3u8`) was treated as a local file and playback died with `open source: open chunklist_<uuid>.m3u8: no such file or directory`. Chunklist names rotate per request and segments are relative, so this can't be fixed by parsing — the robust fix is to let ffmpeg (already a cliamp dependency for AAC/Opus) handle HLS end-to-end.

Two changes:
- **`resolve.resolveM3U`**: detect HLS playlists (`#EXT-X-*` tags) and return a single stream `Track` with the original URL instead of parsing it as a track list.
- **`player`**: route `.m3u8` stream URLs to `decodeFFmpegStream` (ffmpeg-by-URL) so ffmpeg resolves the relative chunklist/segment URIs and follows the live segment window. This also covers stations added via `radios.toml`/favorites, which already hand the player a `.m3u8` URL directly.

ffmpeg is already required for AAC/Opus, so no new dependency.

## Screenshots / video

N/A — no UI changes.

## How to test

Unit (no network):

```sh
go test ./resolve/ ./player/
```

Covers HLS detection (master/media/plain), `resolveM3U` returning a single stream for HLS vs. N tracks for a plain playlist, and `isHLS`.

Live playback (needs ffmpeg + network) — e.g. a Brazilian RBS/Wowza station:

```sh
cliamp "https://liverdgaupoa.rbsdirect.com.br/primary/gaucha_rbs.sdp/playlist.m3u8"
# State: playing; the track is no longer "chunklist_..."
```

ffmpeg decoding proof (the exact command cliamp now runs):

```sh
ffmpeg -i "https://liverdgaupoa.rbsdirect.com.br/primary/gaucha_rbs.sdp/playlist.m3u8" \
  -t 3 -f s16le -acodec pcm_s16le -ar 44100 -ac 2 -loglevel error pipe:1 | wc -c
# => 529200  (3s x 44100 x 2ch x 2 bytes), no errors
```

## Checklist

- [x] `make check` passes
- [X] `docs/` and `site/index.html` updated for user-facing changes

> Note: in-band ICY stream titles aren't surfaced for HLS (ffmpeg opens the URL directly); acceptable since HLS carries timed metadata instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HLS (.m3u8) playback support for master/media playlists — ffmpeg is used to fetch and play HLS streams.
  * HLS live streams expose realtime behavior for live playlists.

* **Documentation**
  * Added HLS streaming guide with usage examples and notes (ffmpeg required; now-playing titles for live HLS rely on timed metadata and may not update via ICY).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->