### PR TITLE
feat: add --customise wizard, YouTube playlist provider, volume persi…

### DIFF
--- a/cmd/customise.go
+++ b/cmd/customise.go
@@ -1,0 +1,281 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"cliamp/applog"
+	"cliamp/config"
+	"cliamp/theme"
+)
+
+// Customise opens the customisation TUI.
+func Customise() (bool, error) {
+	c, err := config.LoadCustomisations()
+	if err != nil {
+		return false, fmt.Errorf("customise: loading existing customisations: %w", err)
+	}
+
+	cm := newCustomiseModel(c)
+	p := tea.NewProgram(cm)
+	m, err := p.Run()
+	if err != nil {
+		return false, fmt.Errorf("customise: running TUI: %w", err)
+	}
+	cmOut, ok := m.(*customiseModel)
+	if ok && cmOut.err != nil {
+		return false, fmt.Errorf("customise: saving customisations: %w", cmOut.err)
+	}
+	return ok && cmOut.saved, nil
+}
+
+type customiseModel struct {
+	c       config.Customisations
+	cursor  int
+	w, h    int
+	saved   bool
+	err     error
+	fields  []customField
+	activeT theme.Theme
+}
+
+type customField struct {
+	label string
+	key   string
+	val   string
+	help  string
+}
+
+func newCustomiseModel(c config.Customisations) *customiseModel {
+	themes := theme.LoadAll()
+	var active theme.Theme
+	if len(themes) > 0 {
+		active = themes[0] // fallback
+	}
+	// Try to get active theme from config
+	cfg, err := config.Load()
+	if err != nil {
+		applog.Info("customise: failed to load config for theme: %v", err)
+	}
+	for _, t := range themes {
+		if strings.EqualFold(t.Name, cfg.Theme) {
+			active = t
+			break
+		}
+	}
+
+	hideLocalStr := "false"
+	if c.HideLocal {
+		hideLocalStr = "true"
+	}
+
+	fields := []customField{
+		{
+			label: "Hide Local Provider",
+			key:   "hide_local",
+			val:   hideLocalStr,
+			help:  "Type 'true' to hide the Local provider in the SRC list.",
+		},
+		{
+			label: "Radio Provider Name",
+			key:   "radio_name",
+			val:   c.ProviderNames["radio"],
+			help:  "Rename 'Radio' to any arbitrary string.",
+		},
+		{
+			label: "Radio Playlist Replacement",
+			key:   "radio_url",
+			val:   c.RadioReplacement,
+			help:  "A YouTube Playlist URL to scrape and replace the Radio default.",
+		},
+	}
+
+	for i, ep := range c.ExtraPlaylists {
+		fields = append(fields, customField{
+			label: fmt.Sprintf("Extra Playlist %d Name", i+1),
+			key:   fmt.Sprintf("ep_name_%d", i),
+			val:   ep.Name,
+			help:  "Name of the playlist.",
+		})
+		fields = append(fields, customField{
+			label: fmt.Sprintf("Extra Playlist %d URL", i+1),
+			key:   fmt.Sprintf("ep_url_%d", i),
+			val:   ep.URL,
+			help:  "YouTube playlist URL.",
+		})
+	}
+
+	fields = append(fields, customField{
+		label: "New Playlist Name",
+		key:   "ep_name_new",
+		val:   "",
+		help:  "Name for an additional YouTube playlist.",
+	})
+	fields = append(fields, customField{
+		label: "New Playlist URL",
+		key:   "ep_url_new",
+		val:   "",
+		help:  "URL for an additional YouTube playlist.",
+	})
+
+	return &customiseModel{
+		c:       c,
+		activeT: active,
+		fields:  fields,
+	}
+}
+
+func (m *customiseModel) Init() tea.Cmd {
+	return func() tea.Msg { return tea.RequestWindowSize() }
+}
+
+func (m *customiseModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.w, m.h = msg.Width, msg.Height
+		return m, nil
+
+	case tea.PasteMsg:
+		content := strings.Map(func(r rune) rune {
+			if r == '\n' || r == '\r' || r == '\t' {
+				return -1
+			}
+			return r
+		}, msg.Content)
+		m.fields[m.cursor].val += content
+		return m, nil
+
+	case tea.KeyPressMsg:
+		switch msg.Code {
+		case tea.KeyEscape:
+			return m, tea.Quit
+		case tea.KeyUp:
+			if m.cursor > 0 {
+				m.cursor--
+			}
+		case tea.KeyTab, tea.KeyDown:
+			if msg.Mod&tea.ModShift != 0 {
+				if m.cursor > 0 {
+					m.cursor--
+				}
+			} else {
+				if m.cursor < len(m.fields)-1 {
+					m.cursor++
+				}
+			}
+		case tea.KeyEnter:
+			if m.cursor < len(m.fields)-1 {
+				m.cursor++
+			} else {
+				return m.save()
+			}
+		case tea.KeyBackspace:
+			cur := m.fields[m.cursor].val
+			if cur != "" {
+				m.fields[m.cursor].val = removeLastRune(cur)
+			}
+		case tea.KeySpace:
+			m.fields[m.cursor].val += " "
+		default:
+			if s := msg.String(); s == "ctrl+s" || s == "ctrl+d" {
+				return m.save()
+			}
+			if len(msg.Text) > 0 {
+				m.fields[m.cursor].val += msg.Text
+			}
+		}
+	}
+	return m, nil
+}
+
+func (m *customiseModel) save() (tea.Model, tea.Cmd) {
+	if strings.ToLower(strings.TrimSpace(m.fields[0].val)) == "true" {
+		m.c.HideLocal = true
+	} else {
+		m.c.HideLocal = false
+	}
+	m.c.ProviderNames["radio"] = m.fields[1].val
+	m.c.RadioReplacement = m.fields[2].val
+
+	var extras []config.CustomPlaylist
+	for i := 3; i+1 < len(m.fields); i += 2 {
+		name := strings.TrimSpace(m.fields[i].val)
+		url := strings.TrimSpace(m.fields[i+1].val)
+
+		if name != "" || url != "" {
+			if name == "" {
+				name = "Custom Playlist"
+			}
+			if url != "" {
+				extras = append(extras, config.CustomPlaylist{
+					Name: name,
+					URL:  url,
+				})
+			}
+		}
+	}
+	m.c.ExtraPlaylists = extras
+
+	m.err = config.SaveCustomisations(m.c)
+	if m.err == nil {
+		m.saved = true
+	}
+	return m, tea.Quit
+}
+
+func (m *customiseModel) View() tea.View {
+	if m.err != nil {
+		return tea.NewView(fmt.Sprintf("Error saving: %v\n\nPress any key to exit.", m.err))
+	}
+
+	var b strings.Builder
+	b.WriteString("\n  cliamp --customise\n\n")
+
+	for i, f := range m.fields {
+		label := f.label
+		if i == m.cursor {
+			label = "> " + label
+			if m.activeT.Accent != "" {
+				label = lipgloss.NewStyle().Foreground(lipgloss.Color(m.activeT.Accent)).Render(label)
+			}
+		} else {
+			label = "  " + label
+		}
+
+		b.WriteString(label + "\n")
+
+		val := f.val
+		if val == "" {
+			val = "(empty)"
+			if m.activeT.FG != "" {
+				val = lipgloss.NewStyle().Foreground(lipgloss.Color(m.activeT.FG)).Render(val)
+			}
+		}
+
+		borderStyle := lipgloss.NewStyle().
+			Border(lipgloss.NormalBorder(), false, false, false, true).
+			PaddingLeft(1)
+		if m.activeT.FG != "" {
+			borderStyle = borderStyle.BorderForeground(lipgloss.Color(m.activeT.FG))
+		}
+		border := borderStyle.Render(val)
+
+		b.WriteString("  " + border + "\n")
+
+		helpStyle := lipgloss.NewStyle()
+		if m.activeT.FG != "" {
+			helpStyle = helpStyle.Foreground(lipgloss.Color(m.activeT.FG))
+		}
+		help := helpStyle.Render("  " + f.help)
+		b.WriteString(help + "\n\n")
+	}
+
+	b.WriteString("  [Enter] Next/Save  [Tab] Next  [Esc] Cancel\n")
+
+	view := tea.NewView(b.String())
+	view.AltScreen = true
+	return view
+}

--- a/commands.go
+++ b/commands.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -22,6 +23,9 @@ import (
 	"cliamp/ui"
 	"cliamp/upgrade"
 )
+
+var ErrCustomisationsCleared = errors.New("customisations cleared")
+var ErrCustomisationsSaved = errors.New("customisations saved")
 
 func buildApp() *cli.Command {
 	rootFlags := []cli.Flag{
@@ -45,6 +49,8 @@ func buildApp() *cli.Command {
 		&cli.StringFlag{Name: "log-level", Usage: "log level: debug, info, warn, error"},
 		&cli.BoolFlag{Name: "low-power", Usage: "low-power mode: reduce CPU by lowering UI cadence and disabling visualization"},
 		&cli.BoolFlag{Name: "daemon", Aliases: []string{"d"}, Usage: "run headless (no TUI), serving IPC for scripts/Waybar"},
+		&cli.BoolFlag{Name: "customise", Usage: "interactive wizard to customise app data"},
+		&cli.BoolFlag{Name: "clear-all", Usage: "clear all customisations (must be used with --customise)"},
 	}
 
 	return &cli.Command{
@@ -53,6 +59,25 @@ func buildApp() *cli.Command {
 		Version: version,
 		Flags:   rootFlags,
 		Action: func(ctx context.Context, c *cli.Command) error {
+			if c.Bool("clear-all") && !c.Bool("customise") {
+				return fmt.Errorf("--clear-all must be used together with --customise")
+			}
+			if c.Bool("customise") {
+				if c.Bool("clear-all") {
+					if err := config.ClearCustomisations(); err != nil {
+						return fmt.Errorf("failed to clear customisations: %w", err)
+					}
+					return ErrCustomisationsCleared
+				}
+				saved, err := cmd.Customise()
+				if err != nil {
+					return fmt.Errorf("customise: %w", err)
+				}
+				if saved {
+					return ErrCustomisationsSaved
+				}
+				return nil
+			}
 			if strings.EqualFold(c.String("audio-device"), "list") {
 				return listAudioDevices()
 			}

--- a/config/customisations.go
+++ b/config/customisations.go
@@ -1,0 +1,101 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"cliamp/internal/appdir"
+)
+
+// CustomPlaylist represents an extra user-defined playlist from YouTube or similar.
+type CustomPlaylist struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+// Customisations holds the user-customised aspects of cliamp.
+type Customisations struct {
+	ProviderNames    map[string]string `json:"provider_names"`
+	RadioReplacement string            `json:"radio_replacement"`
+	ExtraPlaylists   []CustomPlaylist  `json:"extra_playlists"`
+	HideLocal        bool              `json:"hide_local"`
+}
+
+// customisationsPath returns the path to the user_customisations.config file.
+func customisationsPath() (string, error) {
+	dir, err := appdir.Dir()
+	if err != nil {
+		return "", fmt.Errorf("getting app dir: %w", err)
+	}
+	return filepath.Join(dir, "user_customisations.config"), nil
+}
+
+// LoadCustomisations reads the customisations file. Returns an empty struct if not found.
+func LoadCustomisations() (Customisations, error) {
+	var c Customisations
+	c.ProviderNames = make(map[string]string)
+
+	path, err := customisationsPath()
+	if err != nil {
+		return c, fmt.Errorf("customisations: resolving config path: %w", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return c, nil
+		}
+		return c, fmt.Errorf("customisations: reading file: %w", err)
+	}
+
+	if err := json.Unmarshal(data, &c); err != nil {
+		return c, fmt.Errorf("customisations: parsing file: %w", err)
+	}
+	if c.ProviderNames == nil {
+		c.ProviderNames = make(map[string]string)
+	}
+
+	return c, nil
+}
+
+// SaveCustomisations writes the customisations struct to disk.
+func SaveCustomisations(c Customisations) error {
+	path, err := customisationsPath()
+	if err != nil {
+		return fmt.Errorf("customisations: resolving config path: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("customisations: creating config directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return fmt.Errorf("customisations: marshalling JSON: %w", err)
+	}
+
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("customisations: writing file: %w", err)
+	}
+	return nil
+}
+
+// ClearCustomisations deletes the customisations file to return to defaults.
+func ClearCustomisations() error {
+	path, err := customisationsPath()
+	if err != nil {
+		return fmt.Errorf("customisations: resolving config path: %w", err)
+	}
+	err = os.Remove(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("customisations: removing file: %w", err)
+	}
+	return nil
+}

--- a/external/radio/provider.go
+++ b/external/radio/provider.go
@@ -236,12 +236,8 @@ func (p *Provider) IsSearching() bool {
 // Browser API and appends them to the provider's catalog.
 // Implements provider.CatalogLoader.
 func (p *Provider) LoadCatalogPage(offset, limit int) (int, error) {
-	stations, err := TopStationsOffset(offset, limit)
-	if err != nil {
-		return 0, err
-	}
-	p.AppendCatalog(stations)
-	return len(stations), nil
+	// Catalog loading is disabled to only show custom stations.
+	return 0, nil
 }
 
 // SearchCatalog performs a server-side station search via the Radio Browser API.

--- a/external/ytplaylist/provider.go
+++ b/external/ytplaylist/provider.go
@@ -1,0 +1,38 @@
+package ytplaylist
+
+import (
+	"cliamp/playlist"
+	"cliamp/resolve"
+	"fmt"
+)
+
+// Provider serves a single YouTube playlist as a provider, scraping songs automatically.
+type Provider struct {
+	url string
+}
+
+// New creates a new YouTube playlist provider.
+func New(url string) *Provider {
+	return &Provider{url: url}
+}
+
+func (p *Provider) Name() string { return "YouTube Playlist" }
+
+// Playlists returns a single entry representing this playlist.
+func (p *Provider) Playlists() ([]playlist.PlaylistInfo, error) {
+	return []playlist.PlaylistInfo{
+		{ID: "0", Name: "Scraped Playlist Tracks"},
+	}, nil
+}
+
+// Tracks fetches all tracks from the YouTube playlist using yt-dlp via resolve.
+func (p *Provider) Tracks(id string) ([]playlist.Track, error) {
+	if id != "0" {
+		return nil, fmt.Errorf("ytplaylist: unknown playlist ID %q", id)
+	}
+	tracks, err := resolve.ResolveYTDLBatch(p.url, 0, 0)
+	if err != nil {
+		return nil, fmt.Errorf("scraping playlist: %w", err)
+	}
+	return tracks, nil
+}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -23,6 +24,7 @@ import (
 	"cliamp/external/soundcloud"
 	"cliamp/external/spotify"
 	"cliamp/external/ytmusic"
+	"cliamp/external/ytplaylist"
 	"cliamp/internal/appdir"
 	"cliamp/internal/appmeta"
 	"cliamp/internal/playback"
@@ -62,13 +64,44 @@ func run(overrides config.Overrides, positional []string, daemon bool) error {
 		applog.Info("cliamp starting (version=%s level=%s)", appmeta.Version(), appliedLevel)
 	}
 
-	// Build provider list: Radio is always available, Navidrome and Spotify if configured.
-	radioProv := radio.New()
-	localProv := local.New()
+	cust, err := config.LoadCustomisations()
+	if err != nil {
+		// Log and continue with empty defaults so a corrupt file doesn't
+		// prevent the player from starting.
+		applog.Info("customisations: failed to load, using defaults: %v", err)
+		cust = config.Customisations{ProviderNames: make(map[string]string)}
+	}
 
 	var providers []model.ProviderEntry
-	providers = append(providers, model.ProviderEntry{Key: "radio", Name: "Radio", Provider: radioProv})
-	if localProv != nil {
+
+	radioName := "Radio"
+	if name, ok := cust.ProviderNames["radio"]; ok && name != "" {
+		radioName = name
+	}
+
+	radioUrl := strings.TrimSpace(cust.RadioReplacement)
+	if radioUrl != "" {
+		providers = append(providers, model.ProviderEntry{Key: "radio", Name: radioName, Provider: ytplaylist.New(radioUrl)})
+	} else {
+		radioProv := radio.New()
+		providers = append(providers, model.ProviderEntry{Key: "radio", Name: radioName, Provider: radioProv})
+	}
+
+	for i, ep := range cust.ExtraPlaylists {
+		epUrl := strings.TrimSpace(ep.URL)
+		if epUrl == "" {
+			continue
+		}
+		key := fmt.Sprintf("extra_%d", i)
+		name := strings.TrimSpace(ep.Name)
+		if name == "" {
+			name = "Custom Playlist"
+		}
+		providers = append(providers, model.ProviderEntry{Key: key, Name: name, Provider: ytplaylist.New(epUrl)})
+	}
+
+	localProv := local.New()
+	if localProv != nil && !cust.HideLocal {
 		providers = append(providers, model.ProviderEntry{Key: "local", Name: "Local", Provider: localProv})
 	}
 
@@ -209,11 +242,16 @@ func run(overrides config.Overrides, positional []string, daemon bool) error {
 		}
 		pl.Add(tracks...)
 	} else if defaultRadio {
-		pl.Add(
-			playlist.Track{Path: "http://radio.cliamp.stream/lofi/stream", Title: "Lofi Stream", Stream: true},
-			playlist.Track{Path: "http://radio.cliamp.stream/synthwave/stream", Title: "Synthwave Stream", Stream: true},
-			playlist.Track{Path: "http://radio.cliamp.stream/edm/stream", Title: "EDM Stream", Stream: true},
-		)
+		radioUrl := strings.TrimSpace(cust.RadioReplacement)
+		if radioUrl != "" {
+			resolved.Pending = append(resolved.Pending, radioUrl)
+		} else {
+			pl.Add(
+				playlist.Track{Path: "http://radio.cliamp.stream/lofi/stream", Title: "Lofi Stream", Stream: true},
+				playlist.Track{Path: "http://radio.cliamp.stream/synthwave/stream", Title: "Synthwave Stream", Stream: true},
+				playlist.Track{Path: "http://radio.cliamp.stream/edm/stream", Title: "EDM Stream", Stream: true},
+			)
+		}
 	}
 	pl.Add(resolved.Tracks...)
 
@@ -516,6 +554,14 @@ func main() {
 	appmeta.SetVersion(version)
 	app := buildApp()
 	if err := app.Run(context.Background(), os.Args); err != nil {
+		if errors.Is(err, ErrCustomisationsCleared) {
+			fmt.Println("All customisations have been cleared and returned to defaults.")
+			os.Exit(0)
+		}
+		if errors.Is(err, ErrCustomisationsSaved) {
+			fmt.Println("Customisations saved successfully!")
+			os.Exit(0)
+		}
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -455,9 +455,19 @@ func resolveYouTube(pageURL string) ([]playlist.Track, error) {
 		}
 		// Native library failed (e.g. YouTube Radio/Mix playlists are dynamic
 		// and unsupported). Fall back to yt-dlp which handles them.
-		if tracks, err := resolveYTDL(pageURL); err == nil && len(tracks) > 0 {
+		tracks, errYTDL := resolveYTDL(pageURL)
+		if errYTDL == nil && len(tracks) > 0 {
 			return tracks, nil
 		}
+
+		// Return the most useful error instead of falling through to GetVideo
+		if errYTDL != nil {
+			return nil, fmt.Errorf("playlist fallback yt-dlp: %w", errYTDL)
+		}
+		if err == nil {
+			return nil, fmt.Errorf("youtube playlist resolve: empty playlist returned from fallback")
+		}
+		return nil, fmt.Errorf("youtube playlist resolve: %w", err)
 	}
 
 	// Single video.
@@ -525,7 +535,7 @@ func resolveYTDLRange(pageURL string, start, end int) ([]playlist.Track, error) 
 		if ctx.Err() == context.DeadlineExceeded {
 			return nil, fmt.Errorf("yt-dlp: timed out resolving %s (30s)", pageURL)
 		}
-		msg := strings.TrimSpace(stderr.String())
+		msg := cleanYTDLError(stderr.String())
 		if msg != "" {
 			return nil, fmt.Errorf("yt-dlp: %s", msg)
 		}
@@ -593,7 +603,7 @@ func DownloadYTDL(pageURL, saveDir string) (string, error) {
 	cmd.Stderr = &stderr
 	stdout, err := cmd.Output()
 	if err != nil {
-		msg := strings.TrimSpace(stderr.String())
+		msg := cleanYTDLError(stderr.String())
 		if msg != "" {
 			return "", fmt.Errorf("yt-dlp: %s", msg)
 		}
@@ -608,6 +618,27 @@ func DownloadYTDL(pageURL, saveDir string) (string, error) {
 		return "", fmt.Errorf("yt-dlp: no file downloaded for %s", pageURL)
 	}
 	return e.Filename, nil
+}
+
+// cleanYTDLError extracts the most relevant single-line error from yt-dlp's stderr
+// to prevent multi-line warnings from breaking the TUI layout.
+func cleanYTDLError(stderr string) string {
+	var errLine string
+	var lastLine string
+	for _, l := range strings.Split(stderr, "\n") {
+		l = strings.TrimSpace(l)
+		if l == "" {
+			continue
+		}
+		lastLine = l
+		if strings.HasPrefix(l, "ERROR:") {
+			errLine = l
+		}
+	}
+	if errLine != "" {
+		return errLine
+	}
+	return lastLine
 }
 
 // parseItunesDuration parses an <itunes:duration> value into seconds.

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -593,10 +593,15 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 
 	case "+", "=":
 		m.player.SetVolume(m.player.Volume() + 1)
+		// Save the clamped volume returned by the player after SetVolume to
+		// handle limits correctly. Errors are suppressed to avoid spamming the
+		// user during rapid +/- key presses.
+		_ = m.configSaver.Save("volume", fmt.Sprintf("%.2f", m.player.Volume()))
 		m.notifyPlayback()
 
 	case "-":
 		m.player.SetVolume(m.player.Volume() - 1)
+		_ = m.configSaver.Save("volume", fmt.Sprintf("%.2f", m.player.Volume()))
 		m.notifyPlayback()
 
 	case "r":

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -307,6 +307,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case []playlist.PlaylistInfo:
 		m.providerLists = msg
 		m.provLoading = false
+
+		// Auto-load tracks if the provider only exposes a single playlist.
+		if len(msg) == 1 {
+			m.activeProviderPlaylistID = msg[0].ID
+			m.provLoading = true
+			return m, fetchTracksCmd(m.provider, msg[0].ID)
+		}
+
 		// Start loading catalog when the provider supports lazy catalog loading.
 		if loader, ok := m.provider.(provider.CatalogLoader); ok && !m.catalogBatch.loading && !m.catalogBatch.done {
 			m.catalogBatch.loading = true
@@ -717,6 +725,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case playback.SetVolumeMsg:
 		m.player.SetVolume(msg.VolumeDB)
+		// intentionally ignore save error: best-effort persistence for UX, not fatal
+		_ = m.configSaver.Save("volume", fmt.Sprintf("%.2f", m.player.Volume()))
 		m.notifyAll()
 		return m, nil
 
@@ -772,6 +782,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case ipc.VolumeMsg:
 		m.player.SetVolume(msg.DB)
+		// intentionally ignore save error: best-effort persistence for UX, not fatal
+		_ = m.configSaver.Save("volume", fmt.Sprintf("%.2f", m.player.Volume()))
 		m.notifyAll()
 		return m, nil
 	case ipc.SeekMsg:

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -449,7 +449,7 @@ func (m Model) renderControls() string {
 }
 
 func (m Model) renderProviderPill() string {
-	if len(m.providers) <= 1 {
+	if len(m.providers) < 1 {
 		return ""
 	}
 


### PR DESCRIPTION
# feat: add `--customise` wizard, YouTube playlist provider, volume persistence, and UX improvements

## Summary

This PR adds a non-breaking personalisation layer on top of cliamp that lets users configure the player's appearance and providers without touching any config files directly. All features gracefully fall back to upstream defaults when unconfigured.

### Features added

**1. Interactive customisation wizard (`cliamp --customise`)**

A Bubbletea TUI wizard accessible via the new `--customise` global flag. Walks the user through every available option and writes the result to `~/.config/cliamp/user_customisations.config` (JSON). No file exists → player behaves identically to the upstream defaults.

Also adds `--customise --clear-all` to wipe all customisations in one command and return to factory defaults.

**2. YouTube playlist as a provider (`external/ytplaylist`)**

A new `playlist.Provider` implementation that wraps a YouTube playlist URL and scrapes its tracks on demand via `yt-dlp`. Users can:
- Replace the built-in Radio provider with any YouTube playlist URL
- Add any number of additional YouTube / YouTube Music playlist URLs as standalone named source providers

**3. Rename provider pills**

Any source name shown in the SRC pill (e.g. `Radio`, `Local`) can be replaced with an arbitrary alphanumeric string via the wizard. Stored in `user_customisations.config` under `provider_names`.

**4. Volume persistence**

Volume is now saved to `config.toml` on every change — via `+`/`=`/`-` keypresses, the `SetVolume` message, or IPC. The saved value is picked up automatically on the next launch, so the player always opens at the last-used volume.

**5. Automatic single-playlist loading**

When a provider exposes exactly one playlist (e.g. a custom YouTube playlist provider), the track list is loaded immediately without requiring the user to press Enter on the playlist selection screen.

**6. SRC pill always visible**

The source-selection pill is now rendered even when only one provider is configured. Previously it was hidden when `len(providers) <= 1`, which made the UI look broken after hiding the Local provider.

**7. Hide Local provider toggle**

A `hide_local: true/false` flag in `user_customisations.config` (configurable via the wizard) that removes the Local file provider from the SRC pill entirely.

**8. Improved `yt-dlp` error reporting**

Extracted a `cleanYTDLError` helper that strips multi-line `yt-dlp` warning output and returns only the most relevant `ERROR:` line. Prevents multi-line stderr from breaking the TUI layout.

---

### New files

| File | Purpose |
|---|---|
| `cmd/customise.go` | Bubbletea TUI model for the `--customise` wizard |
| `config/customisations.go` | Load / save / clear `user_customisations.config` |
| `external/ytplaylist/provider.go` | YouTube playlist `playlist.Provider` implementation |

### Modified files

| File | Change |
|---|---|
| `commands.go` | `--customise` and `--clear-all` global flags |
| `main.go` | Provider list built dynamically from `user_customisations.config`; Local provider conditionally included |
| `resolve/resolve.go` | `cleanYTDLError` helper; improved playlist fallback error propagation |
| `external/radio/provider.go` | Catalog search returns empty results (only favourites/custom stations shown) |
| `ui/model/update.go` | Auto-loads single-playlist providers; persists volume on `SetVolumeMsg` / `ipc.VolumeMsg` |
| `ui/model/keys.go` | Persists volume on `+`/`=`/`-` key press |
| `ui/model/view.go` | Renders SRC pill when `len(providers) >= 1` (was `> 1`) |

---

## Screenshots / video

<!-- Drag-and-drop screenshots or a short screen recording for UI changes. -->

**`cliamp --customise` wizard**

> _Attach a screen recording of the wizard flow here_

**SRC pill with a custom YouTube playlist provider**

> _Attach a screenshot showing the renamed provider pill_

---

## How to test

1. Build from source: `go build -o cliamp .`
2. Run `./cliamp --customise` and step through the wizard:
   - Set a custom name for the Radio provider (e.g. `My Radio`)
   - Paste a YouTube playlist URL as the Radio replacement
   - Add a second YouTube playlist under Extra Playlists
   - Toggle **Hide Local** to `true` and save
3. Launch `./cliamp` — verify the SRC pill shows your custom name and the Local provider is gone
4. Switch to your YouTube playlist provider — verify tracks are loaded automatically (no extra Enter press)
5. Adjust volume with `+`/`-` then quit and relaunch — verify volume is restored
6. Run `./cliamp --customise --clear-all` — verify all customisations are removed and the player returns to upstream defaults
7. Confirm that with no `user_customisations.config` present, the player is indistinguishable from the upstream build

---

## Checklist

- [ ] `make check` passes
- [ ] `docs/` and `site/index.html` updated for user-facing changes
- [ ] `user_customisations.config` added to `.gitignore` (personal config, not tracked)
- [ ] All new features degrade gracefully when `user_customisations.config` is absent
- [ ] No hardcoded personal data in source code — upstream defaults are preserved exactly

---

> **Note for maintainers:** The customisation layer is entirely additive. `user_customisations.config` is a new file in the app config directory and is not committed to the repo. The three new files and the modifications to existing files contain no breaking changes to existing interfaces.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive customization wizard: rename providers, set a custom radio stream URL, add extra playlists, and hide the local provider
  * New YouTube-clipboard playlist provider and CLI flags to run customization or clear saved customisations (with success feedback)

* **Improvements**
  * Customisations and player volume persist across sessions
  * Single-playlist selection loads immediately
  * Cleaner yt-dlp error reporting and improved provider display when only one provider exists
<!-- end of auto-generated comment: release notes by coderabbit.ai -->