### PR TITLE
docs: add cliamp-plugin-nova to community plugins

### DIFF
--- a/docs/community-plugins.md
+++ b/docs/community-plugins.md
@@ -10,3 +10,4 @@ Plugins built by the community. If you've built a plugin, open a PR to add it he
 | [cliamp-plugin-block-burst](https://github.com/AlexZeitler/cliamp-plugin-vu-meter) | Analog multi VU meter style visualizer | [@AlexZeitler](https://github.com/AlexZeitler) |
 | [cliamp-plugin-nightrider](https://github.com/HANCORE-linux/cliamp-plugin-nightrider) | Nightrider style visualizer | [@HANCORE-linux](https://github.com/HANCORE-linux) |
 | [cliamp-plugin-tubeamp](https://github.com/8bit64k/cliamp-plugin-tubeamp) | Vacuum-tube amplifier visualizer | [@8bit64k](https://github.com/8bit64k) |
+| [cliamp-plugin-nova](https://github.com/8bit64k/cliamp-plugin-nova) | Concentric-ring spectrum visualizer | [@8bit64k](https://github.com/8bit64k) |

--- a/site/index.html
+++ b/site/index.html
@@ -2312,8 +2312,14 @@ p:<span class="fn">on</span>(<span class="str">"track.change"</span>, <span clas
       <div class="community-plugin-author"><a href="https://github.com/HANCORE-linux">@HANCORE-linux</a></div>
     </div>
     <div class="community-plugin">
+    <div class="community-plugin">
       <div class="community-plugin-name"><a href="https://github.com/8bit64k/cliamp-plugin-tubeamp">cliamp-plugin-tubeamp</a></div>
       <div class="community-plugin-desc">Vacuum-tube amplifier visualizer</div>
+      <div class="community-plugin-author"><a href="https://github.com/8bit64k">@8bit64k</a></div>
+    </div>
+    <div class="community-plugin">
+      <div class="community-plugin-name"><a href="https://github.com/8bit64k/cliamp-plugin-nova">cliamp-plugin-nova</a></div>
+      <div class="community-plugin-desc">Concentric-ring spectrum visualizer</div>
       <div class="community-plugin-author"><a href="https://github.com/8bit64k">@8bit64k</a></div>
     </div>
 </section>


### PR DESCRIPTION
## Summary
Greetings @bjarneo --
Would be delighted if you can add Nova plugin to your community plugin section and website. I hope you enjoy and I look forward making another. PS Updates are in queue for Nova to inverse the bands (option for bass on the outer rings)--looks great for certain types of music.

## Changes:
Adds cliamp-plugin-nova to the community plugin listings in both `docs/community-plugins.md` and `site/index.html`.

Nova is a concentric-ring spectrum visualizer with themes, dynamics presets, and transient-triggered overdrive.
## How to test
1. `cliamp plugins install 8bit64k/cliamp-plugin-nova`
2. Verify the plugin appears in `cliamp plugins list`
3. Play any track — the visualizer renders in the plugin pane

## Checklist

- [ ] `make check` passes
- [X] `docs/` and `site/index.html` updated for user-facing changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new community plugin entry for **cliamp-plugin-nova** in the community plugins listing.
  * Included its GitHub link, description (“Concentric-ring spectrum visualizer”), and author details in the documentation and site page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->