### PR TITLE
Fix vertical padding for overlays in expanded-height mode

### DIFF
--- a/ui/model/inline_overlays.go
+++ b/ui/model/inline_overlays.go
@@ -67,7 +67,7 @@ func windowList(items []string, cursor, scroll, budget int) string {
 	for i := scroll; i < len(items) && len(lines) < budget; i++ {
 		lines = append(lines, cursorLine(items[i], i == cursor))
 	}
-	return strings.Join(lines, "\n")
+	return strings.Join(padLines(lines, budget, len(lines)), "\n")
 }
 
 // bodyLines fits pre-built lines into the budget (truncate + pad to budget).

--- a/ui/model/keymap.go
+++ b/ui/model/keymap.go
@@ -405,5 +405,5 @@ func (m Model) renderKeymapList() string {
 			lines = append(lines, cursorLine(line, i == m.keymap.cursor))
 		}
 	}
-	return strings.Join(lines, "\n")
+	return strings.Join(padLines(lines, budget, len(lines)), "\n")
 }

--- a/ui/model/view_overlays.go
+++ b/ui/model/view_overlays.go
@@ -23,7 +23,7 @@ func (m Model) renderVisPickerList() string {
 	for i := scroll; i < len(items) && len(lines) < budget; i++ {
 		lines = append(lines, cursorLine(items[i], i == m.visPicker.cursor))
 	}
-	return strings.Join(lines, "\n")
+	return strings.Join(padLines(lines, budget, len(lines)), "\n")
 }
 
 // — playlist manager (inline) —
@@ -259,5 +259,5 @@ func (m Model) renderSearchList() string {
 		// cursorLine adds the "> "/"  " prefix and selected styling.
 		lines = append(lines, cursorLine(item, j == m.search.cursor))
 	}
-	return strings.Join(lines, "\n")
+	return strings.Join(padLines(lines, budget, len(lines)), "\n")
 }


### PR DESCRIPTION
This PR fixes the issue where expanded height mode `ctrl+x` wouldn't actually fill the whole terminal (for example: the theme picker).

The problem was that several inline rendering helpers weren't padding output with empty lines if the list was short, which caused the footer to jump up and leave a gap at the bottom of the terminal.

Changes:
- Updated `windowList` helper to always pad to the available budget.
- Fixed `renderKeymapList`, `renderVisPickerList`, and `renderSearchList` to ensure they also respect the full height budget.

The UI should now stay pinned to the top and bottom of the terminal as expected when expanded mode is active/enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * List and overlay views now keep a consistent height even when there are fewer items to show.
  * Keymap, search, picker, and window lists no longer render shorter-than-expected panels, improving visual stability and alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->