### PR TITLE
Add file browser local playlist append(related to issue #271)

### DIFF
--- a/cmd/playlist.go
+++ b/cmd/playlist.go
@@ -204,6 +204,25 @@ func PlaylistRemove(name string, index int) error {
 	return nil
 }
 
+// PlaylistDedupe removes duplicate track paths from the named playlist.
+func PlaylistDedupe(name string) error {
+	prov, err := newProvider()
+	if err != nil {
+		return err
+	}
+
+	removed, err := prov.RemoveDuplicateTracks(name)
+	if err != nil {
+		return fmt.Errorf("deduplicating playlist %q: %w", name, err)
+	}
+	if removed == 0 {
+		fmt.Printf("No duplicates found in %q.\n", name)
+		return nil
+	}
+	fmt.Printf("Removed %d duplicate track(s) from %q.\n", removed, name)
+	return nil
+}
+
 // PlaylistDelete deletes an entire playlist.
 func PlaylistDelete(name string) error {
 	prov, err := newProvider()

--- a/cmd/playlist_ops_test.go
+++ b/cmd/playlist_ops_test.go
@@ -221,6 +221,33 @@ func TestPlaylistRemoveOutOfRange(t *testing.T) {
 	}
 }
 
+func TestPlaylistDedupe(t *testing.T) {
+	home := setupTestEnv(t)
+	a := filepath.Join(home, "a.mp3")
+	b := filepath.Join(home, "b.mp3")
+	writeAudioFile(t, a)
+	writeAudioFile(t, b)
+
+	if err := PlaylistCreate("mix", []string{a, b}, ""); err != nil {
+		t.Fatalf("PlaylistCreate: %v", err)
+	}
+	if err := PlaylistAdd("mix", []string{a}); err != nil {
+		t.Fatalf("PlaylistAdd: %v", err)
+	}
+
+	out, err := captureStdout(t, func() error { return PlaylistDedupe("mix") })
+	if err != nil {
+		t.Fatalf("PlaylistDedupe: %v", err)
+	}
+	if !strings.Contains(out, "Removed 1 duplicate") {
+		t.Errorf("output = %q, want duplicate count", out)
+	}
+	out, _ = captureStdout(t, func() error { return PlaylistShow("mix", false) })
+	if !strings.Contains(out, "2 tracks") {
+		t.Errorf("output = %q, want 2 tracks after dedupe", out)
+	}
+}
+
 func TestPlaylistDelete(t *testing.T) {
 	home := setupTestEnv(t)
 	audio := filepath.Join(home, "a.mp3")

--- a/commands.go
+++ b/commands.go
@@ -421,6 +421,17 @@ func playlistCommand() *cli.Command {
 				},
 			},
 			{
+				Name:      "dedupe",
+				Usage:     "remove duplicate tracks by path",
+				ArgsUsage: "\"Name\"",
+				Action: func(ctx context.Context, c *cli.Command) error {
+					if c.Args().Len() == 0 {
+						return fmt.Errorf("usage: cliamp playlist dedupe \"Name\"")
+					}
+					return cmd.PlaylistDedupe(c.Args().First())
+				},
+			},
+			{
 				Name:      "bookmark",
 				Usage:     "toggle bookmark on a track by index",
 				ArgsUsage: "\"Name\"",

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -136,6 +136,7 @@ cliamp playlist show "Name"                   # display tracks
 cliamp playlist show "Name" --json            # machine-readable output
 cliamp playlist remove "Name" --index 3       # remove track by index
 cliamp playlist delete "Name"                 # delete entire playlist
+cliamp playlist dedupe "Name"                 # remove duplicate track paths
 ```
 
 See [playlists.md](playlists.md) for the TOML format and [ssh-streaming.md](ssh-streaming.md) for remote playback.

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -77,6 +77,19 @@ Press `?` or `Ctrl+K` in the player to see all keybindings.
 | `r` | Cycle repeat (Off / All / One) |
 | `z` | Toggle shuffle |
 
+### Inside the file browser
+
+| Key | Action |
+|---|---|
+| `↑` `↓` / `j` `k` | Move cursor |
+| `Space` | Select file or directory |
+| `a` | Toggle all audio files in the current view |
+| `Enter` | Open directory or add selected audio to the current playlist |
+| `R` | Replace the current playlist with selected audio |
+| `p` | Add selected audio to an existing local TOML playlist |
+| `/` | Filter files |
+| `Esc` | Close the file browser |
+
 ### Inside the playlist manager
 
 | Key | Action |
@@ -87,6 +100,7 @@ Press `?` or `Ctrl+K` in the player to see all keybindings.
 | `P` | Tracks screen: play all from the top |
 | `a` | Add the now-playing track (footer shows which track) |
 | `r` | List: rename the playlist |
+| `D` | Remove duplicate track paths from the highlighted/open playlist |
 | `d` | List: delete playlist (confirms) · Tracks: remove the highlighted track |
 | `←` `Backspace` `h` | Tracks screen: go back to the list |
 | `p` `Esc` | Close the playlist manager |

--- a/docs/playlists.md
+++ b/docs/playlists.md
@@ -142,6 +142,9 @@ Press `p` from any view to open the playlist manager:
 7. **Play this**: press `Enter` on the track list to start playback at the highlighted track. The rest of the playlist follows.
 8. **Play all**: press `P` (capital) to start from the top, regardless of cursor position
 9. **New playlist**: select "+ New Playlist...", type a name, and press Enter. If you create a playlist while a `/` filter is active, the filter text is pre-filled as the new playlist name.
+10. **Remove duplicates**: press `D` on a playlist or inside its track list to remove duplicate track paths, keeping the first occurrence.
+
+From the file browser (`o`), select audio files with `Space` and press `p` to choose an existing local TOML playlist to append them to. If no files are selected, `p` adds the highlighted audio file.
 
 Tracks with an `album` field are grouped by album with visual separator headers in the playlist manager (album grouping is hidden while a filter is active) and the main player view.
 
@@ -190,5 +193,5 @@ title = "My Radio"
 | `P` | Play all tracks from the top (tracks screen) |
 | `a` | Add currently playing track |
 | `d` | Delete playlist (confirms) / Remove track |
+| `D` | Remove duplicate track paths |
 | `←` / `Backspace` | Go back from tracks screen to list |
-

--- a/external/local/provider.go
+++ b/external/local/provider.go
@@ -25,10 +25,12 @@ import (
 
 // Compile-time interface checks.
 var (
-	_ provider.PlaylistWriter  = (*Provider)(nil)
-	_ provider.PlaylistDeleter = (*Provider)(nil)
-	_ provider.PlaylistRenamer = (*Provider)(nil)
-	_ provider.Searcher        = (*Provider)(nil)
+	_ provider.PlaylistWriter       = (*Provider)(nil)
+	_ provider.PlaylistDeleter      = (*Provider)(nil)
+	_ provider.PlaylistDeduper      = (*Provider)(nil)
+	_ provider.PlaylistTracksWriter = (*Provider)(nil)
+	_ provider.PlaylistRenamer      = (*Provider)(nil)
+	_ provider.Searcher             = (*Provider)(nil)
 )
 
 // Provider reads and writes TOML-based playlists stored on disk.
@@ -430,6 +432,34 @@ func (p *Provider) RemoveTrack(name string, index int) error {
 		return p.DeletePlaylist(name)
 	}
 	return p.savePlaylist(name, tracks)
+}
+
+// RemoveDuplicateTracks removes duplicate track paths from a playlist,
+// preserving the first occurrence and its metadata.
+func (p *Provider) RemoveDuplicateTracks(name string) (int, error) {
+	if isHistoryName(name) {
+		return 0, errReservedHistoryName
+	}
+	tracks, err := p.Tracks(name)
+	if err != nil {
+		return 0, err
+	}
+
+	seen := make(map[string]struct{}, len(tracks))
+	unique := tracks[:0]
+	removed := 0
+	for _, t := range tracks {
+		if _, ok := seen[t.Path]; ok {
+			removed++
+			continue
+		}
+		seen[t.Path] = struct{}{}
+		unique = append(unique, t)
+	}
+	if removed == 0 {
+		return 0, nil
+	}
+	return removed, p.savePlaylist(name, unique)
 }
 
 // writeTrack writes a single [[track]] TOML section to w.

--- a/external/local/provider_test.go
+++ b/external/local/provider_test.go
@@ -341,6 +341,51 @@ func TestRemoveTrackDeletesEmptyPlaylist(t *testing.T) {
 	}
 }
 
+func TestRemoveDuplicateTracks(t *testing.T) {
+	p := newTestProvider(t)
+	p.AddTracks("dupes", []playlist.Track{
+		{Path: "/a.mp3", Title: "A"},
+		{Path: "/b.mp3", Title: "B"},
+		{Path: "/a.mp3", Title: "A second copy"},
+		{Path: "/c.mp3", Title: "C"},
+		{Path: "/b.mp3", Title: "B second copy"},
+	})
+
+	removed, err := p.RemoveDuplicateTracks("dupes")
+	if err != nil {
+		t.Fatalf("RemoveDuplicateTracks: %v", err)
+	}
+	if removed != 2 {
+		t.Fatalf("removed %d tracks, want 2", removed)
+	}
+	tracks, err := p.Tracks("dupes")
+	if err != nil {
+		t.Fatalf("Tracks: %v", err)
+	}
+	if len(tracks) != 3 {
+		t.Fatalf("got %d tracks, want 3", len(tracks))
+	}
+	if tracks[0].Title != "A" || tracks[1].Title != "B" || tracks[2].Title != "C" {
+		t.Fatalf("unexpected order/metadata after dedupe: %+v", tracks)
+	}
+}
+
+func TestRemoveDuplicateTracksNoop(t *testing.T) {
+	p := newTestProvider(t)
+	p.AddTracks("clean", []playlist.Track{
+		{Path: "/a.mp3", Title: "A"},
+		{Path: "/b.mp3", Title: "B"},
+	})
+
+	removed, err := p.RemoveDuplicateTracks("clean")
+	if err != nil {
+		t.Fatalf("RemoveDuplicateTracks: %v", err)
+	}
+	if removed != 0 {
+		t.Fatalf("removed %d tracks, want 0", removed)
+	}
+}
+
 // --- DeletePlaylist ---
 
 func TestDeletePlaylist(t *testing.T) {
@@ -473,6 +518,7 @@ func TestWritesRejectedForHistoryName(t *testing.T) {
 		{"SavePlaylist", func() error { return p.SavePlaylist(history.PlaylistName, []playlist.Track{track}) }},
 		{"DeletePlaylist", func() error { return p.DeletePlaylist(history.PlaylistName) }},
 		{"RemoveTrack", func() error { return p.RemoveTrack(history.PlaylistName, 0) }},
+		{"RemoveDuplicateTracks", func() error { _, err := p.RemoveDuplicateTracks(history.PlaylistName); return err }},
 		{"SetBookmark", func() error { return p.SetBookmark(history.PlaylistName, 0) }},
 	}
 

--- a/provider/interfaces.go
+++ b/provider/interfaces.go
@@ -67,6 +67,18 @@ type PlaylistDeleter interface {
 	RemoveTrack(name string, index int) error
 }
 
+// PlaylistDeduper is implemented by providers that can remove duplicate
+// tracks from a playlist while preserving the first occurrence.
+type PlaylistDeduper interface {
+	RemoveDuplicateTracks(name string) (int, error)
+}
+
+// PlaylistTracksWriter is implemented by providers that support adding
+// multiple tracks to a playlist in a single call.
+type PlaylistTracksWriter interface {
+	AddTracks(playlistName string, tracks []playlist.Track) error
+}
+
 // PlaylistRenamer is implemented by providers that support renaming playlists.
 type PlaylistRenamer interface {
 	RenamePlaylist(oldName, newName string) error

--- a/site/index.html
+++ b/site/index.html
@@ -1613,7 +1613,7 @@ user_id = "your-account-user-id"</code></pre>
       <div class="feature">
         <div class="feature-icon">☰</div>
         <div class="feature-name">Playlists</div>
-        <p>TOML playlists, M3U/M3U8/PLS support, playlist manager with album grouping.</p>
+        <p>TOML playlists, M3U/M3U8/PLS support, playlist manager with file-browser adds, dedupe, and album grouping.</p>
       </div>
       <div class="feature">
         <div class="feature-icon">⟲</div>
@@ -1974,7 +1974,7 @@ user_id = "your-account-user-id"</code></pre>
           <div class="key-row"><kbd>Ctrl+F</kbd><span>Search active provider (Spotify, Navidrome, Jellyfin, Emby, Plex, NetEase, Local) or YouTube fallback; Local search is fuzzy</span></div>
           <div class="key-row"><kbd>f</kbd><span>Toggle bookmark &#9733; / radio favorite</span></div>
           <div class="key-row"><kbd>u</kbd><span>Load URL (stream / playlist)</span></div>
-          <div class="key-row"><kbd>o</kbd><span>Open file browser</span></div>
+          <div class="key-row"><kbd>o</kbd><span>Open file browser; inside it, <kbd>p</kbd> adds selected files to an existing local playlist</span></div>
           <div class="key-row"><kbd>a / A</kbd><span>Queue (play next) / Queue manager</span></div>
           <div class="key-row"><kbd>x</kbd><span>Remove highlighted track from current playlist</span></div>
           <div class="key-row"><kbd>p</kbd><span>Playlist manager</span></div>
@@ -1991,6 +1991,7 @@ user_id = "your-account-user-id"</code></pre>
           <div class="key-row"><kbd>P</kbd><span>Play all tracks from the top</span></div>
           <div class="key-row"><kbd>a</kbd><span>Add the now-playing track (footer shows which one)</span></div>
           <div class="key-row"><kbd>r</kbd><span>Rename the playlist</span></div>
+          <div class="key-row"><kbd>D</kbd><span>Remove duplicate track paths from the playlist</span></div>
           <div class="key-row"><kbd>d</kbd><span>Delete playlist (confirms) / remove track</span></div>
           <div class="key-row"><kbd>Esc / p</kbd><span>Close (or clear active filter)</span></div>
         </div>

--- a/ui/model/filebrowser.go
+++ b/ui/model/filebrowser.go
@@ -29,6 +29,12 @@ type fbTracksResolvedMsg struct {
 	replace bool
 }
 
+// fbPlaylistTracksResolvedMsg carries tracks selected in the file browser that
+// should be added to an existing local TOML playlist.
+type fbPlaylistTracksResolvedMsg struct {
+	tracks []playlist.Track
+}
+
 func (m *Model) fbCount() int {
 	if m.fileBrowser.searching || m.fileBrowser.search != "" {
 		return len(m.fileBrowser.filtered)
@@ -49,6 +55,7 @@ func (m Model) fbHelpLine() string {
 	}
 	help := helpKey("←↓↑→", "Navigate ") + helpKey("Enter", "Open ") + helpKey("/", "Filter ") +
 		helpKey("Spc", "Select ") + helpKey("a", "All ") +
+		helpKey("p", "Playlist ") +
 		helpKey("←", "Back ") + helpKey("~.", "Home/Cwd ")
 	if os.PathSeparator == '\\' {
 		help += helpKey("AltCZ", "Drive ")
@@ -434,6 +441,9 @@ func (m *Model) handleFileBrowserKey(msg tea.KeyPressMsg) tea.Cmd {
 		if len(m.fileBrowser.selected) > 0 {
 			return m.fbConfirm(true)
 		}
+
+	case "p":
+		return m.fbConfirmToPlaylist()
 	}
 
 	// Change drive letter on Windows by pressing alt+[c..z]
@@ -453,11 +463,9 @@ func (m *Model) handleFileBrowserKey(msg tea.KeyPressMsg) tea.Cmd {
 // directory listing's natural (alphabetical) order so albums play in track
 // order rather than the random map iteration order.
 func (m *Model) fbConfirm(replace bool) tea.Cmd {
-	paths := make([]string, 0, len(m.fileBrowser.selected))
-	for _, e := range m.fileBrowser.entries {
-		if m.fileBrowser.selected[e.path] {
-			paths = append(paths, e.path)
-		}
+	paths := m.fbSelectedPaths(false)
+	if len(paths) == 0 {
+		return nil
 	}
 	m.fileBrowser.visible = false
 
@@ -468,4 +476,47 @@ func (m *Model) fbConfirm(replace bool) tea.Cmd {
 		}
 		return fbTracksResolvedMsg{tracks: r.Tracks, replace: replace}
 	}
+}
+
+// fbConfirmToPlaylist resolves the current file-browser selection and opens
+// the local playlist picker so the tracks can be appended to an existing TOML
+// playlist.
+func (m *Model) fbConfirmToPlaylist() tea.Cmd {
+	if m.localProvider == nil {
+		m.status.Show("Local playlists unavailable", statusTTLDefault)
+		return nil
+	}
+	paths := m.fbSelectedPaths(true)
+	if len(paths) == 0 {
+		m.status.Show("No audio files selected", statusTTLShort)
+		return nil
+	}
+	m.fileBrowser.visible = false
+
+	return func() tea.Msg {
+		r, err := resolve.Args(paths)
+		if err != nil {
+			return err
+		}
+		return fbPlaylistTracksResolvedMsg{tracks: r.Tracks}
+	}
+}
+
+// fbSelectedPaths returns selected paths in directory-listing order. If
+// includeCursorAudio is true and no explicit selection exists, the highlighted
+// audio file is returned as a one-item selection.
+func (m *Model) fbSelectedPaths(includeCursorAudio bool) []string {
+	paths := make([]string, 0, len(m.fileBrowser.selected))
+	for _, e := range m.fileBrowser.entries {
+		if m.fileBrowser.selected[e.path] {
+			paths = append(paths, e.path)
+		}
+	}
+	if len(paths) == 0 && includeCursorAudio && m.fileBrowser.cursor < m.fbCount() {
+		e := m.fbEntry(m.fileBrowser.cursor)
+		if e.isAudio {
+			paths = append(paths, e.path)
+		}
+	}
+	return paths
 }

--- a/ui/model/keymap.go
+++ b/ui/model/keymap.go
@@ -55,6 +55,7 @@ var keymapEntries = []keymapEntry{
 	{key: "E", action: "Open Emby provider"},
 	{key: "Ctrl+J", action: "Jump to time"},
 	{key: "p", action: "Playlist manager"},
+	{key: "D", action: "Playlist manager: dedupe local playlist"},
 	{key: "Ctrl+H", action: "Toggle album headers"},
 	{key: "i", action: "Track info / metadata"},
 	{key: "Ctrl+S", action: "Save/download track to ~/Music"},
@@ -101,7 +102,7 @@ var coreReservedKeys = []string{
 
 	// Features.
 	"r", "z", "m", "e", "a", "A", "ctrl+h",
-	"ctrl+s", "S", "/", "ctrl+f",
+	"ctrl+s", "S", "D", "/", "ctrl+f",
 	"ctrl+j", "J", "E", "p", "t", "i", "y", "o", "u",
 	"N", "L", "R", "P", "Y", "C", "M",
 	"v", "V", "ctrl+v", "ctrl+x", "x", "d", "ctrl+k", "?",

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -1474,7 +1474,7 @@ func (m *Model) handleURLInputKey(msg tea.KeyPressMsg) tea.Cmd {
 func (m *Model) handlePlaylistManagerKey(msg tea.KeyPressMsg) tea.Cmd {
 	// Quick-switch (Shift+letter) jumps to another provider. Only honored when
 	// the manager isn't currently capturing text input (filter, new-name).
-	if m.plManager.screen != plMgrScreenNewName && m.plManager.screen != plMgrScreenRename && !m.plManager.filtering {
+	if !m.plMgrAddMode() && m.plManager.screen != plMgrScreenNewName && m.plManager.screen != plMgrScreenRename && !m.plManager.filtering {
 		if cmd := m.quickSwitchProvider(msg.String()); cmd != nil {
 			return cmd
 		}
@@ -1526,9 +1526,10 @@ func (m *Model) handlePlMgrListKey(msg tea.KeyPressMsg) tea.Cmd {
 	switch msg.String() {
 	case "ctrl+c":
 		m.plManager.visible = false
+		m.plManager.addMode = false
+		m.plManager.addTracks = nil
 		return m.quit()
 	case "/":
-		m.plManager.filtering = true
 		m.plManager.savedCursor = m.plManager.cursor
 		m.plManager.savedScroll = m.plManager.scroll
 		m.plManager.filter = ""
@@ -1575,6 +1576,16 @@ func (m *Model) handlePlMgrListKey(msg tea.KeyPressMsg) tea.Cmd {
 		m.plMgrListMaybeAdjustScroll(m.plMgrListVisible())
 	case "enter", "l", "right":
 		realIdx := m.plMgrPlaylistRealIndex(m.plManager.cursor)
+		if m.plMgrAddMode() {
+			if realIdx >= 0 {
+				name := m.plManager.playlists[realIdx].Name
+				m.addTracksToPlaylist(name, m.plManager.addTracks)
+				m.plManager.addMode = false
+				m.plManager.addTracks = nil
+				m.plManager.visible = false
+			}
+			return nil
+		}
 		if realIdx >= 0 {
 			m.plMgrEnterTrackList(m.plManager.playlists[realIdx].Name)
 		} else {
@@ -1584,6 +1595,9 @@ func (m *Model) handlePlMgrListKey(msg tea.KeyPressMsg) tea.Cmd {
 			m.plManager.newName = m.plManager.filter
 		}
 	case "a":
+		if m.plMgrAddMode() {
+			return nil
+		}
 		// Quick-add current track to the highlighted playlist.
 		realIdx := m.plMgrPlaylistRealIndex(m.plManager.cursor)
 		if realIdx >= 0 {
@@ -1591,6 +1605,9 @@ func (m *Model) handlePlMgrListKey(msg tea.KeyPressMsg) tea.Cmd {
 			m.plMgrRefreshList()
 		}
 	case "r":
+		if m.plMgrAddMode() {
+			return nil
+		}
 		realIdx := m.plMgrPlaylistRealIndex(m.plManager.cursor)
 		if realIdx < 0 {
 			return nil
@@ -1603,7 +1620,20 @@ func (m *Model) handlePlMgrListKey(msg tea.KeyPressMsg) tea.Cmd {
 		m.plManager.renameOldName = name
 		m.plManager.renameName = name
 		m.plManager.screen = plMgrScreenRename
+	case "D":
+		if m.plMgrAddMode() {
+			return nil
+		}
+		realIdx := m.plMgrPlaylistRealIndex(m.plManager.cursor)
+		if realIdx >= 0 {
+			name := m.plManager.playlists[realIdx].Name
+			m.dedupePlaylist(name)
+			m.plMgrRefreshList()
+		}
 	case "d":
+		if m.plMgrAddMode() {
+			return nil
+		}
 		if m.plMgrPlaylistRealIndex(m.plManager.cursor) >= 0 {
 			m.plManager.confirmDel = true
 		}
@@ -1614,6 +1644,8 @@ func (m *Model) handlePlMgrListKey(msg tea.KeyPressMsg) tea.Cmd {
 			return nil
 		}
 		m.plManager.visible = false
+		m.plManager.addMode = false
+		m.plManager.addTracks = nil
 	}
 	return nil
 }
@@ -1624,6 +1656,8 @@ func (m *Model) handlePlMgrFilterKey(msg tea.KeyPressMsg) tea.Cmd {
 	switch msg.String() {
 	case "ctrl+c":
 		m.plManager.visible = false
+		m.plManager.addMode = false
+		m.plManager.addTracks = nil
 		return m.quit()
 	case "esc":
 		// Cancel filter, restore cursor.
@@ -1765,6 +1799,14 @@ func (m *Model) handlePlMgrTracksKey(msg tea.KeyPressMsg) tea.Cmd {
 		}
 	case "a":
 		m.addToPlaylist(m.plManager.selPlaylist)
+		if tracks, err := m.localProvider.Tracks(m.plManager.selPlaylist); err == nil {
+			m.plManager.tracks = tracks
+			if m.plManager.filter != "" {
+				m.plMgrRecomputeFilter()
+			}
+		}
+	case "D":
+		m.dedupePlaylist(m.plManager.selPlaylist)
 		if tracks, err := m.localProvider.Tracks(m.plManager.selPlaylist); err == nil {
 			m.plManager.tracks = tracks
 			if m.plManager.filter != "" {
@@ -1934,6 +1976,41 @@ func (m *Model) addToPlaylist(name string) {
 			m.status.Showf(statusTTLDefault, "Added to %q", name)
 		}
 	}
+}
+
+func (m *Model) addTracksToPlaylist(name string, tracks []playlist.Track) {
+	if len(tracks) == 0 {
+		m.status.Show("No tracks to add", statusTTLShort)
+		return
+	}
+	w, ok := m.localProvider.(provider.PlaylistTracksWriter)
+	if !ok {
+		m.status.Show("Local playlists are read-only", statusTTLDefault)
+		return
+	}
+	if err := w.AddTracks(name, tracks); err != nil {
+		m.status.Showf(statusTTLDefault, "Failed: %s", err)
+		return
+	}
+	m.status.Showf(statusTTLDefault, "Added %d track(s) to %q", len(tracks), name)
+}
+
+func (m *Model) dedupePlaylist(name string) {
+	d, ok := m.localProvider.(provider.PlaylistDeduper)
+	if !ok {
+		m.status.Show("Dedupe unavailable", statusTTLDefault)
+		return
+	}
+	removed, err := d.RemoveDuplicateTracks(name)
+	if err != nil {
+		m.status.Showf(statusTTLDefault, "Dedupe failed: %s", err)
+		return
+	}
+	if removed == 0 {
+		m.status.Showf(statusTTLDefault, "No duplicates in %q", name)
+		return
+	}
+	m.status.Showf(statusTTLDefault, "Removed %d duplicate track(s)", removed)
 }
 
 // handleThemeKey processes key presses while the theme picker is open.

--- a/ui/model/overlays.go
+++ b/ui/model/overlays.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"cliamp/history"
+	"cliamp/playlist"
 	"cliamp/theme"
 	"cliamp/ui"
 )
@@ -200,6 +202,10 @@ func (m *Model) spotSearchPlaylistVisible() int {
 	return m.effectivePlaylistVisible()
 }
 
+func (m Model) plMgrAddMode() bool {
+	return m.plManager.addMode
+}
+
 // navVisible returns the nav-browser list height. The nav browser renders
 // inline in the playlist region, so it shares the playlist's row budget.
 func (m *Model) navVisible() int {
@@ -207,6 +213,12 @@ func (m *Model) navVisible() int {
 }
 
 func (m *Model) plMgrListHelpLine() string {
+	if m.plMgrAddMode() {
+		return helpKey("↓↑→", "Navigate ") +
+			helpKey("Enter", "Add here ") +
+			helpKey("/", "Filter ") +
+			helpKey("Esc", "Cancel")
+	}
 	addLabel := "Add (nothing playing)"
 	if track, idx := m.currentPlaybackTrack(); idx >= 0 && track.Path != "" {
 		addLabel = "Add: " + truncate(track.DisplayName(), 32)
@@ -215,6 +227,7 @@ func (m *Model) plMgrListHelpLine() string {
 		helpKey("Enter", "Open ") +
 		helpKey("a", addLabel+" ") +
 		helpKey("r", "Rename ") +
+		helpKey("D", "Dedupe ") +
 		helpKey("d", "Delete ") +
 		helpKey("/", "Filter ") +
 		helpKey("Esc", "Close")
@@ -237,6 +250,7 @@ func (m *Model) plMgrTracksHelpLine() string {
 		helpKey("Enter", "Play this ") +
 		helpKey("P", "Play all ") +
 		helpKey("a", addLabel+" ") +
+		helpKey("D", "Dedupe ") +
 		helpKey("d", "Remove ") +
 		helpKey("/", "Filter ") +
 		helpKey("Esc", "Back")
@@ -266,6 +280,8 @@ func (m *Model) plMgrTracksMaybeAdjustScroll(visible int) {
 // openPlaylistManager loads playlist metadata and opens the manager overlay.
 func (m *Model) openPlaylistManager() {
 	m.plMgrResetFilter()
+	m.plManager.addMode = false
+	m.plManager.addTracks = nil
 	m.plMgrRefreshList()
 	m.plManager.screen = plMgrScreenList
 	m.plManager.cursor = 0
@@ -275,6 +291,34 @@ func (m *Model) openPlaylistManager() {
 	m.plManager.renameName = ""
 	m.plManager.visible = true
 	m.plMgrListMaybeAdjustScroll(m.plMgrListVisible())
+}
+
+// openPlaylistManagerForTracks opens the manager as a picker for appending
+// file-browser selections to an existing local TOML playlist.
+func (m *Model) openPlaylistManagerForTracks(tracks []playlist.Track) {
+	m.plMgrResetFilter()
+	m.plManager.addMode = true
+	m.plManager.addTracks = tracks
+	m.plMgrRefreshList()
+	m.plManager.playlists = writableLocalPlaylists(m.plManager.playlists)
+	m.plManager.screen = plMgrScreenList
+	m.plManager.cursor = 0
+	m.plManager.scroll = 0
+	m.plManager.confirmDel = false
+	m.plManager.renameOldName = ""
+	m.plManager.renameName = ""
+	m.plManager.visible = true
+	m.plMgrListMaybeAdjustScroll(m.plMgrListVisible())
+}
+
+func writableLocalPlaylists(playlists []playlist.PlaylistInfo) []playlist.PlaylistInfo {
+	out := make([]playlist.PlaylistInfo, 0, len(playlists))
+	for _, pl := range playlists {
+		if pl.Name != history.PlaylistName {
+			out = append(out, pl)
+		}
+	}
+	return out
 }
 
 // plMgrEnterTrackList loads the tracks for a playlist and switches to screen 1.
@@ -392,7 +436,13 @@ func (m *Model) plMgrRefreshList() {
 // (filtered playlists + "+ New Playlist..." entry).
 func (m Model) plMgrListViewCount() int {
 	if m.plManager.filter != "" {
+		if m.plMgrAddMode() {
+			return len(m.plManager.filtered)
+		}
 		return len(m.plManager.filtered) + 1
+	}
+	if m.plMgrAddMode() {
+		return len(m.plManager.playlists)
 	}
 	return len(m.plManager.playlists) + 1
 }

--- a/ui/model/state.go
+++ b/ui/model/state.go
@@ -120,6 +120,8 @@ type plManagerState struct {
 	playlists     []playlist.PlaylistInfo
 	selPlaylist   string           // playlist name open in screen 1
 	tracks        []playlist.Track // tracks in the selected playlist
+	addMode       bool             // true when manager is acting as a playlist picker
+	addTracks     []playlist.Track // pending file-browser tracks to add to a playlist
 	newName       string
 	confirmDel    bool
 	renameOldName string

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -549,6 +549,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case fbPlaylistTracksResolvedMsg:
+		if len(msg.tracks) == 0 {
+			m.status.Show("No audio files found", statusTTLDefault)
+			return m, nil
+		}
+		m.openPlaylistManagerForTracks(msg.tracks)
+		m.status.Showf(statusTTLDefault, "Select playlist for %d track(s)", len(msg.tracks))
+		return m, nil
+
 	case streamPlayedMsg:
 		m.buffering = false
 		if msg.err != nil {

--- a/ui/model/view_overlays.go
+++ b/ui/model/view_overlays.go
@@ -40,6 +40,13 @@ func (m Model) plMgrHeaderLine() string {
 	case plMgrScreenRename:
 		return promptHeader("Rename "+m.plManager.renameOldName, m.plManager.renameName)
 	default:
+		if m.plMgrAddMode() {
+			total := len(m.plManager.playlists)
+			if m.plManager.filter != "" {
+				total = len(m.plManager.filtered)
+			}
+			return sepHeaderN(fmt.Sprintf("Add %d track(s) to Playlist", len(m.plManager.addTracks)), m.plManager.cursor+1, total)
+		}
 		total := len(m.plManager.playlists)
 		if m.plManager.filter != "" {
 			total = len(m.plManager.filtered)
@@ -94,6 +101,12 @@ func (m Model) renderPlMgrListBody() string {
 
 	// Empty state: no playlists at all.
 	if len(m.plManager.playlists) == 0 {
+		if m.plMgrAddMode() {
+			return bodyLines([]string{
+				dimStyle.Render("  No local playlists yet."),
+				dimStyle.Render("  Create one in the playlist manager first."),
+			}, budget)
+		}
 		return bodyLines([]string{
 			dimStyle.Render("  No playlists yet."),
 			dimStyle.Render("  Press Enter on \"+ New Playlist…\" below,"),
@@ -103,8 +116,12 @@ func (m Model) renderPlMgrListBody() string {
 		}, budget)
 	}
 
-	// Filtered with no matches: still allow "+ New Playlist..."
+	// Filtered with no matches: still allow "+ New Playlist..." unless this
+	// is the existing-playlist picker for file-browser additions.
 	if m.plManager.filter != "" && visibleN == 0 {
+		if m.plMgrAddMode() {
+			return bodyMessage(fmt.Sprintf("No playlists match %q", m.plManager.filter), budget)
+		}
 		newLabel := "+ New Playlist \"" + m.plManager.filter + "\"..."
 		return bodyLines([]string{
 			dimStyle.Render(fmt.Sprintf("  No playlists match %q", m.plManager.filter)),
@@ -139,15 +156,17 @@ func (m Model) renderPlMgrListBody() string {
 		})
 	}
 
-	if visibleN > 0 {
+	if visibleN > 0 && !m.plMgrAddMode() {
 		rows = append(rows, plRow{spacer: true, viewIdx: -1})
 	}
 
-	newLabel := "+ New Playlist..."
-	if m.plManager.filter != "" {
-		newLabel = "+ New Playlist \"" + m.plManager.filter + "\"..."
+	if !m.plMgrAddMode() {
+		newLabel := "+ New Playlist..."
+		if m.plManager.filter != "" {
+			newLabel = "+ New Playlist \"" + m.plManager.filter + "\"..."
+		}
+		rows = append(rows, plRow{label: newLabel, realIdx: -1, viewIdx: visibleN})
 	}
-	rows = append(rows, plRow{label: newLabel, realIdx: -1, viewIdx: visibleN})
 
 	// Map the logical scroll position to our row index.
 	startIndex := 0


### PR DESCRIPTION
## Summary

- Add `p` in the file browser to append selected audio files to an existing local TOML playlist
- Add local playlist dedupe support by track path
- Expose dedupe through playlist manager `D` and `cliamp playlist dedupe`
- Update docs and site keybinding references

## Screenshots / video

<img width="1208" height="683" alt="image" src="https://github.com/user-attachments/assets/e4d5629c-6e9a-402b-9fde-88689f48fe24" />

<img width="1206" height="675" alt="image" src="https://github.com/user-attachments/assets/d52692c9-21c8-4f64-8349-cbaa42032437" />

<img width="1194" height="661" alt="image" src="https://github.com/user-attachments/assets/c11dbd11-2ac1-4093-8583-d7d173294c55" />

## How to test

1. make check
2. make build
3. Manual TUI test: selected files in file browser and appended them to a local playlist
4. Manual dedupe test via CLI/TUI

## Checklist

- [x] `make check` passes
- [x] `docs/` and `site/index.html` updated for user-facing changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a playlist dedupe action to remove duplicate track paths while keeping the first occurrence.
  * Added a file-browser flow for adding selected tracks to an existing playlist.
  * Updated keyboard shortcuts and on-screen help to include the new `D` action.

* **Bug Fixes**
  * Improved playlist handling when no duplicates are found or no audio files are selected.
  * Prevented add-mode actions from interfering with normal playlist management.

* **Documentation**
  * Expanded playlist and keybinding docs to cover deduping and track-adding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->