### PR TITLE
Add cliamp-plugin-mandelbrot to community plugins

### DIFF
--- a/docs/community-plugins.md
+++ b/docs/community-plugins.md
@@ -11,3 +11,4 @@ Plugins built by the community. If you've built a plugin, open a PR to add it he
 | [cliamp-plugin-nightrider](https://github.com/HANCORE-linux/cliamp-plugin-nightrider) | Nightrider style visualizer | [@HANCORE-linux](https://github.com/HANCORE-linux) |
 | [cliamp-plugin-tubeamp](https://github.com/8bit64k/cliamp-plugin-tubeamp) | Vacuum-tube amplifier visualizer | [@8bit64k](https://github.com/8bit64k) |
 | [cliamp-plugin-nova](https://github.com/8bit64k/cliamp-plugin-nova) | Concentric-ring spectrum visualizer | [@8bit64k](https://github.com/8bit64k) |
+| [cliamp-plugin-mandelbrot](https://github.com/mikkel-bergmann/cliamp-plugin-mandelbrot) | Zooming psychedelic Mandelbrot set visualizer with braille rendering and bass reactivity | [@mikkel-bergmann](https://github.com/mikkel-bergmann) |


### PR DESCRIPTION
## New community plugin: cliamp-plugin-mandelbrot

**Repo:** https://github.com/mikkel-bergmann/cliamp-plugin-mandelbrot

A zooming Mandelbrot set visualizer rendered entirely in Unicode braille characters, with music reactivity and a 30-colour psychedelic palette.

**Features:**
- Continuously zooms into four classic fractal locations (Sea Horse Valley, Elephant Valley, etc.), cycling when the screen fills
- Every terminal cell is a braille character (U+2800–U+28FF); escape-time iteration count maps to dot density for smooth halftone anti-aliasing
- Bass/kick reactivity — strong hits flash the colour palette
- Slow rotation as it zooms
- Period-coloured interior using Brent cycle detection
- Silence detection — animation freezes when nothing is playing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the `cliamp-plugin-mandelbrot` community plugin to the plugin directory, including its repository link, description, and author information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->