### PR TITLE
fix(httpclient): accept ICY stream responses

### DIFF
--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -2,7 +2,9 @@
 package httpclient
 
 import (
+	"context"
 	"crypto/tls"
+	"net"
 	"net/http"
 	"time"
 )
@@ -16,10 +18,41 @@ import (
 // Proxy is read from the environment (HTTP_PROXY, HTTPS_PROXY, NO_PROXY)
 // so users behind corporate or local proxies aren't bypassed; the rest of
 // the codebase uses http.DefaultTransport, which already honors these vars.
-var Streaming = &http.Client{
-	Transport: &http.Transport{
+var Streaming = &http.Client{Transport: newStreamingTransport()}
+
+func newStreamingTransport() *http.Transport {
+	tr := &http.Transport{
 		Proxy:                 http.ProxyFromEnvironment,
 		ResponseHeaderTimeout: 30 * time.Second,
 		TLSNextProto:          make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
-	},
+	}
+	tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		conn, err := (&net.Dialer{}).DialContext(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		return newICYConn(conn), nil
+	}
+	tr.DialTLSContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		config := &tls.Config{}
+		if tr.TLSClientConfig != nil {
+			config = tr.TLSClientConfig.Clone()
+		}
+		if config.ServerName == "" {
+			host, _, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, err
+			}
+			config.ServerName = host
+		}
+		// Icecast and SHOUTcast servers only support HTTP/1.x.
+		config.NextProtos = nil
+
+		conn, err := (&tls.Dialer{Config: config}).DialContext(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		return newICYConn(conn), nil
+	}
+	return tr
 }

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -4,6 +4,7 @@ package httpclient
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net"
 	"net/http"
 	"time"
@@ -29,7 +30,7 @@ func newStreamingTransport() *http.Transport {
 	tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 		conn, err := (&net.Dialer{}).DialContext(ctx, network, addr)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("dial %s: %w", addr, err)
 		}
 		return newICYConn(conn), nil
 	}
@@ -41,7 +42,7 @@ func newStreamingTransport() *http.Transport {
 		if config.ServerName == "" {
 			host, _, err := net.SplitHostPort(addr)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("split TLS address %q: %w", addr, err)
 			}
 			config.ServerName = host
 		}
@@ -50,7 +51,7 @@ func newStreamingTransport() *http.Transport {
 
 		conn, err := (&tls.Dialer{Config: config}).DialContext(ctx, network, addr)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("dial TLS %s: %w", addr, err)
 		}
 		return newICYConn(conn), nil
 	}

--- a/internal/httpclient/client_test.go
+++ b/internal/httpclient/client_test.go
@@ -1,7 +1,11 @@
 package httpclient
 
 import (
+	"crypto/tls"
+	"crypto/x509"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 )
@@ -39,5 +43,58 @@ func TestStreamingHTTP2Disabled(t *testing.T) {
 func TestStreamingNoOverallTimeout(t *testing.T) {
 	if Streaming.Timeout != 0 {
 		t.Fatalf("Timeout = %v, want 0 (infinite streams)", Streaming.Timeout)
+	}
+}
+
+func TestStreamingClientAcceptsICYStatus(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		tls  bool
+	}{
+		{name: "http"},
+		{name: "https", tls: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				conn, rw, err := w.(http.Hijacker).Hijack()
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+					return
+				}
+				defer conn.Close()
+				_, _ = rw.WriteString("ICY 200 OK\r\nContent-Length: 5\r\nContent-Type: audio/mpeg\r\n\r\nhello")
+				_ = rw.Flush()
+			}))
+			if tt.tls {
+				server.StartTLS()
+			} else {
+				server.Start()
+			}
+			t.Cleanup(server.Close)
+
+			tr := newStreamingTransport()
+			if tt.tls {
+				roots := x509.NewCertPool()
+				roots.AddCert(server.Certificate())
+				tr.TLSClientConfig = &tls.Config{RootCAs: roots}
+			}
+			client := &http.Client{Transport: tr}
+			resp, err := client.Get(server.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got, want := string(body), "hello"; got != want {
+				t.Fatalf("body = %q, want %q", got, want)
+			}
+			if got, want := resp.Proto, "HTTP/1.0"; got != want {
+				t.Fatalf("Proto = %q, want %q", got, want)
+			}
+		})
 	}
 }

--- a/internal/httpclient/icy.go
+++ b/internal/httpclient/icy.go
@@ -1,0 +1,44 @@
+package httpclient
+
+import (
+	"io"
+	"net"
+)
+
+// icyConn translates SHOUTcast's nonstandard "ICY 200 OK" status line to
+// HTTP/1.0 before net/http parses it.
+type icyConn struct {
+	net.Conn
+	prefix []byte
+	err    error
+}
+
+func newICYConn(conn net.Conn) *icyConn {
+	return &icyConn{Conn: conn}
+}
+
+func (c *icyConn) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if c.prefix == nil {
+		var prefix [4]byte
+		n, err := io.ReadFull(c.Conn, prefix[:])
+		c.prefix = prefix[:n]
+		c.err = err
+		if string(c.prefix) == "ICY " {
+			c.prefix = []byte("HTTP/1.0 ")
+		}
+	}
+	if len(c.prefix) > 0 {
+		n := copy(p, c.prefix)
+		c.prefix = c.prefix[n:]
+		return n, nil
+	}
+	if c.err != nil {
+		err := c.err
+		c.err = nil
+		return 0, err
+	}
+	return c.Conn.Read(p)
+}


### PR DESCRIPTION
Fixes #277. Normalizes SHOUTcast ICY status lines before net/http parses them and adds HTTP/HTTPS regression coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming connections now accept SHOUTcast/ICY responses over both HTTP and HTTPS.
  * HTTPS streaming now applies better TLS settings and keeps HTTP/1.x behavior for improved compatibility.
* **Bug Fixes**
  * Streaming responses with ICY status are now correctly transformed into a standard HTTP status so `net/http` can parse them and read the full response body.
* **Tests**
  * Added coverage for ICY handling in both HTTP and HTTPS scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->