### PR TITLE
fix(ui): restore playlist expansion layout

### DIFF
--- a/AI_REVIEW_REQUIRED.txt
+++ b/AI_REVIEW_REQUIRED.txt
@@ -1,1 +1,0 @@
-I use AI, and if this file is not deleted, I haven't reviewed my own code.

--- a/AI_REVIEW_REQUIRED.txt
+++ b/AI_REVIEW_REQUIRED.txt
@@ -1,0 +1,1 @@
+I use AI, and if this file is not deleted, I haven't reviewed my own code.

--- a/ui/model/layout.go
+++ b/ui/model/layout.go
@@ -80,7 +80,9 @@ func (m *Model) recomputeLayout() {
 	if !layout.tooSmall() {
 		layout.bodyRows = max(1, height-2*paddingV-layout.fixedRows-layout.footerRows)
 		limit := maxPlVisible
-		if m.heightExpanded || contentFirst {
+		if m.heightExpanded {
+			limit = layout.bodyRows
+		} else if contentFirst {
 			limit = maxPlExpandVisible
 		}
 		m.plVisible = min(limit, layout.bodyRows)

--- a/ui/model/layout_test.go
+++ b/ui/model/layout_test.go
@@ -117,7 +117,8 @@ func TestExpandedPlaylistUsesAvailableRows(t *testing.T) {
 
 func TestCollapsedPlaylistCentersFrameVertically(t *testing.T) {
 	m := newLayoutTestModel(80, 50)
-	content := strings.Join(m.mainSections(m.renderMainBody(), true, false), "\n")
+	body := ui.FitRect(m.renderMainBody(), m.layout.panelWidth, m.layout.bodyRows)
+	content := strings.Join(m.mainSections(body, true, false), "\n")
 	frameHeight := lipgloss.Height(ui.FrameStyle.Render(content))
 	wantTopPadding := (m.height - frameHeight) / 2
 

--- a/ui/model/layout_test.go
+++ b/ui/model/layout_test.go
@@ -99,6 +99,41 @@ func TestResponsiveViewsFitTerminal(t *testing.T) {
 	}
 }
 
+func TestExpandedPlaylistUsesAvailableRows(t *testing.T) {
+	m := newLayoutTestModel(80, 50)
+	if m.plVisible != maxPlVisible {
+		t.Fatalf("collapsed playlist rows = %d, want %d", m.plVisible, maxPlVisible)
+	}
+
+	m.heightExpanded = true
+	m.recomputeLayout()
+	if m.plVisible != m.layout.bodyRows {
+		t.Fatalf("expanded playlist rows = %d, want available body rows %d", m.plVisible, m.layout.bodyRows)
+	}
+	if m.plVisible <= maxPlExpandVisible {
+		t.Fatalf("expanded playlist rows = %d, want more than previous cap %d", m.plVisible, maxPlExpandVisible)
+	}
+}
+
+func TestCollapsedPlaylistCentersFrameVertically(t *testing.T) {
+	m := newLayoutTestModel(80, 50)
+	content := strings.Join(m.mainSections(m.renderMainBody(), true, false), "\n")
+	frameHeight := lipgloss.Height(ui.FrameStyle.Render(content))
+	wantTopPadding := (m.height - frameHeight) / 2
+
+	out := m.View().Content
+	gotTopPadding := 0
+	for _, line := range strings.Split(out, "\n") {
+		if line != "" {
+			break
+		}
+		gotTopPadding++
+	}
+	if gotTopPadding != wantTopPadding {
+		t.Fatalf("top padding = %d, want %d", gotTopPadding, wantTopPadding)
+	}
+}
+
 func TestResizeClampsActiveOverlayCursor(t *testing.T) {
 	m := newLayoutTestModel(120, 40)
 	m.themePicker.visible = true

--- a/ui/model/model.go
+++ b/ui/model/model.go
@@ -177,7 +177,7 @@ func (s topLevelScreen) label() string {
 }
 
 // maxPlVisible caps the playlist at a readable height even on tall terminals.
-// maxPlExpandVisible is the higher cap used when the user expands with 'x'.
+// maxPlExpandVisible is the higher cap used by content-first list screens.
 const (
 	maxPlVisible       = 12
 	maxPlExpandVisible = 24

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -291,14 +291,15 @@ func (m Model) renderCompactSource() string {
 	return labelStyle.Render("SRC ") + trackStyle.Render("["+name+"]") + dimStyle.Render(fmt.Sprintf(" %d/%d", m.provPillIdx+1, len(m.providers)))
 }
 
-// centerFrame horizontally centers a pre-rendered frame without wasting rows
-// that can instead hold playlist content.
+// centerFrame centers a pre-rendered frame in the terminal.
 func (m Model) centerFrame(frame string) string {
 	frameW := lipgloss.Width(frame)
+	frameH := lipgloss.Height(frame)
 	padLeft := max(0, (m.width-frameW)/2)
+	padTop := max(0, (m.height-frameH)/2)
 
 	if padLeft == 0 {
-		return frame
+		return strings.Repeat("\n", padTop) + frame
 	}
 	// Indent every line by padLeft spaces.
 	prefix := strings.Repeat(" ", padLeft)
@@ -306,7 +307,7 @@ func (m Model) centerFrame(frame string) string {
 	for i, l := range lines {
 		lines[i] = prefix + l
 	}
-	return strings.Join(lines, "\n")
+	return strings.Repeat("\n", padTop) + strings.Join(lines, "\n")
 }
 
 func (m Model) renderTitle() string {


### PR DESCRIPTION
Fixes #283.

- Vertically center collapsed playback frames.
- Let Ctrl+X expand the playlist to all available body rows.
- Add layout regressions for centering and expanded height.

Tests: `make check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playlist layout sizing when expanded, allowing it to use the available screen height.
  * Vertically centered collapsed playlist content within the terminal window.
  * Refined layout behavior for content-first views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->