### PR TITLE
fix: prevent Quickshell widget from stealing focus

### DIFF
--- a/contrib/quickshell/README.md
+++ b/contrib/quickshell/README.md
@@ -1,6 +1,6 @@
 # cliamp quickshell widget
 
-A compact "now playing" card for [Quickshell](https://quickshell.org) (300 x 72), centered along the bottom of every screen and driven by cliamp's MPRIS service (`org.mpris.MediaPlayer2.cliamp`). Two-row layout: title + time on top, artist + transport on the second row, a 10-band Winamp 2-style spectrum below, and a thin click-to-seek line at the bottom. Colors are picked up from the active Omarchy theme (`~/.config/omarchy/current/theme/colors.toml`) and update live when the theme changes. Hides itself when cliamp is not running. Click the card and press Esc or Q to quit the widget.
+A compact "now playing" card for [Quickshell](https://quickshell.org) (300 x 72), centered along the bottom of every screen and driven by cliamp's MPRIS service (`org.mpris.MediaPlayer2.cliamp`). Two-row layout: title + time on top, artist + transport on the second row, a 10-band Winamp 2-style spectrum below, and a thin click-to-seek line at the bottom. Colors are picked up from the active Omarchy theme (`~/.config/omarchy/current/theme/colors.toml`) and update live when the theme changes. Hides itself when cliamp is not running. The card accepts mouse input for playback controls and seeking, but never takes keyboard focus from the active application.
 
 Linux only. Requires Quickshell 0.2+ and cliamp running with its default MPRIS service enabled (it is by default on Linux).
 

--- a/contrib/quickshell/shell.qml
+++ b/contrib/quickshell/shell.qml
@@ -40,9 +40,9 @@ Scope {
 
             exclusionMode: ExclusionMode.Ignore
 
-            // Take keyboard focus on demand so the user can press Esc/Q to
-            // dismiss the widget. Focus is acquired when the card is clicked.
-            WlrLayershell.keyboardFocus: WlrKeyboardFocus.OnDemand
+            // A now-playing overlay must not steal keyboard focus from the
+            // active application when it appears or is clicked.
+            WlrLayershell.keyboardFocus: WlrKeyboardFocus.None
 
             implicitHeight: 72
             color: "transparent"
@@ -54,10 +54,6 @@ Scope {
                 height: parent.height
                 anchors.horizontalCenter: parent.horizontalCenter
                 player: root.cliampPlayer
-                focus: true
-                Keys.onPressed: (e) => {
-                    if (e.key === Qt.Key_Escape || e.key === Qt.Key_Q) Qt.quit();
-                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- make the now-playing layer-shell window keyboard-inert
- remove forced focus and the Esc/Q keyboard handler
- document that mouse playback and seek controls remain available

## Why

The widget used `WlrKeyboardFocus.OnDemand` together with `focus: true`. When the now-playing overlay appeared, it could take keyboard focus from the active desktop application and prevent normal keyboard use. A passive media overlay should not participate in keyboard focus.

## Validation

- `qmllint contrib/quickshell/shell.qml`
- `git diff --check`
- reproduced and validated the equivalent fix in the installed Omarchy shell plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The playback overlay no longer captures keyboard focus.
  * Mouse controls now support playback actions and seeking directly.

* **Documentation**
  * Updated usage instructions to reflect mouse-based controls and the removal of keyboard shortcuts for exiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->