### PR TITLE
fix(upgrade): replace running binary on Windows

### DIFF
--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -193,10 +193,43 @@ func downloadAndReplace(url, destPath, expectedHash string) error {
 		return fmt.Errorf("setting permissions: %w", err)
 	}
 
-	if err := os.Rename(tmpPath, destPath); err != nil {
+	if err := replaceExecutable(tmpPath, destPath); err != nil {
 		os.Remove(tmpPath)
-		return fmt.Errorf("replacing binary: %w (try running with sudo)", err)
+		if runtime.GOOS != "windows" {
+			return fmt.Errorf("replacing binary: %w (try running with sudo)", err)
+		}
+		return fmt.Errorf("replacing binary: %w", err)
 	}
 
+	return nil
+}
+
+func replaceExecutable(sourcePath, destPath string) error {
+	if runtime.GOOS == "windows" {
+		return replaceExecutableOnWindows(sourcePath, destPath)
+	}
+	return os.Rename(sourcePath, destPath)
+}
+
+func replaceExecutableOnWindows(sourcePath, destPath string) error {
+	backupPath := filepath.Join(filepath.Dir(destPath), "."+filepath.Base(destPath)+".old")
+	if err := os.Remove(backupPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("removing previous binary backup: %w", err)
+	}
+
+	if err := os.Rename(destPath, backupPath); err != nil {
+		return fmt.Errorf("moving current binary aside: %w", err)
+	}
+
+	if err := os.Rename(sourcePath, destPath); err != nil {
+		if rollbackErr := os.Rename(backupPath, destPath); rollbackErr != nil {
+			return fmt.Errorf("installing new binary: %w; restoring current binary: %v", err, rollbackErr)
+		}
+		return fmt.Errorf("installing new binary: %w", err)
+	}
+
+	// Windows keeps the running executable locked. A leftover backup is
+	// harmless and will be removed before the next upgrade.
+	_ = os.Remove(backupPath)
 	return nil
 }

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -223,7 +223,7 @@ func replaceExecutableOnWindows(sourcePath, destPath string) error {
 
 	if err := os.Rename(sourcePath, destPath); err != nil {
 		if rollbackErr := os.Rename(backupPath, destPath); rollbackErr != nil {
-			return fmt.Errorf("installing new binary: %w; restoring current binary: %v", err, rollbackErr)
+			return fmt.Errorf("installing new binary: %w; restoring current binary: %w", err, rollbackErr)
 		}
 		return fmt.Errorf("installing new binary: %w", err)
 	}

--- a/upgrade/upgrade_test.go
+++ b/upgrade/upgrade_test.go
@@ -215,6 +215,9 @@ func TestReplaceExecutableOnWindows(t *testing.T) {
 	if _, err := os.Stat(download); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("download still exists or stat failed: %v", err)
 	}
+	if _, err := os.Stat(backup); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("backup still exists or stat failed: %v", err)
+	}
 }
 
 func TestReplaceExecutableOnWindowsRollsBack(t *testing.T) {

--- a/upgrade/upgrade_test.go
+++ b/upgrade/upgrade_test.go
@@ -3,6 +3,7 @@ package upgrade
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -181,6 +182,60 @@ func TestDownloadAndReplace(t *testing.T) {
 	// Verify executable bit is set where the platform models one.
 	if runtime.GOOS != "windows" && info.Mode().Perm()&0o111 == 0 {
 		t.Errorf("target mode = %o, want executable", info.Mode().Perm())
+	}
+}
+
+func TestReplaceExecutableOnWindows(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "cliamp.exe")
+	download := filepath.Join(dir, "cliamp-upgrade.exe")
+	backup := filepath.Join(dir, ".cliamp.exe.old")
+
+	if err := os.WriteFile(target, []byte("OLD"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(download, []byte("NEW"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(backup, []byte("STALE"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := replaceExecutableOnWindows(download, target); err != nil {
+		t.Fatalf("replaceExecutableOnWindows: %v", err)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "NEW" {
+		t.Fatalf("target content = %q, want NEW", got)
+	}
+	if _, err := os.Stat(download); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("download still exists or stat failed: %v", err)
+	}
+}
+
+func TestReplaceExecutableOnWindowsRollsBack(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "cliamp.exe")
+	missingDownload := filepath.Join(dir, "missing.exe")
+
+	if err := os.WriteFile(target, []byte("OLD"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := replaceExecutableOnWindows(missingDownload, target)
+	if err == nil {
+		t.Fatal("replaceExecutableOnWindows should fail for a missing download")
+	}
+	got, readErr := os.ReadFile(target)
+	if readErr != nil {
+		t.Fatalf("reading restored target: %v", readErr)
+	}
+	if string(got) != "OLD" {
+		t.Fatalf("restored target content = %q, want OLD", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix self-upgrades on Windows, where the running executable cannot be replaced in place.

The Windows path now moves the current binary to a `.old` sidecar before installing the already downloaded and checksum-verified replacement. It removes a stale sidecar before the swap, rolls the original binary back if installation fails, and cleans the sidecar up on a best-effort basis after success.

Closes #298.

## Screenshots / video

Not applicable.

## How to test

1. `go test ./upgrade`
2. `go test -race -count=1 ./upgrade`
3. `go vet ./upgrade`
4. `GOOS=windows GOARCH=amd64 go test -run '^$' -exec=true ./...`
5. `GOOS=windows GOARCH=amd64 go vet ./...`

The full native `go test -count=1 ./...` ran all packages that do not require system codec headers. The root and Spotify packages could not build locally because `pkg-config` could not find FLAC, Ogg, and Vorbis; the repository CI installs those prerequisites.

## Checklist

- [ ] `make check` passes
- [x] `docs/` and `site/index.html` updated for user-facing changes (not applicable; no documented interface changed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved executable replacement during upgrades on Windows.
  * Added automatic rollback when installing the new executable fails.
  * Preserved the existing executable until the replacement succeeds.
  * Improved platform-specific error messages during upgrade failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->