### PR TITLE
feat: enrich playlist album via file metadata

### DIFF
--- a/cmd/playlist.go
+++ b/cmd/playlist.go
@@ -492,6 +492,13 @@ func PlaylistBookmarks() error {
 
 // PlaylistEnrich probes duration and derives album metadata for SSH tracks.
 func PlaylistEnrich(name string, source string) error {
+	src := normalizeSortKey(source)
+	switch src {
+		case "path", "metadata":
+		default:
+			return fmt.Errorf("unsupported source key %q (use path or metadata)", source)
+	}
+	
 	prov, err := newProvider()
 	if err != nil {
 		return err
@@ -516,11 +523,16 @@ func PlaylistEnrich(name string, source string) error {
 		}
 
 		if t.Album == "" {
-			if dir := albumFromPath(t.Path); dir != "" && source == "path" {
-				tracks[i].Album = dir
-				changed = true
-			} else if album := probeAlbum(t.Path); album != "" && source == "metadata" {
-				tracks[i].Album = album
+			if src == "path" {
+				if dir := albumFromPath(t.Path); dir != "" {
+					tracks[i].Album = dir
+					changed = true
+				}
+			} else if src == "metadata" {
+				if album := probeAlbum(t.Path); album != "" {
+					tracks[i].Album = album
+					changed = true
+				}
 			}
 		}
 

--- a/cmd/playlist.go
+++ b/cmd/playlist.go
@@ -634,7 +634,9 @@ func collectLocalAudio(paths []string) ([]string, error) {
 		if err != nil {
 			return nil, fmt.Errorf("scanning %q: %w", p, err)
 		}
-		all = append(all, files...)
+		for _, f := range files {
+			all = append(all, strings.ReplaceAll(f, "\\", "/"))
+		}
 	}
 	return all, nil
 }

--- a/cmd/playlist.go
+++ b/cmd/playlist.go
@@ -494,11 +494,11 @@ func PlaylistBookmarks() error {
 func PlaylistEnrich(name string, source string) error {
 	src := normalizeSortKey(source)
 	switch src {
-		case "path", "metadata":
-		default:
-			return fmt.Errorf("unsupported source key %q (use path or metadata)", source)
+	case "path", "metadata":
+	default:
+		return fmt.Errorf("unsupported source key %q (use path or metadata)", source)
 	}
-	
+
 	prov, err := newProvider()
 	if err != nil {
 		return err
@@ -533,6 +533,13 @@ func PlaylistEnrich(name string, source string) error {
 					tracks[i].Album = album
 					changed = true
 				}
+			}
+		}
+		if t.Year == 0 {
+			if year := probeYear(t.Path); year != 0 {
+				tracks[i].Year = year
+				changed = true
+				fmt.Fprintf(os.Stderr, "  %s: %d\n", t.DisplayName(), year)
 			}
 		}
 
@@ -600,6 +607,11 @@ func parseProbeDuration(out []byte) int {
 		return 0
 	}
 	return int(dur)
+}
+
+func probeYear(path string) int {
+	t := playlist.TrackFromPath(path)
+	return t.Year
 }
 
 func probeAlbum(path string) string {

--- a/cmd/playlist.go
+++ b/cmd/playlist.go
@@ -491,7 +491,7 @@ func PlaylistBookmarks() error {
 }
 
 // PlaylistEnrich probes duration and derives album metadata for SSH tracks.
-func PlaylistEnrich(name string) error {
+func PlaylistEnrich(name string, source string) error {
 	prov, err := newProvider()
 	if err != nil {
 		return err
@@ -516,9 +516,11 @@ func PlaylistEnrich(name string) error {
 		}
 
 		if t.Album == "" {
-			if dir := albumFromPath(t.Path); dir != "" {
+			if dir := albumFromPath(t.Path); dir != "" && source == "path" {
 				tracks[i].Album = dir
 				changed = true
+			} else if album := probeAlbum(t.Path); album != "" && source == "metadata" {
+				tracks[i].Album = album
 			}
 		}
 
@@ -586,6 +588,11 @@ func parseProbeDuration(out []byte) int {
 		return 0
 	}
 	return int(dur)
+}
+
+func probeAlbum(path string) string {
+	t := playlist.TrackFromPath(path)
+	return t.Album
 }
 
 func albumFromPath(path string) string {

--- a/commands.go
+++ b/commands.go
@@ -583,11 +583,14 @@ func playlistCommand() *cli.Command {
 				Name:      "enrich",
 				Usage:     "probe duration and album metadata for SSH tracks",
 				ArgsUsage: "\"Name\"",
+				Flags: []cli.Flag{
+					&cli.StringFlag{Name: "source", Usage: "source: metadata, path", Value: "path"},
+				},
 				Action: func(ctx context.Context, c *cli.Command) error {
 					if c.Args().Len() == 0 {
-						return fmt.Errorf("usage: cliamp playlist enrich \"Name\"")
+						return fmt.Errorf("usage: cliamp playlist enrich \"Name\" --source metadata")
 					}
-					return cmd.PlaylistEnrich(c.Args().First())
+					return cmd.PlaylistEnrich(c.Args().First(), c.String("source"))
 				},
 			},
 		},

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -159,8 +159,9 @@ cliamp playlist export "Name" --format pls     # export as PLS to stdout
 cliamp playlist import mix.m3u --name "Name"   # import local M3U/M3U8/PLS
 cliamp playlist bookmark "Name" --index 3      # toggle bookmark flag
 cliamp playlist bookmarks                       # list bookmarked tracks
-cliamp playlist enrich "Name"                  # probe duration/album metadata
-cliamp playlist delete "Name"                 # delete entire playlist
+cliamp playlist enrich "Name"                   # probe duration/album 
+cliamp playlist enrich "Name" --from metadata   # probe duration/album (forces to read metadata)
+cliamp playlist delete "Name"                   # delete entire playlist
 ```
 
 Sort keys: `track`, `title`, `artist`, `album`, `artist+album`, `path`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -160,7 +160,7 @@ cliamp playlist import mix.m3u --name "Name"   # import local M3U/M3U8/PLS
 cliamp playlist bookmark "Name" --index 3      # toggle bookmark flag
 cliamp playlist bookmarks                       # list bookmarked tracks
 cliamp playlist enrich "Name"                   # probe duration/album 
-cliamp playlist enrich "Name" --from metadata   # probe duration/album (forces to read metadata)
+cliamp playlist enrich "Name" --source metadata   # probe duration/album (forces to use the file's metadata as source)
 cliamp playlist delete "Name"                   # delete entire playlist
 ```
 


### PR DESCRIPTION
## Summary

This PR adds the option to enrich the album of the element inside the playlist file using the file's metadata instead of its parent folder. 
This feature came to my mind because of the way I organize my songs: it made cliamp enrich my playlists in an undesired way.

## Screenshots / video
Not applicable.

## How to test

1. `go test ./playlist` and `go vet ./playlist`
2. Run the command `cliamp playlist enrich <playlist>`, adding the optional flag `--source` with either `path` or `metadata` at the end of the command (if none is specified, `path` will be the default value, and cliamp will behave as it is currently behaving).

## Checklist

- [x] `make check` passes
- [x] `docs/` and `site/index.html` updated for user-facing changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Playlist enrichment now supports selecting directory paths or probed audio-file metadata.
  * Added a `--source` option, defaulting to `path`, with `metadata` as an alternative.
  * Invalid source values are rejected, and album information is derived from the selected source.
  * The selected source provides more control over how album details are identified during enrichment.

* **Documentation**
  * Updated CLI guidance with playlist enrichment examples and source-selection details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->