### PR TITLE
feat: dynamic directory playlists via [[dir]] sources

### DIFF
--- a/cmd/playlist.go
+++ b/cmd/playlist.go
@@ -129,16 +129,16 @@ func PlaylistCreate(name string, paths []string, sshHost string, dirs []string) 
 
 	if len(dirs) > 0 {
 		if skipped > 0 {
-			fmt.Printf("Created playlist %q with %d directories and %d explicit tracks (%d duplicate skipped).\n", name, len(dirs), added, skipped)
+			fmt.Printf("Created playlist %q with %d director%s and %d explicit track%s (%d duplicate skipped).\n", name, len(dirs), plural(len(dirs)), added, pluralS(added), skipped)
 		} else {
-			fmt.Printf("Created playlist %q with %d directories and %d explicit tracks.\n", name, len(dirs), added)
+			fmt.Printf("Created playlist %q with %d director%s and %d explicit track%s.\n", name, len(dirs), plural(len(dirs)), added, pluralS(added))
 		}
 		return nil
 	}
 	if skipped > 0 {
-		fmt.Printf("Created playlist %q with %d tracks (%d duplicate skipped).\n", name, added, skipped)
+		fmt.Printf("Created playlist %q with %d track%s (%d duplicate skipped).\n", name, added, pluralS(added), skipped)
 	} else {
-		fmt.Printf("Created playlist %q with %d tracks.\n", name, added)
+		fmt.Printf("Created playlist %q with %d track%s.\n", name, added, pluralS(added))
 	}
 	return nil
 }
@@ -239,6 +239,13 @@ func plural(n int) string {
 		return "y"
 	}
 	return "ies"
+}
+
+func pluralS(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
 }
 
 // PlaylistShow displays the tracks in a playlist. If jsonOutput is true,
@@ -534,7 +541,7 @@ func PlaylistBookmark(name string, index int) error {
 
 	tracks, err := prov.Tracks(name)
 	if err != nil {
-		return err
+		return fmt.Errorf("loading playlist %q: %w", name, err)
 	}
 	if index-1 < 0 || index-1 >= len(tracks) {
 		return fmt.Errorf("track index %d out of range (playlist has %d tracks)", index, len(tracks))
@@ -550,7 +557,7 @@ func PlaylistBookmark(name string, index int) error {
 	// match by path rather than by index.
 	tracks, err = prov.Tracks(name)
 	if err != nil {
-		return err
+		return fmt.Errorf("reloading playlist %q: %w", name, err)
 	}
 	for _, t := range tracks {
 		if t.Path == original.Path {

--- a/cmd/playlist.go
+++ b/cmd/playlist.go
@@ -72,20 +72,21 @@ func PlaylistCreate(name string, paths []string, sshHost string, dirs []string) 
 		return nil
 	}
 
-	if len(dirs) > 0 {
+	// Directories-only creation needs no audio collection.
+	if len(paths) == 0 && sshHost == "" {
 		if err := prov.CreateDirPlaylist(name, dirs); err != nil {
 			return fmt.Errorf("creating playlist: %w", err)
 		}
-		if len(paths) == 0 {
-			if len(dirs) == 1 {
-				fmt.Printf("Created playlist %q referencing directory %s.\n", name, dirs[0])
-			} else {
-				fmt.Printf("Created playlist %q referencing %d directories.\n", name, len(dirs))
-			}
-			return nil
+		if len(dirs) == 1 {
+			fmt.Printf("Created playlist %q referencing directory %s.\n", name, dirs[0])
+		} else {
+			fmt.Printf("Created playlist %q referencing %d directories.\n", name, len(dirs))
 		}
+		return nil
 	}
 
+	// Collect explicit audio paths before any mutation, so a failure (no audio
+	// found, invalid directory) leaves no partially-created playlist behind.
 	var audioPaths []string
 	if sshHost != "" {
 		remotePaths, err := sshFindAudio(sshHost, paths)
@@ -116,6 +117,11 @@ func PlaylistCreate(name string, paths []string, sshHost string, dirs []string) 
 	}
 
 	albumAwareSort(tracks)
+	if len(dirs) > 0 {
+		if err := prov.CreateDirPlaylist(name, dirs); err != nil {
+			return fmt.Errorf("creating playlist: %w", err)
+		}
+	}
 	added, skipped, err := prov.AddTracks(name, tracks)
 	if err != nil {
 		return fmt.Errorf("writing playlist: %w", err)
@@ -152,34 +158,34 @@ func PlaylistAdd(name string, paths []string, dirs []string) error {
 		return fmt.Errorf("no files or directories given")
 	}
 
-	addedDirs := 0
-	for _, dir := range dirs {
-		ok, err := prov.AddDirSource(name, dir)
+	// Resolve explicit audio paths before mutating anything.
+	var audioPaths []string
+	if len(paths) > 0 {
+		var err error
+		audioPaths, err = collectLocalAudio(paths)
 		if err != nil {
-			return fmt.Errorf("adding directory %q: %w", dir, err)
+			return err
 		}
-		if ok {
-			addedDirs++
+		if len(audioPaths) == 0 {
+			return fmt.Errorf("no audio files found in %s", strings.Join(paths, ", "))
 		}
 	}
 
-	if len(paths) == 0 {
-		if addedDirs == 0 {
+	// Validate and persist all directory sources in one atomic step.
+	addedDirs, err := prov.AddDirSources(name, dirs)
+	if err != nil {
+		return fmt.Errorf("adding directory sources: %w", err)
+	}
+
+	if len(audioPaths) == 0 {
+		if len(addedDirs) == 0 {
 			fmt.Printf("No new directories added to %q (already present).\n", name)
-		} else if addedDirs == 1 {
-			fmt.Printf("Added directory %q to %q.\n", dirs[0], name)
+		} else if len(addedDirs) == 1 {
+			fmt.Printf("Added directory %q to %q.\n", addedDirs[0], name)
 		} else {
-			fmt.Printf("Added %d directories to %q.\n", addedDirs, name)
+			fmt.Printf("Added %d directories to %q.\n", len(addedDirs), name)
 		}
 		return nil
-	}
-
-	audioPaths, err := collectLocalAudio(paths)
-	if err != nil {
-		return err
-	}
-	if len(audioPaths) == 0 {
-		return fmt.Errorf("no audio files found in %s", strings.Join(paths, ", "))
 	}
 
 	tracks := make([]playlist.Track, len(audioPaths))
@@ -193,8 +199,8 @@ func PlaylistAdd(name string, paths []string, dirs []string) error {
 		return fmt.Errorf("adding tracks: %w", err)
 	}
 
-	if addedDirs > 0 {
-		fmt.Printf("Added %d director%s and %d tracks to %q.\n", addedDirs, plural(addedDirs), added, name)
+	if len(addedDirs) > 0 {
+		fmt.Printf("Added %d director%s and %d tracks to %q.\n", len(addedDirs), plural(len(addedDirs)), added, name)
 	} else if skipped > 0 {
 		fmt.Printf("Added %d tracks to %q (%d duplicate skipped).\n", added, name, skipped)
 	} else {

--- a/cmd/playlist.go
+++ b/cmd/playlist.go
@@ -48,9 +48,11 @@ func PlaylistList() error {
 	return nil
 }
 
-// PlaylistCreate creates a new playlist from the given file and directory paths.
-// If sshHost is non-empty, remote paths are walked via SSH.
-func PlaylistCreate(name string, paths []string, sshHost string) error {
+// PlaylistCreate creates a new playlist. dirs are referenced as [[dir]] sources
+// (scanned at load time) instead of expanding their files; paths are expanded
+// into explicit [[track]] entries. If sshHost is non-empty, paths are walked
+// remotely via SSH and cannot be combined with dirs.
+func PlaylistCreate(name string, paths []string, sshHost string, dirs []string) error {
 	prov, err := newProvider()
 	if err != nil {
 		return err
@@ -59,12 +61,29 @@ func PlaylistCreate(name string, paths []string, sshHost string) error {
 	if prov.Exists(name) {
 		return fmt.Errorf("playlist %q already exists (use `add` to append)", name)
 	}
-	if len(paths) == 0 && sshHost == "" {
+	if sshHost != "" && len(dirs) > 0 {
+		return fmt.Errorf("--dir cannot be combined with --ssh (SSH playlists do not support directory sources)")
+	}
+	if len(paths) == 0 && sshHost == "" && len(dirs) == 0 {
 		if _, err := prov.CreatePlaylist(context.Background(), name); err != nil {
 			return fmt.Errorf("creating playlist: %w", err)
 		}
 		fmt.Printf("Created empty playlist %q.\n", name)
 		return nil
+	}
+
+	if len(dirs) > 0 {
+		if err := prov.CreateDirPlaylist(name, dirs); err != nil {
+			return fmt.Errorf("creating playlist: %w", err)
+		}
+		if len(paths) == 0 {
+			if len(dirs) == 1 {
+				fmt.Printf("Created playlist %q referencing directory %s.\n", name, dirs[0])
+			} else {
+				fmt.Printf("Created playlist %q referencing %d directories.\n", name, len(dirs))
+			}
+			return nil
+		}
 	}
 
 	var audioPaths []string
@@ -102,6 +121,14 @@ func PlaylistCreate(name string, paths []string, sshHost string) error {
 		return fmt.Errorf("writing playlist: %w", err)
 	}
 
+	if len(dirs) > 0 {
+		if skipped > 0 {
+			fmt.Printf("Created playlist %q with %d directories and %d explicit tracks (%d duplicate skipped).\n", name, len(dirs), added, skipped)
+		} else {
+			fmt.Printf("Created playlist %q with %d directories and %d explicit tracks.\n", name, len(dirs), added)
+		}
+		return nil
+	}
 	if skipped > 0 {
 		fmt.Printf("Created playlist %q with %d tracks (%d duplicate skipped).\n", name, added, skipped)
 	} else {
@@ -110,8 +137,9 @@ func PlaylistCreate(name string, paths []string, sshHost string) error {
 	return nil
 }
 
-// PlaylistAdd appends tracks from the given paths to an existing playlist.
-func PlaylistAdd(name string, paths []string) error {
+// PlaylistAdd appends tracks from the given paths and/or directory sources to
+// an existing playlist.
+func PlaylistAdd(name string, paths []string, dirs []string) error {
 	prov, err := newProvider()
 	if err != nil {
 		return err
@@ -119,6 +147,31 @@ func PlaylistAdd(name string, paths []string) error {
 
 	if !prov.Exists(name) {
 		return fmt.Errorf("playlist %q not found", name)
+	}
+	if len(paths) == 0 && len(dirs) == 0 {
+		return fmt.Errorf("no files or directories given")
+	}
+
+	addedDirs := 0
+	for _, dir := range dirs {
+		ok, err := prov.AddDirSource(name, dir)
+		if err != nil {
+			return fmt.Errorf("adding directory %q: %w", dir, err)
+		}
+		if ok {
+			addedDirs++
+		}
+	}
+
+	if len(paths) == 0 {
+		if addedDirs == 0 {
+			fmt.Printf("No new directories added to %q (already present).\n", name)
+		} else if addedDirs == 1 {
+			fmt.Printf("Added directory %q to %q.\n", dirs[0], name)
+		} else {
+			fmt.Printf("Added %d directories to %q.\n", addedDirs, name)
+		}
+		return nil
 	}
 
 	audioPaths, err := collectLocalAudio(paths)
@@ -140,12 +193,46 @@ func PlaylistAdd(name string, paths []string) error {
 		return fmt.Errorf("adding tracks: %w", err)
 	}
 
-	if skipped > 0 {
+	if addedDirs > 0 {
+		fmt.Printf("Added %d director%s and %d tracks to %q.\n", addedDirs, plural(addedDirs), added, name)
+	} else if skipped > 0 {
 		fmt.Printf("Added %d tracks to %q (%d duplicate skipped).\n", added, name, skipped)
 	} else {
 		fmt.Printf("Added %d tracks to %q.\n", added, name)
 	}
 	return nil
+}
+
+// PlaylistDirs lists the directory sources referenced by a playlist.
+func PlaylistDirs(name string) error {
+	prov, err := newProvider()
+	if err != nil {
+		return err
+	}
+	dirs, err := prov.DirSources(name)
+	if err != nil {
+		return fmt.Errorf("loading playlist %q: %w", name, err)
+	}
+	if len(dirs) == 0 {
+		fmt.Printf("Playlist %q has no directory sources.\n", name)
+		return nil
+	}
+	fmt.Printf("Directory sources for %q:\n", name)
+	for i, src := range dirs {
+		mode := "recursive"
+		if !src.Recursive {
+			mode = "non-recursive"
+		}
+		fmt.Printf("  %d. %s (%s)\n", i+1, src.Path, mode)
+	}
+	return nil
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return "y"
+	}
+	return "ies"
 }
 
 // PlaylistShow displays the tracks in a playlist. If jsonOutput is true,
@@ -307,6 +394,9 @@ func PlaylistSort(name, by string) error {
 		return fmt.Errorf("saving playlist %q: %w", name, err)
 	}
 	fmt.Printf("Sorted %q by %s.\n", name, normalizeSortKey(by))
+	if dirs, _ := prov.DirSources(name); len(dirs) > 0 {
+		fmt.Println("Note: directory-sourced tracks reload in directory scan order on the next load.")
+	}
 	return nil
 }
 
@@ -436,24 +526,37 @@ func PlaylistBookmark(name string, index int) error {
 		return err
 	}
 
-	if err := prov.SetBookmark(name, index-1); err != nil {
-		return fmt.Errorf("toggling bookmark: %w", err)
-	}
-
 	tracks, err := prov.Tracks(name)
 	if err != nil {
 		return err
 	}
 	if index-1 < 0 || index-1 >= len(tracks) {
-		return fmt.Errorf("track %d no longer exists in playlist (now has %d tracks)", index, len(tracks))
+		return fmt.Errorf("track index %d out of range (playlist has %d tracks)", index, len(tracks))
 	}
-	t := tracks[index-1]
-	if t.Bookmark {
-		fmt.Printf("★ %s\n", t.DisplayName())
-	} else {
-		fmt.Printf("☆ %s\n", t.DisplayName())
+	original := tracks[index-1]
+
+	if err := prov.SetBookmark(name, index-1); err != nil {
+		return fmt.Errorf("toggling bookmark: %w", err)
 	}
-	return nil
+
+	// Reload and report the toggled track. Bookmarking a directory-sourced
+	// track materializes it, which can move it within the expanded list, so
+	// match by path rather than by index.
+	tracks, err = prov.Tracks(name)
+	if err != nil {
+		return err
+	}
+	for _, t := range tracks {
+		if t.Path == original.Path {
+			if t.Bookmark {
+				fmt.Printf("★ %s\n", t.DisplayName())
+			} else {
+				fmt.Printf("☆ %s\n", t.DisplayName())
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("track %d no longer exists in playlist (now has %d tracks)", index, len(tracks))
 }
 
 // PlaylistBookmarks lists all bookmarked tracks across all playlists.
@@ -503,7 +606,12 @@ func PlaylistEnrich(name string) error {
 	}
 
 	updated := 0
+	dirSourced := 0
 	for i, t := range tracks {
+		if t.DirSourced {
+			dirSourced++
+			continue
+		}
 		changed := false
 
 		if t.DurationSecs == 0 {
@@ -528,7 +636,11 @@ func PlaylistEnrich(name string) error {
 	}
 
 	if updated == 0 {
-		fmt.Println("All tracks already enriched.")
+		if dirSourced > 0 {
+			fmt.Println("All explicit tracks already enriched; directory-sourced tracks are read from their files at load time.")
+		} else {
+			fmt.Println("All tracks already enriched.")
+		}
 		return nil
 	}
 
@@ -536,6 +648,10 @@ func PlaylistEnrich(name string) error {
 		return fmt.Errorf("saving playlist %q: %w", name, err)
 	}
 
+	if dirSourced > 0 {
+		fmt.Printf("Enriched %d tracks in %q (%d directory-sourced tracks left to their files).\n", updated, name, dirSourced)
+		return nil
+	}
 	fmt.Printf("Enriched %d tracks in %q.\n", updated, name)
 	return nil
 }

--- a/cmd/playlist_dirs_test.go
+++ b/cmd/playlist_dirs_test.go
@@ -166,3 +166,67 @@ func TestPlaylistBookmarkMaterializesDirTrack(t *testing.T) {
 		t.Errorf("PlaylistBookmarks = %q, want 1 bookmark", out)
 	}
 }
+
+func TestPlaylistCreateNoPartialWhenNoAudio(t *testing.T) {
+	setupTestEnv(t)
+	audio := t.TempDir()
+	writeAudioFile(t, audio+"/a.mp3")
+	empty := t.TempDir()
+
+	// Audio collection fails before the playlist is created, so a dirs+paths
+	// create with no audio must leave nothing behind.
+	if err := PlaylistCreate("mix", []string{empty}, "", []string{audio}); err == nil {
+		t.Fatal("create with no audio should fail")
+	}
+	p, err := newProvider()
+	if err != nil {
+		t.Fatalf("newProvider: %v", err)
+	}
+	if p.Exists("mix") {
+		t.Fatal("failed create left a playlist behind")
+	}
+}
+
+func TestPlaylistAddDirNoPartialWhenAudioFails(t *testing.T) {
+	setupTestEnv(t)
+	audio := t.TempDir()
+	writeAudioFile(t, audio+"/a.mp3")
+	if err := PlaylistCreate("mix", nil, "", nil); err != nil {
+		t.Fatalf("PlaylistCreate: %v", err)
+	}
+
+	// The bad path fails audio collection before any directory is added.
+	bad := t.TempDir()
+	if err := PlaylistAdd("mix", []string{bad}, []string{audio}); err == nil {
+		t.Fatal("add with no audio should fail")
+	}
+	out, err := captureStdout(t, func() error { return PlaylistDirs("mix") })
+	if err != nil {
+		t.Fatalf("PlaylistDirs: %v", err)
+	}
+	if !strings.Contains(out, "no directory sources") {
+		t.Fatalf("directory source persisted despite failed add: %q", out)
+	}
+}
+
+func TestPlaylistAddDirBatchAtomic(t *testing.T) {
+	setupTestEnv(t)
+	audio := t.TempDir()
+	writeAudioFile(t, audio+"/a.mp3")
+	if err := PlaylistCreate("mix", nil, "", nil); err != nil {
+		t.Fatalf("PlaylistCreate: %v", err)
+	}
+
+	valid := t.TempDir()
+	missing := t.TempDir() + "/missing"
+	if err := PlaylistAdd("mix", nil, []string{valid, missing}); err == nil {
+		t.Fatal("add with missing dir should fail")
+	}
+	out, err := captureStdout(t, func() error { return PlaylistDirs("mix") })
+	if err != nil {
+		t.Fatalf("PlaylistDirs: %v", err)
+	}
+	if !strings.Contains(out, "no directory sources") {
+		t.Fatalf("valid dir persisted despite failing batch: %q", out)
+	}
+}

--- a/cmd/playlist_dirs_test.go
+++ b/cmd/playlist_dirs_test.go
@@ -1,0 +1,168 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPlaylistCreateWithDirSource(t *testing.T) {
+	setupTestEnv(t)
+	audio := t.TempDir()
+	writeAudioFile(t, audio+"/a.mp3")
+	writeAudioFile(t, audio+"/b.flac")
+
+	out, err := captureStdout(t, func() error { return PlaylistCreate("Music", nil, "", []string{audio}) })
+	if err != nil {
+		t.Fatalf("PlaylistCreate --dir: %v", err)
+	}
+	if !strings.Contains(out, "referencing directory") {
+		t.Errorf("output = %q, want 'referencing directory'", out)
+	}
+
+	// The playlist must reference the directory rather than expand files.
+	if out, err := captureStdout(t, func() error { return PlaylistDirs("Music") }); err != nil {
+		t.Fatalf("PlaylistDirs: %v", err)
+	} else if !strings.Contains(out, audio) {
+		t.Errorf("PlaylistDirs = %q, want %q", out, audio)
+	}
+
+	// Tracks resolve dynamically.
+	out, err = captureStdout(t, func() error { return PlaylistShow("Music", false) })
+	if err != nil {
+		t.Fatalf("PlaylistShow: %v", err)
+	}
+	if !strings.Contains(out, "2 tracks") {
+		t.Errorf("PlaylistShow = %q, want 2 tracks", out)
+	}
+
+	// Recreate must fail.
+	if err := PlaylistCreate("Music", nil, "", []string{audio}); err == nil {
+		t.Fatal("recreating existing playlist should fail")
+	}
+}
+
+func TestPlaylistCreateDirMissingDirFails(t *testing.T) {
+	setupTestEnv(t)
+	err := PlaylistCreate("bad", nil, "", []string{t.TempDir() + "/missing"})
+	if err == nil {
+		t.Fatal("PlaylistCreate --dir with missing directory should fail")
+	}
+}
+
+func TestPlaylistCreateDirWithSSHFails(t *testing.T) {
+	setupTestEnv(t)
+	audio := t.TempDir()
+	writeAudioFile(t, audio+"/a.mp3")
+	err := PlaylistCreate("mix", []string{audio}, "host", []string{audio})
+	if err == nil || !strings.Contains(err.Error(), "--dir cannot be combined with --ssh") {
+		t.Fatalf("expected --dir/--ssh conflict, got: %v", err)
+	}
+}
+
+func TestPlaylistCreateDirPlusExplicitTracks(t *testing.T) {
+	setupTestEnv(t)
+	audio := t.TempDir()
+	writeAudioFile(t, audio+"/a.mp3")
+	outside := t.TempDir()
+	writeAudioFile(t, outside+"/b.mp3")
+
+	out, err := captureStdout(t, func() error {
+		return PlaylistCreate("mix", []string{outside}, "", []string{audio})
+	})
+	if err != nil {
+		t.Fatalf("PlaylistCreate mixed: %v", err)
+	}
+	if !strings.Contains(out, "1 directories and 1 explicit tracks") {
+		t.Errorf("output = %q, want mixed count", out)
+	}
+	if out, err := captureStdout(t, func() error { return PlaylistShow("mix", false) }); err != nil {
+		t.Fatalf("PlaylistShow: %v", err)
+	} else if !strings.Contains(out, "2 tracks") {
+		t.Errorf("PlaylistShow = %q, want 2 tracks", out)
+	}
+}
+
+func TestPlaylistAddDirSource(t *testing.T) {
+	setupTestEnv(t)
+	audio := t.TempDir()
+	writeAudioFile(t, audio+"/a.mp3")
+	if err := PlaylistCreate("empty", nil, "", nil); err != nil {
+		t.Fatalf("PlaylistCreate: %v", err)
+	}
+
+	out, err := captureStdout(t, func() error { return PlaylistAdd("empty", nil, []string{audio}) })
+	if err != nil {
+		t.Fatalf("PlaylistAdd --dir: %v", err)
+	}
+	if !strings.Contains(out, "Added directory") {
+		t.Errorf("output = %q, want 'Added directory'", out)
+	}
+
+	// Adding the same directory again reports it as already present.
+	out, err = captureStdout(t, func() error { return PlaylistAdd("empty", nil, []string{audio}) })
+	if err != nil {
+		t.Fatalf("PlaylistAdd duplicate: %v", err)
+	}
+	if !strings.Contains(out, "No new directories") {
+		t.Errorf("output = %q, want 'No new directories'", out)
+	}
+}
+
+func TestPlaylistAddDirToMissingPlaylistFails(t *testing.T) {
+	setupTestEnv(t)
+	err := PlaylistAdd("ghost", nil, []string{t.TempDir()})
+	if err == nil {
+		t.Fatal("PlaylistAdd --dir to missing playlist should fail")
+	}
+}
+
+func TestPlaylistDirsNone(t *testing.T) {
+	setupTestEnv(t)
+	if err := PlaylistCreate("plain", nil, "", nil); err != nil {
+		t.Fatalf("PlaylistCreate: %v", err)
+	}
+	out, err := captureStdout(t, func() error { return PlaylistDirs("plain") })
+	if err != nil {
+		t.Fatalf("PlaylistDirs: %v", err)
+	}
+	if !strings.Contains(out, "no directory sources") {
+		t.Errorf("output = %q, want 'no directory sources'", out)
+	}
+}
+
+func TestPlaylistRemoveDirSourcedTrackFails(t *testing.T) {
+	setupTestEnv(t)
+	audio := t.TempDir()
+	writeAudioFile(t, audio+"/a.mp3")
+	if err := PlaylistCreate("Music", nil, "", []string{audio}); err != nil {
+		t.Fatalf("PlaylistCreate: %v", err)
+	}
+	err := PlaylistRemove("Music", 1)
+	if err == nil || !strings.Contains(err.Error(), "directory source") {
+		t.Fatalf("expected dir-source removal error, got: %v", err)
+	}
+}
+
+func TestPlaylistBookmarkMaterializesDirTrack(t *testing.T) {
+	setupTestEnv(t)
+	audio := t.TempDir()
+	writeAudioFile(t, audio+"/a.mp3")
+	if err := PlaylistCreate("Music", nil, "", []string{audio}); err != nil {
+		t.Fatalf("PlaylistCreate: %v", err)
+	}
+	out, err := captureStdout(t, func() error { return PlaylistBookmark("Music", 1) })
+	if err != nil {
+		t.Fatalf("PlaylistBookmark: %v", err)
+	}
+	if !strings.Contains(out, "★") {
+		t.Errorf("output = %q, want bookmarked marker", out)
+	}
+	// The bookmark persists after reload because the track was materialized.
+	out, err = captureStdout(t, func() error { return PlaylistBookmarks() })
+	if err != nil {
+		t.Fatalf("PlaylistBookmarks: %v", err)
+	}
+	if !strings.Contains(out, "1 bookmarks") {
+		t.Errorf("PlaylistBookmarks = %q, want 1 bookmark", out)
+	}
+}

--- a/cmd/playlist_dirs_test.go
+++ b/cmd/playlist_dirs_test.go
@@ -72,7 +72,7 @@ func TestPlaylistCreateDirPlusExplicitTracks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PlaylistCreate mixed: %v", err)
 	}
-	if !strings.Contains(out, "1 directories and 1 explicit tracks") {
+	if !strings.Contains(out, "1 directory and 1 explicit track") {
 		t.Errorf("output = %q, want mixed count", out)
 	}
 	if out, err := captureStdout(t, func() error { return PlaylistShow("mix", false) }); err != nil {

--- a/cmd/playlist_ops_test.go
+++ b/cmd/playlist_ops_test.go
@@ -74,7 +74,7 @@ func TestPlaylistCreateAndList(t *testing.T) {
 
 	// Create
 	out, err := captureStdout(t, func() error {
-		return PlaylistCreate("mymix", []string{audioDir}, "")
+		return PlaylistCreate("mymix", []string{audioDir}, "", nil)
 	})
 	if err != nil {
 		t.Fatalf("PlaylistCreate: %v", err)
@@ -103,7 +103,7 @@ func TestPlaylistCreateNoAudio(t *testing.T) {
 		t.Fatalf("MkdirAll: %v", err)
 	}
 
-	err := PlaylistCreate("nothing", []string{emptyDir}, "")
+	err := PlaylistCreate("nothing", []string{emptyDir}, "", nil)
 	if err == nil {
 		t.Fatal("PlaylistCreate with no audio should error")
 	}
@@ -116,7 +116,7 @@ func TestPlaylistCreateEmpty(t *testing.T) {
 	setupTestEnv(t)
 
 	out, err := captureStdout(t, func() error {
-		return PlaylistCreate("empty", nil, "")
+		return PlaylistCreate("empty", nil, "", nil)
 	})
 	if err != nil {
 		t.Fatalf("PlaylistCreate empty: %v", err)
@@ -138,10 +138,10 @@ func TestPlaylistCreateDuplicate(t *testing.T) {
 	audio := filepath.Join(home, "a.mp3")
 	writeAudioFile(t, audio)
 
-	if err := PlaylistCreate("dup", []string{audio}, ""); err != nil {
+	if err := PlaylistCreate("dup", []string{audio}, "", nil); err != nil {
 		t.Fatalf("first PlaylistCreate: %v", err)
 	}
-	err := PlaylistCreate("dup", []string{audio}, "")
+	err := PlaylistCreate("dup", []string{audio}, "", nil)
 	if err == nil {
 		t.Error("duplicate create should error")
 	}
@@ -157,11 +157,11 @@ func TestPlaylistAddAppends(t *testing.T) {
 	writeAudioFile(t, a)
 	writeAudioFile(t, b)
 
-	if err := PlaylistCreate("mix", []string{a}, ""); err != nil {
+	if err := PlaylistCreate("mix", []string{a}, "", nil); err != nil {
 		t.Fatalf("PlaylistCreate: %v", err)
 	}
 
-	if err := PlaylistAdd("mix", []string{b}); err != nil {
+	if err := PlaylistAdd("mix", []string{b}, nil); err != nil {
 		t.Fatalf("PlaylistAdd: %v", err)
 	}
 
@@ -176,10 +176,10 @@ func TestPlaylistAddSkipsDuplicates(t *testing.T) {
 	a := filepath.Join(home, "a.mp3")
 	writeAudioFile(t, a)
 
-	if err := PlaylistCreate("mix", []string{a}, ""); err != nil {
+	if err := PlaylistCreate("mix", []string{a}, "", nil); err != nil {
 		t.Fatalf("PlaylistCreate: %v", err)
 	}
-	out, err := captureStdout(t, func() error { return PlaylistAdd("mix", []string{a}) })
+	out, err := captureStdout(t, func() error { return PlaylistAdd("mix", []string{a}, nil) })
 	if err != nil {
 		t.Fatalf("PlaylistAdd duplicate: %v", err)
 	}
@@ -193,7 +193,7 @@ func TestPlaylistAddNonExistent(t *testing.T) {
 	a := filepath.Join(home, "a.mp3")
 	writeAudioFile(t, a)
 
-	err := PlaylistAdd("ghost", []string{a})
+	err := PlaylistAdd("ghost", []string{a}, nil)
 	if err == nil {
 		t.Error("PlaylistAdd on non-existent playlist should error")
 	}
@@ -211,7 +211,7 @@ func TestPlaylistShowJSON(t *testing.T) {
 	home := setupTestEnv(t)
 	audio := filepath.Join(home, "a.mp3")
 	writeAudioFile(t, audio)
-	if err := PlaylistCreate("mix", []string{audio}, ""); err != nil {
+	if err := PlaylistCreate("mix", []string{audio}, "", nil); err != nil {
 		t.Fatalf("PlaylistCreate: %v", err)
 	}
 
@@ -233,7 +233,7 @@ func TestPlaylistRemove(t *testing.T) {
 	b := filepath.Join(home, "b.mp3")
 	writeAudioFile(t, a)
 	writeAudioFile(t, b)
-	if err := PlaylistCreate("mix", []string{a, b}, ""); err != nil {
+	if err := PlaylistCreate("mix", []string{a, b}, "", nil); err != nil {
 		t.Fatalf("PlaylistCreate: %v", err)
 	}
 
@@ -251,7 +251,7 @@ func TestPlaylistRemoveOutOfRange(t *testing.T) {
 	home := setupTestEnv(t)
 	a := filepath.Join(home, "a.mp3")
 	writeAudioFile(t, a)
-	if err := PlaylistCreate("mix", []string{a}, ""); err != nil {
+	if err := PlaylistCreate("mix", []string{a}, "", nil); err != nil {
 		t.Fatalf("PlaylistCreate: %v", err)
 	}
 
@@ -265,7 +265,7 @@ func TestPlaylistDelete(t *testing.T) {
 	home := setupTestEnv(t)
 	audio := filepath.Join(home, "a.mp3")
 	writeAudioFile(t, audio)
-	if err := PlaylistCreate("todelete", []string{audio}, ""); err != nil {
+	if err := PlaylistCreate("todelete", []string{audio}, "", nil); err != nil {
 		t.Fatalf("PlaylistCreate: %v", err)
 	}
 
@@ -291,7 +291,7 @@ func TestPlaylistRename(t *testing.T) {
 	home := setupTestEnv(t)
 	a := filepath.Join(home, "a.mp3")
 	writeAudioFile(t, a)
-	if err := PlaylistCreate("old", []string{a}, ""); err != nil {
+	if err := PlaylistCreate("old", []string{a}, "", nil); err != nil {
 		t.Fatalf("PlaylistCreate: %v", err)
 	}
 	if err := PlaylistRename("old", "new"); err != nil {
@@ -311,7 +311,7 @@ func TestPlaylistDedupeAndSort(t *testing.T) {
 	b := filepath.Join(home, "b.mp3")
 	writeAudioFile(t, a)
 	writeAudioFile(t, b)
-	if err := PlaylistCreate("mix", nil, ""); err != nil {
+	if err := PlaylistCreate("mix", nil, "", nil); err != nil {
 		t.Fatalf("PlaylistCreate empty: %v", err)
 	}
 	p, err := newProvider()
@@ -341,7 +341,7 @@ func TestPlaylistDoctorFixPrunesMissing(t *testing.T) {
 	a := filepath.Join(home, "a.mp3")
 	missing := filepath.Join(home, "missing.mp3")
 	writeAudioFile(t, a)
-	if err := PlaylistCreate("mix", nil, ""); err != nil {
+	if err := PlaylistCreate("mix", nil, "", nil); err != nil {
 		t.Fatalf("PlaylistCreate empty: %v", err)
 	}
 	p, err := newProvider()
@@ -413,7 +413,7 @@ func TestPlaylistBookmarkToggle(t *testing.T) {
 	home := setupTestEnv(t)
 	audio := filepath.Join(home, "a.mp3")
 	writeAudioFile(t, audio)
-	if err := PlaylistCreate("mix", []string{audio}, ""); err != nil {
+	if err := PlaylistCreate("mix", []string{audio}, "", nil); err != nil {
 		t.Fatalf("PlaylistCreate: %v", err)
 	}
 
@@ -451,7 +451,7 @@ func TestPlaylistBookmarksShowsStars(t *testing.T) {
 	home := setupTestEnv(t)
 	audio := filepath.Join(home, "a.mp3")
 	writeAudioFile(t, audio)
-	if err := PlaylistCreate("mix", []string{audio}, ""); err != nil {
+	if err := PlaylistCreate("mix", []string{audio}, "", nil); err != nil {
 		t.Fatalf("PlaylistCreate: %v", err)
 	}
 	// Bookmark (captureStdout silences the toggle output).

--- a/commands.go
+++ b/commands.go
@@ -413,10 +413,11 @@ func playlistCommand() *cli.Command {
 			},
 			{
 				Name:      "create",
-				Usage:     "create a new playlist, optionally from files/directories",
+				Usage:     "create a new playlist, optionally from files/directories or directory sources",
 				ArgsUsage: "\"Name\" [file|dir ...]",
 				Flags: []cli.Flag{
 					&cli.StringFlag{Name: "ssh", Usage: "SSH host for remote directory walking"},
+					&cli.StringSliceFlag{Name: "dir", Usage: "reference a directory as a [[dir]] source (repeatable)"},
 				},
 				Action: func(ctx context.Context, c *cli.Command) error {
 					if c.Args().Len() == 0 {
@@ -424,7 +425,7 @@ func playlistCommand() *cli.Command {
 					}
 					name := c.Args().First()
 					paths := c.Args().Slice()[1:]
-					return cmd.PlaylistCreate(name, paths, c.String("ssh"))
+					return cmd.PlaylistCreate(name, paths, c.String("ssh"), c.StringSlice("dir"))
 				},
 			},
 			{
@@ -441,13 +442,29 @@ func playlistCommand() *cli.Command {
 			},
 			{
 				Name:      "add",
-				Usage:     "append tracks to an existing playlist",
-				ArgsUsage: "\"Name\" <file|dir> [...]",
+				Usage:     "append tracks or directory sources to an existing playlist",
+				ArgsUsage: "\"Name\" [file|dir ...]",
+				Flags: []cli.Flag{
+					&cli.StringSliceFlag{Name: "dir", Usage: "add a directory as a [[dir]] source (repeatable)"},
+				},
 				Action: func(ctx context.Context, c *cli.Command) error {
-					if c.Args().Len() < 2 {
-						return fmt.Errorf("usage: cliamp playlist add \"Name\" file1 [file2 ...]")
+					if c.Args().Len() == 0 {
+						return fmt.Errorf("usage: cliamp playlist add \"Name\" file1 [file2 ...] [--dir dir]")
 					}
-					return cmd.PlaylistAdd(c.Args().First(), c.Args().Slice()[1:])
+					name := c.Args().First()
+					paths := c.Args().Slice()[1:]
+					return cmd.PlaylistAdd(name, paths, c.StringSlice("dir"))
+				},
+			},
+			{
+				Name:      "dirs",
+				Usage:     "list directory sources referenced by a playlist",
+				ArgsUsage: "\"Name\"",
+				Action: func(ctx context.Context, c *cli.Command) error {
+					if c.Args().Len() == 0 {
+						return fmt.Errorf("usage: cliamp playlist dirs \"Name\"")
+					}
+					return cmd.PlaylistDirs(c.Args().First())
 				},
 			},
 			{

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -145,7 +145,10 @@ cliamp playlist list                          # list playlists with track counts
 cliamp playlist create "Name"                 # create an empty playlist
 cliamp playlist create "Name" file1 dir/ ...  # create from files/folders (recursive, skips duplicate paths)
 cliamp playlist create "Name" --ssh HOST dir/ # create from remote machine via SSH
+cliamp playlist create "Name" --dir ~/Music   # reference a directory as a [[dir]] source (scanned at load)
 cliamp playlist add "Name" file1 ...          # append tracks to existing playlist, skipping duplicates
+cliamp playlist add "Name" --dir ~/Music      # add another directory source
+cliamp playlist dirs "Name"                   # list directory sources
 cliamp playlist rename "Old" "New"            # rename a playlist
 cliamp playlist show "Name"                   # display tracks
 cliamp playlist show "Name" --json            # machine-readable output

--- a/docs/playlists.md
+++ b/docs/playlists.md
@@ -94,6 +94,49 @@ Each `[[track]]` section supports:
 
 HTTP/HTTPS paths are automatically treated as streams.
 
+### Directory Sources (`[[dir]]`)
+
+Instead of listing every file, a playlist can reference a directory that is
+scanned for audio files every time the playlist loads. The directory is read
+at load time, so new files show up automatically and removed files disappear:
+
+```toml
+# ~/.config/cliamp/playlists/music.toml
+
+[[dir]]
+path = "~/Music"
+
+[[track]]
+path = "https://radio.example.com/stream"
+title = "My Radio"
+```
+
+Each `[[dir]]` section supports:
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `path` | Yes | Directory path; `~` and environment variables are expanded |
+| `recursive` | No | Scan subdirectories too (default `true`) |
+
+Directory-sourced tracks are returned in document order, sorted by path within
+each directory. An explicit `[[track]]` with the same path always wins over a
+directory scan, so you can pin a bookmark or custom metadata onto a specific
+file. Bookmarking a directory-sourced track (TUI `f` or
+`cliamp playlist bookmark`) materializes it as an explicit `[[track]]` entry so
+the bookmark survives. Unreadable or missing directories contribute no tracks.
+
+Use `--dir` to create or extend such playlists from the CLI:
+
+```sh
+cliamp playlist create "Music" --dir ~/Music
+cliamp playlist add "Music" --dir ~/Downloads/live
+cliamp playlist dirs "Music"               # list referenced directories
+```
+
+`--dir` cannot be combined with `--ssh`. Removing a directory-sourced track
+(CLI or TUI) is refused, since the file is owned by the directory source;
+delete the file from the directory or edit the `[[dir]]` section instead.
+
 ### Podcast / RSS Feed Playlists
 
 You can save podcast RSS feed URLs in a playlist. Add `feed = true` to mark a track as a feed. When played, the feed is resolved into individual episodes instead of being streamed directly.
@@ -176,7 +219,10 @@ Manage local TOML playlists without opening the TUI:
 cliamp playlist list
 cliamp playlist create "Name"                    # create an empty playlist
 cliamp playlist create "Name" file1 dir/ ...     # create from files/folders
+cliamp playlist create "Name" --dir ~/Music      # reference a directory dynamically
 cliamp playlist add "Name" file1 dir/ ...        # append, skipping duplicate paths
+cliamp playlist add "Name" --dir ~/Music         # add another directory source
+cliamp playlist dirs "Name"                      # list directory sources
 cliamp playlist rename "Old" "New"
 cliamp playlist dedupe "Name"
 cliamp playlist sort "Name" --by artist+album

--- a/docs/playlists.md
+++ b/docs/playlists.md
@@ -52,11 +52,20 @@ If `radio.m3u` is in `~/playlists/`, then `../Music/song.mp3` resolves to `~/Mus
 
 ## Local TOML Playlists
 
-Create and manage your own playlists stored as `.toml` files in `~/.config/cliamp/playlists/`.
+Create and manage your own playlists stored as `.toml` files in `~/.config/cliamp/playlists/`. (The folder follows cliamp's config-dir resolution: `CLIAMP_CONFIG_DIR`, then `XDG_CONFIG_HOME/cliamp`, then `HOME/.config/cliamp`.)
 
 ### File Format
 
-Each playlist is a separate `.toml` file. The filename (minus extension) becomes the playlist name. Empty playlists are kept on disk so they remain visible in the TUI and CLI.
+Each playlist is a separate `.toml` file, and every file in the `playlists/` folder is picked up automatically — whether created by the CLI or written by hand. The filename (minus extension) becomes the playlist name:
+
+```
+~/.config/cliamp/playlists/
+├── radio-stations.toml   → playlist "radio-stations"
+├── music.toml            → playlist "music"
+└── gym.toml              → playlist "gym"
+```
+
+Keep one file per collection; mix hand-written and CLI-created files freely. Empty playlists are kept on disk so they remain visible in the TUI and CLI.
 
 ```toml
 # ~/.config/cliamp/playlists/radio-stations.toml

--- a/docs/playlists.md
+++ b/docs/playlists.md
@@ -56,9 +56,9 @@ Create and manage your own playlists stored as `.toml` files in `~/.config/cliam
 
 ### File Format
 
-Each playlist is a separate `.toml` file, and every file in the `playlists/` folder is picked up automatically — whether created by the CLI or written by hand. The filename (minus extension) becomes the playlist name:
+Each playlist is a separate `.toml` file, and every file in the `playlists/` folder with a `.toml` extension (case-insensitive) is picked up automatically — whether created by the CLI or written by hand. Files that fail to parse are skipped. The filename (minus extension) becomes the playlist name:
 
-```
+```text
 ~/.config/cliamp/playlists/
 ├── radio-stations.toml   → playlist "radio-stations"
 ├── music.toml            → playlist "music"
@@ -171,8 +171,8 @@ path = "https://radio.example.com/stream"
 title = "My Radio"
 ```
 
-Or spread the tracks and directories across many files — every file in the
-`playlists/` folder becomes its own playlist:
+Or spread the tracks and directories across many files — every `.toml` file in
+the `playlists/` folder becomes its own playlist:
 
 ```toml
 # ~/.config/cliamp/playlists/gym.toml

--- a/docs/playlists.md
+++ b/docs/playlists.md
@@ -146,6 +146,72 @@ cliamp playlist dirs "Music"               # list referenced directories
 (CLI or TUI) is refused, since the file is owned by the directory source;
 delete the file from the directory or edit the `[[dir]]` section instead.
 
+### Adding Files and Directories
+
+A playlist file can hold any number of `[[track]]` and `[[dir]]` sections,
+mixed freely. This single `mix.toml` combines two directory sources, two
+absolute file paths, and a stream URL:
+
+```toml
+# ~/.config/cliamp/playlists/mix.toml
+
+[[dir]]
+path = "~/Music"
+
+[[track]]
+path = "/home/user/Downloads/live-set.mp3"
+title = "Live Set"
+
+[[dir]]
+path = "~/Downloads/podcasts"
+recursive = false
+
+[[track]]
+path = "https://radio.example.com/stream"
+title = "My Radio"
+```
+
+Or spread the tracks and directories across many files — every file in the
+`playlists/` folder becomes its own playlist:
+
+```toml
+# ~/.config/cliamp/playlists/gym.toml
+
+[[dir]]
+path = "~/Music/gym"
+
+[[track]]
+path = "/home/user/Documents/warmup.mp3"
+title = "Warmup"
+```
+
+```toml
+# ~/.config/cliamp/playlists/chill.toml
+
+[[track]]
+path = "/home/user/Downloads/chill-lofi.mp3"
+title = "Lofi"
+```
+
+The same playlists can be built from the command line without editing files.
+Positional paths are expanded into `[[track]]` entries; `--dir` keeps a live
+directory reference that re-scans on every load:
+
+```sh
+cliamp playlist create "mix" ~/Downloads/live-set.mp3 --dir ~/Music --dir ~/Downloads/podcasts
+cliamp playlist create "gym" ~/Documents/warmup.mp3 --dir ~/Music/gym
+cliamp playlist create "chill" ~/Downloads/chill-lofi.mp3
+```
+
+Append more files and directories to an existing playlist at any time:
+
+```sh
+cliamp playlist add "mix" another-track.mp3 --dir ~/Downloads/live
+```
+
+Note that `recursive = false` has no CLI flag — set it by editing the
+playlist file's `[[dir]]` section.
+
 ### Podcast / RSS Feed Playlists
 
 You can save podcast RSS feed URLs in a playlist. Add `feed = true` to mark a track as a feed. When played, the feed is resolved into individual episodes instead of being streamed directly.

--- a/external/local/dirs.go
+++ b/external/local/dirs.go
@@ -205,8 +205,9 @@ func rebuildDoc(existing *playlistDoc, explicit []playlist.Track) (tracks []play
 		}
 	}
 	if len(leftovers) > 0 {
-		// Map each dir to its section position, and each file to the first
-		// directory (in document order) that supplies it.
+		// Map each dir to its section position. dirPos tracks where the next
+		// leftover for that directory must be inserted: directly before the
+		// directory section.
 		dirPos := make(map[int]int, len(existing.dirs))
 		di := 0
 		for si, sec := range sections {
@@ -215,33 +216,38 @@ func rebuildDoc(existing *playlistDoc, explicit []playlist.Track) (tracks []play
 				di++
 			}
 		}
-		supplier := make(map[string]int)
-		di = 0
-		for _, src := range existing.dirs {
-			files, err := resolve.AudioFiles(ExpandPath(src.Path), src.Recursive)
-			if err == nil {
-				for _, f := range files {
-					if _, ok := supplier[f]; !ok {
-						supplier[f] = di
-					}
+		// supplierOf returns the first directory (in document order) that would
+		// supply file in a scan. It is a pure path check, so saves never
+		// re-walk the filesystem that the load already scanned.
+		supplierOf := func(file string) (int, bool) {
+			for di, src := range existing.dirs {
+				if dirSuppliesFile(src, file) {
+					return di, true
 				}
 			}
-			di++
+			return 0, false
 		}
 		// Insert before-dir leftovers in reverse so several targeting the same
 		// directory keep their caller order.
 		for i := len(leftovers) - 1; i >= 0; i-- {
 			t := leftovers[i]
-			if d, ok := supplier[t.Path]; ok {
+			if d, ok := supplierOf(t.Path); ok {
 				pos := dirPos[d]
 				sections = append(sections, playlistSection{})
 				copy(sections[pos+1:], sections[pos:])
 				sections[pos] = playlistSection{kind: itemTrack, track: t}
+				// The insertion shifted every later section by one; re-align
+				// the map so the next leftover lands in the right slot.
+				for dd, p := range dirPos {
+					if dd != d && p >= pos {
+						dirPos[dd] = p + 1
+					}
+				}
 			}
 		}
 		// Leftovers no directory supplies are appended in caller order.
 		for _, t := range leftovers {
-			if _, ok := supplier[t.Path]; !ok {
+			if _, ok := supplierOf(t.Path); !ok {
 				sections = append(sections, playlistSection{kind: itemTrack, track: t})
 			}
 		}
@@ -284,4 +290,23 @@ func validateDirSource(dir string) error {
 		return fmt.Errorf("%q is not a directory", dir)
 	}
 	return nil
+}
+
+// dirSuppliesFile reports whether a scan of dir would include file: the path
+// lives under the expanded directory and, for non-recursive sources, not below
+// an immediate subdirectory. The check is path-only so save-time rewrites do
+// not repeat the filesystem walk done at load.
+func dirSuppliesFile(dir DirSource, file string) bool {
+	root := ExpandPath(dir.Path)
+	rel, err := filepath.Rel(root, file)
+	if err != nil {
+		return false
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	if !dir.Recursive && strings.ContainsRune(rel, filepath.Separator) {
+		return false
+	}
+	return true
 }

--- a/external/local/dirs.go
+++ b/external/local/dirs.go
@@ -130,6 +130,150 @@ func writeDir(w io.Writer, src DirSource) {
 	}
 }
 
+// playlistSection is one [[track]] or [[dir]] section in a rewritten document.
+type playlistSection struct {
+	kind  uint8 // itemTrack or itemDir
+	track playlist.Track
+	dir   DirSource
+}
+
+// rebuildDoc merges the caller's explicit tracks back into an existing parsed
+// document, preserving the interleaving of [[track]] and [[dir]] sections.
+//
+// Directory sections keep their slots. Explicit tracks are matched back onto
+// their original slots by path, so removals drop the slot (without shifting
+// siblings) and metadata updates (e.g. enrichment) stay in place. When the
+// caller reordered the explicit tracks, the caller's order wins for the track
+// slots while directories stay anchored. Explicit tracks without an original
+// slot — additions and bookmark materializations — are inserted directly
+// before the directory section that would otherwise supply them, so a
+// materialized track keeps its position among the directory's tracks; tracks
+// no directory provides are appended at the end.
+func rebuildDoc(existing *playlistDoc, explicit []playlist.Track) (tracks []playlist.Track, dirs []DirSource, order []uint8) {
+	origPaths := make([]string, len(existing.tracks))
+	for i, t := range existing.tracks {
+		origPaths[i] = t.Path
+	}
+	origSet := make(map[string]struct{}, len(origPaths))
+	for _, p := range origPaths {
+		origSet[p] = struct{}{}
+	}
+	var callerSubseq []string
+	for _, t := range explicit {
+		if _, ok := origSet[t.Path]; ok {
+			callerSubseq = append(callerSubseq, t.Path)
+		}
+	}
+	reordered := !isSubsequence(origPaths, callerSubseq)
+
+	byPath := make(map[string]playlist.Track, len(explicit))
+	placed := make(map[string]struct{}, len(explicit))
+	for _, t := range explicit {
+		byPath[t.Path] = t
+	}
+
+	ti, di, used := 0, 0, 0
+	var sections []playlistSection
+	for _, kind := range existing.order {
+		if kind == itemDir {
+			sections = append(sections, playlistSection{kind: itemDir, dir: existing.dirs[di]})
+			di++
+			continue
+		}
+		orig := existing.tracks[ti]
+		ti++
+		if reordered {
+			if used < len(explicit) {
+				t := explicit[used]
+				sections = append(sections, playlistSection{kind: itemTrack, track: t})
+				placed[t.Path] = struct{}{}
+				used++
+			}
+			continue
+		}
+		if t, ok := byPath[orig.Path]; ok {
+			sections = append(sections, playlistSection{kind: itemTrack, track: t})
+			placed[orig.Path] = struct{}{}
+			delete(byPath, orig.Path)
+		}
+	}
+
+	var leftovers []playlist.Track
+	for _, t := range explicit {
+		if _, ok := placed[t.Path]; !ok {
+			leftovers = append(leftovers, t)
+		}
+	}
+	if len(leftovers) > 0 {
+		// Map each dir to its section position, and each file to the first
+		// directory (in document order) that supplies it.
+		dirPos := make(map[int]int, len(existing.dirs))
+		di := 0
+		for si, sec := range sections {
+			if sec.kind == itemDir {
+				dirPos[di] = si
+				di++
+			}
+		}
+		supplier := make(map[string]int)
+		di = 0
+		for _, src := range existing.dirs {
+			files, err := resolve.AudioFiles(ExpandPath(src.Path), src.Recursive)
+			if err == nil {
+				for _, f := range files {
+					if _, ok := supplier[f]; !ok {
+						supplier[f] = di
+					}
+				}
+			}
+			di++
+		}
+		// Insert before-dir leftovers in reverse so several targeting the same
+		// directory keep their caller order.
+		for i := len(leftovers) - 1; i >= 0; i-- {
+			t := leftovers[i]
+			if d, ok := supplier[t.Path]; ok {
+				pos := dirPos[d]
+				sections = append(sections, playlistSection{})
+				copy(sections[pos+1:], sections[pos:])
+				sections[pos] = playlistSection{kind: itemTrack, track: t}
+			}
+		}
+		// Leftovers no directory supplies are appended in caller order.
+		for _, t := range leftovers {
+			if _, ok := supplier[t.Path]; !ok {
+				sections = append(sections, playlistSection{kind: itemTrack, track: t})
+			}
+		}
+	}
+
+	for _, sec := range sections {
+		if sec.kind == itemDir {
+			dirs = append(dirs, sec.dir)
+			order = append(order, itemDir)
+		} else {
+			tracks = append(tracks, sec.track)
+			order = append(order, itemTrack)
+		}
+	}
+	return tracks, dirs, order
+}
+
+// isSubsequence reports whether sub appears in orig in the same relative order.
+func isSubsequence(orig, sub []string) bool {
+	i := 0
+	for _, p := range sub {
+		for i < len(orig) && orig[i] != p {
+			i++
+		}
+		if i == len(orig) {
+			return false
+		}
+		i++
+	}
+	return true
+}
+
 // validateDirSource expands dir and verifies it exists and is a directory.
 func validateDirSource(dir string) error {
 	info, err := os.Stat(ExpandPath(dir))

--- a/external/local/dirs.go
+++ b/external/local/dirs.go
@@ -1,0 +1,143 @@
+package local
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/bjarneo/cliamp/internal/tomlutil"
+	"github.com/bjarneo/cliamp/playlist"
+	"github.com/bjarneo/cliamp/resolve"
+)
+
+// DirSource is a [[dir]] section in a playlist file: a directory that is
+// scanned for audio files every time the playlist loads, instead of listing
+// every file explicitly.
+type DirSource struct {
+	Path      string // directory path; supports ~ and environment variables
+	Recursive bool   // scan subdirectories too (default true)
+}
+
+// ExpandPath expands a leading ~ and environment variables in p.
+func ExpandPath(p string) string {
+	if p == "" {
+		return p
+	}
+	expanded := os.ExpandEnv(p)
+	if expanded == "~" || strings.HasPrefix(expanded, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, strings.TrimPrefix(expanded, "~"))
+		}
+	}
+	return expanded
+}
+
+// Section kinds tracked in playlistDoc.order.
+const (
+	itemTrack uint8 = iota
+	itemDir
+)
+
+// playlistDoc is a parsed playlist file: explicit [[track]] entries and
+// [[dir]] sources, with section order preserved for ordered expansion.
+type playlistDoc struct {
+	tracks []playlist.Track
+	dirs   []DirSource
+	order  []uint8 // itemTrack or itemDir per section, in document order
+}
+
+// parsePlaylistDoc parses a playlist TOML document. Directory sources are
+// parsed but not scanned; call expand to resolve them into tracks.
+func parsePlaylistDoc(data []byte) *playlistDoc {
+	doc := &playlistDoc{}
+	tomlutil.ParseNamedSections(data, []string{"track", "dir"}, func(section string, f map[string]string) {
+		switch section {
+		case "track":
+			doc.tracks = append(doc.tracks, parseTrackFields(f))
+			doc.order = append(doc.order, itemTrack)
+		case "dir":
+			if f["path"] == "" {
+				return
+			}
+			doc.dirs = append(doc.dirs, DirSource{
+				Path:      f["path"],
+				Recursive: f["recursive"] != "false",
+			})
+			doc.order = append(doc.order, itemDir)
+		}
+	})
+	return doc
+}
+
+// expand returns the full track list: explicit [[track]] entries plus tracks
+// scanned from [[dir]] sources, in document order. A file supplied by a
+// directory scan is skipped when an explicit [[track]] with the same path
+// exists anywhere in the document, so explicit entries (with their custom
+// metadata and bookmarks) always win. Directory-scanned tracks are marked
+// DirSourced. Unreadable or missing directories contribute no tracks.
+//
+// When withTags is false, directory tracks are returned without reading
+// their tags (titles fall back to filename parsing), for cheap operations
+// such as counting.
+func (d *playlistDoc) expand(withTags bool) []playlist.Track {
+	explicit := make(map[string]struct{}, len(d.tracks))
+	for _, t := range d.tracks {
+		explicit[t.Path] = struct{}{}
+	}
+	ti, di := 0, 0
+	var out []playlist.Track
+	for _, kind := range d.order {
+		if kind == itemTrack {
+			out = append(out, d.tracks[ti])
+			ti++
+			continue
+		}
+		src := d.dirs[di]
+		di++
+		files, err := resolve.AudioFiles(ExpandPath(src.Path), src.Recursive)
+		if err != nil {
+			continue
+		}
+		var dirTracks []playlist.Track
+		if withTags {
+			dirTracks = resolve.TracksFromPaths(files)
+		} else {
+			dirTracks = make([]playlist.Track, len(files))
+			for i, f := range files {
+				dirTracks[i] = playlist.TrackFromFilename(f)
+			}
+		}
+		for _, t := range dirTracks {
+			if _, dup := explicit[t.Path]; dup {
+				continue
+			}
+			explicit[t.Path] = struct{}{}
+			t.DirSourced = true
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// writeDir writes a single [[dir]] TOML section to w.
+func writeDir(w io.Writer, src DirSource) {
+	fmt.Fprintln(w, "[[dir]]")
+	fmt.Fprintf(w, "path = %q\n", src.Path)
+	if !src.Recursive {
+		fmt.Fprintln(w, "recursive = false")
+	}
+}
+
+// validateDirSource expands dir and verifies it exists and is a directory.
+func validateDirSource(dir string) error {
+	info, err := os.Stat(ExpandPath(dir))
+	if err != nil {
+		return fmt.Errorf("directory %q: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%q is not a directory", dir)
+	}
+	return nil
+}

--- a/external/local/dirs.go
+++ b/external/local/dirs.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/bjarneo/cliamp/internal/tomlutil"
+	"github.com/bjarneo/cliamp/player"
 	"github.com/bjarneo/cliamp/playlist"
 	"github.com/bjarneo/cliamp/resolve"
 )
@@ -293,10 +294,14 @@ func validateDirSource(dir string) error {
 }
 
 // dirSuppliesFile reports whether a scan of dir would include file: the path
-// lives under the expanded directory and, for non-recursive sources, not below
-// an immediate subdirectory. The check is path-only so save-time rewrites do
-// not repeat the filesystem walk done at load.
+// has a supported audio extension, lives under the expanded directory and, for
+// non-recursive sources, not below an immediate subdirectory. The check is
+// path-only so save-time rewrites do not repeat the filesystem walk done at
+// load.
 func dirSuppliesFile(dir DirSource, file string) bool {
+	if !player.SupportedExts[strings.ToLower(filepath.Ext(file))] {
+		return false
+	}
 	root := ExpandPath(dir.Path)
 	rel, err := filepath.Rel(root, file)
 	if err != nil {

--- a/external/local/dirs_test.go
+++ b/external/local/dirs_test.go
@@ -693,6 +693,55 @@ func TestSavePlaylistMultiMaterializedKeepsDirPositions(t *testing.T) {
 	checkOrder(t, tracks, []string{"a.mp3", "x.mp3", "b.mp3"})
 }
 
+func TestDirSuppliesFileExtensionFilter(t *testing.T) {
+	dir := t.TempDir()
+	rec := DirSource{Path: dir, Recursive: true}
+	if !dirSuppliesFile(rec, filepath.Join(dir, "song.mp3")) {
+		t.Fatal("audio file under dir should be supplied")
+	}
+	if dirSuppliesFile(rec, filepath.Join(dir, "cover.jpg")) {
+		t.Fatal("non-audio file under dir must not be treated as dir-supplied")
+	}
+	if dirSuppliesFile(rec, filepath.Join(dir, "cover.JPG")) {
+		t.Fatal("non-audio file with uppercase extension must not be dir-supplied")
+	}
+	if dirSuppliesFile(rec, filepath.Join(dir, "noextension")) {
+		t.Fatal("extension-less file must not be treated as dir-supplied")
+	}
+	nonRec := DirSource{Path: dir, Recursive: false}
+	if dirSuppliesFile(nonRec, filepath.Join(dir, "sub", "song.mp3")) {
+		t.Fatal("subdir file must not be supplied by a non-recursive source")
+	}
+	if !dirSuppliesFile(nonRec, filepath.Join(dir, "song.mp3")) {
+		t.Fatal("top-level audio file should be supplied by a non-recursive source")
+	}
+}
+
+func TestSavePlaylistNonAudioTrackAppendedNotPlacedBeforeDir(t *testing.T) {
+	p := newTestProvider(t)
+	dirA := t.TempDir()
+	writeAudioFile(t, filepath.Join(dirA, "a.mp3"))
+	cover := filepath.Join(dirA, "cover.jpg")
+	if err := p.CreateDirPlaylist("mix", []string{dirA}); err != nil {
+		t.Fatalf("CreateDirPlaylist: %v", err)
+	}
+	// A new explicit track for a non-audio file that lives under the directory
+	// must not be treated as dir-supplied; it belongs at the end.
+	added, skipped, err := p.AddTracks("mix", []playlist.Track{{Path: cover, Title: "Cover"}})
+	if err != nil {
+		t.Fatalf("AddTracks: %v", err)
+	}
+	if added != 1 || skipped != 0 {
+		t.Fatalf("added=%d skipped=%d, want 1/0", added, skipped)
+	}
+	tracks, err := p.Tracks("mix")
+	if err != nil {
+		t.Fatalf("Tracks: %v", err)
+	}
+	// Expanded order: a.mp3 (dir), then cover.jpg (explicit, appended at end).
+	checkOrder(t, tracks, []string{"a.mp3", "cover.jpg"})
+}
+
 func TestAddDirSourcesAtomic(t *testing.T) {
 	p := newTestProvider(t)
 	audio := t.TempDir()

--- a/external/local/dirs_test.go
+++ b/external/local/dirs_test.go
@@ -335,6 +335,35 @@ func TestSetBookmarkMaterializesDirTrack(t *testing.T) {
 	}
 }
 
+func TestSavePlaylistReadErrorAbortsRewrite(t *testing.T) {
+	p := newTestProvider(t)
+	audio := t.TempDir()
+	writeAudioFile(t, filepath.Join(audio, "a.mp3"))
+	if err := p.CreateDirPlaylist("music", []string{audio}); err != nil {
+		t.Fatalf("CreateDirPlaylist: %v", err)
+	}
+	// Replace the playlist file with a directory so ReadFile fails (EISDIR).
+	path := filepath.Join(p.dir, "music.toml")
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	// A failed read must abort the rewrite instead of replacing the playlist
+	// with a copy missing its [[dir]] sections.
+	if err := p.SetBookmark("music", 0); err == nil {
+		t.Fatal("SetBookmark should fail when the playlist cannot be read")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("playlist path removed: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatal("playlist was rewritten despite read failure")
+	}
+}
+
 func TestSetBookmarkByPathMaterializesDirTrack(t *testing.T) {
 	p := newTestProvider(t)
 	audio := t.TempDir()

--- a/external/local/dirs_test.go
+++ b/external/local/dirs_test.go
@@ -693,27 +693,30 @@ func TestSavePlaylistMultiMaterializedKeepsDirPositions(t *testing.T) {
 	checkOrder(t, tracks, []string{"a.mp3", "x.mp3", "b.mp3"})
 }
 
-func TestDirSuppliesFileExtensionFilter(t *testing.T) {
+func TestDirSuppliesFile(t *testing.T) {
 	dir := t.TempDir()
 	rec := DirSource{Path: dir, Recursive: true}
-	if !dirSuppliesFile(rec, filepath.Join(dir, "song.mp3")) {
-		t.Fatal("audio file under dir should be supplied")
-	}
-	if dirSuppliesFile(rec, filepath.Join(dir, "cover.jpg")) {
-		t.Fatal("non-audio file under dir must not be treated as dir-supplied")
-	}
-	if dirSuppliesFile(rec, filepath.Join(dir, "cover.JPG")) {
-		t.Fatal("non-audio file with uppercase extension must not be dir-supplied")
-	}
-	if dirSuppliesFile(rec, filepath.Join(dir, "noextension")) {
-		t.Fatal("extension-less file must not be treated as dir-supplied")
-	}
 	nonRec := DirSource{Path: dir, Recursive: false}
-	if dirSuppliesFile(nonRec, filepath.Join(dir, "sub", "song.mp3")) {
-		t.Fatal("subdir file must not be supplied by a non-recursive source")
+	tests := []struct {
+		name string
+		src  DirSource
+		file string
+		want bool
+	}{
+		{name: "audio under recursive dir", src: rec, file: filepath.Join(dir, "song.mp3"), want: true},
+		{name: "audio at non-recursive top level", src: nonRec, file: filepath.Join(dir, "song.mp3"), want: true},
+		{name: "non-audio under recursive dir", src: rec, file: filepath.Join(dir, "cover.jpg"), want: false},
+		{name: "non-audio uppercase extension", src: rec, file: filepath.Join(dir, "cover.JPG"), want: false},
+		{name: "extension-less file", src: rec, file: filepath.Join(dir, "noextension"), want: false},
+		{name: "audio in subdir of non-recursive dir", src: nonRec, file: filepath.Join(dir, "sub", "song.mp3"), want: false},
+		{name: "audio outside dir", src: rec, file: filepath.Join(dir, "..", "outside.mp3"), want: false},
 	}
-	if !dirSuppliesFile(nonRec, filepath.Join(dir, "song.mp3")) {
-		t.Fatal("top-level audio file should be supplied by a non-recursive source")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := dirSuppliesFile(tt.src, tt.file); got != tt.want {
+				t.Fatalf("dirSuppliesFile(%+v, %q) = %v, want %v", tt.src, tt.file, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/external/local/dirs_test.go
+++ b/external/local/dirs_test.go
@@ -81,7 +81,7 @@ func TestParsePlaylistDocSkipsEmptyDirPath(t *testing.T) {
 func TestExpandPathEnvAndTilde(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("CLIAMP_TEST_DIR", dir)
-	if got := ExpandPath("$CLIAMP_TEST_DIR/sub"); got != filepath.Join(dir, "sub") {
+	if got := filepath.Clean(ExpandPath("$CLIAMP_TEST_DIR/sub")); got != filepath.Join(dir, "sub") {
 		t.Fatalf("env expand = %q", got)
 	}
 	home, err := os.UserHomeDir()
@@ -254,16 +254,14 @@ func TestSavePlaylistPreservesDirsAndSkipsDirTracks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
-	content := string(data)
-	if !strings.Contains(content, "[[dir]]") || !strings.Contains(content, quote(audio)) {
-		t.Fatalf("[[dir]] section lost:\n%s", content)
+	// Assert on the parsed document rather than raw text: the writer escapes
+	// backslashes (%q), so a substring match would break on Windows paths.
+	doc := parsePlaylistDoc(data)
+	if len(doc.dirs) != 1 || doc.dirs[0].Path != audio {
+		t.Fatalf("[[dir]] section lost or wrong: %+v", doc.dirs)
 	}
-	if !strings.Contains(content, "[[track]]") || !strings.Contains(content, quote(explicit)) {
-		t.Fatalf("explicit track lost:\n%s", content)
-	}
-	// The dir-sourced a.mp3 must appear only inside the [[dir]] section.
-	if n := strings.Count(content, quote(audio)); n != 1 {
-		t.Fatalf("dir-sourced track persisted (path appears %d times):\n%s", n, content)
+	if len(doc.tracks) != 1 || doc.tracks[0].Path != explicit {
+		t.Fatalf("explicit track lost or wrong: %+v", doc.tracks)
 	}
 }
 

--- a/external/local/dirs_test.go
+++ b/external/local/dirs_test.go
@@ -1,0 +1,441 @@
+package local
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bjarneo/cliamp/playlist"
+)
+
+// writeAudioFile creates an empty file with a supported extension. Tag reading
+// falls back to filename parsing for empty files, so fixtures stay simple.
+func writeAudioFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte{}, 0o644); err != nil {
+		t.Fatalf("writeAudioFile(%s): %v", path, err)
+	}
+}
+
+// makeAudioTree creates dir with two audio files and a subdir with one more.
+func makeAudioTree(t *testing.T, dir string) {
+	t.Helper()
+	writeAudioFile(t, filepath.Join(dir, "b.mp3"))
+	writeAudioFile(t, filepath.Join(dir, "a.flac"))
+	sub := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeAudioFile(t, filepath.Join(sub, "c.ogg"))
+}
+
+func TestParsePlaylistDocMixedOrder(t *testing.T) {
+	data := []byte(`[[track]]
+path = "/a.mp3"
+title = "A"
+
+[[dir]]
+path = "/music"
+
+[[track]]
+path = "/b.mp3"
+
+[[dir]]
+path = "/other"
+recursive = false
+`)
+	doc := parsePlaylistDoc(data)
+	if len(doc.tracks) != 2 {
+		t.Fatalf("got %d tracks, want 2", len(doc.tracks))
+	}
+	if len(doc.dirs) != 2 {
+		t.Fatalf("got %d dirs, want 2", len(doc.dirs))
+	}
+	if doc.dirs[0].Path != "/music" || !doc.dirs[0].Recursive {
+		t.Fatalf("dir 0 = %+v, want /music recursive", doc.dirs[0])
+	}
+	if doc.dirs[1].Path != "/other" || doc.dirs[1].Recursive {
+		t.Fatalf("dir 1 = %+v, want /other non-recursive", doc.dirs[1])
+	}
+	// Order must follow the document: track, dir, track, dir.
+	if len(doc.order) != 4 {
+		t.Fatalf("order length = %d, want 4", len(doc.order))
+	}
+	if doc.order[0] != itemTrack || doc.order[1] != itemDir || doc.order[2] != itemTrack || doc.order[3] != itemDir {
+		t.Fatalf("unexpected order: %v", doc.order)
+	}
+}
+
+func TestParsePlaylistDocSkipsEmptyDirPath(t *testing.T) {
+	doc := parsePlaylistDoc([]byte("[[dir]]\n[[track]]\npath = \"/a.mp3\"\n"))
+	if len(doc.dirs) != 0 {
+		t.Fatalf("got %d dirs, want 0", len(doc.dirs))
+	}
+	if len(doc.tracks) != 1 {
+		t.Fatalf("got %d tracks, want 1", len(doc.tracks))
+	}
+}
+
+func TestExpandPathEnvAndTilde(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CLIAMP_TEST_DIR", dir)
+	if got := ExpandPath("$CLIAMP_TEST_DIR/sub"); got != filepath.Join(dir, "sub") {
+		t.Fatalf("env expand = %q", got)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("no home dir: %v", err)
+	}
+	if got := ExpandPath("~/music"); got != filepath.Join(home, "music") {
+		t.Fatalf("tilde expand = %q, want %q", got, filepath.Join(home, "music"))
+	}
+	if got := ExpandPath("plain"); got != "plain" {
+		t.Fatalf("plain expand = %q", got)
+	}
+}
+
+func TestValidateDirSource(t *testing.T) {
+	dir := t.TempDir()
+	if err := validateDirSource(dir); err != nil {
+		t.Fatalf("existing dir rejected: %v", err)
+	}
+	file := filepath.Join(dir, "f.mp3")
+	writeAudioFile(t, file)
+	if err := validateDirSource(file); err == nil {
+		t.Fatal("file accepted as directory source")
+	}
+	if err := validateDirSource(filepath.Join(dir, "missing")); err == nil {
+		t.Fatal("missing dir accepted")
+	}
+}
+
+func TestPlaylistDocExpand(t *testing.T) {
+	audio := t.TempDir()
+	makeAudioTree(t, audio)
+
+	doc := parsePlaylistDoc([]byte("[[dir]]\npath = " + quote(audio) + "\n"))
+	tracks := doc.expand(true)
+	if len(tracks) != 3 {
+		t.Fatalf("expand = %d tracks, want 3", len(tracks))
+	}
+	for _, tr := range tracks {
+		if !tr.DirSourced {
+			t.Fatalf("track %q should be DirSourced", tr.Path)
+		}
+	}
+	// Sorted by path: a.flac, b.mp3, sub/c.ogg.
+	if filepath.Base(tracks[0].Path) != "a.flac" || filepath.Base(tracks[1].Path) != "b.mp3" || filepath.Base(tracks[2].Path) != "c.ogg" {
+		for i, tr := range tracks {
+			t.Logf("  [%d] %s", i, tr.Path)
+		}
+		t.Fatal("unexpected scan order")
+	}
+}
+
+func TestPlaylistDocExpandNonRecursive(t *testing.T) {
+	audio := t.TempDir()
+	makeAudioTree(t, audio)
+	doc := parsePlaylistDoc([]byte("[[dir]]\npath = " + quote(audio) + "\nrecursive = false\n"))
+	tracks := doc.expand(false)
+	if len(tracks) != 2 {
+		t.Fatalf("expand = %d tracks, want 2 (no subdir)", len(tracks))
+	}
+}
+
+func TestPlaylistDocExpandExplicitShadowsDir(t *testing.T) {
+	audio := t.TempDir()
+	makeAudioTree(t, audio)
+	explicit := filepath.Join(audio, "b.mp3")
+
+	doc := parsePlaylistDoc([]byte(
+		"[[dir]]\npath = " + quote(audio) + "\n\n" +
+			"[[track]]\npath = " + quote(explicit) + "\ntitle = \"Custom\"\nbookmark = true\n"))
+	tracks := doc.expand(true)
+	if len(tracks) != 3 {
+		t.Fatalf("expand = %d tracks, want 3", len(tracks))
+	}
+	// The explicit b.mp3 must appear once, with its custom metadata.
+	found := false
+	for _, tr := range tracks {
+		if tr.Path == explicit {
+			if found {
+				t.Fatal("explicit track duplicated by dir scan")
+			}
+			found = true
+			if tr.Title != "Custom" || !tr.Bookmark || tr.DirSourced {
+				t.Fatalf("explicit track overridden: %+v", tr)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("explicit track missing")
+	}
+}
+
+func TestPlaylistDocExpandMissingDir(t *testing.T) {
+	doc := parsePlaylistDoc([]byte("[[dir]]\npath = \"/nonexistent/xyz\"\n"))
+	if tracks := doc.expand(true); len(tracks) != 0 {
+		t.Fatalf("missing dir contributed %d tracks", len(tracks))
+	}
+}
+
+func TestCreateDirPlaylist(t *testing.T) {
+	p := newTestProvider(t)
+	audio := t.TempDir()
+	writeAudioFile(t, filepath.Join(audio, "a.mp3"))
+
+	if err := p.CreateDirPlaylist("music", []string{audio}); err != nil {
+		t.Fatalf("CreateDirPlaylist: %v", err)
+	}
+	dirs, err := p.DirSources("music")
+	if err != nil {
+		t.Fatalf("DirSources: %v", err)
+	}
+	if len(dirs) != 1 || dirs[0].Path != audio || !dirs[0].Recursive {
+		t.Fatalf("dirs = %+v", dirs)
+	}
+	// Reject duplicate create.
+	if err := p.CreateDirPlaylist("music", []string{audio}); err == nil {
+		t.Fatal("duplicate create should fail")
+	}
+	// Reject missing directory.
+	if err := p.CreateDirPlaylist("bad", []string{filepath.Join(audio, "missing")}); err == nil {
+		t.Fatal("create with missing dir should fail")
+	}
+}
+
+func TestAddDirSource(t *testing.T) {
+	p := newTestProvider(t)
+	audio := t.TempDir()
+	writeAudioFile(t, filepath.Join(audio, "a.mp3"))
+
+	// Creates the playlist if needed.
+	ok, err := p.AddDirSource("music", audio)
+	if err != nil || !ok {
+		t.Fatalf("first AddDirSource: ok=%v err=%v", ok, err)
+	}
+	// Same dir is deduped.
+	ok, err = p.AddDirSource("music", audio)
+	if err != nil || ok {
+		t.Fatalf("duplicate AddDirSource: ok=%v err=%v (want ok=false)", ok, err)
+	}
+	dirs, _ := p.DirSources("music")
+	if len(dirs) != 1 {
+		t.Fatalf("dirs = %+v, want 1 entry", dirs)
+	}
+	// Missing dir rejected.
+	if _, err := p.AddDirSource("music", filepath.Join(audio, "missing")); err == nil {
+		t.Fatal("AddDirSource with missing dir should fail")
+	}
+}
+
+func TestSavePlaylistPreservesDirsAndSkipsDirTracks(t *testing.T) {
+	p := newTestProvider(t)
+	audio := t.TempDir()
+	writeAudioFile(t, filepath.Join(audio, "a.mp3"))
+	explicit := filepath.Join(audio, "b.mp3")
+	writeAudioFile(t, explicit)
+
+	if err := p.CreateDirPlaylist("music", []string{audio}); err != nil {
+		t.Fatalf("CreateDirPlaylist: %v", err)
+	}
+	tracks := []playlist.Track{
+		{Path: explicit, Title: "B"},
+		// Simulated dir-sourced track that must not be persisted.
+		{Path: filepath.Join(audio, "a.mp3"), Title: "A", DirSourced: true},
+	}
+	if err := p.SavePlaylist("music", tracks); err != nil {
+		t.Fatalf("SavePlaylist: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(p.dir, "music.toml"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "[[dir]]") || !strings.Contains(content, quote(audio)) {
+		t.Fatalf("[[dir]] section lost:\n%s", content)
+	}
+	if !strings.Contains(content, "[[track]]") || !strings.Contains(content, quote(explicit)) {
+		t.Fatalf("explicit track lost:\n%s", content)
+	}
+	// The dir-sourced a.mp3 must appear only inside the [[dir]] section.
+	if n := strings.Count(content, quote(audio)); n != 1 {
+		t.Fatalf("dir-sourced track persisted (path appears %d times):\n%s", n, content)
+	}
+}
+
+func TestTracksExpandsDirs(t *testing.T) {
+	p := newTestProvider(t)
+	audio := t.TempDir()
+	makeAudioTree(t, audio)
+	if err := p.CreateDirPlaylist("music", []string{audio}); err != nil {
+		t.Fatalf("CreateDirPlaylist: %v", err)
+	}
+	tracks, err := p.Tracks("music")
+	if err != nil {
+		t.Fatalf("Tracks: %v", err)
+	}
+	if len(tracks) != 3 {
+		t.Fatalf("Tracks = %d, want 3", len(tracks))
+	}
+}
+
+func TestPlaylistsCountIncludesDirTracks(t *testing.T) {
+	p := newTestProvider(t)
+	audio := t.TempDir()
+	makeAudioTree(t, audio)
+	if err := p.CreateDirPlaylist("music", []string{audio}); err != nil {
+		t.Fatalf("CreateDirPlaylist: %v", err)
+	}
+	lists, err := p.Playlists()
+	if err != nil {
+		t.Fatalf("Playlists: %v", err)
+	}
+	found := false
+	for _, pl := range lists {
+		if pl.Name == "music" {
+			found = true
+			if pl.TrackCount != 3 {
+				t.Fatalf("music TrackCount = %d, want 3", pl.TrackCount)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("music playlist missing from Playlists()")
+	}
+}
+
+func TestSetBookmarkMaterializesDirTrack(t *testing.T) {
+	p := newTestProvider(t)
+	audio := t.TempDir()
+	writeAudioFile(t, filepath.Join(audio, "a.mp3"))
+	if err := p.CreateDirPlaylist("music", []string{audio}); err != nil {
+		t.Fatalf("CreateDirPlaylist: %v", err)
+	}
+
+	if err := p.SetBookmark("music", 0); err != nil {
+		t.Fatalf("SetBookmark: %v", err)
+	}
+	tracks, err := p.Tracks("music")
+	if err != nil {
+		t.Fatalf("Tracks: %v", err)
+	}
+	if len(tracks) != 1 || !tracks[0].Bookmark {
+		t.Fatalf("bookmark not persisted: %+v", tracks)
+	}
+	if tracks[0].DirSourced {
+		t.Fatal("bookmarked track should be materialized (DirSourced=false)")
+	}
+	// The materialized track must now be an explicit [[track]] entry.
+	data, _ := os.ReadFile(filepath.Join(p.dir, "music.toml"))
+	if strings.Count(string(data), "[[track]]") != 1 {
+		t.Fatalf("materialized track not written as [[track]]:\n%s", data)
+	}
+}
+
+func TestSetBookmarkByPathMaterializesDirTrack(t *testing.T) {
+	p := newTestProvider(t)
+	audio := t.TempDir()
+	writeAudioFile(t, filepath.Join(audio, "a.mp3"))
+	if err := p.CreateDirPlaylist("music", []string{audio}); err != nil {
+		t.Fatalf("CreateDirPlaylist: %v", err)
+	}
+	trackPath := filepath.Join(audio, "a.mp3")
+	if err := p.SetBookmarkByPath("music", trackPath); err != nil {
+		t.Fatalf("SetBookmarkByPath: %v", err)
+	}
+	tracks, err := p.Tracks("music")
+	if err != nil {
+		t.Fatalf("Tracks: %v", err)
+	}
+	if len(tracks) != 1 || !tracks[0].Bookmark || tracks[0].DirSourced {
+		t.Fatalf("materialized bookmark failed: %+v", tracks)
+	}
+}
+
+func TestRemoveTrackDirSourcedError(t *testing.T) {
+	p := newTestProvider(t)
+	audio := t.TempDir()
+	writeAudioFile(t, filepath.Join(audio, "a.mp3"))
+	if err := p.CreateDirPlaylist("music", []string{audio}); err != nil {
+		t.Fatalf("CreateDirPlaylist: %v", err)
+	}
+	if err := p.RemoveTrack("music", 0); err == nil {
+		t.Fatal("removing a dir-sourced track should error")
+	}
+	// The playlist file must be untouched.
+	tracks, err := p.Tracks("music")
+	if err != nil || len(tracks) != 1 {
+		t.Fatalf("playlist changed after rejected removal: %+v err=%v", tracks, err)
+	}
+}
+
+func TestRemoveTrackExplicitAfterDir(t *testing.T) {
+	p := newTestProvider(t)
+	audio := t.TempDir()
+	writeAudioFile(t, filepath.Join(audio, "a.mp3"))
+	// An explicit track outside the scanned directory is not shadowed.
+	explicit := filepath.Join(t.TempDir(), "b.mp3")
+	writeAudioFile(t, explicit)
+	if err := p.CreateDirPlaylist("music", []string{audio}); err != nil {
+		t.Fatalf("CreateDirPlaylist: %v", err)
+	}
+	if _, _, err := p.AddTracks("music", []playlist.Track{{Path: explicit, Title: "B"}}); err != nil {
+		t.Fatalf("AddTracks: %v", err)
+	}
+	// Expanded order: a.mp3 (dir), b.mp3 (explicit). Removing index 1 must
+	// drop the explicit track but keep the dir source.
+	if err := p.RemoveTrack("music", 1); err != nil {
+		t.Fatalf("RemoveTrack: %v", err)
+	}
+	dirs, _ := p.DirSources("music")
+	if len(dirs) != 1 {
+		t.Fatalf("dir source removed: %+v", dirs)
+	}
+	tracks, err := p.Tracks("music")
+	if err != nil || len(tracks) != 1 {
+		t.Fatalf("after removal tracks = %+v err=%v", tracks, err)
+	}
+	if tracks[0].Path == explicit {
+		t.Fatal("explicit track still present")
+	}
+}
+
+func TestAddTracksSkipsDirSourcedPaths(t *testing.T) {
+	p := newTestProvider(t)
+	audio := t.TempDir()
+	writeAudioFile(t, filepath.Join(audio, "a.mp3"))
+	if err := p.CreateDirPlaylist("music", []string{audio}); err != nil {
+		t.Fatalf("CreateDirPlaylist: %v", err)
+	}
+	added, skipped, err := p.AddTracks("music", []playlist.Track{{Path: filepath.Join(audio, "a.mp3")}})
+	if err != nil {
+		t.Fatalf("AddTracks: %v", err)
+	}
+	if added != 0 || skipped != 1 {
+		t.Fatalf("added=%d skipped=%d, want 0/1", added, skipped)
+	}
+}
+
+func TestWriteDirRoundTrip(t *testing.T) {
+	var b strings.Builder
+	writeDir(&b, DirSource{Path: "/music", Recursive: true})
+	writeDir(&b, DirSource{Path: "/other", Recursive: false})
+	doc := parsePlaylistDoc([]byte(b.String()))
+	if len(doc.dirs) != 2 {
+		t.Fatalf("round trip dirs = %d", len(doc.dirs))
+	}
+	if doc.dirs[0].Path != "/music" || !doc.dirs[0].Recursive {
+		t.Fatalf("dir 0 = %+v", doc.dirs[0])
+	}
+	if doc.dirs[1].Path != "/other" || doc.dirs[1].Recursive {
+		t.Fatalf("dir 1 = %+v", doc.dirs[1])
+	}
+}
+
+// quote returns a double-quoted Go string literal for use in TOML fixtures.
+func quote(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `\"`) + `"`
+}

--- a/external/local/dirs_test.go
+++ b/external/local/dirs_test.go
@@ -620,6 +620,39 @@ func TestSavePlaylistReorderKeepsDirSlots(t *testing.T) {
 	checkOrder(t, tracks, []string{"y.mp3", "a.mp3", "x.mp3", "b.mp3", "c.ogg"})
 }
 
+func TestSavePlaylistMultiMaterializedKeepsDirPositions(t *testing.T) {
+	p := newTestProvider(t)
+	dirA := t.TempDir()
+	writeAudioFile(t, filepath.Join(dirA, "a.mp3"))
+	dirB := t.TempDir()
+	writeAudioFile(t, filepath.Join(dirB, "b.mp3"))
+	x := filepath.Join(t.TempDir(), "x.mp3")
+	writeAudioFile(t, x)
+	// Document: [[dir A]], [[track x]], [[dir B]].
+	doc := "[[dir]]\npath = " + quote(dirA) + "\n\n" +
+		"[[track]]\npath = " + quote(x) + "\n\n" +
+		"[[dir]]\npath = " + quote(dirB) + "\n"
+	if err := os.WriteFile(filepath.Join(p.dir, "mix.toml"), []byte(doc), 0o644); err != nil {
+		t.Fatalf("writing mix.toml: %v", err)
+	}
+	// Both dir tracks are materialized bookmarks handed back out of document
+	// order, as a TUI reorder after bookmarking would. The first leftover
+	// (dirA) is inserted last in reverse order and shifts the dirB section, so
+	// the dirB leftover must not land before x.
+	if err := p.SavePlaylist("mix", []playlist.Track{
+		{Path: x, Title: "X"},
+		{Path: filepath.Join(dirB, "b.mp3"), Title: "B", Bookmark: true},
+		{Path: filepath.Join(dirA, "a.mp3"), Title: "A", Bookmark: true},
+	}); err != nil {
+		t.Fatalf("SavePlaylist: %v", err)
+	}
+	tracks, err := p.Tracks("mix")
+	if err != nil {
+		t.Fatalf("Tracks: %v", err)
+	}
+	checkOrder(t, tracks, []string{"a.mp3", "x.mp3", "b.mp3"})
+}
+
 func TestAddDirSourcesAtomic(t *testing.T) {
 	p := newTestProvider(t)
 	audio := t.TempDir()

--- a/external/local/dirs_test.go
+++ b/external/local/dirs_test.go
@@ -439,3 +439,215 @@ func TestWriteDirRoundTrip(t *testing.T) {
 func quote(s string) string {
 	return `"` + strings.ReplaceAll(s, `"`, `\"`) + `"`
 }
+
+// writeInterleavedDoc writes a hand-authored mix.toml with the order
+// [[track]] x, [[dir]] dirA, [[track]] y, [[dir]] dirB so rewrites must not
+// flatten the interleaving.
+func writeInterleavedDoc(t *testing.T, p *Provider, x, dirA, y, dirB string) {
+	t.Helper()
+	doc := "[[track]]\npath = " + quote(x) + "\n\n" +
+		"[[dir]]\npath = " + quote(dirA) + "\n\n" +
+		"[[track]]\npath = " + quote(y) + "\n\n" +
+		"[[dir]]\npath = " + quote(dirB) + "\n"
+	if err := os.WriteFile(filepath.Join(p.dir, "mix.toml"), []byte(doc), 0o644); err != nil {
+		t.Fatalf("writing mix.toml: %v", err)
+	}
+}
+
+func checkOrder(t *testing.T, tracks []playlist.Track, want []string) {
+	t.Helper()
+	if len(tracks) != len(want) {
+		got := make([]string, len(tracks))
+		for i, tr := range tracks {
+			got[i] = filepath.Base(tr.Path)
+		}
+		t.Fatalf("tracks = %v, want %v", got, want)
+	}
+	for i, w := range want {
+		if filepath.Base(tracks[i].Path) != w {
+			got := make([]string, len(tracks))
+			for j, tr := range tracks {
+				got[j] = filepath.Base(tr.Path)
+			}
+			t.Fatalf("tracks = %v, want %v (index %d)", got, want, i)
+		}
+	}
+}
+
+func TestSavePlaylistPreservesSectionOrder(t *testing.T) {
+	p := newTestProvider(t)
+	dirA := t.TempDir()
+	writeAudioFile(t, filepath.Join(dirA, "a.mp3"))
+	dirB := t.TempDir()
+	writeAudioFile(t, filepath.Join(dirB, "b.mp3"))
+	writeAudioFile(t, filepath.Join(dirB, "c.ogg"))
+	x := filepath.Join(t.TempDir(), "x.mp3")
+	y := filepath.Join(t.TempDir(), "y.mp3")
+	writeAudioFile(t, x)
+	writeAudioFile(t, y)
+	writeInterleavedDoc(t, p, x, dirA, y, dirB)
+
+	// Expanded order follows the document interleaving.
+	tracks, err := p.Tracks("mix")
+	if err != nil {
+		t.Fatalf("Tracks: %v", err)
+	}
+	checkOrder(t, tracks, []string{"x.mp3", "a.mp3", "y.mp3", "b.mp3", "c.ogg"})
+
+	// Removing x must drop only its slot: y stays anchored before dirB.
+	if err := p.RemoveTrack("mix", 0); err != nil {
+		t.Fatalf("RemoveTrack: %v", err)
+	}
+	tracks, err = p.Tracks("mix")
+	if err != nil {
+		t.Fatalf("Tracks: %v", err)
+	}
+	checkOrder(t, tracks, []string{"a.mp3", "y.mp3", "b.mp3", "c.ogg"})
+
+	// A metadata update (enrich-style) keeps y in place.
+	var yt *playlist.Track
+	for i := range tracks {
+		if tracks[i].Path == y {
+			yt = &tracks[i]
+		}
+	}
+	if yt == nil {
+		t.Fatal("y missing after removal")
+	}
+	yt.Album = "Studio"
+	if err := p.SavePlaylist("mix", tracks); err != nil {
+		t.Fatalf("SavePlaylist: %v", err)
+	}
+	tracks, err = p.Tracks("mix")
+	if err != nil {
+		t.Fatalf("Tracks: %v", err)
+	}
+	checkOrder(t, tracks, []string{"a.mp3", "y.mp3", "b.mp3", "c.ogg"})
+	for _, tr := range tracks {
+		if tr.Path == y && tr.Album != "Studio" {
+			t.Fatalf("metadata update lost: %+v", tr)
+		}
+	}
+}
+
+func TestSetBookmarkKeepsDirPosition(t *testing.T) {
+	p := newTestProvider(t)
+	dirA := t.TempDir()
+	writeAudioFile(t, filepath.Join(dirA, "a.mp3"))
+	dirB := t.TempDir()
+	writeAudioFile(t, filepath.Join(dirB, "b.mp3"))
+	writeAudioFile(t, filepath.Join(dirB, "c.ogg"))
+	x := filepath.Join(t.TempDir(), "x.mp3")
+	y := filepath.Join(t.TempDir(), "y.mp3")
+	writeAudioFile(t, x)
+	writeAudioFile(t, y)
+	writeInterleavedDoc(t, p, x, dirA, y, dirB)
+
+	// Expanded: x, a, y, b, c. Bookmark b (index 3).
+	if err := p.SetBookmark("mix", 3); err != nil {
+		t.Fatalf("SetBookmark: %v", err)
+	}
+	tracks, err := p.Tracks("mix")
+	if err != nil {
+		t.Fatalf("Tracks: %v", err)
+	}
+	// The materialized track stays at b's position instead of jumping around.
+	checkOrder(t, tracks, []string{"x.mp3", "a.mp3", "y.mp3", "b.mp3", "c.ogg"})
+	for _, tr := range tracks {
+		if tr.Path == filepath.Join(dirB, "b.mp3") {
+			if !tr.Bookmark || tr.DirSourced {
+				t.Fatalf("materialized bookmark wrong: %+v", tr)
+			}
+		}
+	}
+}
+
+func TestSavePlaylistReorderKeepsDirSlots(t *testing.T) {
+	p := newTestProvider(t)
+	dirA := t.TempDir()
+	writeAudioFile(t, filepath.Join(dirA, "a.mp3"))
+	dirB := t.TempDir()
+	writeAudioFile(t, filepath.Join(dirB, "b.mp3"))
+	writeAudioFile(t, filepath.Join(dirB, "c.ogg"))
+	x := filepath.Join(t.TempDir(), "x.mp3")
+	y := filepath.Join(t.TempDir(), "y.mp3")
+	writeAudioFile(t, x)
+	writeAudioFile(t, y)
+	writeInterleavedDoc(t, p, x, dirA, y, dirB)
+
+	tracks, err := p.Tracks("mix")
+	if err != nil {
+		t.Fatalf("Tracks: %v", err)
+	}
+	// Reorder so y leads: [y, x, a, b, c].
+	reordered := []playlist.Track{tracks[2], tracks[0], tracks[1], tracks[3], tracks[4]}
+	if err := p.SavePlaylist("mix", reordered); err != nil {
+		t.Fatalf("SavePlaylist: %v", err)
+	}
+	tracks, err = p.Tracks("mix")
+	if err != nil {
+		t.Fatalf("Tracks: %v", err)
+	}
+	checkOrder(t, tracks, []string{"y.mp3", "a.mp3", "x.mp3", "b.mp3", "c.ogg"})
+}
+
+func TestAddDirSourcesAtomic(t *testing.T) {
+	p := newTestProvider(t)
+	audio := t.TempDir()
+	writeAudioFile(t, filepath.Join(audio, "a.mp3"))
+	if err := p.CreateDirPlaylist("mix", []string{audio}); err != nil {
+		t.Fatalf("CreateDirPlaylist: %v", err)
+	}
+
+	// A batch with one missing directory must fail without persisting the
+	// valid one.
+	valid := t.TempDir()
+	missing := filepath.Join(t.TempDir(), "missing")
+	if _, err := p.AddDirSources("mix", []string{valid, missing}); err == nil {
+		t.Fatal("batch with missing dir should fail")
+	}
+	dirs, err := p.DirSources("mix")
+	if err != nil {
+		t.Fatalf("DirSources: %v", err)
+	}
+	if len(dirs) != 1 {
+		t.Fatalf("partial batch persisted: dirs = %+v", dirs)
+	}
+
+	// A failing batch on a new playlist must not create the file.
+	if _, err := p.AddDirSources("ghost", []string{missing}); err == nil {
+		t.Fatal("batch with missing dir should fail")
+	}
+	if p.Exists("ghost") {
+		t.Fatal("failed batch created a playlist")
+	}
+
+	// Dedupe: batch of already-present + new adds only the new one.
+	added, err := p.AddDirSources("mix", []string{audio, valid})
+	if err != nil {
+		t.Fatalf("AddDirSources: %v", err)
+	}
+	if len(added) != 1 || added[0] != valid {
+		t.Fatalf("added = %v, want [%s]", added, valid)
+	}
+	dirs, _ = p.DirSources("mix")
+	if len(dirs) != 2 {
+		t.Fatalf("dirs = %+v, want 2", dirs)
+	}
+}
+
+func TestCreateDirPlaylistNoFileOnInvalidDir(t *testing.T) {
+	p := newTestProvider(t)
+	valid := t.TempDir()
+	missing := filepath.Join(t.TempDir(), "missing")
+	if err := p.CreateDirPlaylist("mix", []string{valid, missing}); err == nil {
+		t.Fatal("create with missing dir should fail")
+	}
+	entries, err := os.ReadDir(p.dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("partial playlist created: %v", entries)
+	}
+}

--- a/external/local/dirs_test.go
+++ b/external/local/dirs_test.go
@@ -1,6 +1,7 @@
 package local
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -445,6 +446,45 @@ func TestAddTracksSkipsDirSourcedPaths(t *testing.T) {
 	}
 	if added != 0 || skipped != 1 {
 		t.Fatalf("added=%d skipped=%d, want 0/1", added, skipped)
+	}
+}
+
+func TestAddTracksPersistsCrossPlaylistDirTrack(t *testing.T) {
+	p := newTestProvider(t)
+	audio := t.TempDir()
+	writeAudioFile(t, filepath.Join(audio, "a.mp3"))
+	if err := p.CreateDirPlaylist("src", []string{audio}); err != nil {
+		t.Fatalf("CreateDirPlaylist: %v", err)
+	}
+	srcTracks, err := p.Tracks("src")
+	if err != nil || len(srcTracks) != 1 || !srcTracks[0].DirSourced {
+		t.Fatalf("src tracks = %+v err=%v, want one dir-sourced track", srcTracks, err)
+	}
+	if _, err := p.CreatePlaylist(context.Background(), "dst"); err != nil {
+		t.Fatalf("CreatePlaylist: %v", err)
+	}
+	// Adding a dir-sourced track to another playlist must persist it as an
+	// explicit [[track]] entry instead of counting it as added and dropping it.
+	added, skipped, err := p.AddTracks("dst", srcTracks)
+	if err != nil {
+		t.Fatalf("AddTracks: %v", err)
+	}
+	if added != 1 || skipped != 0 {
+		t.Fatalf("added=%d skipped=%d, want 1/0", added, skipped)
+	}
+	dstTracks, err := p.Tracks("dst")
+	if err != nil {
+		t.Fatalf("Tracks: %v", err)
+	}
+	if len(dstTracks) != 1 || dstTracks[0].Path != srcTracks[0].Path {
+		t.Fatalf("dst tracks = %+v, want the transferred track", dstTracks)
+	}
+	if dstTracks[0].DirSourced {
+		t.Fatal("transferred track must be persisted as an explicit [[track]]")
+	}
+	data, _ := os.ReadFile(filepath.Join(p.dir, "dst.toml"))
+	if strings.Count(string(data), "[[track]]") != 1 {
+		t.Fatalf("transferred track not written as [[track]]:\n%s", data)
 	}
 }
 

--- a/external/local/provider.go
+++ b/external/local/provider.go
@@ -105,7 +105,10 @@ func (p *Provider) Playlists() ([]playlist.PlaylistInfo, error) {
 		if err != nil {
 			continue
 		}
-		// Count without tag reads so the playlist browser stays fast.
+		// Count without tag reads so the playlist browser stays fast; durations
+		// stay unknown (0) for directory-backed playlists, which the browser
+		// omits from display. Directory sources are still walked to count the
+		// files they supply.
 		tracks := doc.expand(false)
 		lists = append(lists, playlist.PlaylistInfo{
 			ID:           name,
@@ -214,6 +217,11 @@ func (p *Provider) AddTracks(playlistName string, tracks []playlist.Track) (adde
 			skipped++
 			continue
 		}
+		// Incoming tracks may carry the DirSourced flag from a directory-backed
+		// playlist. Added to a different playlist here, they must persist as
+		// explicit [[track]] entries; the save would otherwise drop them since
+		// this document has no owning [[dir]] section for them.
+		t.DirSourced = false
 		seen[t.Path] = struct{}{}
 		existing = append(existing, t)
 		added++

--- a/external/local/provider.go
+++ b/external/local/provider.go
@@ -10,7 +10,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -18,9 +17,9 @@ import (
 	"github.com/bjarneo/cliamp/history"
 	"github.com/bjarneo/cliamp/internal/appdir"
 	"github.com/bjarneo/cliamp/internal/fuzzy"
-	"github.com/bjarneo/cliamp/internal/tomlutil"
 	"github.com/bjarneo/cliamp/playlist"
 	"github.com/bjarneo/cliamp/provider"
+	"github.com/bjarneo/cliamp/resolve"
 )
 
 // Compile-time interface checks.
@@ -102,10 +101,12 @@ func (p *Provider) Playlists() ([]playlist.PlaylistInfo, error) {
 			continue
 		}
 		name := strings.TrimSuffix(e.Name(), filepath.Ext(e.Name()))
-		tracks, err := p.loadTOML(filepath.Join(p.dir, e.Name()))
+		doc, err := p.loadDoc(filepath.Join(p.dir, e.Name()))
 		if err != nil {
 			continue
 		}
+		// Count without tag reads so the playlist browser stays fast.
+		tracks := doc.expand(false)
 		lists = append(lists, playlist.PlaylistInfo{
 			ID:           name,
 			Name:         name,
@@ -134,8 +135,9 @@ func (p *Provider) historyInfo() (playlist.PlaylistInfo, bool) {
 	}, true
 }
 
-// Tracks parses the TOML file for the given playlist name and returns its tracks.
-// The reserved "Recently Played" name is served from the history store.
+// Tracks returns the full track list for the named playlist: explicit
+// [[track]] entries plus tracks scanned from any [[dir]] sources, in document
+// order. The reserved "Recently Played" name is served from the history store.
 func (p *Provider) Tracks(playlistID string) ([]playlist.Track, error) {
 	if isHistoryName(playlistID) {
 		if p.history == nil {
@@ -143,11 +145,20 @@ func (p *Provider) Tracks(playlistID string) ([]playlist.Track, error) {
 		}
 		return p.history.Tracks(0)
 	}
-	path, err := p.safePath(playlistID)
+	doc, err := p.loadDocByName(playlistID)
 	if err != nil {
 		return nil, err
 	}
-	return p.loadTOML(path)
+	return doc.expand(true), nil
+}
+
+// expandedTracks loads a named playlist and expands its directory sources.
+func (p *Provider) expandedTracks(name string) ([]playlist.Track, error) {
+	doc, err := p.loadDocByName(name)
+	if err != nil {
+		return nil, err
+	}
+	return doc.expand(true), nil
 }
 
 // AddTrack appends a track to the named playlist, creating the directory and
@@ -157,8 +168,9 @@ func (p *Provider) AddTrack(playlistName string, track playlist.Track) error {
 	return err
 }
 
-// AddTracks appends multiple tracks, skipping exact path duplicates already in
-// the playlist or repeated in the input. It creates the playlist file if needed.
+// AddTracks appends multiple tracks, skipping exact path duplicates already
+// provided by the playlist (explicit [[track]] entries or [[dir]] sources) or
+// repeated in the input. It creates the playlist file if needed.
 func (p *Provider) AddTracks(playlistName string, tracks []playlist.Track) (added, skipped int, err error) {
 	if isHistoryName(playlistName) {
 		return 0, 0, errReservedHistoryName
@@ -171,7 +183,7 @@ func (p *Provider) AddTracks(playlistName string, tracks []playlist.Track) (adde
 		return 0, 0, err
 	}
 
-	existing, err := p.loadTOML(path)
+	doc, err := p.loadDoc(path)
 	if err != nil {
 		if !errors.Is(err, fs.ErrNotExist) {
 			return 0, 0, err
@@ -179,13 +191,24 @@ func (p *Provider) AddTracks(playlistName string, tracks []playlist.Track) (adde
 		if err := validateNewName(playlistName); err != nil {
 			return 0, 0, err
 		}
-		existing = nil
+		doc = &playlistDoc{}
 	}
 
-	seen := make(map[string]struct{}, len(existing)+len(tracks))
-	for _, t := range existing {
+	seen := make(map[string]struct{}, len(doc.tracks)+len(tracks))
+	for _, t := range doc.tracks {
 		seen[t.Path] = struct{}{}
 	}
+	for _, src := range doc.dirs {
+		files, err := resolve.AudioFiles(ExpandPath(src.Path), src.Recursive)
+		if err != nil {
+			continue
+		}
+		for _, f := range files {
+			seen[f] = struct{}{}
+		}
+	}
+
+	existing := doc.tracks
 	for _, t := range tracks {
 		if _, ok := seen[t.Path]; ok {
 			skipped++
@@ -235,6 +258,142 @@ func (p *Provider) CreatePlaylist(_ context.Context, name string) (string, error
 	return name, nil
 }
 
+// CreateDirPlaylist creates a new playlist that references the given
+// directories via [[dir]] sections instead of expanding their files. Fails
+// when the playlist already exists or a directory does not exist.
+func (p *Provider) CreateDirPlaylist(name string, dirs []string) error {
+	if isHistoryName(name) {
+		return errReservedHistoryName
+	}
+	if err := os.MkdirAll(p.dir, 0o755); err != nil {
+		return err
+	}
+	if err := validateNewName(name); err != nil {
+		return err
+	}
+	for _, dir := range dirs {
+		if err := validateDirSource(dir); err != nil {
+			return err
+		}
+	}
+	path, err := p.safePath(name)
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		if errors.Is(err, fs.ErrExist) {
+			return fmt.Errorf("playlist %q already exists", name)
+		}
+		return err
+	}
+	for i, dir := range dirs {
+		if i > 0 {
+			fmt.Fprintln(f)
+		}
+		writeDir(f, DirSource{Path: dir, Recursive: true})
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// AddDirSource appends a [[dir]] section referencing dir to the named
+// playlist, creating the playlist if needed. Returns false when the playlist
+// already references the same directory. The directory must exist.
+func (p *Provider) AddDirSource(name, dir string) (bool, error) {
+	if isHistoryName(name) {
+		return false, errReservedHistoryName
+	}
+	if err := validateDirSource(dir); err != nil {
+		return false, err
+	}
+	if err := os.MkdirAll(p.dir, 0o755); err != nil {
+		return false, err
+	}
+	path, err := p.safePath(name)
+	if err != nil {
+		return false, err
+	}
+	doc, err := p.loadDoc(path)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return false, err
+		}
+		if err := validateNewName(name); err != nil {
+			return false, err
+		}
+		doc = &playlistDoc{}
+	}
+
+	target := ExpandPath(dir)
+	for _, src := range doc.dirs {
+		if ExpandPath(src.Path) == target {
+			return false, nil
+		}
+	}
+	doc.dirs = append(doc.dirs, DirSource{Path: dir, Recursive: true})
+	doc.order = append(doc.order, itemDir)
+	return true, p.saveDoc(name, doc)
+}
+
+// DirSources returns the directory sources referenced by a playlist.
+func (p *Provider) DirSources(name string) ([]DirSource, error) {
+	if isHistoryName(name) {
+		return nil, errReservedHistoryName
+	}
+	doc, err := p.loadDocByName(name)
+	if err != nil {
+		return nil, err
+	}
+	return doc.dirs, nil
+}
+
+// saveDoc writes a parsed document back to disk, preserving section order.
+func (p *Provider) saveDoc(name string, doc *playlistDoc) error {
+	if err := os.MkdirAll(p.dir, 0o755); err != nil {
+		return err
+	}
+	path, err := p.safePath(name)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(path); errors.Is(err, fs.ErrNotExist) {
+		if err := validateNewName(name); err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+
+	tmp := path + ".tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return err
+	}
+	ti, di := 0, 0
+	sections := 0
+	for _, kind := range doc.order {
+		if sections > 0 {
+			fmt.Fprintln(f)
+		}
+		if kind == itemTrack {
+			writeTrack(f, doc.tracks[ti])
+			ti++
+		} else {
+			writeDir(f, doc.dirs[di])
+			di++
+		}
+		sections++
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
 // Exists reports whether a playlist with the given name exists on disk, or
 // whether it refers to the virtual "Recently Played" history with at least
 // one entry recorded.
@@ -251,7 +410,10 @@ func (p *Provider) Exists(name string) bool {
 	return err == nil
 }
 
-// savePlaylist overwrites the named playlist with the given tracks.
+// savePlaylist overwrites the named playlist with the given tracks,
+// preserving any [[dir]] sections already present in the file.
+// Tracks marked DirSourced are not persisted; they are re-derived from the
+// directory sources on the next load.
 func (p *Provider) savePlaylist(name string, tracks []playlist.Track) error {
 	if err := os.MkdirAll(p.dir, 0o755); err != nil {
 		return err
@@ -276,11 +438,28 @@ func (p *Provider) savePlaylist(name string, tracks []playlist.Track) error {
 		return err
 	}
 
-	for i, t := range tracks {
-		if i > 0 {
+	// Preserve [[dir]] sections from the existing file so directory-sourced
+	// playlists stay dynamic across rewrites. Tracks marked DirSourced are
+	// skipped: they are re-derived from the directories on load, and
+	// persisting them would shadow the [[dir]] reference.
+	dirs := p.existingDirs(path)
+	sections := 0
+	for _, src := range dirs {
+		if sections > 0 {
+			fmt.Fprintln(f)
+		}
+		writeDir(f, src)
+		sections++
+	}
+	for _, t := range tracks {
+		if t.DirSourced {
+			continue
+		}
+		if sections > 0 {
 			fmt.Fprintln(f)
 		}
 		writeTrack(f, t)
+		sections++
 	}
 	if err := f.Close(); err != nil {
 		os.Remove(tmp)
@@ -289,16 +468,30 @@ func (p *Provider) savePlaylist(name string, tracks []playlist.Track) error {
 	return os.Rename(tmp, path)
 }
 
+// existingDirs parses path and returns its [[dir]] sections. Missing files
+// yield no directories.
+func (p *Provider) existingDirs(path string) []DirSource {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	return parsePlaylistDoc(data).dirs
+}
+
 // errReservedHistoryName is returned when a caller tries to write to or
 // otherwise mutate the synthetic history playlist.
 var errReservedHistoryName = errors.New(`"Recently Played" is a virtual history playlist and cannot be modified`)
 
 // SetBookmark toggles the bookmark flag on a track and rewrites the playlist.
+// The index refers to the expanded track list (explicit entries plus
+// directory-scanned ones). Bookmarking a directory-scanned track materializes
+// it as an explicit [[track]] entry so the bookmark persists; it then loads
+// after the directory-sourced tracks.
 func (p *Provider) SetBookmark(playlistName string, idx int) error {
 	if isHistoryName(playlistName) {
 		return errReservedHistoryName
 	}
-	tracks, err := p.loadTOMLByName(playlistName)
+	tracks, err := p.expandedTracks(playlistName)
 	if err != nil {
 		return err
 	}
@@ -306,36 +499,40 @@ func (p *Provider) SetBookmark(playlistName string, idx int) error {
 		return fmt.Errorf("index %d out of range (playlist has %d tracks)", idx, len(tracks))
 	}
 	tracks[idx].Bookmark = !tracks[idx].Bookmark
+	tracks[idx].DirSourced = false // materialize so the change persists
 	return p.savePlaylist(playlistName, tracks)
 }
 
 // SetBookmarkByPath toggles the bookmark flag on the first track with path and
 // rewrites the playlist. This avoids corrupting saved playlists when the live
 // queue has been filtered, reordered, or otherwise diverged from file order.
+// Directory-scanned tracks are materialized as explicit entries so the
+// bookmark persists.
 func (p *Provider) SetBookmarkByPath(playlistName string, path string) error {
 	if isHistoryName(playlistName) {
 		return errReservedHistoryName
 	}
-	tracks, err := p.loadTOMLByName(playlistName)
+	tracks, err := p.expandedTracks(playlistName)
 	if err != nil {
 		return err
 	}
 	for i := range tracks {
 		if tracks[i].Path == path {
 			tracks[i].Bookmark = !tracks[i].Bookmark
+			tracks[i].DirSourced = false // materialize so the change persists
 			return p.savePlaylist(playlistName, tracks)
 		}
 	}
 	return fmt.Errorf("track path %q not found in playlist %q", path, playlistName)
 }
 
-// loadTOMLByName loads tracks for a named playlist.
-func (p *Provider) loadTOMLByName(name string) ([]playlist.Track, error) {
+// loadDocByName loads a named playlist's parsed document.
+func (p *Provider) loadDocByName(name string) (*playlistDoc, error) {
 	path, err := p.safePath(name)
 	if err != nil {
 		return nil, err
 	}
-	return p.loadTOML(path)
+	return p.loadDoc(path)
 }
 
 // SavePlaylist overwrites a playlist with the given tracks.
@@ -386,11 +583,11 @@ func (p *Provider) SearchTracks(_ context.Context, query string, limit int) ([]p
 		if e.IsDir() || !strings.HasSuffix(strings.ToLower(e.Name()), ".toml") {
 			continue
 		}
-		tracks, err := p.loadTOML(filepath.Join(p.dir, e.Name()))
+		doc, err := p.loadDoc(filepath.Join(p.dir, e.Name()))
 		if err != nil {
 			continue
 		}
-		for _, t := range tracks {
+		for _, t := range doc.expand(true) {
 			if _, dup := seen[t.Path]; dup {
 				continue
 			}
@@ -483,20 +680,40 @@ func (p *Provider) ClearHistory() error {
 }
 
 // RemoveTrack removes a track by index from the named playlist.
-// Empty playlists are kept on disk; deleting a playlist remains explicit.
+// The index refers to the expanded track list. Directory-scanned tracks
+// cannot be removed: they are re-derived from the [[dir]] source on every
+// load. Empty playlists are kept on disk; deleting a playlist remains explicit.
 func (p *Provider) RemoveTrack(name string, index int) error {
 	if isHistoryName(name) {
 		return errReservedHistoryName
 	}
-	tracks, err := p.Tracks(name)
+	tracks, err := p.expandedTracks(name)
 	if err != nil {
 		return err
 	}
 	if index < 0 || index >= len(tracks) {
 		return fmt.Errorf("track index %d out of range", index)
 	}
-	tracks = slices.Delete(tracks, index, index+1)
-	return p.savePlaylist(name, tracks)
+	if tracks[index].DirSourced {
+		return fmt.Errorf("track %d (%s) is supplied by a directory source; remove the file from the directory or edit the playlist's [[dir]] section", index+1, tracks[index].Path)
+	}
+
+	kept := tracks[:0]
+	removed := false
+	for i, t := range tracks {
+		if t.DirSourced {
+			continue
+		}
+		if i == index {
+			removed = true
+			continue
+		}
+		kept = append(kept, t)
+	}
+	if !removed {
+		return fmt.Errorf("track index %d out of range", index)
+	}
+	return p.savePlaylist(name, kept)
 }
 
 // writeTrack writes a single [[track]] TOML section to w.
@@ -536,43 +753,43 @@ func writeTrack(w io.Writer, t playlist.Track) {
 	}
 }
 
-// loadTOML parses a minimal TOML file with [[track]] sections.
-// Each section supports path, title, and artist keys.
-func (p *Provider) loadTOML(path string) ([]playlist.Track, error) {
+// parseTrackFields converts a parsed [[track]] section into a Track.
+func parseTrackFields(f map[string]string) playlist.Track {
+	t := playlist.Track{
+		Path:   f["path"],
+		Title:  f["title"],
+		Artist: f["artist"],
+		Album:  f["album"],
+		Genre:  f["genre"],
+		Feed:   f["feed"] == "true",
+	}
+	t.EmbeddedLyrics = f["embedded_lyrics"]
+	t.AlbumArtURL = f["album_art_url"]
+	t.Stream = playlist.IsURL(t.Path)
+	// "favorite" is the pre-rename alias for "bookmark"; prefer bookmark.
+	bookmark, ok := f["bookmark"]
+	if !ok {
+		bookmark = f["favorite"]
+	}
+	t.Bookmark = bookmark == "true"
+	if n, err := strconv.Atoi(f["year"]); err == nil {
+		t.Year = n
+	}
+	if n, err := strconv.Atoi(f["track_number"]); err == nil {
+		t.TrackNumber = n
+	}
+	if n, err := strconv.Atoi(f["duration_secs"]); err == nil {
+		t.DurationSecs = n
+	}
+	return t
+}
+
+// loadDoc reads and parses a playlist file into explicit tracks and
+// directory sources, without scanning any directories.
+func (p *Provider) loadDoc(path string) (*playlistDoc, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
-
-	var tracks []playlist.Track
-	tomlutil.ParseSections(data, "track", func(f map[string]string) {
-		t := playlist.Track{
-			Path:   f["path"],
-			Title:  f["title"],
-			Artist: f["artist"],
-			Album:  f["album"],
-			Genre:  f["genre"],
-			Feed:   f["feed"] == "true",
-		}
-		t.EmbeddedLyrics = f["embedded_lyrics"]
-		t.AlbumArtURL = f["album_art_url"]
-		t.Stream = playlist.IsURL(t.Path)
-		// "favorite" is the pre-rename alias for "bookmark"; prefer bookmark.
-		bookmark, ok := f["bookmark"]
-		if !ok {
-			bookmark = f["favorite"]
-		}
-		t.Bookmark = bookmark == "true"
-		if n, err := strconv.Atoi(f["year"]); err == nil {
-			t.Year = n
-		}
-		if n, err := strconv.Atoi(f["track_number"]); err == nil {
-			t.TrackNumber = n
-		}
-		if n, err := strconv.Atoi(f["duration_secs"]); err == nil {
-			t.DurationSecs = n
-		}
-		tracks = append(tracks, t)
-	})
-	return tracks, nil
+	return parsePlaylistDoc(data), nil
 }

--- a/external/local/provider.go
+++ b/external/local/provider.go
@@ -470,7 +470,10 @@ func (p *Provider) savePlaylist(name string, tracks []playlist.Track) error {
 	} else if err != nil {
 		return fmt.Errorf("stat playlist %q: %w", name, err)
 	} else {
-		existing = p.existingDoc(path)
+		existing, err = p.existingDoc(path)
+		if err != nil {
+			return err
+		}
 	}
 
 	var explicit []playlist.Track
@@ -484,14 +487,18 @@ func (p *Provider) savePlaylist(name string, tracks []playlist.Track) error {
 	return p.saveDoc(name, &playlistDoc{tracks: tracks, dirs: dirs, order: order})
 }
 
-// existingDoc parses path into a document, or returns an empty document when
-// the file cannot be read or parsed.
-func (p *Provider) existingDoc(path string) *playlistDoc {
+// existingDoc parses path into a document, returning an empty document only
+// when the file does not exist. Read failures are wrapped and propagated so a
+// broken playlist is never silently rewritten without its [[dir]] sections.
+func (p *Provider) existingDoc(path string) (*playlistDoc, error) {
 	data, err := os.ReadFile(path)
-	if err != nil {
-		return &playlistDoc{}
+	if errors.Is(err, fs.ErrNotExist) {
+		return &playlistDoc{}, nil
 	}
-	return parsePlaylistDoc(data)
+	if err != nil {
+		return nil, fmt.Errorf("read playlist %q: %w", path, err)
+	}
+	return parsePlaylistDoc(data), nil
 }
 
 // errReservedHistoryName is returned when a caller tries to write to or

--- a/external/local/provider.go
+++ b/external/local/provider.go
@@ -260,13 +260,14 @@ func (p *Provider) CreatePlaylist(_ context.Context, name string) (string, error
 
 // CreateDirPlaylist creates a new playlist that references the given
 // directories via [[dir]] sections instead of expanding their files. Fails
-// when the playlist already exists or a directory does not exist.
+// when the playlist already exists or a directory does not exist, leaving no
+// file behind.
 func (p *Provider) CreateDirPlaylist(name string, dirs []string) error {
 	if isHistoryName(name) {
 		return errReservedHistoryName
 	}
 	if err := os.MkdirAll(p.dir, 0o755); err != nil {
-		return err
+		return fmt.Errorf("creating playlist dir: %w", err)
 	}
 	if err := validateNewName(name); err != nil {
 		return err
@@ -278,64 +279,99 @@ func (p *Provider) CreateDirPlaylist(name string, dirs []string) error {
 	}
 	path, err := p.safePath(name)
 	if err != nil {
-		return err
+		return fmt.Errorf("resolving playlist path: %w", err)
 	}
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
-	if err != nil {
+	if _, err := os.Stat(path); err == nil {
+		return fmt.Errorf("playlist %q already exists", name)
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("stat playlist %q: %w", name, err)
+	}
+
+	var b strings.Builder
+	for i, dir := range dirs {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		writeDir(&b, DirSource{Path: dir, Recursive: true})
+	}
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(b.String()), 0o644); err != nil {
+		return fmt.Errorf("writing playlist %q: %w", name, err)
+	}
+	// Link is atomic and fails when the final path already exists, preserving
+	// the create-only semantics without a partial-write window.
+	if err := os.Link(tmp, path); err != nil {
+		os.Remove(tmp)
 		if errors.Is(err, fs.ErrExist) {
 			return fmt.Errorf("playlist %q already exists", name)
 		}
-		return err
+		return fmt.Errorf("creating playlist %q: %w", name, err)
 	}
-	for i, dir := range dirs {
-		if i > 0 {
-			fmt.Fprintln(f)
+	return os.Remove(tmp)
+}
+
+// AddDirSources appends [[dir]] sections for every directory in dirs that the
+// named playlist does not already reference, creating the playlist if needed.
+// All directories are validated before anything is persisted, so a failing
+// input leaves the playlist untouched. Returns the directories that were added.
+func (p *Provider) AddDirSources(name string, dirs []string) ([]string, error) {
+	if isHistoryName(name) {
+		return nil, errReservedHistoryName
+	}
+	for _, dir := range dirs {
+		if err := validateDirSource(dir); err != nil {
+			return nil, err
 		}
-		writeDir(f, DirSource{Path: dir, Recursive: true})
 	}
-	if err := f.Close(); err != nil {
-		return err
+	if err := os.MkdirAll(p.dir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating playlist dir: %w", err)
 	}
-	return nil
+	path, err := p.safePath(name)
+	if err != nil {
+		return nil, fmt.Errorf("resolving playlist path: %w", err)
+	}
+	doc, err := p.loadDoc(path)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return nil, err
+		}
+		if err := validateNewName(name); err != nil {
+			return nil, err
+		}
+		doc = &playlistDoc{}
+	}
+
+	known := make(map[string]struct{}, len(doc.dirs))
+	for _, src := range doc.dirs {
+		known[ExpandPath(src.Path)] = struct{}{}
+	}
+	var added []string
+	for _, dir := range dirs {
+		target := ExpandPath(dir)
+		if _, ok := known[target]; ok {
+			continue
+		}
+		known[target] = struct{}{}
+		added = append(added, dir)
+		doc.dirs = append(doc.dirs, DirSource{Path: dir, Recursive: true})
+		doc.order = append(doc.order, itemDir)
+	}
+	if len(added) == 0 {
+		return nil, nil
+	}
+	return added, p.saveDoc(name, doc)
 }
 
 // AddDirSource appends a [[dir]] section referencing dir to the named
 // playlist, creating the playlist if needed. Returns false when the playlist
 // already references the same directory. The directory must exist.
 func (p *Provider) AddDirSource(name, dir string) (bool, error) {
-	if isHistoryName(name) {
-		return false, errReservedHistoryName
-	}
-	if err := validateDirSource(dir); err != nil {
-		return false, err
-	}
-	if err := os.MkdirAll(p.dir, 0o755); err != nil {
-		return false, err
-	}
-	path, err := p.safePath(name)
+	added, err := p.AddDirSources(name, []string{dir})
 	if err != nil {
 		return false, err
 	}
-	doc, err := p.loadDoc(path)
-	if err != nil {
-		if !errors.Is(err, fs.ErrNotExist) {
-			return false, err
-		}
-		if err := validateNewName(name); err != nil {
-			return false, err
-		}
-		doc = &playlistDoc{}
-	}
-
-	target := ExpandPath(dir)
-	for _, src := range doc.dirs {
-		if ExpandPath(src.Path) == target {
-			return false, nil
-		}
-	}
-	doc.dirs = append(doc.dirs, DirSource{Path: dir, Recursive: true})
-	doc.order = append(doc.order, itemDir)
-	return true, p.saveDoc(name, doc)
+	return len(added) == 1, nil
 }
 
 // DirSources returns the directory sources referenced by a playlist.
@@ -351,47 +387,49 @@ func (p *Provider) DirSources(name string) ([]DirSource, error) {
 }
 
 // saveDoc writes a parsed document back to disk, preserving section order.
+// The full document is rendered in memory before the atomic rename so a
+// partial write can never clobber the existing playlist.
 func (p *Provider) saveDoc(name string, doc *playlistDoc) error {
 	if err := os.MkdirAll(p.dir, 0o755); err != nil {
-		return err
+		return fmt.Errorf("creating playlist dir: %w", err)
 	}
 	path, err := p.safePath(name)
 	if err != nil {
-		return err
+		return fmt.Errorf("resolving playlist path: %w", err)
 	}
 	if _, err := os.Stat(path); errors.Is(err, fs.ErrNotExist) {
 		if err := validateNewName(name); err != nil {
 			return err
 		}
 	} else if err != nil {
-		return err
+		return fmt.Errorf("stat playlist %q: %w", name, err)
 	}
 
-	tmp := path + ".tmp"
-	f, err := os.Create(tmp)
-	if err != nil {
-		return err
-	}
-	ti, di := 0, 0
-	sections := 0
+	var b strings.Builder
+	ti, di, sections := 0, 0, 0
 	for _, kind := range doc.order {
 		if sections > 0 {
-			fmt.Fprintln(f)
+			b.WriteByte('\n')
 		}
 		if kind == itemTrack {
-			writeTrack(f, doc.tracks[ti])
+			writeTrack(&b, doc.tracks[ti])
 			ti++
 		} else {
-			writeDir(f, doc.dirs[di])
+			writeDir(&b, doc.dirs[di])
 			di++
 		}
 		sections++
 	}
-	if err := f.Close(); err != nil {
-		os.Remove(tmp)
-		return err
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(b.String()), 0o644); err != nil {
+		return fmt.Errorf("writing playlist %q: %w", name, err)
 	}
-	return os.Rename(tmp, path)
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("saving playlist %q: %w", name, err)
+	}
+	return nil
 }
 
 // Exists reports whether a playlist with the given name exists on disk, or
@@ -410,72 +448,50 @@ func (p *Provider) Exists(name string) bool {
 	return err == nil
 }
 
-// savePlaylist overwrites the named playlist with the given tracks,
-// preserving any [[dir]] sections already present in the file.
+// savePlaylist overwrites the named playlist with the given tracks, preserving
+// [[dir]] sections and their interleaving with explicit [[track]] sections.
 // Tracks marked DirSourced are not persisted; they are re-derived from the
 // directory sources on the next load.
 func (p *Provider) savePlaylist(name string, tracks []playlist.Track) error {
 	if err := os.MkdirAll(p.dir, 0o755); err != nil {
-		return err
+		return fmt.Errorf("creating playlist dir: %w", err)
 	}
 
 	path, err := p.safePath(name)
 	if err != nil {
-		return err
+		return fmt.Errorf("resolving playlist path: %w", err)
 	}
+	var existing *playlistDoc
 	if _, err := os.Stat(path); errors.Is(err, fs.ErrNotExist) {
 		if err := validateNewName(name); err != nil {
 			return err
 		}
+		existing = &playlistDoc{}
 	} else if err != nil {
-		return err
+		return fmt.Errorf("stat playlist %q: %w", name, err)
+	} else {
+		existing = p.existingDoc(path)
 	}
 
-	// Atomic write: write to temp file, then rename.
-	tmp := path + ".tmp"
-	f, err := os.Create(tmp)
-	if err != nil {
-		return err
-	}
-
-	// Preserve [[dir]] sections from the existing file so directory-sourced
-	// playlists stay dynamic across rewrites. Tracks marked DirSourced are
-	// skipped: they are re-derived from the directories on load, and
-	// persisting them would shadow the [[dir]] reference.
-	dirs := p.existingDirs(path)
-	sections := 0
-	for _, src := range dirs {
-		if sections > 0 {
-			fmt.Fprintln(f)
-		}
-		writeDir(f, src)
-		sections++
-	}
+	var explicit []playlist.Track
 	for _, t := range tracks {
 		if t.DirSourced {
 			continue
 		}
-		if sections > 0 {
-			fmt.Fprintln(f)
-		}
-		writeTrack(f, t)
-		sections++
+		explicit = append(explicit, t)
 	}
-	if err := f.Close(); err != nil {
-		os.Remove(tmp)
-		return err
-	}
-	return os.Rename(tmp, path)
+	tracks, dirs, order := rebuildDoc(existing, explicit)
+	return p.saveDoc(name, &playlistDoc{tracks: tracks, dirs: dirs, order: order})
 }
 
-// existingDirs parses path and returns its [[dir]] sections. Missing files
-// yield no directories.
-func (p *Provider) existingDirs(path string) []DirSource {
+// existingDoc parses path into a document, or returns an empty document when
+// the file cannot be read or parsed.
+func (p *Provider) existingDoc(path string) *playlistDoc {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil
+		return &playlistDoc{}
 	}
-	return parsePlaylistDoc(data).dirs
+	return parsePlaylistDoc(data)
 }
 
 // errReservedHistoryName is returned when a caller tries to write to or

--- a/external/local/provider_test.go
+++ b/external/local/provider_test.go
@@ -192,9 +192,9 @@ title = "A"
 	path := filepath.Join(p.dir, "commented.toml")
 	os.WriteFile(path, []byte(content), 0o644)
 
-	tracks, err := p.loadTOML(path)
+	tracks, err := p.Tracks("commented")
 	if err != nil {
-		t.Fatalf("loadTOML: %v", err)
+		t.Fatalf("Tracks: %v", err)
 	}
 	if len(tracks) != 1 {
 		t.Fatalf("got %d tracks, want 1", len(tracks))
@@ -536,9 +536,9 @@ title = "Live Radio"
 	path := filepath.Join(p.dir, "radio.toml")
 	os.WriteFile(path, []byte(content), 0o644)
 
-	tracks, err := p.loadTOML(path)
+	tracks, err := p.Tracks("radio")
 	if err != nil {
-		t.Fatalf("loadTOML: %v", err)
+		t.Fatalf("Tracks: %v", err)
 	}
 	if !tracks[0].Stream {
 		t.Fatal("URL path should set Stream=true")

--- a/internal/tomlutil/sections.go
+++ b/internal/tomlutil/sections.go
@@ -40,6 +40,14 @@ func ParseNamedSections(data []byte, sections []string, emit func(section string
 			cur = name
 			continue
 		}
+		if strings.HasPrefix(line, "[[") && strings.HasSuffix(line, "]]") {
+			// Unrecognized array-table header: flush the section we were in so
+			// its fields cannot leak into the next recognized section.
+			flush()
+			fields = nil
+			cur = ""
+			continue
+		}
 		if fields == nil {
 			continue
 		}

--- a/internal/tomlutil/sections.go
+++ b/internal/tomlutil/sections.go
@@ -9,11 +9,24 @@ import "strings"
 // ignored. An empty section still triggers emit, so callers apply their own
 // validation. When a key repeats within a section, the last value wins.
 func ParseSections(data []byte, section string, emit func(fields map[string]string)) {
-	header := "[[" + section + "]]"
+	ParseNamedSections(data, []string{section}, func(_ string, fields map[string]string) {
+		emit(fields)
+	})
+}
+
+// ParseNamedSections is like ParseSections but accepts several section names
+// and passes the matched section name to emit. Sections may be interleaved;
+// emit follows document order.
+func ParseNamedSections(data []byte, sections []string, emit func(section string, fields map[string]string)) {
+	headers := make(map[string]string, len(sections))
+	for _, s := range sections {
+		headers["[["+s+"]]"] = s
+	}
 	var fields map[string]string
+	cur := ""
 	flush := func() {
 		if fields != nil {
-			emit(fields)
+			emit(cur, fields)
 		}
 	}
 	for rawLine := range strings.SplitSeq(string(data), "\n") {
@@ -21,9 +34,10 @@ func ParseSections(data []byte, section string, emit func(fields map[string]stri
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
-		if line == header {
+		if name, ok := headers[line]; ok {
 			flush()
 			fields = make(map[string]string)
+			cur = name
 			continue
 		}
 		if fields == nil {

--- a/internal/tomlutil/sections_test.go
+++ b/internal/tomlutil/sections_test.go
@@ -104,3 +104,27 @@ path = "/a.mp3"
 		t.Fatalf("emit count = %d, want 1", count)
 	}
 }
+
+func TestParseNamedSectionsUnknownHeaderDoesNotLeakFields(t *testing.T) {
+	data := []byte(`[[track]]
+path = "/a.mp3"
+
+[[unknown]]
+title = "leaked"
+
+[[track]]
+path = "/b.mp3"
+title = "B"
+`)
+	var got []string
+	ParseNamedSections(data, []string{"track"}, func(section string, f map[string]string) {
+		got = append(got, section+":"+f["path"]+":"+f["title"])
+	})
+	want := []string{
+		"track:/a.mp3:",
+		"track:/b.mp3:B",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ParseNamedSections = %v, want %v (unknown section fields leaked)", got, want)
+	}
+}

--- a/internal/tomlutil/sections_test.go
+++ b/internal/tomlutil/sections_test.go
@@ -51,3 +51,56 @@ func TestParseSectionsEmptySectionEmits(t *testing.T) {
 		t.Fatalf("emit count = %d, want 2", count)
 	}
 }
+
+func TestParseNamedSectionsInterleavedOrder(t *testing.T) {
+	data := []byte(`[[dir]]
+path = "/music"
+recursive = "false"
+
+[[track]]
+path = "/a.mp3"
+title = "A"
+
+[[dir]]
+path = "$EXTRA_DIR"
+
+[[track]]
+path = "/b.mp3"
+title = "B"
+`)
+	t.Setenv("EXTRA_DIR", "/extra")
+
+	var got []string
+	ParseNamedSections(data, []string{"track", "dir"}, func(section string, f map[string]string) {
+		switch section {
+		case "track":
+			got = append(got, "track:"+f["path"])
+		case "dir":
+			got = append(got, "dir:"+f["path"]+" rec="+f["recursive"])
+		}
+	})
+
+	want := []string{
+		"dir:/music rec=false",
+		"track:/a.mp3",
+		"dir:$EXTRA_DIR rec=",
+		"track:/b.mp3",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ParseNamedSections = %v, want %v", got, want)
+	}
+}
+
+func TestParseNamedSectionsUnknownHeaderIgnored(t *testing.T) {
+	data := []byte(`[[unknown]]
+path = "/x"
+
+[[track]]
+path = "/a.mp3"
+`)
+	count := 0
+	ParseNamedSections(data, []string{"track"}, func(_ string, _ map[string]string) { count++ })
+	if count != 1 {
+		t.Fatalf("emit count = %d, want 1", count)
+	}
+}

--- a/playlist/playlist.go
+++ b/playlist/playlist.go
@@ -48,6 +48,8 @@ type Track struct {
 
 	Unplayable bool // true when the track is known not playable in the current playback context
 
+	DirSourced bool // true when expanded from a [[dir]] playlist section; re-derived on load, never persisted
+
 	EmbeddedLyrics string // embedded lyrics from local file tags, when present
 	AlbumArtURL    string // file:// URL for cached embedded album art, when present
 

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -307,22 +307,27 @@ func CollectAudioFiles(path string) ([]string, error) {
 // false only the directory's immediate children are considered. A file path
 // with a supported extension is returned directly.
 func AudioFiles(dir string, recursive bool) ([]string, error) {
-	if recursive {
-		info, err := os.Stat(dir)
-		if err != nil {
-			return nil, err
+	info, err := os.Stat(dir)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		if player.SupportedExts[strings.ToLower(filepath.Ext(dir))] {
+			return []string{dir}, nil
 		}
-		if !info.IsDir() {
-			if player.SupportedExts[strings.ToLower(filepath.Ext(dir))] {
-				return []string{dir}, nil
-			}
-			return nil, nil
-		}
+		return nil, nil
+	}
 
+	if recursive {
 		var files []string
-		err = filepath.WalkDir(dir, func(p string, d fs.DirEntry, err error) error {
+		err := filepath.WalkDir(dir, func(p string, d fs.DirEntry, err error) error {
 			if err != nil {
-				return err
+				// Skip entries we cannot read instead of aborting the scan, so
+				// one unreadable subdirectory cannot empty the whole result.
+				if d != nil && d.IsDir() {
+					return fs.SkipDir
+				}
+				return nil
 			}
 			if !d.IsDir() && player.SupportedExts[strings.ToLower(filepath.Ext(p))] {
 				files = append(files, p)
@@ -337,16 +342,6 @@ func AudioFiles(dir string, recursive bool) ([]string, error) {
 		return files, nil
 	}
 
-	info, err := os.Stat(dir)
-	if err != nil {
-		return nil, err
-	}
-	if !info.IsDir() {
-		if player.SupportedExts[strings.ToLower(filepath.Ext(dir))] {
-			return []string{dir}, nil
-		}
-		return nil, nil
-	}
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -309,7 +309,7 @@ func CollectAudioFiles(path string) ([]string, error) {
 func AudioFiles(dir string, recursive bool) ([]string, error) {
 	info, err := os.Stat(dir)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("stat audio path %q: %w", dir, err)
 	}
 	if !info.IsDir() {
 		if player.SupportedExts[strings.ToLower(filepath.Ext(dir))] {
@@ -335,7 +335,7 @@ func AudioFiles(dir string, recursive bool) ([]string, error) {
 			return nil
 		})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("walk audio directory %q: %w", dir, err)
 		}
 
 		slices.Sort(files)
@@ -344,7 +344,7 @@ func AudioFiles(dir string, recursive bool) ([]string, error) {
 
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read audio directory %q: %w", dir, err)
 	}
 	var files []string
 	for _, e := range entries {

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -300,34 +300,75 @@ func sniffFeedURL(rawURL string) bool {
 // If path is a directory, it walks it recursively collecting supported files.
 // If path is a file with a supported extension, it returns it directly.
 func CollectAudioFiles(path string) ([]string, error) {
-	info, err := os.Stat(path)
+	return AudioFiles(path, true)
+}
+
+// AudioFiles returns sorted audio file paths under dir. When recursive is
+// false only the directory's immediate children are considered. A file path
+// with a supported extension is returned directly.
+func AudioFiles(dir string, recursive bool) ([]string, error) {
+	if recursive {
+		info, err := os.Stat(dir)
+		if err != nil {
+			return nil, err
+		}
+		if !info.IsDir() {
+			if player.SupportedExts[strings.ToLower(filepath.Ext(dir))] {
+				return []string{dir}, nil
+			}
+			return nil, nil
+		}
+
+		var files []string
+		err = filepath.WalkDir(dir, func(p string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if !d.IsDir() && player.SupportedExts[strings.ToLower(filepath.Ext(p))] {
+				files = append(files, p)
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		slices.Sort(files)
+		return files, nil
+	}
+
+	info, err := os.Stat(dir)
 	if err != nil {
 		return nil, err
 	}
-
 	if !info.IsDir() {
-		if player.SupportedExts[strings.ToLower(filepath.Ext(path))] {
-			return []string{path}, nil
+		if player.SupportedExts[strings.ToLower(filepath.Ext(dir))] {
+			return []string{dir}, nil
 		}
 		return nil, nil
 	}
-
-	var files []string
-	err = filepath.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if !d.IsDir() && player.SupportedExts[strings.ToLower(filepath.Ext(p))] {
-			files = append(files, p)
-		}
-		return nil
-	})
+	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}
-
+	var files []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		p := filepath.Join(dir, e.Name())
+		if player.SupportedExts[strings.ToLower(filepath.Ext(p))] {
+			files = append(files, p)
+		}
+	}
 	slices.Sort(files)
 	return files, nil
+}
+
+// TracksFromPaths converts file paths to Tracks concurrently with tag
+// reading, preserving order.
+func TracksFromPaths(files []string) []playlist.Track {
+	return scanTracks(files)
 }
 
 // LocalPlaylist resolves a local M3U/M3U8 or PLS playlist file into tracks.

--- a/resolve/resolve_test.go
+++ b/resolve/resolve_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -228,6 +229,9 @@ func TestResolveM3U_PlainPlaylist_StillParsesTracks(t *testing.T) {
 }
 
 func TestAudioFilesSkipsUnreadableSubdir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod does not map to Unix directory permissions on Windows")
+	}
 	if os.Geteuid() == 0 {
 		t.Skip("permission checks do not apply to root")
 	}

--- a/resolve/resolve_test.go
+++ b/resolve/resolve_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -222,5 +224,42 @@ func TestResolveM3U_PlainPlaylist_StillParsesTracks(t *testing.T) {
 	}
 	if len(tracks) != 2 {
 		t.Fatalf("got %d tracks, want 2 (regression guard)", len(tracks))
+	}
+}
+
+func TestAudioFilesSkipsUnreadableSubdir(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission checks do not apply to root")
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.mp3"), []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	locked := filepath.Join(dir, "locked")
+	if err := os.MkdirAll(locked, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(locked, "b.mp3"), []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(locked, "c.ogg"), []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(locked, 0o755) })
+
+	files, err := AudioFiles(dir, true)
+	if err != nil {
+		t.Fatalf("AudioFiles: %v", err)
+	}
+	if len(files) != 1 || filepath.Base(files[0]) != "a.mp3" {
+		t.Fatalf("AudioFiles = %v, want only a.mp3 (unreadable subdir must be skipped)", files)
+	}
+
+	// Non-recursive mode must behave the same way (no abort either).
+	if files, err := AudioFiles(dir, false); err != nil || len(files) != 1 {
+		t.Fatalf("non-recursive AudioFiles = %v err=%v, want only a.mp3", files, err)
 	}
 }

--- a/site/index.html
+++ b/site/index.html
@@ -750,7 +750,7 @@ user_id = "your-account-user-id"</code></pre>
     <div class="features-grid reveal">
       <div class="feature"><div class="feature-icon">≡</div><div class="feature-name">10-Band Equalizer</div><p>Parametric EQ with presets: Rock, Jazz, Pop, Classical, and more.</p></div>
       <div class="feature"><div class="feature-icon">◈</div><div class="feature-name">Themes &amp; Visualizers</div><p>20 built-in themes and spectrum, waveform, particle, and true-stereo modes. Stereo provides dedicated L/R horizontal LED peak meters. Hot-swap with <kbd>t</kbd> / <kbd>v</kbd>.</p></div>
-      <div class="feature"><div class="feature-icon">☰</div><div class="feature-name">Playlists</div><p>TOML playlists, M3U/M3U8/PLS import/export, duplicate-safe writes, and TUI/CLI sort tools.</p></div>
+      <div class="feature"><div class="feature-icon">☰</div><div class="feature-name">Playlists</div><p>TOML playlists with dynamic directory sources (<code>--dir</code>), M3U/M3U8/PLS import/export, duplicate-safe writes, and TUI/CLI sort tools.</p></div>
       <div class="feature"><div class="feature-icon">⟲</div><div class="feature-name">Recently Played</div><p>Auto-recorded listening history. Browse it as a virtual playlist or run <code>cliamp history</code> from the shell.</p></div>
       <div class="feature"><div class="feature-icon">→</div><div class="feature-name">HTTP Streaming</div><p>Play from URLs, internet radio, remote M3U playlists, and HLS (<code>.m3u8</code>) live streams via ffmpeg.</p></div>
       <div class="feature"><div class="feature-icon">♪</div><div class="feature-name">Synced Lyrics</div><p>Embedded local lyrics first, then LRCLIB/NetEase fallback. Auto-scrolling for timestamped lyrics.</p></div>

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -2139,6 +2139,12 @@ func (m *Model) plMgrRemoveSelectedTracks() {
 	if len(indices) == 0 {
 		return
 	}
+	for _, i := range indices {
+		if m.plManager.tracks[i].DirSourced {
+			m.status.Showf(statusTTLDefault, "Can't remove %q: it's supplied by the playlist's directory source", m.plManager.tracks[i].DisplayName())
+			return
+		}
+	}
 	m.plMgrSetTrackUndo()
 	for i := len(indices) - 1; i >= 0; i-- {
 		idx := indices[i]
@@ -2241,8 +2247,19 @@ func (m *Model) persistLoadedPlaylistOrder() {
 	if !ok {
 		return
 	}
+	hasDirTracks := false
+	for _, t := range m.playlist.Tracks() {
+		if t.DirSourced {
+			hasDirTracks = true
+			break
+		}
+	}
 	if err := saver.SavePlaylist(m.loadedPlaylist, m.playlist.Tracks()); err != nil {
 		m.status.Showf(statusTTLDefault, "Save failed: %s", err)
+		return
+	}
+	if hasDirTracks {
+		m.status.Showf(statusTTLDefault, "Reordered %q (directory-sourced tracks keep scan order)", m.loadedPlaylist)
 		return
 	}
 	m.status.Showf(statusTTLDefault, "Reordered %q", m.loadedPlaylist)

--- a/ui/model/playback.go
+++ b/ui/model/playback.go
@@ -191,6 +191,10 @@ func (m *Model) removeSelectedFromPlaylist() {
 	}
 	snapshot := m.playlist.Snapshot()
 	track := m.playlist.Tracks()[idx]
+	if track.DirSourced {
+		m.status.Showf(statusTTLDefault, "Can't remove %q: it's supplied by the playlist's directory source", track.DisplayName())
+		return
+	}
 	loaded := m.loadedPlaylist
 	var saved []playlist.Track
 	persisted := false

--- a/ui/model/playback.go
+++ b/ui/model/playback.go
@@ -206,12 +206,22 @@ func (m *Model) removeSelectedFromPlaylist() {
 				m.status.Showf(statusTTLDefault, "Remove failed: %s", err)
 				return
 			}
-			if idx >= len(saved) {
-				m.status.Showf(statusTTLDefault, "Remove failed: selected track is not in %q", loaded)
+			// saved rescans directory sources, so a new file could have shifted
+			// indexes since the queue was loaded. Match the persisted explicit
+			// track by path so the wrong track is never removed.
+			savedIdx := -1
+			for i, candidate := range saved {
+				if !candidate.DirSourced && candidate.Path == track.Path {
+					savedIdx = i
+					break
+				}
+			}
+			if savedIdx < 0 {
+				m.status.Showf(statusTTLDefault, "Remove failed: selected track is no longer in %q", loaded)
 				return
 			}
 			original := cloneTracks(saved)
-			saved = append(saved[:idx:idx], saved[idx+1:]...)
+			saved = append(saved[:savedIdx:savedIdx], saved[savedIdx+1:]...)
 			if err := saver.SavePlaylist(loaded, saved); err != nil {
 				m.status.Showf(statusTTLDefault, "Remove failed: %s", err)
 				return


### PR DESCRIPTION
# Dynamic directory playlists via `[[dir]]` sources

## Problem

Local TOML playlists hardcode every track as a `[[track]]` entry. Pointing a playlist at a music library like `~/Music` means writing hundreds of lines to the file, and the playlist goes stale the moment a file is added, renamed, or removed.

## What this adds

A playlist file can now reference a directory that is scanned for audio files **every time the playlist loads**, instead of listing each file:

```toml
# ~/.config/cliamp/playlists/music.toml
[[dir]]
path = "~/Music"
```

Only 4 lines to reference an entire library. New files show up automatically, removed files disappear — no editing needed.

## How to use it

### CLI

```sh
# Reference a directory instead of expanding its files
cliamp playlist create "Music" --dir ~/Music

# Add more directories to the same playlist (repeatable)
cliamp playlist create "Chill" --dir ~/Music --dir ~/Downloads/podcasts
cliamp playlist add "Chill" --dir ~/Downloads/live

# See which directories a playlist references
cliamp playlist dirs "Chill"

# Mix explicit tracks with directory sources in one playlist
cliamp playlist create "Mix" --dir ~/Music --ssh host:/remote  # refused: --dir cannot combine with --ssh
```

### Manual TOML

**Where the files live:** playlists are plain `.toml` files in the config directory's `playlists/` subfolder — the filename (minus extension) becomes the playlist name, so every non-directory `.toml` file in the folder is picked up automatically, CLI-created or hand-written (files that fail to parse are skipped):

```
~/.config/cliamp/playlists/
  Music.toml      → playlist "Music"
  Chill.toml      → playlist "Chill"
  gym.toml        → playlist "gym"
```

(The folder is created automatically on first use. It follows cliamp's config-dir resolution: `CLIAMP_CONFIG_DIR`, then `XDG_CONFIG_HOME/cliamp`, then `HOME/.config/cliamp`.)

Users can keep one file per collection and mix hand-written and CLI-created files freely. One playlist file can hold any number of `[[dir]]` and `[[track]]` sections, in any order:

```toml
[[dir]]
path = "~/Music"          # recursive by default (scans subdirectories)

[[dir]]
path = "~/Recordings"
recursive = false         # top-level files only

[[track]]
path = "/home/user/song.mp3"   # explicit entries always win over the scan
bookmark = true
```

`path` supports `~` and environment variables (e.g. `$MUSIC_DIR`). Unreadable or missing directories simply contribute no tracks.

## Behavior details

- **Document order preserved** — explicit tracks and directory scans are merged in the order they appear in the file; files are sorted by path within each directory.
- **Explicit tracks shadow the scan** — a `[[track]]` with the same path as a scanned file wins, so you can pin a bookmark or custom metadata onto a specific file.
- **Dynamic counts** — `playlist list` and the TUI browser count tracks without reading tags, so a large library stays fast.
- **Bookmarks persist** — bookmarking a directory-sourced track (TUI `f` or `playlist bookmark`) materializes it as an explicit `[[track]]` entry.
- **Removal is safe** — removing a directory-sourced track (CLI or TUI) is refused with a clear message; delete the file from the directory or edit the `[[dir]]` section instead.
- **No duplicates** — adding a file that a directory source already covers is deduped (`0 added, 1 skipped`).
- **Search includes directory sources** — global search matches tracks inside referenced folders.

## Files changed

- `internal/tomlutil`: `ParseNamedSections` for multi-section TOML documents
- `resolve`: `AudioFiles(dir, recursive)` and `TracksFromPaths` (concurrent tag reads)
- `playlist`: `DirSourced` flag on `Track`
- `external/local`: `[[dir]]` parsing, expansion, and persistence (`CreateDirPlaylist`, `AddDirSource`, `DirSources`), plus reworked load/save/bookmark/remove on the expanded view
- `cmd` + `commands.go`: `--dir` flags on `playlist create`/`add`, new `playlist dirs` subcommand
- `ui/model`: guards so directory-sourced tracks can't be silently removed or reordered
- `docs`: `[[dir]]` format documented in `docs/playlists.md` and `docs/cli.md`
- Tests: 26 new tests covering parsing, expansion, shadowing, dedupe, bookmark materialization, and CLI wiring

## Testing

- `gofmt` clean, `go vet` clean
- `go test ./...` — all packages pass
- Manually verified against a 424-track `~/Music`: playlist shows 424 tracks live, bookmarks materialize, dir-track removal is refused, and `--dir ~/Music` vs absolute path dedupe correctly

## Code review hardening

Fixes from review findings on top of the feature work:

- **Section-order preservation**: playlists are rewritten with their `[[track]]`/`[[dir]]` interleaving intact instead of flattening all dirs first. Removals drop only their own slot, reorders of explicit tracks are honored, metadata enrichment stays in place, and a bookmarked directory track materializes directly before the directory that supplies it.
- **Index-race on removal**: the TUI matches the persisted explicit track by path before removing, so a rescan between load and save can no longer remove the wrong track.
- **No partial writes**: documents are rendered in memory before the atomic rename, so a failed/short write can never truncate an existing playlist.
- **Validate before persist**: `playlist create`/`add` resolve audio paths and validate all directory sources before any file is written; directory sources are persisted as a single atomic batch (`AddDirSources`), so a failing input leaves no partial playlist behind.
- **Resilient scans**: unreadable entries are skipped during recursive scans instead of aborting the whole directory.
- **Errors** are wrapped with context so failures name the failing operation.
- ~20 additional regression tests for all of the above.

### Follow-up hardening

- **Leftover insertion alignment**: when two directory-sourced tracks are materialized in one save (e.g. bookmark + reorder), section positions are re-aligned after each insertion so neither lands in the wrong slot (regression test verified to fail pre-fix: `[a b x]` instead of `[a x b]`).
- **No save-time rescans**: supplier detection is now a pure path check (`filepath.Rel` + recursive flag), so saves no longer re-walk the filesystem the load already scanned.
- **Read failures abort rewrites**: a playlist that cannot be read is never silently rewritten without its `[[dir]]` sections.
- **TOML parser hardening**: unknown `[[...]]` headers flush and reset the current section so their fields can't leak into a recognized one.
- **Docs/site** now describe the exact `.toml` discovery rule and pass markdownlint (MD040); the unreadable-subdir test is skipped on Windows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Create and add playlists from directories with repeatable `--dir` options.
  - Support recursive scanning, dynamic track discovery, and environment/path expansion.
  - Added `playlist dirs` to view referenced directory sources.
  - Explicit tracks take precedence over directory-discovered duplicates.

- **Behavior Updates**
  - Directory-sourced tracks cannot be removed directly and retain scan order after reloads.
  - Bookmarked directory tracks are saved explicitly.
  - SSH and directory sources cannot be combined.
  - Invalid, missing, empty, or duplicate sources are safely validated.

- **Documentation**
  - Added CLI and playlist guidance for directory sources and restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
