### PR TITLE
feat: add Tidal provider with lossless streaming

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -1,7 +1,7 @@
 // Package cmd implements interactive subcommands invoked from the CLI.
 // setup.go contains the provider onboarding wizard reachable via
 // `cliamp setup`. It walks the user through configuring each remote
-// provider (Navidrome, Plex, Jellyfin, Spotify, Qobuz, NetEase, YouTube Music),
+// provider (Navidrome, Plex, Jellyfin, Spotify, Qobuz, Tidal, NetEase, YouTube Music),
 // validates the connection where possible, and writes the resulting
 // TOML section to ~/.config/cliamp/config.toml.
 //
@@ -95,6 +95,7 @@ const (
 	keyYTMusicMode    = "_mode"
 	keySpotifyMode    = "_spotify_mode"
 	keyQobuzQuality   = "_qobuz_quality"
+	keyTidalQuality   = "_tidal_quality"
 )
 
 func providers() []providerSpec {
@@ -366,6 +367,39 @@ func providers() []providerSpec {
 				return strings.Join([]string{
 					"enabled = true",
 					fmt.Sprintf("quality = %s", q),
+				}, "\n")
+			},
+		},
+		{
+			key:     "tidal",
+			name:    "Tidal",
+			section: "tidal",
+			intro: []string{
+				"Lossless streaming. Requires a paid Tidal subscription",
+				"(every paid plan includes lossless FLAC).",
+				"",
+				"No API credentials needed - cliamp uses built-in ones.",
+				"After setup, launch cliamp, select Tidal, and press Enter to",
+				"sign in: approve the link.tidal.com device code in a browser.",
+			},
+			picker: &pickerSpec{
+				key:   keyTidalQuality,
+				label: "Stream quality",
+				options: []pickerOption{
+					{value: "lossless", label: "FLAC 16-bit/44.1kHz (CD) - recommended"},
+					{value: "hires", label: "FLAC 24-bit Hi-Res (falls back to CD for now)"},
+					{value: "high", label: "AAC 320kbps"},
+					{value: "low", label: "AAC 96kbps"},
+				},
+			},
+			body: func(v map[string]string) string {
+				q := v[keyTidalQuality]
+				if q == "" {
+					q = "lossless"
+				}
+				return strings.Join([]string{
+					"enabled = true",
+					fmt.Sprintf("quality = %q", q),
 				}, "\n")
 			},
 		},

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -386,8 +386,8 @@ func providers() []providerSpec {
 				key:   keyTidalQuality,
 				label: "Stream quality",
 				options: []pickerOption{
-					{value: "lossless", label: "FLAC 16-bit/44.1kHz (CD) - recommended"},
-					{value: "hires", label: "FLAC 24-bit Hi-Res (falls back to CD for now)"},
+					{value: "lossless", label: "FLAC (hi-res masters; AAC 320 otherwise) - recommended"},
+					{value: "hires", label: "FLAC hi-res (same delivery as lossless)"},
 					{value: "high", label: "AAC 320kbps"},
 					{value: "low", label: "AAC 96kbps"},
 				},

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -279,6 +279,37 @@ func TestQobuzSetupBody(t *testing.T) {
 	}
 }
 
+func TestTidalSetupBody(t *testing.T) {
+	spec := providerSpec{}
+	for _, p := range providers() {
+		if p.section == "tidal" {
+			spec = p
+			break
+		}
+	}
+	if spec.section == "" {
+		t.Fatal("tidal spec missing")
+	}
+
+	// Explicit quality selection.
+	body := spec.body(map[string]string{keyTidalQuality: "hires"})
+	for _, want := range []string{"enabled = true", `quality = "hires"`} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body missing %q: %q", want, body)
+		}
+	}
+
+	// Default quality when none picked.
+	if got := spec.body(map[string]string{}); !strings.Contains(got, `quality = "lossless"`) {
+		t.Fatalf("default quality not lossless: %q", got)
+	}
+
+	// No live probe (auth happens interactively in the TUI).
+	if spec.validate != nil {
+		t.Fatal("tidal spec should not define a validate probe")
+	}
+}
+
 func TestNetEasePickerSelectionFiltersFields(t *testing.T) {
 	base := newSetupModel()
 	neteaseIdx := -1

--- a/commands.go
+++ b/commands.go
@@ -358,7 +358,26 @@ func qobuzCommand() *cli.Command {
 }
 
 func tidalCommand() *cli.Command {
-	return providerCredsCommand("tidal", "Tidal", tidal.CredsPath, tidal.DeleteCreds)
+	cmd := providerCredsCommand("tidal", "Tidal", tidal.CredsPath, tidal.DeleteCreds)
+	cmd.Commands = append(cmd.Commands, &cli.Command{
+		Name:      "probe",
+		Usage:     "print sanitized playback diagnostics for each quality tier (no tokens or signed URLs)",
+		ArgsUsage: "[search query]",
+		Action: func(ctx context.Context, c *cli.Command) error {
+			query := strings.Join(c.Args().Slice(), " ")
+			if query == "" {
+				query = "Random Access Memories Get Lucky"
+			}
+			cfg, err := config.Load()
+			if err != nil {
+				return fmt.Errorf("config: %w", err)
+			}
+			probeCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+			defer cancel()
+			return tidal.Probe(probeCtx, os.Stdout, query, cfg.Tidal.ClientID, cfg.Tidal.ClientSecret)
+		},
+	})
+	return cmd
 }
 
 // providerCredsCommand builds the `cliamp <provider> reset` subcommand shared

--- a/commands.go
+++ b/commands.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bjarneo/cliamp/config"
 	"github.com/bjarneo/cliamp/external/qobuz"
 	"github.com/bjarneo/cliamp/external/spotify"
+	"github.com/bjarneo/cliamp/external/tidal"
 	"github.com/bjarneo/cliamp/ipc"
 	"github.com/bjarneo/cliamp/player"
 	"github.com/bjarneo/cliamp/pluginmgr"
@@ -33,7 +34,7 @@ func buildApp() *cli.Command {
 		&cli.BoolFlag{Name: "no-mono", Usage: "disable mono output"},
 		&cli.BoolFlag{Name: "auto-play", Usage: "start playback immediately"},
 		&cli.BoolFlag{Name: "compact", Usage: "compact mode (80 columns)"},
-		&cli.StringFlag{Name: "provider", Usage: "default provider: radio, navidrome, plex, jellyfin, emby, spotify, qobuz, soundcloud, netease, audiobookshelf, abs, yt, youtube, ytmusic"},
+		&cli.StringFlag{Name: "provider", Usage: "default provider: radio, navidrome, plex, jellyfin, emby, spotify, qobuz, tidal, soundcloud, netease, audiobookshelf, abs, yt, youtube, ytmusic"},
 		&cli.StringFlag{Name: "start-theme", Usage: "UI theme name"},
 		&cli.StringFlag{Name: "visualizer", Usage: "visualizer mode"},
 		&cli.StringFlag{Name: "eq-preset", Usage: "EQ preset name"},
@@ -74,6 +75,7 @@ func buildApp() *cli.Command {
 			setupCommand(),
 			spotifyCommand(),
 			qobuzCommand(),
+			tidalCommand(),
 			ipcSimpleCommand("play", "resume playback"),
 			ipcSimpleCommand("pause", "pause playback"),
 			ipcSimpleCommand("toggle", "play/pause toggle"),
@@ -159,10 +161,10 @@ func overridesFromFlags(c *cli.Command) (config.Overrides, error) {
 			v = "audiobookshelf"
 		}
 		switch v {
-		case "radio", "navidrome", "spotify", "qobuz", "plex", "jellyfin", "emby", "audiobookshelf", "soundcloud", "netease", "yt", "youtube", "ytmusic":
+		case "radio", "navidrome", "spotify", "qobuz", "tidal", "plex", "jellyfin", "emby", "audiobookshelf", "soundcloud", "netease", "yt", "youtube", "ytmusic":
 			ov.Provider = &v
 		default:
-			return ov, fmt.Errorf("--provider must be radio, navidrome, spotify, qobuz, plex, jellyfin, emby, audiobookshelf, soundcloud, netease, yt, youtube, or ytmusic (got %q)", v)
+			return ov, fmt.Errorf("--provider must be radio, navidrome, spotify, qobuz, tidal, plex, jellyfin, emby, audiobookshelf, soundcloud, netease, yt, youtube, or ytmusic (got %q)", v)
 		}
 	}
 	if c.IsSet("start-theme") {
@@ -338,8 +340,9 @@ func setupCommand() *cli.Command {
 		Name:  "setup",
 		Usage: "interactive wizard to configure remote providers",
 		Description: "Walks through configuring Navidrome, Plex, Jellyfin, Spotify,\n" +
-			"Qobuz, NetEase, Audiobookshelf, and YouTube Music. Validates connections\n" +
-			"and writes ~/.config/cliamp/config.toml.",
+			"Qobuz, Tidal, NetEase, Audiobookshelf, and YouTube Music. Validates\n" +
+			"connections and writes ~/.config/cliamp/config.toml.",
+
 		Action: func(ctx context.Context, c *cli.Command) error {
 			return cmd.Setup()
 		},
@@ -347,58 +350,42 @@ func setupCommand() *cli.Command {
 }
 
 func spotifyCommand() *cli.Command {
-	return &cli.Command{
-		Name:  "spotify",
-		Usage: "manage Spotify integration",
-		Commands: []*cli.Command{
-			{
-				Name:  "reset",
-				Usage: "clear stored Spotify credentials and force re-authentication",
-				Action: func(ctx context.Context, c *cli.Command) error {
-					path, err := spotify.CredsPath()
-					if err != nil {
-						return fmt.Errorf("locate credentials: %w", err)
-					}
-					removed, err := spotify.DeleteCreds()
-					if err != nil {
-						return fmt.Errorf("remove credentials: %w", err)
-					}
-					if !removed {
-						fmt.Println("No stored Spotify credentials to remove.")
-						return nil
-					}
-					fmt.Printf("Removed %s\n", path)
-					fmt.Println("Restart cliamp and select Spotify to sign in again.")
-					return nil
-				},
-			},
-		},
-	}
+	return providerCredsCommand("spotify", "Spotify", spotify.CredsPath, spotify.DeleteCreds)
 }
 
 func qobuzCommand() *cli.Command {
+	return providerCredsCommand("qobuz", "Qobuz", qobuz.CredsPath, qobuz.DeleteCreds)
+}
+
+func tidalCommand() *cli.Command {
+	return providerCredsCommand("tidal", "Tidal", tidal.CredsPath, tidal.DeleteCreds)
+}
+
+// providerCredsCommand builds the `cliamp <provider> reset` subcommand shared
+// by providers that cache OAuth credentials on disk.
+func providerCredsCommand(key, display string, credsPath func() (string, error), deleteCreds func() (bool, error)) *cli.Command {
 	return &cli.Command{
-		Name:  "qobuz",
-		Usage: "manage Qobuz integration",
+		Name:  key,
+		Usage: "manage " + display + " integration",
 		Commands: []*cli.Command{
 			{
 				Name:  "reset",
-				Usage: "clear stored Qobuz credentials and force re-authentication",
+				Usage: "clear stored " + display + " credentials and force re-authentication",
 				Action: func(ctx context.Context, c *cli.Command) error {
-					path, err := qobuz.CredsPath()
+					path, err := credsPath()
 					if err != nil {
 						return fmt.Errorf("locate credentials: %w", err)
 					}
-					removed, err := qobuz.DeleteCreds()
+					removed, err := deleteCreds()
 					if err != nil {
 						return fmt.Errorf("remove credentials: %w", err)
 					}
 					if !removed {
-						fmt.Println("No stored Qobuz credentials to remove.")
+						fmt.Printf("No stored %s credentials to remove.\n", display)
 						return nil
 					}
 					fmt.Printf("Removed %s\n", path)
-					fmt.Println("Restart cliamp and select Qobuz to sign in again.")
+					fmt.Printf("Restart cliamp and select %s to sign in again.\n", display)
 					return nil
 				},
 			},

--- a/config.toml.example
+++ b/config.toml.example
@@ -43,7 +43,7 @@ eq_preset = "Flat"
 # Saved Custom curve; applied when eq_preset is "Custom" or empty
 eq = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 
-# Default provider on startup: "radio", "navidrome", "spotify", "qobuz", "plex", "jellyfin", "emby", "soundcloud", "netease", "audiobookshelf", or a YouTube provider
+# Default provider on startup: "radio", "navidrome", "spotify", "qobuz", "tidal", "plex", "jellyfin", "emby", "soundcloud", "netease", "audiobookshelf", or a YouTube provider
 # provider = "radio"
 
 # Compact mode: cap UI width at 80 columns (default: fluid/full-width)
@@ -101,6 +101,32 @@ eq = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 #   7  = FLAC 24-bit up to 96kHz
 #   27 = FLAC 24-bit up to 192kHz (Hi-Res)
 # quality = 6
+
+# ---
+# Tidal (optional)
+# Requires a paid Tidal subscription (all paid plans include lossless FLAC).
+#
+# Enable the provider, then run cliamp, select Tidal, and press Enter to
+# sign in. A link.tidal.com URL with a short code is shown (and opened in a
+# browser); approve the device there. Credentials are cached at
+# ~/.config/cliamp/tidal_credentials.json and refreshed silently on later
+# launches. Run "cliamp tidal reset" to clear them.
+# [tidal]
+# enabled = true
+#
+# Stream quality. Default "lossless".
+#   "low"      = 96 kbps AAC
+#   "high"     = 320 kbps AAC
+#   "lossless" = FLAC 16-bit/44.1kHz (CD)
+#   "hires"    = FLAC 24-bit (currently falls back to lossless: Tidal ships
+#                hi-res as segmented DASH, which cliamp cannot stream yet)
+# quality = "lossless"
+#
+# cliamp uses built-in fallback OAuth client credentials. Tidal revokes leaked
+# client IDs from time to time; if sign-in fails with a client error, set a
+# fresh pair here without waiting for a cliamp release.
+# client_id = ""
+# client_secret = ""
 
 # ---
 # Navidrome / Subsonic server (optional)

--- a/config.toml.example
+++ b/config.toml.example
@@ -117,9 +117,11 @@ eq = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 # Stream quality. Default "lossless".
 #   "low"      = 96 kbps AAC
 #   "high"     = 320 kbps AAC
-#   "lossless" = FLAC 16-bit/44.1kHz (CD)
-#   "hires"    = FLAC 24-bit (currently falls back to lossless: Tidal ships
-#                hi-res as segmented DASH, which cliamp cannot stream yet)
+#   "lossless" = FLAC up to 24-bit/192kHz where available (see note)
+#   "hires"    = same delivery as "lossless"
+# Note: Tidal serves FLAC to this client type only for tracks with a hi-res
+# ("Max") master; other tracks are downgraded to AAC 320 server-side. cliamp
+# shows a footer notice when that happens. See docs/tidal.md.
 # quality = "lossless"
 #
 # cliamp uses built-in fallback OAuth client credentials. Tidal revokes leaked

--- a/config/config.go
+++ b/config/config.go
@@ -122,6 +122,25 @@ func (q QobuzConfig) IsSet() bool {
 	return !q.Disabled && q.Enabled
 }
 
+// TidalConfig holds settings for the Tidal provider. Requires a paid Tidal
+// subscription (all paid plans include lossless FLAC). Sign-in is an OAuth
+// device flow (link.tidal.com). Built-in fallback client credentials are used
+// when none are configured; Tidal revokes leaked client IDs periodically, so
+// client_id/client_secret can be overridden without waiting for a release.
+type TidalConfig struct {
+	Disabled     bool   // true only when user explicitly sets enabled = false
+	Enabled      bool   // true when [tidal] section exists
+	ClientID     string // OAuth client ID (overrides built-in fallback)
+	ClientSecret string // OAuth client secret (overrides built-in fallback)
+	Quality      string // preferred quality: "low", "high", "lossless", "hires"
+}
+
+// IsSet reports whether the Tidal provider should be shown. Section presence
+// is enough — built-in fallback client credentials are used when none are set.
+func (t TidalConfig) IsSet() bool {
+	return !t.Disabled && t.Enabled
+}
+
 // YouTubeMusicConfig holds settings for the YouTube Music provider.
 // If no client_id/client_secret are set, built-in fallback credentials are
 // used automatically (same pattern as Spotify).
@@ -265,7 +284,7 @@ type Config struct {
 	Speed            float64                      // playback speed ratio: 0.25–2.0 (default 1.0)
 	AutoPlay         bool                         // start playback automatically on launch (radio streams, CLI tracks)
 	SeekStepLarge    int                          // seconds for Shift+Left/Right seek jumps
-	Provider         string                       // default provider: "radio", "navidrome", "spotify", "qobuz", "plex", "jellyfin", "emby", "audiobookshelf", "soundcloud", "netease", "ytmusic" (default "radio")
+	Provider         string                       // default provider: "radio", "navidrome", "spotify", "qobuz", "tidal", "plex", "jellyfin", "emby", "audiobookshelf", "soundcloud", "netease", "ytmusic" (default "radio")
 	Theme            string                       // theme name, or "" for ANSI default
 	Visualizer       string                       // visualizer mode name, or "" for default (Bars)
 	SampleRate       int                          // output sample rate: 22050, 44100, 48000, 96000, 192000
@@ -281,6 +300,7 @@ type Config struct {
 	Navidrome        NavidromeConfig              // optional Navidrome/Subsonic server credentials
 	Spotify          SpotifyConfig                // optional Spotify provider (requires Premium)
 	Qobuz            QobuzConfig                  // optional Qobuz provider (requires subscription)
+	Tidal            TidalConfig                  // optional Tidal provider (requires subscription)
 	YouTubeMusic     YouTubeMusicConfig           // optional YouTube Music provider
 	Plex             PlexConfig                   // optional Plex Media Server credentials
 	Jellyfin         JellyfinConfig               // optional Jellyfin server credentials
@@ -357,6 +377,8 @@ func Load() (Config, error) {
 				cfg.Spotify.Enabled = true
 			case "qobuz":
 				cfg.Qobuz.Enabled = true
+			case "tidal":
+				cfg.Tidal.Enabled = true
 			}
 			// Initialize plugin sub-maps for [plugins] and [plugins.*] sections.
 			if section == "plugins" || strings.HasPrefix(section, "plugins.") {
@@ -415,6 +437,17 @@ func Load() (Config, error) {
 				if v, err := strconv.Atoi(val); err == nil {
 					cfg.Qobuz.Quality = v
 				}
+			}
+		case "tidal":
+			switch key {
+			case "enabled":
+				cfg.Tidal.Disabled = strings.ToLower(val) == "false"
+			case "client_id":
+				cfg.Tidal.ClientID = parseString(val)
+			case "client_secret":
+				cfg.Tidal.ClientSecret = parseString(val)
+			case "quality":
+				cfg.Tidal.Quality = parseString(val)
 			}
 		case "ytmusic":
 			switch key {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -496,6 +496,47 @@ func TestLoadQobuz(t *testing.T) {
 	}
 }
 
+func TestLoadTidal(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		wantIsSet bool
+		wantCfg   TidalConfig
+	}{
+		{"section enables", "[tidal]\n", true, TidalConfig{Enabled: true}},
+		{
+			"full config",
+			"[tidal]\nquality = \"hires\"\nclient_id = \"id\"\nclient_secret = \"sec\"\n",
+			true,
+			TidalConfig{Enabled: true, Quality: "hires", ClientID: "id", ClientSecret: "sec"},
+		},
+		{"disabled", "[tidal]\nenabled = false\n", false, TidalConfig{Enabled: true, Disabled: true}},
+		{"absent", "", false, TidalConfig{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			path := filepath.Join(os.Getenv("HOME"), ".config", "cliamp", "config.toml")
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatalf("MkdirAll: %v", err)
+			}
+			if err := os.WriteFile(path, []byte(tt.body), 0o644); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if got := cfg.Tidal.IsSet(); got != tt.wantIsSet {
+				t.Errorf("Tidal.IsSet() = %v, want %v", got, tt.wantIsSet)
+			}
+			if cfg.Tidal != tt.wantCfg {
+				t.Errorf("Tidal = %+v, want %+v", cfg.Tidal, tt.wantCfg)
+			}
+		})
+	}
+}
+
 func TestPlexIsSet(t *testing.T) {
 	tests := []struct {
 		name string

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -138,7 +138,7 @@ CLI flags override config file values for the current session only. They are not
 
 ## Setup wizard
 
-Configure remote providers (Navidrome, Plex, Jellyfin, Emby, Spotify, Qobuz, Tidal, NetEase, Audiobookshelf, YouTube Music) through a small TUI. Each provider page links to where to find the required credentials, validates the connection live, and writes the resulting `[provider]` block to `~/.config/cliamp/config.toml` without disturbing the rest of the file.
+Configure remote providers (Navidrome, Plex, Jellyfin, Emby, Spotify, Qobuz, Tidal, NetEase, Audiobookshelf, YouTube Music) through a small TUI. Each provider page links to where to find the required credentials, validates the connection live where the provider supports it (media servers like Navidrome, Plex, Jellyfin, Emby, and Audiobookshelf), and writes the resulting `[provider]` block to `~/.config/cliamp/config.toml` without disturbing the rest of the file. OAuth providers (Spotify, Qobuz, Tidal) authenticate later, interactively in the player.
 
 ```sh
 cliamp setup

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -138,7 +138,7 @@ CLI flags override config file values for the current session only. They are not
 
 ## Setup wizard
 
-Configure remote providers (Navidrome, Plex, Jellyfin, Emby, Spotify, Qobuz, NetEase, Audiobookshelf, YouTube Music) through a small TUI. Each provider page links to where to find the required credentials, validates the connection live, and writes the resulting `[provider]` block to `~/.config/cliamp/config.toml` without disturbing the rest of the file.
+Configure remote providers (Navidrome, Plex, Jellyfin, Emby, Spotify, Qobuz, Tidal, NetEase, Audiobookshelf, YouTube Music) through a small TUI. Each provider page links to where to find the required credentials, validates the connection live, and writes the resulting `[provider]` block to `~/.config/cliamp/config.toml` without disturbing the rest of the file.
 
 ```sh
 cliamp setup

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,7 +6,7 @@ For remote providers (Navidrome, Plex, Jellyfin, Emby, Spotify, Qobuz, Tidal, Ne
 cliamp setup
 ```
 
-It validates your credentials live and writes the right TOML block without touching the rest of your config. See [cli.md](cli.md#setup-wizard) for details.
+It writes the right TOML block without touching the rest of your config, and validates server credentials live where the provider supports it (Navidrome, Plex, Jellyfin, Emby). OAuth providers such as Spotify, Qobuz, and Tidal sign in later, interactively in the player — Tidal via a `link.tidal.com` device code. See [cli.md](cli.md#setup-wizard) for details.
 
 ## Config directory
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-For remote providers (Navidrome, Plex, Jellyfin, Emby, Spotify, Qobuz, NetEase, Audiobookshelf, YouTube Music), the fastest path is the interactive wizard:
+For remote providers (Navidrome, Plex, Jellyfin, Emby, Spotify, Qobuz, Tidal, NetEase, Audiobookshelf, YouTube Music), the fastest path is the interactive wizard:
 
 ```sh
 cliamp setup
@@ -160,7 +160,7 @@ Set which provider to start with:
 provider = "radio"
 ```
 
-Valid values: `radio` (default), `navidrome`, `spotify`, `plex`, `jellyfin`, `emby`, `qobuz`, `soundcloud`, `netease`, `audiobookshelf`, `yt`, `youtube`, `ytmusic`.
+Valid values: `radio` (default), `navidrome`, `spotify`, `plex`, `jellyfin`, `emby`, `qobuz`, `tidal`, `soundcloud`, `netease`, `audiobookshelf`, `yt`, `youtube`, `ytmusic`.
 
 You can also override from the CLI: `cliamp --provider jellyfin`.
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -75,7 +75,7 @@ active when the picker opened. While typing a filter, `Enter` finishes it and
 | Key | Action |
 |---|---|
 | `f` | Toggle bookmark ★ on selected track (or favorite radio station in radio browser) |
-| `Ctrl+F` | Search — active provider's native search (Spotify, Qobuz, Navidrome, Jellyfin, Emby, Plex, Audiobookshelf, NetEase, Local) or YouTube fallback. Available from playlist and provider-browser views. |
+| `Ctrl+F` | Search — active provider's native search (Spotify, Qobuz, Tidal, Navidrome, Jellyfin, Emby, Plex, Audiobookshelf, NetEase, Local) or YouTube fallback. Available from playlist and provider-browser views. |
 | `u` | Load URL (stream/playlist) |
 | `y` | Show or close lyrics |
 | `r` | Retry lyrics lookup while lyrics are open |
@@ -93,6 +93,7 @@ active when the picker opened. While typing a filter, `Enter` finishes it and
 | `C` | Open SoundCloud provider |
 | `M` | Open NetEase provider |
 | `Q` | Open Qobuz provider |
+| `T` | Open Tidal provider |
 | `B` | Open Audiobookshelf provider |
 
 ## Playlist and Queue
@@ -144,7 +145,7 @@ Shift-letter keys are reserved for provider switching, so playlist-manager track
 
 ## Provider browser (`N` key)
 
-When you press `N` to drill into a provider (Navidrome, Plex, Jellyfin, Emby, Audiobookshelf, Spotify, Qobuz, YouTube Music), the album/artist/track screens use:
+When you press `N` to drill into a provider (Navidrome, Plex, Jellyfin, Emby, Audiobookshelf, Spotify, Qobuz, Tidal, YouTube Music), the album/artist/track screens use:
 
 | Key | Action |
 |---|---|
@@ -203,7 +204,7 @@ This applies to:
 - `/` file browser filter
 - `Ctrl+F` when the active provider is Local (your saved playlists)
 
-Other `Ctrl+F` providers (Spotify, Qobuz, Navidrome, Jellyfin, Emby, Plex, Audiobookshelf, NetEase, YouTube) send your query to their own search API, so matching there follows each service's rules.
+Other `Ctrl+F` providers (Spotify, Qobuz, Tidal, Navidrome, Jellyfin, Emby, Plex, Audiobookshelf, NetEase, YouTube) send your query to their own search API, so matching there follows each service's rules.
 
 ## General
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -157,7 +157,7 @@ When you press `N` to drill into a provider (Navidrome, Plex, Jellyfin, Emby, Au
 | `a` | Append all visible tracks to the queue |
 | `q` | Queue the highlighted track to play next |
 | `s` | Cycle album sort (album list only) |
-| `S` `N` `P` `J` `E` `Y` `C` `M` `Q` `L` | Quick-switch to that provider without going back through the main pane. `R` replaces the queue on the track screen. |
+| `S` `N` `P` `J` `E` `Y` `C` `M` `Q` `T` `L` | Quick-switch to that provider without going back through the main pane. `R` replaces the queue on the track screen. |
 | `Esc` `b` | Walk back one level / close the browser |
 
 The header shows a source breadcrumb such as `Navidrome / Miles Davis / Kind of Blue / Tracks`, so the current provider and drill-down location remain visible. Track rows show right-aligned durations when the provider returns them.

--- a/docs/tidal.md
+++ b/docs/tidal.md
@@ -1,0 +1,103 @@
+# Tidal Integration
+
+cliamp can stream your [Tidal](https://tidal.com/) library directly through its audio pipeline. EQ, visualizer, and all effects apply. Requires a paid Tidal subscription — every paid plan includes lossless FLAC.
+
+Tidal delivers lossless FLAC, so cliamp streams it through the same buffer-while-playing + ffmpeg pipeline used for other lossless providers. `ffmpeg` must be on `PATH`.
+
+## Setup
+
+The fastest path is the interactive wizard: run `cliamp setup`, pick **Tidal**, choose a stream quality, and it writes the `[tidal]` block for you.
+
+Or configure it manually in `~/.config/cliamp/config.toml`:
+
+```toml
+[tidal]
+enabled = true
+quality = "lossless"
+```
+
+No developer credentials are needed — cliamp ships built-in OAuth client credentials.
+
+Run `cliamp`, select Tidal as a provider, and press `Enter` to sign in. cliamp shows a `link.tidal.com` URL with a short device code (and opens it in your browser). Approve the device there; cliamp waits up to 5 minutes. Once authorized, credentials are cached at `~/.config/cliamp/tidal_credentials.json` and subsequent launches refresh silently.
+
+### Quality
+
+`quality` selects the Tidal stream tier. If omitted, cliamp uses `"lossless"`. Supported values:
+
+| Value | Format |
+|---|---|
+| `"low"` | AAC 96 kbps |
+| `"high"` | AAC 320 kbps |
+| `"lossless"` | FLAC 16-bit / 44.1 kHz (CD) |
+| `"hires"` | FLAC 24-bit up to 192 kHz (see note) |
+
+> **Hi-Res note:** Tidal delivers `hires` as a segmented MPEG-DASH stream, which cliamp's player cannot consume yet. When a track comes back as DASH, cliamp automatically falls back to `lossless` (CD-quality FLAC) for that track. Native hi-res playback is planned.
+
+Any other value falls back to `"lossless"`.
+
+For hi-res-capable playback settings, see [audio-quality.md](audio-quality.md) — `bit_depth = 32` with a matching `sample_rate` is the lossless recipe.
+
+### Custom client credentials
+
+cliamp's built-in OAuth client credentials are shared with other open-source Tidal clients, and Tidal revokes such client IDs from time to time. If sign-in suddenly fails with a client error, you can set a fresh pair yourself without waiting for a cliamp release:
+
+```toml
+[tidal]
+client_id = "your-client-id"
+client_secret = "your-client-secret"
+```
+
+After changing credentials, run `cliamp tidal reset` and sign in again.
+
+## Usage
+
+Start directly on Tidal:
+
+```sh
+cliamp --provider tidal
+```
+
+Once authenticated, Tidal appears as a provider alongside the others. Press `T` to jump straight to Tidal, or `Esc`/`b` to open the provider browser and select it.
+
+The provider surfaces your Tidal library:
+
+- **Favorite Tracks**: your liked songs (up to 500).
+- **Your playlists**: playlists you created or subscribed to.
+- **Favorite albums**: browsable in the album view.
+- **Favorite artists**: browse an artist to see their albums.
+
+Press `Ctrl+F` while Tidal is active to search the Tidal catalog for tracks.
+
+## Controls
+
+When focused on the provider panel:
+
+| Key | Action |
+|---|---|
+| `Up` `Down` / `j` `k` | Navigate |
+| `Enter` | Load the selected playlist/album or play the selected track |
+| `Ctrl+F` | Search Tidal tracks |
+| `Ctrl+R` | Refresh (re-resolves stream URLs) |
+| `Tab` | Switch between provider and playlist focus |
+| `Esc` / `b` | Open provider browser |
+
+After loading a playlist or album you return to the standard playlist view with all the usual controls (seek, volume, EQ, shuffle, repeat, queue, search, lyrics).
+
+## Troubleshooting
+
+- **Sign-in fails immediately / "client_id may be revoked"**: Tidal periodically revokes the shared client credentials cliamp ships. Set your own `client_id`/`client_secret` in the `[tidal]` section (see above), run `cliamp tidal reset`, and sign in again.
+- **Device code expired**: the `link.tidal.com` code is valid for about 5 minutes. Press `Enter` on the Tidal provider again to get a fresh code.
+- **Re-authenticate**: run `cliamp tidal reset` to clear stored credentials, then relaunch cliamp and select Tidal to sign in again. (Equivalent to deleting `~/.config/cliamp/tidal_credentials.json` manually.)
+- **Track is unplayable / skipped**: the track may not be streamable in your region, or its stream may be encrypted for your client type. cliamp marks such tracks unplayable and moves on.
+- **Hi-Res delivered as CD quality**: expected for now — see the Hi-Res note above.
+- **Stalls after a long idle session**: signed stream URLs expire over time. Press `Ctrl+R` to refresh, which re-resolves the URLs.
+
+## Requirements
+
+- A paid Tidal subscription
+- `ffmpeg` on `PATH` for FLAC/AAC decoding
+- No developer/API registration: built-in credentials are used automatically
+
+## A note on the API
+
+cliamp uses Tidal's private client API (the same one open-source players like python-tidal-based clients use), because Tidal's official developer API only allows 30-second previews for third-party apps. cliamp streams only — it never writes decoded audio to disk.

--- a/docs/tidal.md
+++ b/docs/tidal.md
@@ -28,10 +28,9 @@ Run `cliamp`, select Tidal as a provider, and press `Enter` to sign in. cliamp s
 |---|---|
 | `"low"` | AAC 96 kbps |
 | `"high"` | AAC 320 kbps |
-| `"lossless"` | FLAC 16-bit / 44.1 kHz (CD) |
-| `"hires"` | FLAC 24-bit up to 192 kHz (see note) |
+| `"lossless"` / `"hires"` | FLAC up to 24-bit / 192 kHz where available (see note) |
 
-> **Hi-Res note:** Tidal delivers `hires` as a segmented MPEG-DASH stream, which cliamp's player cannot consume yet. When a track comes back as DASH, cliamp automatically falls back to `lossless` (CD-quality FLAC) for that track. Native hi-res playback is planned.
+> **FLAC availability note:** Tidal only serves FLAC to third-party clients of cliamp's type for tracks that have a hi-res ("Max") master, delivered as unencrypted MPEG-DASH — which cliamp plays natively, at full hi-res quality. For tracks without a hi-res master, Tidal downgrades this client to AAC 320 server-side (the same limitation the python-tidal ecosystem reports). cliamp shows a one-time notice in the footer when that happens. Sign-in via Tidal's Android-type (PKCE) client, which unlocks FLAC for the whole catalog, is planned.
 
 Any other value falls back to `"lossless"`.
 
@@ -89,8 +88,8 @@ After loading a playlist or album you return to the standard playlist view with 
 - **Device code expired**: the `link.tidal.com` code is valid for about 5 minutes. Press `Enter` on the Tidal provider again to get a fresh code.
 - **Re-authenticate**: run `cliamp tidal reset` to clear stored credentials, then relaunch cliamp and select Tidal to sign in again. (Equivalent to deleting `~/.config/cliamp/tidal_credentials.json` manually.)
 - **Track is unplayable / skipped**: the track may not be streamable in your region, or its stream may be encrypted for your client type. cliamp marks such tracks unplayable and moves on.
-- **Hi-Res delivered as CD quality**: expected for now — see the Hi-Res note above.
-- **Stalls after a long idle session**: signed stream URLs expire over time. Press `Ctrl+R` to refresh, which re-resolves the URLs.
+- **"delivered as HIGH (AAC)" notice**: the track has no hi-res master, so Tidal refuses FLAC to this client type — see the FLAC availability note above. Playback continues at AAC 320.
+- **Long-idle sessions**: stream URLs are resolved fresh each time a track starts, so queued tracks keep playing after any idle period without a manual refresh. `Ctrl+R` re-fetches the playlist lists themselves.
 
 ## Requirements
 

--- a/external/qobuz/provider.go
+++ b/external/qobuz/provider.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"slices"
-	"strconv"
 	"sync"
 	"time"
 
@@ -481,7 +480,7 @@ func (p *QobuzProvider) buildTrack(ctx context.Context, c *client, t apiTrack, a
 	if album != nil {
 		track.Album = album.Title
 		track.Genre = album.Genre.Name
-		track.Year = parseYear(album.ReleaseDateOriginal)
+		track.Year = provider.YearFromDate(album.ReleaseDateOriginal)
 	}
 
 	if !t.Streamable {
@@ -520,20 +519,8 @@ func albumInfo(a apiAlbum) provider.AlbumInfo {
 		Name:       a.Title,
 		Artist:     a.Artist.Name,
 		ArtistID:   a.Artist.ID.String(),
-		Year:       parseYear(a.ReleaseDateOriginal),
+		Year:       provider.YearFromDate(a.ReleaseDateOriginal),
 		TrackCount: a.TracksCount,
 		Genre:      a.Genre.Name,
 	}
-}
-
-// parseYear extracts the year from a Qobuz "YYYY-MM-DD" date string.
-func parseYear(date string) int {
-	if len(date) < 4 {
-		return 0
-	}
-	y, err := strconv.Atoi(date[:4])
-	if err != nil {
-		return 0
-	}
-	return y
 }

--- a/external/qobuz/provider_test.go
+++ b/external/qobuz/provider_test.go
@@ -7,25 +7,6 @@ import (
 	"testing"
 )
 
-func TestParseYear(t *testing.T) {
-	tests := []struct {
-		in   string
-		want int
-	}{
-		{"2021-05-14", 2021},
-		{"1999", 1999},
-		{"", 0},
-		{"abc", 0},
-		{"20", 0},
-		{"19xy-01-01", 0},
-	}
-	for _, tt := range tests {
-		if got := parseYear(tt.in); got != tt.want {
-			t.Errorf("parseYear(%q) = %d, want %d", tt.in, got, tt.want)
-		}
-	}
-}
-
 func TestTrackArtist(t *testing.T) {
 	withPerformer := apiTrack{Performer: apiArtist{Name: "Performer"}}
 	if got := trackArtist(withPerformer, nil); got != "Performer" {

--- a/external/tidal/auth.go
+++ b/external/tidal/auth.go
@@ -1,0 +1,243 @@
+package tidal
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/bjarneo/cliamp/applog"
+	"github.com/bjarneo/cliamp/internal/browser"
+)
+
+const (
+	deviceAuthURL   = "https://auth.tidal.com/v1/oauth2/device_authorization"
+	defaultTokenURL = "https://auth.tidal.com/v1/oauth2/token"
+	oauthScope      = "r_usr w_usr w_sub"
+)
+
+// authURLObserver is invoked with the device-flow URL when interactive auth
+// begins. Used by the TUI to display the URL when the launched browser does
+// not reach the user (containers, headless environments).
+var authURLObserver atomic.Pointer[func(string)]
+
+// SetAuthURLObserver registers a callback invoked once with the device-flow
+// URL at the start of an interactive sign-in. Pass nil to remove.
+func SetAuthURLObserver(fn func(string)) {
+	if fn == nil {
+		authURLObserver.Store(nil)
+		return
+	}
+	authURLObserver.Store(&fn)
+}
+
+func notifyAuthURL(u string) {
+	applog.Info("tidal: sign-in URL: %s", u)
+	if p := authURLObserver.Load(); p != nil {
+		(*p)(u)
+	}
+}
+
+// deviceAuth is the device_authorization response. verificationUriComplete
+// already embeds the user code (e.g. "link.tidal.com/ABCDE").
+type deviceAuth struct {
+	DeviceCode              string `json:"deviceCode"`
+	VerificationURIComplete string `json:"verificationUriComplete"`
+	ExpiresIn               int    `json:"expiresIn"`
+	Interval                int    `json:"interval"`
+}
+
+// tokenResponse is the oauth2/token response. Error is set on OAuth-level
+// failures (e.g. "authorization_pending" while device-flow polling).
+type tokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
+	Error        string `json:"error"`
+	ErrorDesc    string `json:"error_description"`
+}
+
+// postForm POSTs a form to an auth endpoint and decodes the JSON response.
+// OAuth-level errors arrive with 4xx status codes and a JSON body, so those
+// are decoded rather than treated as transport failures.
+func postForm(ctx context.Context, httpc *http.Client, endpoint string, form url.Values, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return fmt.Errorf("tidal: build auth request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", apiUA)
+
+	resp, err := httpc.Do(req)
+	if err != nil {
+		return fmt.Errorf("tidal: auth request: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBody))
+	if err != nil {
+		return fmt.Errorf("tidal: read auth response: %w", err)
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("tidal: HTTP %d: decode auth response: %w", resp.StatusCode, err)
+	}
+	return nil
+}
+
+// Sentinel errors for the device-flow poll loop (RFC 8628 error codes).
+var (
+	errAuthPending = errors.New("tidal: authorization pending")
+	errSlowDown    = errors.New("tidal: polling too fast")
+)
+
+// requestToken calls the token endpoint. authorization_pending and slow_down
+// are surfaced as sentinels so the device-flow poll loop can continue; other
+// OAuth errors are returned as plain errors.
+func requestToken(ctx context.Context, httpc *http.Client, endpoint string, form url.Values) (tokenResponse, error) {
+	var tok tokenResponse
+	if err := postForm(ctx, httpc, endpoint, form, &tok); err != nil {
+		return tokenResponse{}, err
+	}
+	switch tok.Error {
+	case "":
+	case "authorization_pending":
+		return tokenResponse{}, errAuthPending
+	case "slow_down":
+		return tokenResponse{}, errSlowDown
+	default:
+		return tokenResponse{}, fmt.Errorf("tidal: %s: %s", tok.Error, tok.ErrorDesc)
+	}
+	if tok.AccessToken == "" {
+		return tokenResponse{}, errors.New("tidal: token response missing access_token")
+	}
+	return tok, nil
+}
+
+// newClientSilent builds an authenticated client from stored credentials only.
+// It never opens a browser; if no usable credentials exist it returns an error.
+func newClientSilent(ctx context.Context) (*client, error) {
+	creds, err := loadCreds()
+	if err != nil {
+		return nil, fmt.Errorf("tidal: no stored credentials: %w", err)
+	}
+	if creds.ClientID == "" || creds.RefreshToken == "" {
+		return nil, fmt.Errorf("tidal: incomplete stored credentials")
+	}
+
+	c := newClient(creds.ClientID, creds.ClientSecret)
+	c.accessToken = creds.AccessToken
+	c.refreshToken = creds.RefreshToken
+	c.tokenType = creds.TokenType
+	c.expiresAt = creds.ExpiresAt
+	c.userID = creds.UserID
+	c.countryCode = creds.CountryCode
+
+	if err := c.ensureToken(ctx, ""); err != nil {
+		return nil, err
+	}
+	// Validates the token and refreshes session/country data.
+	if err := c.loadSession(ctx); err != nil {
+		return nil, fmt.Errorf("tidal: stored token rejected: %w", err)
+	}
+	_ = saveCreds(credsFromClient(c))
+	return c, nil
+}
+
+// newClientInteractive runs the OAuth device flow: it shows a link.tidal.com
+// URL (and opens it in a browser, best-effort), then polls the token endpoint
+// until the user approves the device, persisting the result on success.
+func newClientInteractive(ctx context.Context, clientID, clientSecret string) (*client, error) {
+	c := newClient(clientID, clientSecret)
+
+	var da deviceAuth
+	err := postForm(ctx, c.http, deviceAuthURL, url.Values{
+		"client_id": {clientID},
+		"scope":     {oauthScope},
+	}, &da)
+	if err != nil {
+		return nil, err
+	}
+	if da.DeviceCode == "" || da.VerificationURIComplete == "" {
+		return nil, errors.New("tidal: device authorization failed (client_id may be revoked; set [tidal] client_id in config.toml)")
+	}
+
+	authURL := da.VerificationURIComplete
+	if !strings.HasPrefix(authURL, "http") {
+		authURL = "https://" + authURL
+	}
+	notifyAuthURL(authURL)
+	_ = browser.Open(authURL) // best-effort; user can open the URL manually
+
+	tok, err := pollDeviceToken(ctx, c.http, c.tokenURL, clientID, clientSecret, da)
+	if err != nil {
+		return nil, err
+	}
+
+	c.mu.Lock()
+	c.applyTokenLocked(tok)
+	c.mu.Unlock()
+
+	if err := c.loadSession(ctx); err != nil {
+		return nil, fmt.Errorf("tidal: load session: %w", err)
+	}
+	if err := saveCreds(credsFromClient(c)); err != nil {
+		applog.UserError("tidal: failed to save credentials: %v", err)
+	}
+	return c, nil
+}
+
+// pollDeviceToken polls the token endpoint until the user approves the device
+// authorization, it expires, or ctx is cancelled.
+func pollDeviceToken(ctx context.Context, httpc *http.Client, endpoint, clientID, clientSecret string, da deviceAuth) (tokenResponse, error) {
+	form := url.Values{
+		"grant_type":    {"urn:ietf:params:oauth:grant-type:device_code"},
+		"device_code":   {da.DeviceCode},
+		"client_id":     {clientID},
+		"client_secret": {clientSecret},
+		"scope":         {oauthScope},
+	}
+
+	// RFC 8628 §3.2: clients MUST default to 5 seconds when the server
+	// provides no polling interval.
+	interval := time.Duration(da.Interval) * time.Second
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	expiry := time.Duration(da.ExpiresIn) * time.Second
+	if expiry <= 0 {
+		expiry = 5 * time.Minute
+	}
+	deadline := time.Now().Add(expiry)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return tokenResponse{}, fmt.Errorf("tidal: authentication cancelled: %w", ctx.Err())
+		case <-ticker.C:
+		}
+		if time.Now().After(deadline) {
+			return tokenResponse{}, errors.New("tidal: device authorization expired before approval")
+		}
+		tok, err := requestToken(ctx, httpc, endpoint, form)
+		switch {
+		case errors.Is(err, errAuthPending):
+			continue
+		case errors.Is(err, errSlowDown):
+			// RFC 8628: back off by widening the poll interval.
+			interval += 5 * time.Second
+			ticker.Reset(interval)
+			continue
+		case err != nil:
+			return tokenResponse{}, err
+		}
+		return tok, nil
+	}
+}

--- a/external/tidal/auth.go
+++ b/external/tidal/auth.go
@@ -90,10 +90,14 @@ func postForm(ctx context.Context, httpc *http.Client, endpoint string, form url
 	return nil
 }
 
-// Sentinel errors for the device-flow poll loop (RFC 8628 error codes).
+// Sentinel errors for OAuth-level failures. errAuthPending and errSlowDown
+// drive the device-flow poll loop (RFC 8628 error codes); errAuthRevoked
+// means the refresh token was revoked or expired and the user must sign in
+// again interactively.
 var (
 	errAuthPending = errors.New("tidal: authorization pending")
 	errSlowDown    = errors.New("tidal: polling too fast")
+	errAuthRevoked = errors.New("tidal: authorization revoked")
 )
 
 // requestToken calls the token endpoint. authorization_pending and slow_down
@@ -110,6 +114,8 @@ func requestToken(ctx context.Context, httpc *http.Client, endpoint string, form
 		return tokenResponse{}, errAuthPending
 	case "slow_down":
 		return tokenResponse{}, errSlowDown
+	case "invalid_grant", "expired_token":
+		return tokenResponse{}, fmt.Errorf("%w: %s: %s", errAuthRevoked, tok.Error, tok.ErrorDesc)
 	default:
 		return tokenResponse{}, fmt.Errorf("tidal: %s: %s", tok.Error, tok.ErrorDesc)
 	}

--- a/external/tidal/client.go
+++ b/external/tidal/client.go
@@ -132,10 +132,15 @@ func (c *client) ensureToken(ctx context.Context, staleToken string) error {
 	return nil
 }
 
+// rateLimitRetries is how many times a 429 response is retried (honoring
+// Retry-After) before giving up.
+const rateLimitRetries = 2
+
 // doGet performs an authenticated GET against the private API and decodes the
-// JSON response into out. A 401 triggers one forced token refresh and retry.
+// JSON response into out. A 401 triggers one forced token refresh and retry;
+// a 429 is retried with backoff.
 func (c *client) doGet(ctx context.Context, path string, params url.Values, out any) error {
-	body, err := c.doRequest(ctx, path, params, false)
+	body, err := c.doRequest(ctx, path, params)
 	if err != nil {
 		return err
 	}
@@ -148,55 +153,79 @@ func (c *client) doGet(ctx context.Context, path string, params url.Values, out 
 	return nil
 }
 
-func (c *client) doRequest(ctx context.Context, path string, params url.Values, retried bool) ([]byte, error) {
-	if err := c.ensureToken(ctx, ""); err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
-	if err != nil {
-		return nil, fmt.Errorf("tidal: %s: build request: %w", path, err)
-	}
-
-	q := url.Values{}
-	for k, vs := range params {
-		q[k] = vs
-	}
-	c.mu.Lock()
-	if c.countryCode != "" {
-		q.Set("countryCode", c.countryCode)
-	}
-	if c.sessionID != "" {
-		q.Set("sessionId", c.sessionID)
-	}
-	token := c.accessToken
-	auth := c.tokenType + " " + token
-	c.mu.Unlock()
-	req.URL.RawQuery = q.Encode()
-	req.Header.Set("User-Agent", apiUA)
-	req.Header.Set("x-tidal-client-version", clientVersion)
-	req.Header.Set("Authorization", auth)
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("tidal: %s: request: %w", path, err)
-	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBody))
-	if err != nil {
-		return nil, fmt.Errorf("tidal: %s: read response: %w", path, err)
-	}
-
-	if resp.StatusCode == http.StatusUnauthorized && !retried {
-		if err := c.ensureToken(ctx, token); err != nil {
+func (c *client) doRequest(ctx context.Context, path string, params url.Values) ([]byte, error) {
+	refreshed := false
+	rateRetries := 0
+	for {
+		if err := c.ensureToken(ctx, ""); err != nil {
 			return nil, err
 		}
-		return c.doRequest(ctx, path, params, true)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+		if err != nil {
+			return nil, fmt.Errorf("tidal: %s: build request: %w", path, err)
+		}
+
+		q := url.Values{}
+		for k, vs := range params {
+			q[k] = vs
+		}
+		c.mu.Lock()
+		if c.countryCode != "" {
+			q.Set("countryCode", c.countryCode)
+		}
+		if c.sessionID != "" {
+			q.Set("sessionId", c.sessionID)
+		}
+		token := c.accessToken
+		auth := c.tokenType + " " + token
+		c.mu.Unlock()
+		req.URL.RawQuery = q.Encode()
+		req.Header.Set("User-Agent", apiUA)
+		req.Header.Set("x-tidal-client-version", clientVersion)
+		req.Header.Set("Authorization", auth)
+
+		resp, err := c.http.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("tidal: %s: request: %w", path, err)
+		}
+		body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBody))
+		resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("tidal: %s: read response: %w", path, err)
+		}
+
+		switch {
+		case resp.StatusCode == http.StatusUnauthorized && !refreshed:
+			if err := c.ensureToken(ctx, token); err != nil {
+				return nil, err
+			}
+			refreshed = true
+			continue
+		case resp.StatusCode == http.StatusTooManyRequests && rateRetries < rateLimitRetries:
+			rateRetries++
+			select {
+			case <-time.After(retryAfter(resp, rateRetries)):
+				continue
+			case <-ctx.Done():
+				return nil, fmt.Errorf("tidal: %s: %w", path, ctx.Err())
+			}
+		case resp.StatusCode >= 400:
+			return nil, fmt.Errorf("tidal: %s: HTTP %d: %s", path, resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+		return body, nil
 	}
-	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("tidal: %s: HTTP %d: %s", path, resp.StatusCode, strings.TrimSpace(string(body)))
+}
+
+// retryAfter returns the server-requested backoff for a 429 response, or an
+// attempt-scaled default when the header is absent or unparseable.
+func retryAfter(resp *http.Response, attempt int) time.Duration {
+	if v := resp.Header.Get("Retry-After"); v != "" {
+		if secs, err := strconv.Atoi(v); err == nil && secs > 0 && secs <= 60 {
+			return time.Duration(secs) * time.Second
+		}
 	}
-	return body, nil
+	return time.Duration(attempt) * time.Second
 }
 
 // loadSession fetches the current session (validating the token) and stores
@@ -266,9 +295,18 @@ func unwrapFavorites[T any](in []apiFavoriteItem[T]) []T {
 	return out
 }
 
-// userPlaylists returns the authenticated user's playlists.
+// userPlaylists returns the user's own playlists plus playlists they have
+// favorited ("subscribed to"), which the plain /playlists endpoint omits.
 func (c *client) userPlaylists(ctx context.Context) ([]apiPlaylist, error) {
-	return fetchList[apiPlaylist](ctx, c, "users/"+c.user()+"/playlists", 0)
+	items, err := fetchList[apiPlaylistItem](ctx, c, "users/"+c.user()+"/playlistsAndFavoritePlaylists", 0)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]apiPlaylist, len(items))
+	for i, it := range items {
+		out[i] = it.Playlist
+	}
+	return out, nil
 }
 
 // playlistTracks returns the tracks of a playlist, following pagination.

--- a/external/tidal/client.go
+++ b/external/tidal/client.go
@@ -1,0 +1,360 @@
+package tidal
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	apiBaseURL = "https://api.tidal.com/v1/"
+
+	// apiUA mirrors the Android WebView user agent python-tidal sends; the
+	// private API is only exercised by official clients, so a generic Go UA
+	// would stand out.
+	apiUA         = "Mozilla/5.0 (Linux; Android 12; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/91.0.4472.114 Safari/537.36"
+	clientVersion = "2025.7.16"
+)
+
+// maxResponseBody limits JSON API responses to 20 MB.
+const maxResponseBody = 20 << 20
+
+// pageSize is the per-request page size for paginated list endpoints. Tidal
+// caps most v1 list endpoints at 100 items per request.
+const pageSize = 100
+
+// tokenSlack is how long before the recorded expiry a token is refreshed, so
+// requests never race the actual expiry.
+const tokenSlack = time.Minute
+
+// client is a Tidal private-API client. Token state is guarded by mu; the
+// remaining fields are not mutated after construction.
+type client struct {
+	clientID     string
+	clientSecret string
+	baseURL      string // apiBaseURL in production; overridden in tests
+	tokenURL     string // defaultTokenURL in production; overridden in tests
+	http         *http.Client
+
+	mu           sync.Mutex
+	accessToken  string
+	refreshToken string
+	tokenType    string
+	expiresAt    time.Time
+	userID       string
+	countryCode  string
+	sessionID    string
+}
+
+func newClient(clientID, clientSecret string) *client {
+	return &client{
+		clientID:     clientID,
+		clientSecret: clientSecret,
+		baseURL:      apiBaseURL,
+		tokenURL:     defaultTokenURL,
+		http:         &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// credsFromClient snapshots the client's token state for persistence.
+func credsFromClient(c *client) *storedCreds {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.credsLocked()
+}
+
+// credsLocked is credsFromClient for callers already holding c.mu.
+func (c *client) credsLocked() *storedCreds {
+	return &storedCreds{
+		ClientID:     c.clientID,
+		ClientSecret: c.clientSecret,
+		AccessToken:  c.accessToken,
+		RefreshToken: c.refreshToken,
+		TokenType:    c.tokenType,
+		ExpiresAt:    c.expiresAt,
+		UserID:       c.userID,
+		CountryCode:  c.countryCode,
+	}
+}
+
+// applyTokenLocked stores a token response. The refresh token is only
+// replaced when the response carries one (refresh responses usually omit it).
+// Callers must hold c.mu.
+func (c *client) applyTokenLocked(tok tokenResponse) {
+	c.accessToken = tok.AccessToken
+	c.tokenType = tok.TokenType
+	if c.tokenType == "" {
+		c.tokenType = "Bearer"
+	}
+	if tok.RefreshToken != "" {
+		c.refreshToken = tok.RefreshToken
+	}
+	c.expiresAt = time.Now().Add(time.Duration(tok.ExpiresIn) * time.Second)
+}
+
+// ensureToken refreshes the access token when it is missing, expired, or
+// equal to staleToken (the token a request just got a 401 for). Holding mu
+// across the refresh single-flights it: concurrent callers block, then see a
+// fresh token that differs from their stale one and return without another
+// round-trip. Rotated tokens are persisted so later launches stay silent.
+func (c *client) ensureToken(ctx context.Context, staleToken string) error {
+	c.mu.Lock()
+	if c.accessToken != "" && c.accessToken != staleToken && time.Now().Before(c.expiresAt.Add(-tokenSlack)) {
+		c.mu.Unlock()
+		return nil
+	}
+	if c.refreshToken == "" {
+		c.mu.Unlock()
+		return fmt.Errorf("tidal: no refresh token stored")
+	}
+	tok, err := requestToken(ctx, c.http, c.tokenURL, url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {c.refreshToken},
+		"client_id":     {c.clientID},
+		"client_secret": {c.clientSecret},
+		"scope":         {oauthScope},
+	})
+	if err != nil {
+		c.mu.Unlock()
+		return fmt.Errorf("tidal: refresh token: %w", err)
+	}
+	c.applyTokenLocked(tok)
+	creds := c.credsLocked()
+	c.mu.Unlock()
+	_ = saveCreds(creds)
+	return nil
+}
+
+// doGet performs an authenticated GET against the private API and decodes the
+// JSON response into out. A 401 triggers one forced token refresh and retry.
+func (c *client) doGet(ctx context.Context, path string, params url.Values, out any) error {
+	body, err := c.doRequest(ctx, path, params, false)
+	if err != nil {
+		return err
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("tidal: %s: decode: %w", path, err)
+	}
+	return nil
+}
+
+func (c *client) doRequest(ctx context.Context, path string, params url.Values, retried bool) ([]byte, error) {
+	if err := c.ensureToken(ctx, ""); err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("tidal: %s: build request: %w", path, err)
+	}
+
+	q := url.Values{}
+	for k, vs := range params {
+		q[k] = vs
+	}
+	c.mu.Lock()
+	if c.countryCode != "" {
+		q.Set("countryCode", c.countryCode)
+	}
+	if c.sessionID != "" {
+		q.Set("sessionId", c.sessionID)
+	}
+	token := c.accessToken
+	auth := c.tokenType + " " + token
+	c.mu.Unlock()
+	req.URL.RawQuery = q.Encode()
+	req.Header.Set("User-Agent", apiUA)
+	req.Header.Set("x-tidal-client-version", clientVersion)
+	req.Header.Set("Authorization", auth)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("tidal: %s: request: %w", path, err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBody))
+	if err != nil {
+		return nil, fmt.Errorf("tidal: %s: read response: %w", path, err)
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized && !retried {
+		if err := c.ensureToken(ctx, token); err != nil {
+			return nil, err
+		}
+		return c.doRequest(ctx, path, params, true)
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("tidal: %s: HTTP %d: %s", path, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return body, nil
+}
+
+// loadSession fetches the current session (validating the token) and stores
+// the session ID, country code, and user ID the catalog endpoints need.
+func (c *client) loadSession(ctx context.Context) error {
+	var out struct {
+		SessionID   string      `json:"sessionId"`
+		CountryCode string      `json:"countryCode"`
+		UserID      json.Number `json:"userId"`
+	}
+	if err := c.doGet(ctx, "sessions", nil, &out); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	c.sessionID = out.SessionID
+	c.countryCode = out.CountryCode
+	c.userID = out.UserID.String()
+	c.mu.Unlock()
+	return nil
+}
+
+// user returns the authenticated user's ID.
+func (c *client) user() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.userID
+}
+
+// fetchList follows limit/offset pagination for a list endpoint. maxItems
+// caps the total (0 = no cap). The offset advances by the number of items
+// actually returned, so a short page mid-stream does not skip entries.
+func fetchList[T any](ctx context.Context, c *client, path string, maxItems int) ([]T, error) {
+	var all []T
+	// The next offset is always the number of items fetched so far.
+	for offset := 0; ; offset = len(all) {
+		p := url.Values{
+			"limit":  {strconv.Itoa(pageSize)},
+			"offset": {strconv.Itoa(offset)},
+		}
+
+		var out apiList[T]
+		if err := c.doGet(ctx, path, p, &out); err != nil {
+			return nil, err
+		}
+		all = append(all, out.Items...)
+		if maxItems > 0 && len(all) >= maxItems {
+			return all[:maxItems], nil
+		}
+		switch {
+		case len(out.Items) == 0:
+			return all, nil
+		case out.TotalNumberOfItems > 0 && len(all) >= out.TotalNumberOfItems:
+			return all, nil
+		case len(out.Items) < pageSize && out.TotalNumberOfItems <= 0:
+			// Partial page with no reported total: assume the end.
+			return all, nil
+		}
+	}
+}
+
+// unwrapFavorites strips the {created, item} wrapper of favorites responses.
+func unwrapFavorites[T any](in []apiFavoriteItem[T]) []T {
+	out := make([]T, len(in))
+	for i, f := range in {
+		out[i] = f.Item
+	}
+	return out
+}
+
+// userPlaylists returns the authenticated user's playlists.
+func (c *client) userPlaylists(ctx context.Context) ([]apiPlaylist, error) {
+	return fetchList[apiPlaylist](ctx, c, "users/"+c.user()+"/playlists", 0)
+}
+
+// playlistTracks returns the tracks of a playlist, following pagination.
+func (c *client) playlistTracks(ctx context.Context, playlistUUID string) ([]apiTrack, error) {
+	return fetchList[apiTrack](ctx, c, "playlists/"+url.PathEscape(playlistUUID)+"/tracks", 0)
+}
+
+// favoriteTracks returns the user's favorite tracks, capped at maxItems.
+func (c *client) favoriteTracks(ctx context.Context, maxItems int) ([]apiTrack, error) {
+	items, err := fetchList[apiFavoriteItem[apiTrack]](ctx, c, "users/"+c.user()+"/favorites/tracks", maxItems)
+	if err != nil {
+		return nil, err
+	}
+	return unwrapFavorites(items), nil
+}
+
+// favoriteAlbums returns one page of the user's favorite albums.
+func (c *client) favoriteAlbums(ctx context.Context, offset, limit int) ([]apiAlbum, error) {
+	if limit <= 0 || limit > pageSize {
+		limit = pageSize
+	}
+	params := url.Values{
+		"limit":  {strconv.Itoa(limit)},
+		"offset": {strconv.Itoa(offset)},
+	}
+	var out apiList[apiFavoriteItem[apiAlbum]]
+	if err := c.doGet(ctx, "users/"+c.user()+"/favorites/albums", params, &out); err != nil {
+		return nil, err
+	}
+	return unwrapFavorites(out.Items), nil
+}
+
+// favoriteArtists returns all of the user's favorite artists.
+func (c *client) favoriteArtists(ctx context.Context) ([]apiArtist, error) {
+	items, err := fetchList[apiFavoriteItem[apiArtist]](ctx, c, "users/"+c.user()+"/favorites/artists", 0)
+	if err != nil {
+		return nil, err
+	}
+	return unwrapFavorites(items), nil
+}
+
+// artistAlbums returns the albums of an artist, following pagination.
+func (c *client) artistAlbums(ctx context.Context, artistID string) ([]apiAlbum, error) {
+	return fetchList[apiAlbum](ctx, c, "artists/"+url.PathEscape(artistID)+"/albums", 0)
+}
+
+// albumGet returns an album's metadata.
+func (c *client) albumGet(ctx context.Context, albumID string) (apiAlbum, error) {
+	var out apiAlbum
+	if err := c.doGet(ctx, "albums/"+url.PathEscape(albumID), nil, &out); err != nil {
+		return apiAlbum{}, err
+	}
+	return out, nil
+}
+
+// albumTracks returns the tracks of an album.
+func (c *client) albumTracks(ctx context.Context, albumID string) ([]apiTrack, error) {
+	return fetchList[apiTrack](ctx, c, "albums/"+url.PathEscape(albumID)+"/tracks", 0)
+}
+
+// searchTracks searches the Tidal catalog for tracks.
+func (c *client) searchTracks(ctx context.Context, query string, limit int) ([]apiTrack, error) {
+	if limit <= 0 || limit > pageSize {
+		limit = pageSize
+	}
+	params := url.Values{
+		"query": {query},
+		"limit": {strconv.Itoa(limit)},
+	}
+	var out apiList[apiTrack]
+	if err := c.doGet(ctx, "search/tracks", params, &out); err != nil {
+		return nil, err
+	}
+	return out.Items, nil
+}
+
+// playbackInfo returns the playback manifest for a track at the given quality.
+func (c *client) playbackInfo(ctx context.Context, trackID, quality string) (apiPlaybackInfo, error) {
+	params := url.Values{
+		"playbackmode":      {"STREAM"},
+		"audioquality":      {quality},
+		"assetpresentation": {"FULL"},
+	}
+	var out apiPlaybackInfo
+	if err := c.doGet(ctx, "tracks/"+url.PathEscape(trackID)+"/playbackinfopostpaywall", params, &out); err != nil {
+		return apiPlaybackInfo{}, err
+	}
+	return out, nil
+}

--- a/external/tidal/client_test.go
+++ b/external/tidal/client_test.go
@@ -89,6 +89,10 @@ func TestFetchListMaxItems(t *testing.T) {
 }
 
 func TestDoRequestRefreshesOn401(t *testing.T) {
+	// The refresh path persists rotated tokens; keep the write away from the
+	// user's real credentials file.
+	t.Setenv("CLIAMP_CONFIG_DIR", t.TempDir())
+
 	var apiCalls, tokenCalls atomic.Int32
 	mux := http.NewServeMux()
 	mux.HandleFunc("/sessions", func(w http.ResponseWriter, r *http.Request) {

--- a/external/tidal/client_test.go
+++ b/external/tidal/client_test.go
@@ -1,0 +1,124 @@
+package tidal
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// testClient returns a client with a valid-looking token pointed at srv.
+func testClient(srv *httptest.Server) *client {
+	c := newClient("id", "secret")
+	c.baseURL = srv.URL + "/"
+	c.http = srv.Client()
+	c.accessToken = "token"
+	c.tokenType = "Bearer"
+	c.refreshToken = "refresh"
+	c.expiresAt = time.Now().Add(time.Hour)
+	c.countryCode = "US"
+	c.userID = "42"
+	return c
+}
+
+func TestFetchListPagination(t *testing.T) {
+	// 150 favorite artists: page 1 full (100), page 2 partial (50).
+	total := 150
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("countryCode"); got != "US" {
+			t.Errorf("countryCode = %q, want US", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer token" {
+			t.Errorf("Authorization = %q", got)
+		}
+		offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+		limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+		var items []map[string]any
+		for i := offset; i < offset+limit && i < total; i++ {
+			items = append(items, map[string]any{
+				"item": map[string]any{"id": i, "name": fmt.Sprintf("artist-%d", i)},
+			})
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items":              items,
+			"totalNumberOfItems": total,
+		})
+	}))
+	defer srv.Close()
+
+	c := testClient(srv)
+	artists, err := c.favoriteArtists(context.Background())
+	if err != nil {
+		t.Fatalf("favoriteArtists: %v", err)
+	}
+	if len(artists) != total {
+		t.Fatalf("got %d artists, want %d", len(artists), total)
+	}
+	if artists[0].Name != "artist-0" || artists[total-1].Name != "artist-149" {
+		t.Errorf("unexpected boundary items: %q, %q", artists[0].Name, artists[total-1].Name)
+	}
+}
+
+func TestFetchListMaxItems(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+		items := make([]map[string]any, limit)
+		for i := range items {
+			items[i] = map[string]any{"item": map[string]any{"id": i, "title": "t"}}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items":              items,
+			"totalNumberOfItems": 10000,
+		})
+	}))
+	defer srv.Close()
+
+	c := testClient(srv)
+	tracks, err := c.favoriteTracks(context.Background(), 250)
+	if err != nil {
+		t.Fatalf("favoriteTracks: %v", err)
+	}
+	if len(tracks) != 250 {
+		t.Errorf("got %d tracks, want cap of 250", len(tracks))
+	}
+}
+
+func TestDoRequestRefreshesOn401(t *testing.T) {
+	var apiCalls, tokenCalls atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/sessions", func(w http.ResponseWriter, r *http.Request) {
+		apiCalls.Add(1)
+		if r.Header.Get("Authorization") != "Bearer fresh" {
+			w.WriteHeader(http.StatusUnauthorized)
+			fmt.Fprint(w, `{"status":401}`)
+			return
+		}
+		fmt.Fprint(w, `{"sessionId":"s","countryCode":"NO","userId":7}`)
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		tokenCalls.Add(1)
+		fmt.Fprint(w, `{"access_token":"fresh","token_type":"Bearer","expires_in":3600}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := testClient(srv)
+	c.tokenURL = srv.URL + "/token"
+	if err := c.loadSession(context.Background()); err != nil {
+		t.Fatalf("loadSession: %v", err)
+	}
+	if got := tokenCalls.Load(); got != 1 {
+		t.Errorf("token refreshes = %d, want 1", got)
+	}
+	if got := apiCalls.Load(); got != 2 {
+		t.Errorf("api calls = %d, want 2 (401 then retry)", got)
+	}
+	if c.countryCode != "NO" {
+		t.Errorf("countryCode = %q, want NO", c.countryCode)
+	}
+}

--- a/external/tidal/client_test.go
+++ b/external/tidal/client_test.go
@@ -3,6 +3,7 @@ package tidal
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +11,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/bjarneo/cliamp/playlist"
 )
 
 // testClient returns a client with a valid-looking token pointed at srv.
@@ -124,5 +127,56 @@ func TestDoRequestRefreshesOn401(t *testing.T) {
 	}
 	if c.countryCode != "NO" {
 		t.Errorf("countryCode = %q, want NO", c.countryCode)
+	}
+}
+
+func TestRevokedRefreshTokenDropsClientAndAsksForAuth(t *testing.T) {
+	t.Setenv("CLIAMP_CONFIG_DIR", t.TempDir())
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, `{"error":"invalid_grant","error_description":"revoked"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := testClient(srv)
+	c.tokenURL = srv.URL + "/token"
+	c.expiresAt = time.Now().Add(-time.Hour) // force a refresh attempt
+
+	p := New("lossless", "", "")
+	p.client = c
+
+	_, err := p.Tracks(favoriteTracksID)
+	if !errors.Is(err, playlist.ErrNeedsAuth) {
+		t.Fatalf("err = %v, want playlist.ErrNeedsAuth", err)
+	}
+	p.mu.Lock()
+	dropped := p.client == nil
+	p.mu.Unlock()
+	if !dropped {
+		t.Error("client not dropped after revoked refresh token")
+	}
+}
+
+func TestDoRequestRetriesOn429(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		fmt.Fprint(w, `{"sessionId":"s","countryCode":"NO","userId":7}`)
+	}))
+	defer srv.Close()
+
+	c := testClient(srv)
+	if err := c.loadSession(context.Background()); err != nil {
+		t.Fatalf("loadSession after 429: %v", err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("calls = %d, want 2 (429 then success)", got)
 	}
 }

--- a/external/tidal/creds.go
+++ b/external/tidal/creds.go
@@ -1,0 +1,95 @@
+package tidal
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/bjarneo/cliamp/internal/appdir"
+	"github.com/bjarneo/cliamp/internal/fileutil"
+)
+
+// Built-in fallback OAuth client credentials: the device ("TV") client pair
+// that the python-tidal ecosystem ships. Tidal revokes leaked client IDs
+// periodically; when that happens, users can set client_id/client_secret in
+// the [tidal] config section to a fresh pair without waiting for a cliamp
+// release.
+const (
+	fallbackClientID     = "fX2JxdmntZWK0ixT"
+	fallbackClientSecret = "1Nn9AfDAjxrgJFJbKNWLeAyKGVGmINuXPPLHVXAvxAg="
+)
+
+// storedCreds holds persisted Tidal OAuth tokens so the user only signs in
+// once. The client credentials that minted the tokens are stored alongside
+// them because token refresh must use the same client.
+type storedCreds struct {
+	ClientID     string    `json:"client_id"`
+	ClientSecret string    `json:"client_secret"`
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token"`
+	TokenType    string    `json:"token_type"`
+	ExpiresAt    time.Time `json:"expires_at"`
+	UserID       string    `json:"user_id"`
+	CountryCode  string    `json:"country_code"`
+}
+
+// CredsPath returns the absolute path to the stored Tidal credentials file.
+func CredsPath() (string, error) {
+	dir, err := appdir.Dir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "tidal_credentials.json"), nil
+}
+
+// DeleteCreds removes the stored Tidal credentials file. Returns true if a
+// file was removed, false if it did not exist.
+func DeleteCreds() (bool, error) {
+	path, err := CredsPath()
+	if err != nil {
+		return false, err
+	}
+	if err := os.Remove(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func loadCreds() (*storedCreds, error) {
+	path, err := CredsPath()
+	if err != nil {
+		return nil, fmt.Errorf("tidal: credentials path: %w", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("tidal: read credentials: %w", err)
+	}
+	var creds storedCreds
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return nil, fmt.Errorf("tidal: parse credentials: %w", err)
+	}
+	return &creds, nil
+}
+
+func saveCreds(creds *storedCreds) error {
+	path, err := CredsPath()
+	if err != nil {
+		return fmt.Errorf("tidal: credentials path: %w", err)
+	}
+	data, err := json.Marshal(creds)
+	if err != nil {
+		return fmt.Errorf("tidal: encode credentials: %w", err)
+	}
+	// Atomic write: Tidal rotates tokens, so this file is rewritten during
+	// normal use — a torn write would force a fresh device-flow sign-in.
+	if err := fileutil.WriteFileAtomic(path, data, 0o600); err != nil {
+		return fmt.Errorf("tidal: write credentials: %w", err)
+	}
+	return nil
+}

--- a/external/tidal/creds.go
+++ b/external/tidal/creds.go
@@ -40,7 +40,7 @@ type storedCreds struct {
 func CredsPath() (string, error) {
 	dir, err := appdir.Dir()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("tidal: config dir: %w", err)
 	}
 	return filepath.Join(dir, "tidal_credentials.json"), nil
 }
@@ -56,7 +56,7 @@ func DeleteCreds() (bool, error) {
 		if errors.Is(err, os.ErrNotExist) {
 			return false, nil
 		}
-		return false, err
+		return false, fmt.Errorf("tidal: remove credentials: %w", err)
 	}
 	return true, nil
 }

--- a/external/tidal/dash.go
+++ b/external/tidal/dash.go
@@ -1,0 +1,95 @@
+package tidal
+
+import (
+	"encoding/xml"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// mpd is the subset of a Tidal MPEG-DASH manifest needed to reconstruct the
+// segment URL list. Tidal audio manifests carry a single Representation with
+// an absolute-URL SegmentTemplate and a SegmentTimeline.
+type mpd struct {
+	Periods []mpdPeriod `xml:"Period"`
+}
+
+type mpdPeriod struct {
+	AdaptationSets []mpdAdaptationSet `xml:"AdaptationSet"`
+}
+
+type mpdAdaptationSet struct {
+	SegmentTemplate *segmentTemplate    `xml:"SegmentTemplate"`
+	Representations []mpdRepresentation `xml:"Representation"`
+}
+
+type mpdRepresentation struct {
+	Codecs          string           `xml:"codecs,attr"`
+	SegmentTemplate *segmentTemplate `xml:"SegmentTemplate"`
+}
+
+type segmentTemplate struct {
+	Initialization string `xml:"initialization,attr"`
+	Media          string `xml:"media,attr"`
+	StartNumber    *int   `xml:"startNumber,attr"`
+	Timeline       *struct {
+		S []struct {
+			D int `xml:"d,attr"`
+			R int `xml:"r,attr"`
+		} `xml:"S"`
+	} `xml:"SegmentTimeline"`
+}
+
+// dashSegments extracts the ordered segment URL list (initialization segment
+// followed by every media segment) from a raw MPD document.
+func dashSegments(raw []byte) ([]string, error) {
+	var doc mpd
+	if err := xml.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("tidal: parse DASH manifest: %w", err)
+	}
+	for _, p := range doc.Periods {
+		for _, a := range p.AdaptationSets {
+			for _, r := range a.Representations {
+				st := r.SegmentTemplate
+				if st == nil {
+					st = a.SegmentTemplate
+				}
+				if st == nil || st.Media == "" {
+					continue
+				}
+				return st.urls()
+			}
+		}
+	}
+	return nil, fmt.Errorf("tidal: DASH manifest has no usable segment template")
+}
+
+// urls expands the segment template into concrete URLs. Only the
+// $Number$-substitution form Tidal uses is supported.
+func (st *segmentTemplate) urls() ([]string, error) {
+	count := 0
+	if st.Timeline != nil {
+		for _, s := range st.Timeline.S {
+			count += 1 + s.R // r is the number of additional repeats
+		}
+	}
+	if count == 0 {
+		return nil, fmt.Errorf("tidal: DASH segment timeline is empty")
+	}
+	if !strings.Contains(st.Media, "$Number$") {
+		return nil, fmt.Errorf("tidal: unsupported DASH media template %q", st.Media)
+	}
+	start := 1
+	if st.StartNumber != nil {
+		start = *st.StartNumber
+	}
+
+	urls := make([]string, 0, count+1)
+	if st.Initialization != "" {
+		urls = append(urls, st.Initialization)
+	}
+	for i := 0; i < count; i++ {
+		urls = append(urls, strings.ReplaceAll(st.Media, "$Number$", strconv.Itoa(start+i)))
+	}
+	return urls, nil
+}

--- a/external/tidal/dash_test.go
+++ b/external/tidal/dash_test.go
@@ -1,0 +1,78 @@
+package tidal
+
+import "testing"
+
+// sampleMPD mirrors the structure of Tidal's live hi-res manifests: one FLAC
+// representation, absolute URLs with XML-escaped query strings, $Number$
+// media template, and a SegmentTimeline using a repeat count.
+const sampleMPD = `<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" type="static">
+  <Period>
+    <AdaptationSet contentType="audio" mimeType="audio/mp4">
+      <Representation id="0" codecs="flac" audioSamplingRate="48000" bandwidth="1500000">
+        <SegmentTemplate initialization="https://cdn.tidal.com/init.mp4?token=t&amp;x=1" media="https://cdn.tidal.com/seg$Number$.m4s" startNumber="1" timescale="48000">
+          <SegmentTimeline>
+            <S t="0" d="192512" r="1"/>
+            <S d="65536"/>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>`
+
+func TestDashSegments(t *testing.T) {
+	segments, err := dashSegments([]byte(sampleMPD))
+	if err != nil {
+		t.Fatalf("dashSegments: %v", err)
+	}
+	// r="1" means one extra repeat: S(d=192512) x2 + S(d=65536) = 3 media
+	// segments, plus the init segment.
+	if len(segments) != 4 {
+		t.Fatalf("got %d segments, want 4: %v", len(segments), segments)
+	}
+	if segments[0] != "https://cdn.tidal.com/init.mp4?token=t&x=1" {
+		t.Errorf("init = %q (entities must be decoded)", segments[0])
+	}
+	if segments[3] != "https://cdn.tidal.com/seg3.m4s" {
+		t.Errorf("last = %q", segments[3])
+	}
+}
+
+func TestDashSegmentsStartNumber(t *testing.T) {
+	const mpd = `<MPD><Period><AdaptationSet>
+	  <SegmentTemplate initialization="https://x/init" media="https://x/s$Number$" startNumber="5">
+	    <SegmentTimeline><S d="1"/><S d="1"/></SegmentTimeline>
+	  </SegmentTemplate>
+	  <Representation codecs="flac"/>
+	</AdaptationSet></Period></MPD>`
+	segments, err := dashSegments([]byte(mpd))
+	if err != nil {
+		t.Fatalf("dashSegments: %v", err)
+	}
+	want := []string{"https://x/init", "https://x/s5", "https://x/s6"}
+	for i := range want {
+		if segments[i] != want[i] {
+			t.Errorf("segment[%d] = %q, want %q", i, segments[i], want[i])
+		}
+	}
+}
+
+func TestDashSegmentsErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		mpd  string
+	}{
+		{"not xml", "{json}"},
+		{"no template", `<MPD><Period><AdaptationSet><Representation codecs="flac"/></AdaptationSet></Period></MPD>`},
+		{"empty timeline", `<MPD><Period><AdaptationSet><Representation codecs="flac"><SegmentTemplate media="https://x/$Number$"/></Representation></AdaptationSet></Period></MPD>`},
+		{"unsupported template", `<MPD><Period><AdaptationSet><Representation codecs="flac"><SegmentTemplate media="https://x/$Time$"><SegmentTimeline><S d="1"/></SegmentTimeline></SegmentTemplate></Representation></AdaptationSet></Period></MPD>`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if segs, err := dashSegments([]byte(tt.mpd)); err == nil {
+				t.Errorf("expected error, got %v", segs)
+			}
+		})
+	}
+}

--- a/external/tidal/doc.go
+++ b/external/tidal/doc.go
@@ -1,0 +1,15 @@
+// Package tidal implements a cliamp provider for the Tidal streaming service.
+//
+// It uses Tidal's private client API (api.tidal.com/v1) — the same API the
+// python-tidal ecosystem uses — because the official developer API only
+// allows 30-second previews for third-party clients. Sign-in is an OAuth 2.0
+// device flow: the user opens link.tidal.com and enters a short code, which
+// fits the TUI without a local redirect server.
+//
+// Playback resolves a per-track stream URL via the playbackinfopostpaywall
+// endpoint. LOW/HIGH/LOSSLESS qualities are delivered as direct CDN URLs
+// (Tidal's "BTS" manifest) and routed through the player's buffered ffmpeg
+// pipeline, exactly like Qobuz streams. HI_RES_LOSSLESS is DASH-segmented,
+// which the pipeline cannot stream yet, so it falls back per track to
+// LOSSLESS (FLAC 16-bit/44.1kHz).
+package tidal

--- a/external/tidal/manifest.go
+++ b/external/tidal/manifest.go
@@ -45,6 +45,8 @@ var errDASHManifest = errors.New("tidal: DASH manifest not supported")
 // direct CDN URLs, delivered base64-encoded in the playbackinfo response for
 // LOW/HIGH/LOSSLESS qualities.
 type btsManifest struct {
+	MimeType       string   `json:"mimeType"`
+	Codecs         string   `json:"codecs"`
 	EncryptionType string   `json:"encryptionType"`
 	URLs           []string `json:"urls"`
 }

--- a/external/tidal/manifest.go
+++ b/external/tidal/manifest.go
@@ -1,0 +1,100 @@
+package tidal
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Audio quality values accepted by the playbackinfo endpoint. Any paid Tidal
+// subscription includes all four tiers (the HiFi/HiFi Plus split ended in
+// 2024).
+const (
+	qualityLow      = "LOW"             // 96 kbps AAC
+	qualityHigh     = "HIGH"            // 320 kbps AAC
+	qualityLossless = "LOSSLESS"        // FLAC 16-bit/44.1kHz
+	qualityHiRes    = "HI_RES_LOSSLESS" // FLAC 24-bit up to 192kHz (DASH)
+)
+
+// normalizeQuality maps a [tidal] config quality string to a Tidal
+// audioquality value. ok is false when s is not a recognized quality name.
+func normalizeQuality(s string) (quality string, ok bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "low":
+		return qualityLow, true
+	case "high":
+		return qualityHigh, true
+	case "", "lossless":
+		return qualityLossless, true
+	case "hires", "hi_res", "hi-res", "hi_res_lossless", "max":
+		return qualityHiRes, true
+	default:
+		return "", false
+	}
+}
+
+// errDASHManifest signals that playbackinfo returned a segmented MPEG-DASH
+// manifest, which the player pipeline cannot stream directly. Tidal delivers
+// HI_RES_LOSSLESS via DASH; resolveStreamURL falls back to LOSSLESS (plain
+// FLAC over HTTP) when it sees this.
+var errDASHManifest = errors.New("tidal: DASH manifest not supported")
+
+// btsManifest is Tidal's "basic track stream" manifest: a JSON document with
+// direct CDN URLs, delivered base64-encoded in the playbackinfo response for
+// LOW/HIGH/LOSSLESS qualities.
+type btsManifest struct {
+	EncryptionType string   `json:"encryptionType"`
+	URLs           []string `json:"urls"`
+}
+
+// streamURLFromManifest extracts a direct stream URL from a playbackinfo
+// response. Returns errDASHManifest for DASH manifests (hi-res tiers).
+func streamURLFromManifest(pi apiPlaybackInfo) (string, error) {
+	switch {
+	case strings.Contains(pi.ManifestMimeType, "dash+xml"):
+		return "", errDASHManifest
+	case strings.Contains(pi.ManifestMimeType, "vnd.tidal.bts"):
+	default:
+		return "", fmt.Errorf("tidal: unsupported manifest type %q", pi.ManifestMimeType)
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(pi.Manifest)
+	if err != nil {
+		return "", fmt.Errorf("tidal: decode manifest: %w", err)
+	}
+	var m btsManifest
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return "", fmt.Errorf("tidal: parse manifest: %w", err)
+	}
+	if m.EncryptionType != "" && m.EncryptionType != "NONE" {
+		return "", fmt.Errorf("tidal: stream is encrypted (%s), not supported", m.EncryptionType)
+	}
+	if len(m.URLs) == 0 || m.URLs[0] == "" {
+		return "", errors.New("tidal: manifest contains no stream URL")
+	}
+	return m.URLs[0], nil
+}
+
+// resolveStreamURL fetches playback info at the requested quality and extracts
+// a direct stream URL. When HI_RES_LOSSLESS comes back as a DASH manifest, it
+// re-requests at LOSSLESS so hi-res users still get CD-quality FLAC. The
+// quality that actually produced the URL is returned so callers can stop
+// requesting hi-res once it proves undeliverable.
+func resolveStreamURL(quality string, fetch func(quality string) (apiPlaybackInfo, error)) (u, usedQuality string, err error) {
+	pi, err := fetch(quality)
+	if err != nil {
+		return "", "", err
+	}
+	u, err = streamURLFromManifest(pi)
+	if errors.Is(err, errDASHManifest) && quality == qualityHiRes {
+		pi, err = fetch(qualityLossless)
+		if err != nil {
+			return "", "", err
+		}
+		u, err = streamURLFromManifest(pi)
+		return u, qualityLossless, err
+	}
+	return u, quality, err
+}

--- a/external/tidal/manifest.go
+++ b/external/tidal/manifest.go
@@ -15,7 +15,7 @@ const (
 	qualityLow      = "LOW"             // 96 kbps AAC
 	qualityHigh     = "HIGH"            // 320 kbps AAC
 	qualityLossless = "LOSSLESS"        // FLAC 16-bit/44.1kHz
-	qualityHiRes    = "HI_RES_LOSSLESS" // FLAC 24-bit up to 192kHz (DASH)
+	qualityHiRes    = "HI_RES_LOSSLESS" // FLAC up to 24-bit/192kHz
 )
 
 // normalizeQuality maps a [tidal] config quality string to a Tidal
@@ -35,15 +35,27 @@ func normalizeQuality(s string) (quality string, ok bool) {
 	}
 }
 
-// errDASHManifest signals that playbackinfo returned a segmented MPEG-DASH
-// manifest, which the player pipeline cannot stream directly. Tidal delivers
-// HI_RES_LOSSLESS via DASH; resolveStreamURL falls back to LOSSLESS (plain
-// FLAC over HTTP) when it sees this.
-var errDASHManifest = errors.New("tidal: DASH manifest not supported")
+// isFLACQuality reports whether q names a lossless (FLAC) delivery tier.
+func isFLACQuality(q string) bool {
+	return q == qualityLossless || q == qualityHiRes
+}
+
+// requestQuality maps the user's configured quality to the value actually
+// sent to playbackinfo. The device client cliamp uses never receives the
+// LOSSLESS tier (BTS caps at HIGH AAC — verified against the live API), so
+// both FLAC settings request HI_RES_LOSSLESS: that returns DASH FLAC when
+// the track has it and downgrades to HIGH AAC otherwise, which
+// streamSource's delivered-quality reporting surfaces.
+func requestQuality(configured string) string {
+	if isFLACQuality(configured) {
+		return qualityHiRes
+	}
+	return configured
+}
 
 // btsManifest is Tidal's "basic track stream" manifest: a JSON document with
 // direct CDN URLs, delivered base64-encoded in the playbackinfo response for
-// LOW/HIGH/LOSSLESS qualities.
+// the AAC tiers.
 type btsManifest struct {
 	MimeType       string   `json:"mimeType"`
 	Codecs         string   `json:"codecs"`
@@ -51,52 +63,45 @@ type btsManifest struct {
 	URLs           []string `json:"urls"`
 }
 
-// streamURLFromManifest extracts a direct stream URL from a playbackinfo
-// response. Returns errDASHManifest for DASH manifests (hi-res tiers).
-func streamURLFromManifest(pi apiPlaybackInfo) (string, error) {
-	switch {
-	case strings.Contains(pi.ManifestMimeType, "dash+xml"):
-		return "", errDASHManifest
-	case strings.Contains(pi.ManifestMimeType, "vnd.tidal.bts"):
-	default:
-		return "", fmt.Errorf("tidal: unsupported manifest type %q", pi.ManifestMimeType)
-	}
-
-	raw, err := base64.StdEncoding.DecodeString(pi.Manifest)
-	if err != nil {
-		return "", fmt.Errorf("tidal: decode manifest: %w", err)
-	}
-	var m btsManifest
-	if err := json.Unmarshal(raw, &m); err != nil {
-		return "", fmt.Errorf("tidal: parse manifest: %w", err)
-	}
-	if m.EncryptionType != "" && m.EncryptionType != "NONE" {
-		return "", fmt.Errorf("tidal: stream is encrypted (%s), not supported", m.EncryptionType)
-	}
-	if len(m.URLs) == 0 || m.URLs[0] == "" {
-		return "", errors.New("tidal: manifest contains no stream URL")
-	}
-	return m.URLs[0], nil
+// streamSource is a playable source extracted from a playbackinfo response:
+// either a direct URL (BTS) or an ordered DASH segment list, plus the quality
+// the server actually delivered.
+type streamSource struct {
+	url      string
+	segments []string
+	quality  string // delivered audioQuality (may be lower than requested)
 }
 
-// resolveStreamURL fetches playback info at the requested quality and extracts
-// a direct stream URL. When HI_RES_LOSSLESS comes back as a DASH manifest, it
-// re-requests at LOSSLESS so hi-res users still get CD-quality FLAC. The
-// quality that actually produced the URL is returned so callers can stop
-// requesting hi-res once it proves undeliverable.
-func resolveStreamURL(quality string, fetch func(quality string) (apiPlaybackInfo, error)) (u, usedQuality string, err error) {
-	pi, err := fetch(quality)
+// streamSourceFromManifest decodes the base64 manifest in a playbackinfo
+// response into a playable source.
+func streamSourceFromManifest(pi apiPlaybackInfo) (streamSource, error) {
+	raw, err := base64.StdEncoding.DecodeString(pi.Manifest)
 	if err != nil {
-		return "", "", err
+		return streamSource{}, fmt.Errorf("tidal: decode manifest: %w", err)
 	}
-	u, err = streamURLFromManifest(pi)
-	if errors.Is(err, errDASHManifest) && quality == qualityHiRes {
-		pi, err = fetch(qualityLossless)
-		if err != nil {
-			return "", "", err
+
+	switch {
+	case strings.Contains(pi.ManifestMimeType, "vnd.tidal.bts"):
+		var m btsManifest
+		if err := json.Unmarshal(raw, &m); err != nil {
+			return streamSource{}, fmt.Errorf("tidal: parse manifest: %w", err)
 		}
-		u, err = streamURLFromManifest(pi)
-		return u, qualityLossless, err
+		if m.EncryptionType != "" && m.EncryptionType != "NONE" {
+			return streamSource{}, fmt.Errorf("tidal: stream is encrypted (%s), not supported", m.EncryptionType)
+		}
+		if len(m.URLs) == 0 || m.URLs[0] == "" {
+			return streamSource{}, errors.New("tidal: manifest contains no stream URL")
+		}
+		return streamSource{url: m.URLs[0], quality: pi.AudioQuality}, nil
+
+	case strings.Contains(pi.ManifestMimeType, "dash+xml"):
+		segments, err := dashSegments(raw)
+		if err != nil {
+			return streamSource{}, err
+		}
+		return streamSource{segments: segments, quality: pi.AudioQuality}, nil
+
+	default:
+		return streamSource{}, fmt.Errorf("tidal: unsupported manifest type %q", pi.ManifestMimeType)
 	}
-	return u, quality, err
 }

--- a/external/tidal/manifest_test.go
+++ b/external/tidal/manifest_test.go
@@ -1,0 +1,187 @@
+package tidal
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestNormalizeQuality(t *testing.T) {
+	tests := []struct {
+		in     string
+		want   string
+		wantOK bool
+	}{
+		{"low", qualityLow, true},
+		{"high", qualityHigh, true},
+		{"lossless", qualityLossless, true},
+		{"", qualityLossless, true},
+		{"LOSSLESS", qualityLossless, true},
+		{"  lossless  ", qualityLossless, true},
+		{"hires", qualityHiRes, true},
+		{"hi_res", qualityHiRes, true},
+		{"hi-res", qualityHiRes, true},
+		{"hi_res_lossless", qualityHiRes, true},
+		{"max", qualityHiRes, true},
+		{"320", "", false},
+		{"flac", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, ok := normalizeQuality(tt.in)
+			if got != tt.want || ok != tt.wantOK {
+				t.Errorf("normalizeQuality(%q) = (%q, %v), want (%q, %v)", tt.in, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}
+
+func btsBase64(jsonBody string) string {
+	return base64.StdEncoding.EncodeToString([]byte(jsonBody))
+}
+
+func TestStreamURLFromManifest(t *testing.T) {
+	tests := []struct {
+		name    string
+		pi      apiPlaybackInfo
+		want    string // expected URL; empty (with nil wantErr) = any error
+		wantErr error  // sentinel to match
+	}{
+		{
+			name: "bts flac",
+			pi: apiPlaybackInfo{
+				ManifestMimeType: "application/vnd.tidal.bts",
+				Manifest:         btsBase64(`{"mimeType":"audio/flac","codecs":"flac","encryptionType":"NONE","urls":["https://cdn.tidal.com/x.flac"]}`),
+			},
+			want: "https://cdn.tidal.com/x.flac",
+		},
+		{
+			name: "bts empty encryption type",
+			pi: apiPlaybackInfo{
+				ManifestMimeType: "application/vnd.tidal.bts",
+				Manifest:         btsBase64(`{"urls":["https://cdn.tidal.com/y.m4a"]}`),
+			},
+			want: "https://cdn.tidal.com/y.m4a",
+		},
+		{
+			name: "dash manifest",
+			pi: apiPlaybackInfo{
+				ManifestMimeType: "application/dash+xml",
+				Manifest:         btsBase64(`<MPD></MPD>`),
+			},
+			wantErr: errDASHManifest,
+		},
+		{
+			name: "encrypted stream",
+			pi: apiPlaybackInfo{
+				ManifestMimeType: "application/vnd.tidal.bts",
+				Manifest:         btsBase64(`{"encryptionType":"OLD_AES","urls":["https://cdn.tidal.com/z"]}`),
+			},
+		},
+		{
+			name: "unknown mime type",
+			pi:   apiPlaybackInfo{ManifestMimeType: "application/vnd.tidal.emu"},
+		},
+		{
+			name: "invalid base64",
+			pi: apiPlaybackInfo{
+				ManifestMimeType: "application/vnd.tidal.bts",
+				Manifest:         "!!!not-base64!!!",
+			},
+		},
+		{
+			name: "no urls",
+			pi: apiPlaybackInfo{
+				ManifestMimeType: "application/vnd.tidal.bts",
+				Manifest:         btsBase64(`{"encryptionType":"NONE","urls":[]}`),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := streamURLFromManifest(tt.pi)
+			switch {
+			case tt.wantErr != nil:
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("err = %v, want %v", err, tt.wantErr)
+				}
+			case tt.want == "":
+				if err == nil {
+					t.Errorf("expected error, got url %q", got)
+				}
+			default:
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got != tt.want {
+					t.Errorf("url = %q, want %q", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveStreamURL(t *testing.T) {
+	bts := func(u string) apiPlaybackInfo {
+		return apiPlaybackInfo{
+			ManifestMimeType: "application/vnd.tidal.bts",
+			Manifest:         btsBase64(fmt.Sprintf(`{"encryptionType":"NONE","urls":[%q]}`, u)),
+		}
+	}
+	dash := apiPlaybackInfo{ManifestMimeType: "application/dash+xml", Manifest: btsBase64(`<MPD/>`)}
+
+	t.Run("lossless direct", func(t *testing.T) {
+		var qualities []string
+		u, used, err := resolveStreamURL(qualityLossless, func(q string) (apiPlaybackInfo, error) {
+			qualities = append(qualities, q)
+			return bts("https://cdn/a.flac"), nil
+		})
+		if err != nil || u != "https://cdn/a.flac" || used != qualityLossless {
+			t.Fatalf("got (%q, %q, %v)", u, used, err)
+		}
+		if len(qualities) != 1 || qualities[0] != qualityLossless {
+			t.Errorf("fetched qualities = %v", qualities)
+		}
+	})
+
+	t.Run("hires falls back to lossless on dash", func(t *testing.T) {
+		var qualities []string
+		u, used, err := resolveStreamURL(qualityHiRes, func(q string) (apiPlaybackInfo, error) {
+			qualities = append(qualities, q)
+			if q == qualityHiRes {
+				return dash, nil
+			}
+			return bts("https://cdn/cd.flac"), nil
+		})
+		if err != nil || u != "https://cdn/cd.flac" {
+			t.Fatalf("got (%q, %v)", u, err)
+		}
+		if used != qualityLossless {
+			t.Errorf("used quality = %q, want %q", used, qualityLossless)
+		}
+		want := []string{qualityHiRes, qualityLossless}
+		if len(qualities) != 2 || qualities[0] != want[0] || qualities[1] != want[1] {
+			t.Errorf("fetched qualities = %v, want %v", qualities, want)
+		}
+	})
+
+	t.Run("lossless dash does not fall back", func(t *testing.T) {
+		_, _, err := resolveStreamURL(qualityLossless, func(q string) (apiPlaybackInfo, error) {
+			return dash, nil
+		})
+		if !errors.Is(err, errDASHManifest) {
+			t.Errorf("err = %v, want errDASHManifest", err)
+		}
+	})
+
+	t.Run("fetch error propagates", func(t *testing.T) {
+		wantErr := errors.New("boom")
+		_, _, err := resolveStreamURL(qualityHiRes, func(q string) (apiPlaybackInfo, error) {
+			return apiPlaybackInfo{}, wantErr
+		})
+		if !errors.Is(err, wantErr) {
+			t.Errorf("err = %v, want %v", err, wantErr)
+		}
+	})
+}

--- a/external/tidal/manifest_test.go
+++ b/external/tidal/manifest_test.go
@@ -2,8 +2,8 @@ package tidal
 
 import (
 	"encoding/base64"
-	"errors"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -37,151 +37,118 @@ func TestNormalizeQuality(t *testing.T) {
 	}
 }
 
+func TestRequestQuality(t *testing.T) {
+	// The device client never receives LOSSLESS via BTS (downgrades to HIGH
+	// AAC — verified live), so both FLAC settings must request HI_RES_LOSSLESS.
+	tests := []struct{ in, want string }{
+		{qualityLow, qualityLow},
+		{qualityHigh, qualityHigh},
+		{qualityLossless, qualityHiRes},
+		{qualityHiRes, qualityHiRes},
+	}
+	for _, tt := range tests {
+		if got := requestQuality(tt.in); got != tt.want {
+			t.Errorf("requestQuality(%s) = %s, want %s", tt.in, got, tt.want)
+		}
+	}
+}
+
 func btsBase64(jsonBody string) string {
 	return base64.StdEncoding.EncodeToString([]byte(jsonBody))
 }
 
-func TestStreamURLFromManifest(t *testing.T) {
-	tests := []struct {
-		name    string
-		pi      apiPlaybackInfo
-		want    string // expected URL; empty (with nil wantErr) = any error
-		wantErr error  // sentinel to match
-	}{
-		{
-			name: "bts flac",
-			pi: apiPlaybackInfo{
-				ManifestMimeType: "application/vnd.tidal.bts",
-				Manifest:         btsBase64(`{"mimeType":"audio/flac","codecs":"flac","encryptionType":"NONE","urls":["https://cdn.tidal.com/x.flac"]}`),
-			},
-			want: "https://cdn.tidal.com/x.flac",
-		},
-		{
-			name: "bts empty encryption type",
-			pi: apiPlaybackInfo{
-				ManifestMimeType: "application/vnd.tidal.bts",
-				Manifest:         btsBase64(`{"urls":["https://cdn.tidal.com/y.m4a"]}`),
-			},
-			want: "https://cdn.tidal.com/y.m4a",
-		},
-		{
-			name: "dash manifest",
-			pi: apiPlaybackInfo{
-				ManifestMimeType: "application/dash+xml",
-				Manifest:         btsBase64(`<MPD></MPD>`),
-			},
-			wantErr: errDASHManifest,
-		},
-		{
-			name: "encrypted stream",
-			pi: apiPlaybackInfo{
-				ManifestMimeType: "application/vnd.tidal.bts",
-				Manifest:         btsBase64(`{"encryptionType":"OLD_AES","urls":["https://cdn.tidal.com/z"]}`),
-			},
-		},
-		{
-			name: "unknown mime type",
-			pi:   apiPlaybackInfo{ManifestMimeType: "application/vnd.tidal.emu"},
-		},
-		{
-			name: "invalid base64",
-			pi: apiPlaybackInfo{
-				ManifestMimeType: "application/vnd.tidal.bts",
-				Manifest:         "!!!not-base64!!!",
-			},
-		},
-		{
-			name: "no urls",
-			pi: apiPlaybackInfo{
-				ManifestMimeType: "application/vnd.tidal.bts",
-				Manifest:         btsBase64(`{"encryptionType":"NONE","urls":[]}`),
-			},
-		},
+// btsPlaybackInfo mirrors the sanitized live captures: BTS manifests carry
+// AAC with encryptionType NONE.
+func btsPlaybackInfo(quality, codecs, u string) apiPlaybackInfo {
+	return apiPlaybackInfo{
+		AudioQuality:     quality,
+		ManifestMimeType: "application/vnd.tidal.bts",
+		Manifest: btsBase64(fmt.Sprintf(
+			`{"mimeType":"audio/mp4","codecs":%q,"encryptionType":"NONE","urls":[%q]}`, codecs, u)),
 	}
-	for _, tt := range tests {
+}
+
+func TestStreamSourceFromManifestBTS(t *testing.T) {
+	t.Run("delivered quality and url", func(t *testing.T) {
+		// Live capture shape: requested LOSSLESS, delivered HIGH AAC.
+		src, err := streamSourceFromManifest(btsPlaybackInfo(qualityHigh, "mp4a.40.2", "https://cdn.tidal.com/x.mp4"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if src.url != "https://cdn.tidal.com/x.mp4" || len(src.segments) != 0 {
+			t.Errorf("src = %+v", src)
+		}
+		if src.quality != qualityHigh {
+			t.Errorf("delivered quality = %q, want %q", src.quality, qualityHigh)
+		}
+	})
+
+	t.Run("empty encryption type accepted", func(t *testing.T) {
+		pi := apiPlaybackInfo{
+			ManifestMimeType: "application/vnd.tidal.bts",
+			Manifest:         btsBase64(`{"urls":["https://cdn.tidal.com/y.m4a"]}`),
+		}
+		if _, err := streamSourceFromManifest(pi); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	errCases := []struct {
+		name string
+		pi   apiPlaybackInfo
+	}{
+		{"encrypted stream", apiPlaybackInfo{
+			ManifestMimeType: "application/vnd.tidal.bts",
+			Manifest:         btsBase64(`{"encryptionType":"OLD_AES","urls":["https://cdn.tidal.com/z"]}`),
+		}},
+		{"unknown mime type", apiPlaybackInfo{ManifestMimeType: "application/vnd.tidal.emu"}},
+		{"invalid base64", apiPlaybackInfo{
+			ManifestMimeType: "application/vnd.tidal.bts",
+			Manifest:         "!!!not-base64!!!",
+		}},
+		{"no urls", apiPlaybackInfo{
+			ManifestMimeType: "application/vnd.tidal.bts",
+			Manifest:         btsBase64(`{"encryptionType":"NONE","urls":[]}`),
+		}},
+	}
+	for _, tt := range errCases {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := streamURLFromManifest(tt.pi)
-			switch {
-			case tt.wantErr != nil:
-				if !errors.Is(err, tt.wantErr) {
-					t.Errorf("err = %v, want %v", err, tt.wantErr)
-				}
-			case tt.want == "":
-				if err == nil {
-					t.Errorf("expected error, got url %q", got)
-				}
-			default:
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if got != tt.want {
-					t.Errorf("url = %q, want %q", got, tt.want)
-				}
+			if src, err := streamSourceFromManifest(tt.pi); err == nil {
+				t.Errorf("expected error, got %+v", src)
 			}
 		})
 	}
 }
 
-func TestResolveStreamURL(t *testing.T) {
-	bts := func(u string) apiPlaybackInfo {
-		return apiPlaybackInfo{
-			ManifestMimeType: "application/vnd.tidal.bts",
-			Manifest:         btsBase64(fmt.Sprintf(`{"encryptionType":"NONE","urls":[%q]}`, u)),
+func TestStreamSourceFromManifestDASH(t *testing.T) {
+	// Structure of a live hi-res capture: single FLAC representation,
+	// absolute URLs, SegmentTimeline with a repeat.
+	src, err := streamSourceFromManifest(apiPlaybackInfo{
+		AudioQuality:     qualityHiRes,
+		ManifestMimeType: "application/dash+xml",
+		Manifest:         base64.StdEncoding.EncodeToString([]byte(sampleMPD)),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if src.quality != qualityHiRes {
+		t.Errorf("delivered quality = %q", src.quality)
+	}
+	want := []string{
+		"https://cdn.tidal.com/init.mp4?token=t&x=1",
+		"https://cdn.tidal.com/seg1.m4s",
+		"https://cdn.tidal.com/seg2.m4s",
+		"https://cdn.tidal.com/seg3.m4s",
+	}
+	if len(src.segments) != len(want) {
+		t.Fatalf("segments = %v, want %v", src.segments, want)
+	}
+	for i := range want {
+		if src.segments[i] != want[i] {
+			t.Errorf("segment[%d] = %q, want %q", i, src.segments[i], want[i])
 		}
 	}
-	dash := apiPlaybackInfo{ManifestMimeType: "application/dash+xml", Manifest: btsBase64(`<MPD/>`)}
-
-	t.Run("lossless direct", func(t *testing.T) {
-		var qualities []string
-		u, used, err := resolveStreamURL(qualityLossless, func(q string) (apiPlaybackInfo, error) {
-			qualities = append(qualities, q)
-			return bts("https://cdn/a.flac"), nil
-		})
-		if err != nil || u != "https://cdn/a.flac" || used != qualityLossless {
-			t.Fatalf("got (%q, %q, %v)", u, used, err)
-		}
-		if len(qualities) != 1 || qualities[0] != qualityLossless {
-			t.Errorf("fetched qualities = %v", qualities)
-		}
-	})
-
-	t.Run("hires falls back to lossless on dash", func(t *testing.T) {
-		var qualities []string
-		u, used, err := resolveStreamURL(qualityHiRes, func(q string) (apiPlaybackInfo, error) {
-			qualities = append(qualities, q)
-			if q == qualityHiRes {
-				return dash, nil
-			}
-			return bts("https://cdn/cd.flac"), nil
-		})
-		if err != nil || u != "https://cdn/cd.flac" {
-			t.Fatalf("got (%q, %v)", u, err)
-		}
-		if used != qualityLossless {
-			t.Errorf("used quality = %q, want %q", used, qualityLossless)
-		}
-		want := []string{qualityHiRes, qualityLossless}
-		if len(qualities) != 2 || qualities[0] != want[0] || qualities[1] != want[1] {
-			t.Errorf("fetched qualities = %v, want %v", qualities, want)
-		}
-	})
-
-	t.Run("lossless dash does not fall back", func(t *testing.T) {
-		_, _, err := resolveStreamURL(qualityLossless, func(q string) (apiPlaybackInfo, error) {
-			return dash, nil
-		})
-		if !errors.Is(err, errDASHManifest) {
-			t.Errorf("err = %v, want errDASHManifest", err)
-		}
-	})
-
-	t.Run("fetch error propagates", func(t *testing.T) {
-		wantErr := errors.New("boom")
-		_, _, err := resolveStreamURL(qualityHiRes, func(q string) (apiPlaybackInfo, error) {
-			return apiPlaybackInfo{}, wantErr
-		})
-		if !errors.Is(err, wantErr) {
-			t.Errorf("err = %v, want %v", err, wantErr)
-		}
-	})
+	if strings.Contains(src.segments[0], "&amp;") {
+		t.Error("XML entities were not decoded in segment URLs")
+	}
 }

--- a/external/tidal/probe.go
+++ b/external/tidal/probe.go
@@ -1,0 +1,152 @@
+package tidal
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"path"
+	"regexp"
+	"strings"
+)
+
+// probeQualities is every tier the playbackinfo endpoint accepts, in
+// ascending order.
+var probeQualities = []string{qualityLow, qualityHigh, qualityLossless, qualityHiRes}
+
+// Probe requests playback info for one track at every quality tier and writes
+// a sanitized diagnostic report to w: delivered audioQuality, manifest type,
+// codec, bit depth, sample rate, and the CDN host/extension. Tokens and
+// signed URLs are never printed, so the output is safe to share verbatim.
+//
+// It authenticates from stored credentials, falling back to an interactive
+// device-flow sign-in with the URL printed to w. clientID/clientSecret follow
+// the same fallback rules as New.
+func Probe(ctx context.Context, w io.Writer, query, clientID, clientSecret string) error {
+	if clientID == "" {
+		clientID, clientSecret = fallbackClientID, fallbackClientSecret
+	} else if clientSecret == "" {
+		clientSecret = clientID
+	}
+
+	c, err := newClientSilent(ctx)
+	if err != nil {
+		fmt.Fprintln(w, "No stored credentials; starting device-flow sign-in.")
+		SetAuthURLObserver(func(u string) {
+			fmt.Fprintf(w, "Open %s and approve this device.\n", u)
+		})
+		defer SetAuthURLObserver(nil)
+		c, err = newClientInteractive(ctx, clientID, clientSecret)
+		if err != nil {
+			return err
+		}
+	}
+
+	tracks, err := c.searchTracks(ctx, query, 1)
+	if err != nil {
+		return fmt.Errorf("tidal: probe search: %w", err)
+	}
+	if len(tracks) == 0 {
+		return fmt.Errorf("tidal: probe: no results for %q", query)
+	}
+	t := tracks[0]
+
+	fmt.Fprintf(w, "Track: %s — %s (id %s, streamReady=%v allowStreaming=%v)\n",
+		trackArtist(t, t.Album), t.Title, t.ID.String(), t.StreamReady, t.AllowStreaming)
+	clientKind := "embedded fallback"
+	if c.clientID != fallbackClientID {
+		clientKind = "user-configured"
+	}
+	fmt.Fprintf(w, "Client: %s credentials (client_id ends %q)\n\n", clientKind, tail(c.clientID, 4))
+
+	for _, q := range probeQualities {
+		fmt.Fprintf(w, "requested=%s\n", q)
+		pi, err := c.playbackInfo(ctx, t.ID.String(), q)
+		if err != nil {
+			fmt.Fprintf(w, "  error: %v\n\n", sanitizeError(err))
+			continue
+		}
+		fmt.Fprintf(w, "  audioQuality=%s manifestMimeType=%s", pi.AudioQuality, pi.ManifestMimeType)
+		if pi.BitDepth > 0 || pi.SampleRate > 0 {
+			fmt.Fprintf(w, " bitDepth=%d sampleRate=%d", pi.BitDepth, pi.SampleRate)
+		}
+		fmt.Fprintln(w)
+		describeManifest(w, pi)
+		fmt.Fprintln(w)
+	}
+	return nil
+}
+
+// describeManifest writes sanitized details of the decoded manifest.
+func describeManifest(w io.Writer, pi apiPlaybackInfo) {
+	raw, err := base64.StdEncoding.DecodeString(pi.Manifest)
+	if err != nil {
+		fmt.Fprintf(w, "  manifest: base64 decode failed: %v\n", err)
+		return
+	}
+	switch {
+	case strings.Contains(pi.ManifestMimeType, "vnd.tidal.bts"):
+		var m btsManifest
+		if err := json.Unmarshal(raw, &m); err != nil {
+			fmt.Fprintf(w, "  bts: parse failed: %v\n", err)
+			return
+		}
+		fmt.Fprintf(w, "  bts: mimeType=%s codecs=%s encryptionType=%s urls=%d",
+			m.MimeType, m.Codecs, m.EncryptionType, len(m.URLs))
+		if len(m.URLs) > 0 {
+			fmt.Fprintf(w, " url[0]=%s", sanitizeURL(m.URLs[0]))
+		}
+		fmt.Fprintln(w)
+	case strings.Contains(pi.ManifestMimeType, "dash+xml"):
+		fmt.Fprintf(w, "  dash: codecs=%s audioSamplingRate=%s segments~=%d\n",
+			mpdAttr(raw, "codecs"), mpdAttr(raw, "audioSamplingRate"), mpdSegmentCount(raw))
+	default:
+		fmt.Fprintf(w, "  manifest: unrecognized type, %d bytes\n", len(raw))
+	}
+}
+
+// mpdAttr extracts the first value of an XML attribute from a raw MPD without
+// a full DASH parser; good enough for diagnostics.
+func mpdAttr(raw []byte, attr string) string {
+	re := regexp.MustCompile(attr + `="([^"]*)"`)
+	if m := re.FindSubmatch(raw); m != nil {
+		return string(m[1])
+	}
+	return "?"
+}
+
+// mpdSegmentCount estimates the segment count from a SegmentTimeline, when
+// present.
+func mpdSegmentCount(raw []byte) int {
+	return len(regexp.MustCompile(`<S\s`).FindAll(raw, -1))
+}
+
+// sanitizeURL reduces a signed CDN URL to host + file extension, dropping the
+// path and every query parameter (which carry the signature).
+func sanitizeURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "(unparseable)"
+	}
+	return fmt.Sprintf("host=%s ext=%s", u.Host, path.Ext(u.Path))
+}
+
+// sanitizeError strips anything after a '?' so signed URLs inside wrapped
+// HTTP errors cannot leak into shared output.
+func sanitizeError(err error) string {
+	s := err.Error()
+	if i := strings.IndexByte(s, '?'); i >= 0 {
+		s = s[:i] + "?…"
+	}
+	return s
+}
+
+// tail returns the last n characters of s.
+func tail(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[len(s)-n:]
+}

--- a/external/tidal/probe_test.go
+++ b/external/tidal/probe_test.go
@@ -1,0 +1,40 @@
+package tidal
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeURL(t *testing.T) {
+	got := sanitizeURL("https://sp-pr-cf.audio.tidal.com/mediatracks/abc123/0.flac?token=SECRET&Expires=123")
+	if strings.Contains(got, "SECRET") || strings.Contains(got, "abc123") {
+		t.Fatalf("sanitizeURL leaked signed parts: %q", got)
+	}
+	if got != "host=sp-pr-cf.audio.tidal.com ext=.flac" {
+		t.Errorf("sanitizeURL = %q", got)
+	}
+}
+
+func TestSanitizeError(t *testing.T) {
+	err := &testErr{"tidal: GET https://cdn/x.flac?token=SECRET failed"}
+	if got := sanitizeError(err); strings.Contains(got, "SECRET") {
+		t.Errorf("sanitizeError leaked query: %q", got)
+	}
+}
+
+type testErr struct{ s string }
+
+func (e *testErr) Error() string { return e.s }
+
+func TestMPDAttr(t *testing.T) {
+	mpd := []byte(`<Representation codecs="flac" audioSamplingRate="96000"><SegmentTimeline><S d="1"/><S d="2"/></SegmentTimeline>`)
+	if got := mpdAttr(mpd, "codecs"); got != "flac" {
+		t.Errorf("codecs = %q", got)
+	}
+	if got := mpdAttr(mpd, "audioSamplingRate"); got != "96000" {
+		t.Errorf("audioSamplingRate = %q", got)
+	}
+	if got := mpdAttr(mpd, "missing"); got != "?" {
+		t.Errorf("missing attr = %q", got)
+	}
+}

--- a/external/tidal/provider.go
+++ b/external/tidal/provider.go
@@ -1,0 +1,466 @@
+package tidal
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/bjarneo/cliamp/applog"
+	"github.com/bjarneo/cliamp/playlist"
+	"github.com/bjarneo/cliamp/provider"
+)
+
+// Compile-time interface checks.
+var (
+	_ playlist.Provider         = (*TidalProvider)(nil)
+	_ playlist.Authenticator    = (*TidalProvider)(nil)
+	_ playlist.Refresher        = (*TidalProvider)(nil)
+	_ provider.Searcher         = (*TidalProvider)(nil)
+	_ provider.ArtistBrowser    = (*TidalProvider)(nil)
+	_ provider.AlbumBrowser     = (*TidalProvider)(nil)
+	_ provider.AlbumTrackLoader = (*TidalProvider)(nil)
+	_ provider.Closer           = (*TidalProvider)(nil)
+)
+
+// favoriteTracksID is the synthetic playlist ID for the user's favorite tracks.
+const favoriteTracksID = "favorites/tracks"
+
+// favoriteTracksLimit caps the synthetic Favorite Tracks list. Each track
+// costs one playbackinfo call to resolve a (short-lived) stream URL, so
+// resolving an unbounded library would be slow and wasteful. Matches Qobuz.
+const favoriteTracksLimit = 500
+
+// resolveConcurrency bounds how many playbackinfo calls run in parallel when
+// resolving a playlist's streaming URLs.
+const resolveConcurrency = 8
+
+// albumSortTypes is the static sort list for Tidal album browsing. The private
+// API has no global catalog listing, so browsing surfaces favorite albums.
+var albumSortTypes = []provider.SortType{
+	{ID: "favorites", Label: "Favorite Albums"},
+}
+
+// TidalProvider implements playlist.Provider backed by Tidal's private client
+// API. Streaming URLs are resolved per track via playbackinfopostpaywall and
+// routed through the player's buffered pipeline (see stream.go).
+type TidalProvider struct {
+	quality      string // normalized Tidal audioquality value
+	clientID     string
+	clientSecret string
+
+	// hiresFallback latches once a HI_RES_LOSSLESS request comes back as a
+	// DASH manifest, so later tracks skip the doomed hi-res round-trip and
+	// request LOSSLESS directly.
+	hiresFallback atomic.Bool
+
+	mu         sync.Mutex
+	client     *client
+	authCancel context.CancelFunc
+
+	listCache  []playlist.PlaylistInfo
+	trackCache map[string][]playlist.Track
+}
+
+// New creates a TidalProvider. Authentication is deferred until the user first
+// selects the provider. quality is a [tidal] config quality name (see
+// NormalizeQuality); unrecognized values fall back to lossless. Empty client
+// credentials fall back to the built-in pair.
+func New(quality, clientID, clientSecret string) *TidalProvider {
+	q, ok := normalizeQuality(quality)
+	if !ok {
+		applog.UserError("tidal: unknown quality %q, using \"lossless\" (valid: low, high, lossless, hires)", quality)
+		q = qualityLossless
+	}
+	if clientID == "" {
+		clientID, clientSecret = fallbackClientID, fallbackClientSecret
+	} else if clientSecret == "" {
+		// Matches python-tidal: a client without a secret uses its ID as one.
+		clientSecret = clientID
+	}
+	return &TidalProvider{
+		quality:      q,
+		clientID:     clientID,
+		clientSecret: clientSecret,
+		trackCache:   make(map[string][]playlist.Track),
+	}
+}
+
+func (p *TidalProvider) Name() string { return "Tidal" }
+
+// ensureClient builds an authenticated client from stored credentials only
+// (no browser). Returns playlist.ErrNeedsAuth if interactive sign-in is needed.
+func (p *TidalProvider) ensureClient() (*client, error) {
+	p.mu.Lock()
+	if p.client != nil {
+		c := p.client
+		p.mu.Unlock()
+		return c, nil
+	}
+	p.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	c, err := newClientSilent(ctx)
+	if err != nil {
+		applog.Debug("tidal: silent auth failed, prompting sign-in: %v", err)
+		return nil, playlist.ErrNeedsAuth
+	}
+
+	p.mu.Lock()
+	p.client = c
+	p.mu.Unlock()
+	return c, nil
+}
+
+// Authenticate runs the interactive device-flow sign-in (shows a
+// link.tidal.com URL, waits for approval). Implements playlist.Authenticator.
+func (p *TidalProvider) Authenticate() error {
+	p.mu.Lock()
+	if p.client != nil {
+		p.mu.Unlock()
+		return nil
+	}
+	if p.authCancel != nil {
+		p.authCancel()
+		p.authCancel = nil
+	}
+	p.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	p.mu.Lock()
+	p.authCancel = cancel
+	p.mu.Unlock()
+
+	c, err := newClientInteractive(ctx, p.clientID, p.clientSecret)
+
+	p.mu.Lock()
+	p.authCancel = nil
+	p.mu.Unlock()
+	cancel()
+
+	if err != nil {
+		return err
+	}
+	p.mu.Lock()
+	p.client = c
+	p.mu.Unlock()
+	return nil
+}
+
+// Close cancels any in-progress sign-in. Implements provider.Closer.
+func (p *TidalProvider) Close() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.authCancel != nil {
+		p.authCancel()
+		p.authCancel = nil
+	}
+}
+
+// Refresh clears cached playlists and tracks so the next call re-fetches and
+// re-resolves streaming URLs (which expire). Implements playlist.Refresher.
+func (p *TidalProvider) Refresh() {
+	p.mu.Lock()
+	p.listCache = nil
+	p.trackCache = make(map[string][]playlist.Track)
+	p.mu.Unlock()
+}
+
+// Playlists returns the user's Tidal playlists plus a synthetic Favorite
+// Tracks entry.
+func (p *TidalProvider) Playlists() ([]playlist.PlaylistInfo, error) {
+	c, err := p.ensureClient()
+	if err != nil {
+		return nil, err
+	}
+
+	p.mu.Lock()
+	if p.listCache != nil {
+		cached := slices.Clone(p.listCache)
+		p.mu.Unlock()
+		return cached, nil
+	}
+	p.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	pls, err := c.userPlaylists(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	lists := []playlist.PlaylistInfo{
+		{
+			ID:      favoriteTracksID,
+			Name:    "Favorite Tracks",
+			Section: "Library",
+		},
+	}
+	for _, pl := range pls {
+		lists = append(lists, playlist.PlaylistInfo{
+			ID:           pl.UUID,
+			Name:         pl.Title,
+			TrackCount:   pl.NumberOfTracks,
+			DurationSecs: pl.Duration,
+			Section:      "Your playlists",
+		})
+	}
+
+	p.mu.Lock()
+	p.listCache = lists
+	p.mu.Unlock()
+	return slices.Clone(lists), nil
+}
+
+// Tracks returns the tracks of a playlist (or the synthetic Favorite Tracks
+// entry), each with a resolved streaming URL.
+func (p *TidalProvider) Tracks(playlistID string) ([]playlist.Track, error) {
+	c, err := p.ensureClient()
+	if err != nil {
+		return nil, err
+	}
+
+	p.mu.Lock()
+	if cached, ok := p.trackCache[playlistID]; ok {
+		tracks := slices.Clone(cached)
+		p.mu.Unlock()
+		return tracks, nil
+	}
+	p.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	var apiTracks []apiTrack
+	if playlistID == favoriteTracksID {
+		apiTracks, err = c.favoriteTracks(ctx, favoriteTracksLimit)
+	} else {
+		apiTracks, err = c.playlistTracks(ctx, playlistID)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	tracks := p.resolveTracks(ctx, c, apiTracks, nil)
+
+	p.mu.Lock()
+	p.trackCache[playlistID] = tracks
+	p.mu.Unlock()
+	return slices.Clone(tracks), nil
+}
+
+// SearchTracks searches the Tidal catalog. Implements provider.Searcher.
+func (p *TidalProvider) SearchTracks(ctx context.Context, query string, limit int) ([]playlist.Track, error) {
+	c, err := p.ensureClient()
+	if err != nil {
+		return nil, err
+	}
+	apiTracks, err := c.searchTracks(ctx, query, limit)
+	if err != nil {
+		return nil, err
+	}
+	return p.resolveTracks(ctx, c, apiTracks, nil), nil
+}
+
+// Artists returns the user's favorite artists. Implements provider.ArtistBrowser.
+func (p *TidalProvider) Artists() ([]provider.ArtistInfo, error) {
+	c, err := p.ensureClient()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	artists, err := c.favoriteArtists(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]provider.ArtistInfo, 0, len(artists))
+	for _, a := range artists {
+		out = append(out, provider.ArtistInfo{
+			ID:   a.ID.String(),
+			Name: a.Name,
+		})
+	}
+	return out, nil
+}
+
+// ArtistAlbums returns the albums of an artist. Implements provider.ArtistBrowser.
+func (p *TidalProvider) ArtistAlbums(artistID string) ([]provider.AlbumInfo, error) {
+	c, err := p.ensureClient()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	albums, err := c.artistAlbums(ctx, artistID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]provider.AlbumInfo, 0, len(albums))
+	for _, a := range albums {
+		out = append(out, albumInfo(a))
+	}
+	return out, nil
+}
+
+// AlbumList returns the user's favorite albums (the private API has no global
+// album catalog to browse). Implements provider.AlbumBrowser.
+func (p *TidalProvider) AlbumList(_ string, offset, size int) ([]provider.AlbumInfo, error) {
+	c, err := p.ensureClient()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	albums, err := c.favoriteAlbums(ctx, offset, size)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]provider.AlbumInfo, 0, len(albums))
+	for _, a := range albums {
+		out = append(out, albumInfo(a))
+	}
+	return out, nil
+}
+
+func (p *TidalProvider) AlbumSortTypes() []provider.SortType { return albumSortTypes }
+
+func (p *TidalProvider) DefaultAlbumSort() string { return "favorites" }
+
+// AlbumTracks returns the tracks of an album. Implements provider.AlbumTrackLoader.
+func (p *TidalProvider) AlbumTracks(albumID string) ([]playlist.Track, error) {
+	c, err := p.ensureClient()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	// The album metadata (used only as a fallback for track fields) and the
+	// track list are independent round-trips; fetch them concurrently.
+	var (
+		album     apiAlbum
+		albumErr  error
+		tracks    []apiTrack
+		tracksErr error
+		wg        sync.WaitGroup
+	)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		album, albumErr = c.albumGet(ctx, albumID)
+	}()
+	go func() {
+		defer wg.Done()
+		tracks, tracksErr = c.albumTracks(ctx, albumID)
+	}()
+	wg.Wait()
+	if albumErr != nil {
+		return nil, albumErr
+	}
+	if tracksErr != nil {
+		return nil, tracksErr
+	}
+	return p.resolveTracks(ctx, c, tracks, &album), nil
+}
+
+// resolveTracks converts API tracks into playable tracks, resolving a signed
+// streaming URL for each in parallel. albumFallback supplies album metadata
+// for tracks that lack it (albums/{id}/tracks nests tracks without an album
+// field). Tracks that are not streamable or fail URL resolution are returned
+// as unplayable.
+func (p *TidalProvider) resolveTracks(ctx context.Context, c *client, in []apiTrack, albumFallback *apiAlbum) []playlist.Track {
+	out := make([]playlist.Track, len(in))
+	sem := make(chan struct{}, resolveConcurrency)
+	var wg sync.WaitGroup
+
+	for i := range in {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(idx int) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			out[idx] = p.buildTrack(ctx, c, in[idx], albumFallback)
+		}(i)
+	}
+	wg.Wait()
+	return out
+}
+
+// buildTrack maps a single API track to a playlist.Track, resolving its stream
+// URL unless the track is not streamable.
+func (p *TidalProvider) buildTrack(ctx context.Context, c *client, t apiTrack, albumFallback *apiAlbum) playlist.Track {
+	album := t.Album
+	if album == nil {
+		album = albumFallback
+	}
+
+	track := playlist.Track{
+		Title:        t.Title,
+		Artist:       trackArtist(t, album),
+		TrackNumber:  t.TrackNumber,
+		DurationSecs: t.Duration,
+		Stream:       true,
+		ProviderMeta: map[string]string{provider.MetaTidalID: t.ID.String()},
+	}
+	if album != nil {
+		track.Album = album.Title
+		track.Year = provider.YearFromDate(album.ReleaseDate)
+	}
+
+	if !t.AllowStreaming || !t.StreamReady {
+		track.Unplayable = true
+		return track
+	}
+
+	quality := p.quality
+	if quality == qualityHiRes && p.hiresFallback.Load() {
+		quality = qualityLossless
+	}
+	u, used, err := resolveStreamURL(quality, func(q string) (apiPlaybackInfo, error) {
+		return c.playbackInfo(ctx, t.ID.String(), q)
+	})
+	if err != nil {
+		applog.Debug("tidal: resolve stream url for track %s: %v", t.ID.String(), err)
+		track.Unplayable = true
+		return track
+	}
+	if quality == qualityHiRes && used != qualityHiRes && p.hiresFallback.CompareAndSwap(false, true) {
+		applog.Info("tidal: hi-res streams are DASH-delivered (unsupported); using lossless for this session")
+	}
+	registerStreamURL(u)
+	track.Path = u
+	return track
+}
+
+// trackArtist picks the best available artist name for a track.
+func trackArtist(t apiTrack, album *apiAlbum) string {
+	if t.Artist.Name != "" {
+		return t.Artist.Name
+	}
+	if len(t.Artists) > 0 && t.Artists[0].Name != "" {
+		return t.Artists[0].Name
+	}
+	if album != nil {
+		return album.Artist.Name
+	}
+	return ""
+}
+
+// albumInfo maps a Tidal album to provider.AlbumInfo.
+func albumInfo(a apiAlbum) provider.AlbumInfo {
+	return provider.AlbumInfo{
+		ID:         a.ID.String(),
+		Name:       a.Title,
+		Artist:     a.Artist.Name,
+		ArtistID:   a.Artist.ID.String(),
+		Year:       provider.YearFromDate(a.ReleaseDate),
+		TrackCount: a.NumberOfTracks,
+	}
+}

--- a/external/tidal/provider.go
+++ b/external/tidal/provider.go
@@ -461,8 +461,15 @@ func (p *TidalProvider) ResolveSource(uri string) (streamURL string, segments []
 	p.noteDowngrade(src.quality)
 
 	if len(src.segments) > 0 {
+		detail := ""
+		if pi.BitDepth > 0 && pi.SampleRate > 0 {
+			detail = fmt.Sprintf(", %d-bit/%dHz", pi.BitDepth, pi.SampleRate)
+		}
+		applog.Info("tidal: track %s delivered %s via DASH FLAC (%d segments%s)",
+			trackID, src.quality, len(src.segments), detail)
 		return "", src.segments, nil
 	}
+	applog.Info("tidal: track %s delivered %s via direct URL (AAC)", trackID, src.quality)
 	streamURLs.register(trackID, src.url)
 	return src.url, nil, nil
 }

--- a/external/tidal/provider.go
+++ b/external/tidal/provider.go
@@ -2,7 +2,10 @@ package tidal
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -27,14 +30,14 @@ var (
 // favoriteTracksID is the synthetic playlist ID for the user's favorite tracks.
 const favoriteTracksID = "favorites/tracks"
 
-// favoriteTracksLimit caps the synthetic Favorite Tracks list. Each track
-// costs one playbackinfo call to resolve a (short-lived) stream URL, so
-// resolving an unbounded library would be slow and wasteful. Matches Qobuz.
+// favoriteTracksLimit caps the synthetic Favorite Tracks list, matching Qobuz.
 const favoriteTracksLimit = 500
 
-// resolveConcurrency bounds how many playbackinfo calls run in parallel when
-// resolving a playlist's streaming URLs.
-const resolveConcurrency = 8
+// TrackURIPrefix is the custom URI scheme for Tidal tracks. Track paths are
+// "tidal://track/<id>"; the player resolves them to a fresh signed URL (or
+// DASH segment list) at play time via the SourceResolver registered in
+// main.go, so queue entries never hold expirable URLs.
+const TrackURIPrefix = "tidal://track/"
 
 // albumSortTypes is the static sort list for Tidal album browsing. The private
 // API has no global catalog listing, so browsing surfaces favorite albums.
@@ -43,17 +46,16 @@ var albumSortTypes = []provider.SortType{
 }
 
 // TidalProvider implements playlist.Provider backed by Tidal's private client
-// API. Streaming URLs are resolved per track via playbackinfopostpaywall and
-// routed through the player's buffered pipeline (see stream.go).
+// API. Tracks carry tidal:// URIs; ResolveSource turns them into playable
+// sources when playback starts (see stream.go for the URL registry).
 type TidalProvider struct {
 	quality      string // normalized Tidal audioquality value
 	clientID     string
 	clientSecret string
 
-	// hiresFallback latches once a HI_RES_LOSSLESS request comes back as a
-	// DASH manifest, so later tracks skip the doomed hi-res round-trip and
-	// request LOSSLESS directly.
-	hiresFallback atomic.Bool
+	// downgradeNoticed dedupes the "delivered as AAC" footer notice so a
+	// playlist of AAC-only tracks warns once per session, not per track.
+	downgradeNoticed atomic.Bool
 
 	mu         sync.Mutex
 	client     *client
@@ -159,13 +161,31 @@ func (p *TidalProvider) Close() {
 	}
 }
 
-// Refresh clears cached playlists and tracks so the next call re-fetches and
-// re-resolves streaming URLs (which expire). Implements playlist.Refresher.
+// Refresh clears cached playlist and track lists so the next call re-fetches
+// them. Stream URLs are resolved fresh at play time (see ResolveSource), so
+// no URL state needs repairing here. Implements playlist.Refresher.
 func (p *TidalProvider) Refresh() {
 	p.mu.Lock()
 	p.listCache = nil
 	p.trackCache = make(map[string][]playlist.Track)
 	p.mu.Unlock()
+}
+
+// mapErr translates client errors into provider-level errors: a revoked
+// refresh token drops the cached client so the next access runs the
+// interactive sign-in instead of failing forever.
+func (p *TidalProvider) mapErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, errAuthRevoked) {
+		applog.UserWarn("tidal: session revoked, sign in again")
+		p.mu.Lock()
+		p.client = nil
+		p.mu.Unlock()
+		return playlist.ErrNeedsAuth
+	}
+	return err
 }
 
 // Playlists returns the user's Tidal playlists plus a synthetic Favorite
@@ -189,7 +209,7 @@ func (p *TidalProvider) Playlists() ([]playlist.PlaylistInfo, error) {
 
 	pls, err := c.userPlaylists(ctx)
 	if err != nil {
-		return nil, err
+		return nil, p.mapErr(err)
 	}
 
 	lists := []playlist.PlaylistInfo{
@@ -216,7 +236,7 @@ func (p *TidalProvider) Playlists() ([]playlist.PlaylistInfo, error) {
 }
 
 // Tracks returns the tracks of a playlist (or the synthetic Favorite Tracks
-// entry), each with a resolved streaming URL.
+// entry). Tracks carry tidal:// URIs; stream URLs resolve at play time.
 func (p *TidalProvider) Tracks(playlistID string) ([]playlist.Track, error) {
 	c, err := p.ensureClient()
 	if err != nil {
@@ -231,7 +251,7 @@ func (p *TidalProvider) Tracks(playlistID string) ([]playlist.Track, error) {
 	}
 	p.mu.Unlock()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
 	var apiTracks []apiTrack
@@ -241,10 +261,10 @@ func (p *TidalProvider) Tracks(playlistID string) ([]playlist.Track, error) {
 		apiTracks, err = c.playlistTracks(ctx, playlistID)
 	}
 	if err != nil {
-		return nil, err
+		return nil, p.mapErr(err)
 	}
 
-	tracks := p.resolveTracks(ctx, c, apiTracks, nil)
+	tracks := tracksFromAPI(apiTracks, nil)
 
 	p.mu.Lock()
 	p.trackCache[playlistID] = tracks
@@ -260,9 +280,12 @@ func (p *TidalProvider) SearchTracks(ctx context.Context, query string, limit in
 	}
 	apiTracks, err := c.searchTracks(ctx, query, limit)
 	if err != nil {
+		return nil, p.mapErr(err)
+	}
+	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	return p.resolveTracks(ctx, c, apiTracks, nil), nil
+	return tracksFromAPI(apiTracks, nil), nil
 }
 
 // Artists returns the user's favorite artists. Implements provider.ArtistBrowser.
@@ -276,7 +299,7 @@ func (p *TidalProvider) Artists() ([]provider.ArtistInfo, error) {
 
 	artists, err := c.favoriteArtists(ctx)
 	if err != nil {
-		return nil, err
+		return nil, p.mapErr(err)
 	}
 	out := make([]provider.ArtistInfo, 0, len(artists))
 	for _, a := range artists {
@@ -299,7 +322,7 @@ func (p *TidalProvider) ArtistAlbums(artistID string) ([]provider.AlbumInfo, err
 
 	albums, err := c.artistAlbums(ctx, artistID)
 	if err != nil {
-		return nil, err
+		return nil, p.mapErr(err)
 	}
 	out := make([]provider.AlbumInfo, 0, len(albums))
 	for _, a := range albums {
@@ -320,7 +343,7 @@ func (p *TidalProvider) AlbumList(_ string, offset, size int) ([]provider.AlbumI
 
 	albums, err := c.favoriteAlbums(ctx, offset, size)
 	if err != nil {
-		return nil, err
+		return nil, p.mapErr(err)
 	}
 	out := make([]provider.AlbumInfo, 0, len(albums))
 	for _, a := range albums {
@@ -362,46 +385,35 @@ func (p *TidalProvider) AlbumTracks(albumID string) ([]playlist.Track, error) {
 	}()
 	wg.Wait()
 	if albumErr != nil {
-		return nil, albumErr
+		return nil, p.mapErr(albumErr)
 	}
 	if tracksErr != nil {
-		return nil, tracksErr
+		return nil, p.mapErr(tracksErr)
 	}
-	return p.resolveTracks(ctx, c, tracks, &album), nil
+	return tracksFromAPI(tracks, &album), nil
 }
 
-// resolveTracks converts API tracks into playable tracks, resolving a signed
-// streaming URL for each in parallel. albumFallback supplies album metadata
-// for tracks that lack it (albums/{id}/tracks nests tracks without an album
-// field). Tracks that are not streamable or fail URL resolution are returned
-// as unplayable.
-func (p *TidalProvider) resolveTracks(ctx context.Context, c *client, in []apiTrack, albumFallback *apiAlbum) []playlist.Track {
+// tracksFromAPI converts API tracks into playlist tracks carrying tidal://
+// URIs. albumFallback supplies album metadata for tracks that lack it
+// (albums/{id}/tracks nests tracks without an album field). No network calls
+// happen here; sources resolve at play time.
+func tracksFromAPI(in []apiTrack, albumFallback *apiAlbum) []playlist.Track {
 	out := make([]playlist.Track, len(in))
-	sem := make(chan struct{}, resolveConcurrency)
-	var wg sync.WaitGroup
-
-	for i := range in {
-		wg.Add(1)
-		sem <- struct{}{}
-		go func(idx int) {
-			defer wg.Done()
-			defer func() { <-sem }()
-			out[idx] = p.buildTrack(ctx, c, in[idx], albumFallback)
-		}(i)
+	for i, t := range in {
+		out[i] = trackFromAPI(t, albumFallback)
 	}
-	wg.Wait()
 	return out
 }
 
-// buildTrack maps a single API track to a playlist.Track, resolving its stream
-// URL unless the track is not streamable.
-func (p *TidalProvider) buildTrack(ctx context.Context, c *client, t apiTrack, albumFallback *apiAlbum) playlist.Track {
+// trackFromAPI maps a single API track to a playlist.Track.
+func trackFromAPI(t apiTrack, albumFallback *apiAlbum) playlist.Track {
 	album := t.Album
 	if album == nil {
 		album = albumFallback
 	}
 
 	track := playlist.Track{
+		Path:         TrackURIPrefix + t.ID.String(),
 		Title:        t.Title,
 		Artist:       trackArtist(t, album),
 		TrackNumber:  t.TrackNumber,
@@ -413,30 +425,58 @@ func (p *TidalProvider) buildTrack(ctx context.Context, c *client, t apiTrack, a
 		track.Album = album.Title
 		track.Year = provider.YearFromDate(album.ReleaseDate)
 	}
-
 	if !t.AllowStreaming || !t.StreamReady {
 		track.Unplayable = true
-		return track
+	}
+	return track
+}
+
+// ResolveSource turns a tidal://track/<id> URI into a playable source when
+// playback starts: a direct CDN URL for BTS (AAC) deliveries, or the DASH
+// segment list for FLAC. Resolving at play time keeps signed URLs fresh no
+// matter how long the track sat in a queue, and reports server-side quality
+// downgrades. It is registered as the player's SourceResolver in main.go.
+func (p *TidalProvider) ResolveSource(uri string) (streamURL string, segments []string, err error) {
+	trackID := strings.TrimPrefix(uri, TrackURIPrefix)
+	if trackID == "" || trackID == uri {
+		return "", nil, fmt.Errorf("tidal: invalid track URI %q", uri)
+	}
+	c, err := p.ensureClient()
+	if err != nil {
+		return "", nil, err
 	}
 
-	quality := p.quality
-	if quality == qualityHiRes && p.hiresFallback.Load() {
-		quality = qualityLossless
-	}
-	u, used, err := resolveStreamURL(quality, func(q string) (apiPlaybackInfo, error) {
-		return c.playbackInfo(ctx, t.ID.String(), q)
-	})
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	requested := requestQuality(p.quality)
+	pi, err := c.playbackInfo(ctx, trackID, requested)
 	if err != nil {
-		applog.Debug("tidal: resolve stream url for track %s: %v", t.ID.String(), err)
-		track.Unplayable = true
-		return track
+		return "", nil, p.mapErr(err)
 	}
-	if quality == qualityHiRes && used != qualityHiRes && p.hiresFallback.CompareAndSwap(false, true) {
-		applog.Info("tidal: hi-res streams are DASH-delivered (unsupported); using lossless for this session")
+	src, err := streamSourceFromManifest(pi)
+	if err != nil {
+		return "", nil, err
 	}
-	registerStreamURL(u)
-	track.Path = u
-	return track
+	p.noteDowngrade(src.quality)
+
+	if len(src.segments) > 0 {
+		return "", src.segments, nil
+	}
+	streamURLs.register(trackID, src.url)
+	return src.url, nil, nil
+}
+
+// noteDowngrade warns (once per session) when a FLAC quality setting is being
+// served an AAC tier — the device client cliamp uses cannot get FLAC for
+// tracks without a hi-res master.
+func (p *TidalProvider) noteDowngrade(delivered string) {
+	if !isFLACQuality(p.quality) || isFLACQuality(delivered) || delivered == "" {
+		return
+	}
+	if p.downgradeNoticed.CompareAndSwap(false, true) {
+		applog.UserWarn("tidal: delivered %s (AAC) — no FLAC for this track with cliamp's client type", delivered)
+	}
 }
 
 // trackArtist picks the best available artist name for a track.

--- a/external/tidal/provider_test.go
+++ b/external/tidal/provider_test.go
@@ -1,0 +1,117 @@
+package tidal
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNewNormalizesQualityAndCredentials(t *testing.T) {
+	tests := []struct {
+		name         string
+		quality      string
+		clientID     string
+		clientSecret string
+		wantQuality  string
+		wantID       string
+		wantSecret   string
+	}{
+		{
+			name:        "defaults",
+			wantQuality: qualityLossless,
+			wantID:      fallbackClientID,
+			wantSecret:  fallbackClientSecret,
+		},
+		{
+			name:        "invalid quality falls back to lossless",
+			quality:     "ultra",
+			wantQuality: qualityLossless,
+			wantID:      fallbackClientID,
+			wantSecret:  fallbackClientSecret,
+		},
+		{
+			name:         "custom credentials",
+			quality:      "hires",
+			clientID:     "my-id",
+			clientSecret: "my-secret",
+			wantQuality:  qualityHiRes,
+			wantID:       "my-id",
+			wantSecret:   "my-secret",
+		},
+		{
+			name:        "custom id without secret uses id as secret",
+			quality:     "high",
+			clientID:    "solo-id",
+			wantQuality: qualityHigh,
+			wantID:      "solo-id",
+			wantSecret:  "solo-id",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := New(tt.quality, tt.clientID, tt.clientSecret)
+			if p.quality != tt.wantQuality {
+				t.Errorf("quality = %q, want %q", p.quality, tt.wantQuality)
+			}
+			if p.clientID != tt.wantID {
+				t.Errorf("clientID = %q, want %q", p.clientID, tt.wantID)
+			}
+			if p.clientSecret != tt.wantSecret {
+				t.Errorf("clientSecret = %q, want %q", p.clientSecret, tt.wantSecret)
+			}
+		})
+	}
+}
+
+func TestTrackArtist(t *testing.T) {
+	album := &apiAlbum{Artist: apiArtist{Name: "Album Artist"}}
+	tests := []struct {
+		name  string
+		track apiTrack
+		album *apiAlbum
+		want  string
+	}{
+		{
+			name:  "main artist",
+			track: apiTrack{Artist: apiArtist{Name: "Main"}, Artists: []apiArtist{{Name: "First"}}},
+			want:  "Main",
+		},
+		{
+			name:  "first of artists list",
+			track: apiTrack{Artists: []apiArtist{{Name: "First"}, {Name: "Second"}}},
+			want:  "First",
+		},
+		{
+			name:  "album artist fallback",
+			track: apiTrack{},
+			album: album,
+			want:  "Album Artist",
+		},
+		{
+			name:  "no artist anywhere",
+			track: apiTrack{},
+			want:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := trackArtist(tt.track, tt.album); got != tt.want {
+				t.Errorf("trackArtist = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAlbumInfo(t *testing.T) {
+	a := apiAlbum{
+		ID:             json.Number("123"),
+		Title:          "Album",
+		NumberOfTracks: 12,
+		ReleaseDate:    "2021-01-02",
+		Artist:         apiArtist{ID: json.Number("7"), Name: "Artist"},
+	}
+	got := albumInfo(a)
+	if got.ID != "123" || got.Name != "Album" || got.Artist != "Artist" ||
+		got.ArtistID != "7" || got.Year != 2021 || got.TrackCount != 12 {
+		t.Errorf("albumInfo = %+v", got)
+	}
+}

--- a/external/tidal/provider_test.go
+++ b/external/tidal/provider_test.go
@@ -115,3 +115,48 @@ func TestAlbumInfo(t *testing.T) {
 		t.Errorf("albumInfo = %+v", got)
 	}
 }
+
+func TestTrackFromAPI(t *testing.T) {
+	tr := trackFromAPI(apiTrack{
+		ID:             json.Number("42"),
+		Title:          "Song",
+		Duration:       200,
+		AllowStreaming: true,
+		StreamReady:    true,
+		Artist:         apiArtist{Name: "Artist"},
+	}, nil)
+	if tr.Path != "tidal://track/42" {
+		t.Errorf("Path = %q", tr.Path)
+	}
+	if !tr.Stream || tr.Unplayable {
+		t.Errorf("Stream=%v Unplayable=%v", tr.Stream, tr.Unplayable)
+	}
+	if tr.ProviderMeta["tidal.id"] != "42" {
+		t.Errorf("meta = %v", tr.ProviderMeta)
+	}
+
+	blocked := trackFromAPI(apiTrack{ID: json.Number("7"), StreamReady: true}, nil)
+	if !blocked.Unplayable {
+		t.Error("allowStreaming=false must be unplayable")
+	}
+}
+
+func TestNoteDowngradeOncePerSession(t *testing.T) {
+	p := New("lossless", "", "")
+	p.noteDowngrade(qualityHigh) // should latch
+	if !p.downgradeNoticed.Load() {
+		t.Fatal("downgrade not latched")
+	}
+
+	aac := New("high", "", "")
+	aac.noteDowngrade(qualityHigh) // AAC requested: not a downgrade
+	if aac.downgradeNoticed.Load() {
+		t.Error("AAC quality setting must not warn")
+	}
+
+	flac := New("hires", "", "")
+	flac.noteDowngrade(qualityHiRes) // FLAC delivered: no warning
+	if flac.downgradeNoticed.Load() {
+		t.Error("delivered FLAC must not warn")
+	}
+}

--- a/external/tidal/stream.go
+++ b/external/tidal/stream.go
@@ -1,0 +1,26 @@
+package tidal
+
+import "sync"
+
+// streamURLs records the signed CDN URLs that the provider has resolved via
+// playbackinfopostpaywall. The player consults IsStreamURL through a
+// registered buffered-URL matcher so Tidal FLAC/AAC streams are routed through
+// the buffer-while-playing + ffmpeg pipeline (which auto-detects the codec and
+// supports seeking), exactly like Qobuz streams.
+var streamURLs sync.Map // map[string]struct{}
+
+// registerStreamURL marks u as a Tidal stream URL.
+func registerStreamURL(u string) {
+	if u == "" {
+		return
+	}
+	streamURLs.Store(u, struct{}{})
+}
+
+// IsStreamURL reports whether u is a Tidal signed stream URL previously
+// resolved by the provider. It is registered with the player's buffered-URL
+// matcher in main.go.
+func IsStreamURL(u string) bool {
+	_, ok := streamURLs.Load(u)
+	return ok
+}

--- a/external/tidal/stream.go
+++ b/external/tidal/stream.go
@@ -2,25 +2,43 @@ package tidal
 
 import "sync"
 
-// streamURLs records the signed CDN URLs that the provider has resolved via
-// playbackinfopostpaywall. The player consults IsStreamURL through a
-// registered buffered-URL matcher so Tidal FLAC/AAC streams are routed through
-// the buffer-while-playing + ffmpeg pipeline (which auto-detects the codec and
-// supports seeking), exactly like Qobuz streams.
-var streamURLs sync.Map // map[string]struct{}
+// urlRegistry maps resolved track IDs to their latest signed CDN URL so the
+// player's buffered-URL matcher recognizes Tidal streams. Re-resolving a
+// track (every play, since resolution happens at play time) replaces its
+// previous entry, so the registry stays bounded by the tracks played this
+// session instead of growing with every resolution.
+type urlRegistry struct {
+	mu      sync.Mutex
+	byTrack map[string]string
+	urls    map[string]struct{}
+}
 
-// registerStreamURL marks u as a Tidal stream URL.
-func registerStreamURL(u string) {
+var streamURLs = urlRegistry{
+	byTrack: make(map[string]string),
+	urls:    make(map[string]struct{}),
+}
+
+// register records u as trackID's current stream URL, evicting the track's
+// previous URL.
+func (r *urlRegistry) register(trackID, u string) {
 	if u == "" {
 		return
 	}
-	streamURLs.Store(u, struct{}{})
+	r.mu.Lock()
+	if old, ok := r.byTrack[trackID]; ok {
+		delete(r.urls, old)
+	}
+	r.byTrack[trackID] = u
+	r.urls[u] = struct{}{}
+	r.mu.Unlock()
 }
 
-// IsStreamURL reports whether u is a Tidal signed stream URL previously
+// IsStreamURL reports whether u is a live Tidal stream URL previously
 // resolved by the provider. It is registered with the player's buffered-URL
 // matcher in main.go.
 func IsStreamURL(u string) bool {
-	_, ok := streamURLs.Load(u)
+	streamURLs.mu.Lock()
+	defer streamURLs.mu.Unlock()
+	_, ok := streamURLs.urls[u]
 	return ok
 }

--- a/external/tidal/stream_test.go
+++ b/external/tidal/stream_test.go
@@ -1,0 +1,18 @@
+package tidal
+
+import "testing"
+
+func TestStreamURLRegistry(t *testing.T) {
+	const u = "https://sp-pr-cf.audio.tidal.com/mediatracks/abc/0.flac"
+	if IsStreamURL(u) {
+		t.Fatalf("unregistered URL reported as stream URL")
+	}
+	registerStreamURL(u)
+	if !IsStreamURL(u) {
+		t.Fatalf("registered URL not recognized")
+	}
+	registerStreamURL("")
+	if IsStreamURL("") {
+		t.Fatalf("empty URL must not be registered")
+	}
+}

--- a/external/tidal/stream_test.go
+++ b/external/tidal/stream_test.go
@@ -2,17 +2,27 @@ package tidal
 
 import "testing"
 
-func TestStreamURLRegistry(t *testing.T) {
-	const u = "https://sp-pr-cf.audio.tidal.com/mediatracks/abc/0.flac"
-	if IsStreamURL(u) {
-		t.Fatalf("unregistered URL reported as stream URL")
+func TestStreamURLRegistryEvictsOnReResolve(t *testing.T) {
+	const first = "https://cdn.tidal.com/mediatracks/abc/0.flac?exp=1"
+	const second = "https://cdn.tidal.com/mediatracks/abc/0.flac?exp=2"
+
+	streamURLs.register("track-1", first)
+	if !IsStreamURL(first) {
+		t.Fatal("registered URL not recognized")
 	}
-	registerStreamURL(u)
-	if !IsStreamURL(u) {
-		t.Fatalf("registered URL not recognized")
+
+	// Re-resolving the same track replaces its URL: the stale one must be
+	// evicted so the registry stays bounded by tracks, not resolutions.
+	streamURLs.register("track-1", second)
+	if IsStreamURL(first) {
+		t.Error("stale URL still registered after re-resolve")
 	}
-	registerStreamURL("")
+	if !IsStreamURL(second) {
+		t.Error("fresh URL not recognized")
+	}
+
+	streamURLs.register("track-2", "")
 	if IsStreamURL("") {
-		t.Fatalf("empty URL must not be registered")
+		t.Error("empty URL must not be registered")
 	}
 }

--- a/external/tidal/types.go
+++ b/external/tidal/types.go
@@ -1,0 +1,60 @@
+package tidal
+
+import "encoding/json"
+
+// apiArtist is the Tidal artist object.
+type apiArtist struct {
+	ID   json.Number `json:"id"`
+	Name string      `json:"name"`
+}
+
+// apiAlbum is the Tidal album object. releaseDate is "YYYY-MM-DD".
+type apiAlbum struct {
+	ID             json.Number `json:"id"`
+	Title          string      `json:"title"`
+	NumberOfTracks int         `json:"numberOfTracks"`
+	ReleaseDate    string      `json:"releaseDate"`
+	Artist         apiArtist   `json:"artist"`
+}
+
+// apiTrack is the Tidal track object. Album is absent when the track is
+// nested inside an albums/{id}/tracks response.
+type apiTrack struct {
+	ID             json.Number `json:"id"`
+	Title          string      `json:"title"`
+	TrackNumber    int         `json:"trackNumber"`
+	Duration       int         `json:"duration"`
+	AllowStreaming bool        `json:"allowStreaming"`
+	StreamReady    bool        `json:"streamReady"`
+	Artist         apiArtist   `json:"artist"`
+	Artists        []apiArtist `json:"artists"`
+	Album          *apiAlbum   `json:"album"`
+}
+
+// apiPlaylist is the Tidal playlist object. Playlists are keyed by UUID, not
+// numeric ID.
+type apiPlaylist struct {
+	UUID           string `json:"uuid"`
+	Title          string `json:"title"`
+	NumberOfTracks int    `json:"numberOfTracks"`
+	Duration       int    `json:"duration"`
+}
+
+// apiList is a paginated Tidal list response.
+type apiList[T any] struct {
+	Items              []T `json:"items"`
+	TotalNumberOfItems int `json:"totalNumberOfItems"`
+}
+
+// apiFavoriteItem wraps an entry in a users/{id}/favorites/* response.
+type apiFavoriteItem[T any] struct {
+	Item T `json:"item"`
+}
+
+// apiPlaybackInfo is the tracks/{id}/playbackinfopostpaywall response. The
+// manifest is base64-encoded; its format depends on manifestMimeType (see
+// manifest.go).
+type apiPlaybackInfo struct {
+	ManifestMimeType string `json:"manifestMimeType"`
+	Manifest         string `json:"manifest"`
+}

--- a/external/tidal/types.go
+++ b/external/tidal/types.go
@@ -53,8 +53,13 @@ type apiFavoriteItem[T any] struct {
 
 // apiPlaybackInfo is the tracks/{id}/playbackinfopostpaywall response. The
 // manifest is base64-encoded; its format depends on manifestMimeType (see
-// manifest.go).
+// manifest.go). AudioQuality is the quality the server actually delivered,
+// which may be lower than requested; BitDepth/SampleRate are present on newer
+// API responses only.
 type apiPlaybackInfo struct {
+	AudioQuality     string `json:"audioQuality"`
 	ManifestMimeType string `json:"manifestMimeType"`
 	Manifest         string `json:"manifest"`
+	BitDepth         int    `json:"bitDepth"`
+	SampleRate       int    `json:"sampleRate"`
 }

--- a/external/tidal/types.go
+++ b/external/tidal/types.go
@@ -40,6 +40,11 @@ type apiPlaylist struct {
 	Duration       int    `json:"duration"`
 }
 
+// apiPlaylistItem wraps an entry in a playlistsAndFavoritePlaylists response.
+type apiPlaylistItem struct {
+	Playlist apiPlaylist `json:"playlist"`
+}
+
 // apiList is a paginated Tidal list response.
 type apiList[T any] struct {
 	Items              []T `json:"items"`

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/bjarneo/cliamp/external/radiometa"
 	"github.com/bjarneo/cliamp/external/soundcloud"
 	"github.com/bjarneo/cliamp/external/spotify"
+	"github.com/bjarneo/cliamp/external/tidal"
 	"github.com/bjarneo/cliamp/external/ytmusic"
 	"github.com/bjarneo/cliamp/internal/appdir"
 	"github.com/bjarneo/cliamp/internal/appmeta"
@@ -113,6 +114,12 @@ func run(overrides config.Overrides, positional []string, daemon bool) error {
 	if cfg.Qobuz.IsSet() {
 		qobuzProv = qobuz.New(cfg.Qobuz.Quality)
 		providers = append(providers, model.ProviderEntry{Key: "qobuz", Name: "Qobuz", Provider: qobuzProv})
+	}
+
+	var tidalProv *tidal.TidalProvider
+	if cfg.Tidal.IsSet() {
+		tidalProv = tidal.New(cfg.Tidal.Quality, cfg.Tidal.ClientID, cfg.Tidal.ClientSecret)
+		providers = append(providers, model.ProviderEntry{Key: "tidal", Name: "Tidal", Provider: tidalProv})
 	}
 
 	if scProv := soundcloud.NewFromConfig(soundcloud.Config{
@@ -205,6 +212,9 @@ func run(overrides config.Overrides, positional []string, daemon bool) error {
 	}
 	if qobuzProv != nil {
 		defer qobuzProv.Close()
+	}
+	if tidalProv != nil {
+		defer tidalProv.Close()
 	}
 	if closeYouTube != nil {
 		defer closeYouTube()
@@ -303,7 +313,7 @@ func run(overrides config.Overrides, positional []string, daemon bool) error {
 	}
 
 	p.RegisterBufferedURLMatcher(func(u string) bool {
-		return navidrome.IsSubsonicStreamURL(u) || jellyfin.IsStreamURL(u) || emby.IsStreamURL(u) || plex.IsStreamURL(u) || qobuz.IsStreamURL(u) || audiobookshelf.IsStreamURL(u)
+		return navidrome.IsSubsonicStreamURL(u) || jellyfin.IsStreamURL(u) || emby.IsStreamURL(u) || plex.IsStreamURL(u) || qobuz.IsStreamURL(u) || tidal.IsStreamURL(u) || audiobookshelf.IsStreamURL(u)
 	})
 
 	// Pull now-playing for stations that carry no inline ICY metadata (NTS, FIP).
@@ -448,6 +458,12 @@ func run(overrides config.Overrides, positional []string, daemon bool) error {
 			prog.Send(model.ProvAuthURLMsg{ProviderName: qobuzProv.Name(), URL: u})
 		})
 		defer qobuz.SetAuthURLObserver(nil)
+	}
+	if tidalProv != nil {
+		tidal.SetAuthURLObserver(func(u string) {
+			prog.Send(model.ProvAuthURLMsg{ProviderName: tidalProv.Name(), URL: u})
+		})
+		defer tidal.SetAuthURLObserver(nil)
 	}
 
 	svc, svcErr := wireMediaCtl(prog)

--- a/main.go
+++ b/main.go
@@ -312,6 +312,15 @@ func run(overrides config.Overrides, positional []string, daemon bool) error {
 		p.RegisterStreamerFactory("spotify:", spotifyProv.NewStreamer)
 	}
 
+	if tidalProv != nil {
+		// Tidal tracks carry tidal:// URIs; the provider resolves them to a
+		// fresh signed URL or DASH segment list when playback starts.
+		p.RegisterSourceResolver(tidal.TrackURIPrefix, func(uri string) (player.ResolvedSource, error) {
+			u, segments, err := tidalProv.ResolveSource(uri)
+			return player.ResolvedSource{URL: u, Segments: segments}, err
+		})
+	}
+
 	p.RegisterBufferedURLMatcher(func(u string) bool {
 		return navidrome.IsSubsonicStreamURL(u) || jellyfin.IsStreamURL(u) || emby.IsStreamURL(u) || plex.IsStreamURL(u) || qobuz.IsStreamURL(u) || tidal.IsStreamURL(u) || audiobookshelf.IsStreamURL(u)
 	})

--- a/player/decode.go
+++ b/player/decode.go
@@ -128,6 +128,17 @@ func (p *Player) matchCustomURI(path string) StreamerFactory {
 	return nil
 }
 
+// matchSourceResolver returns the SourceResolver for the given path if it
+// matches a registered scheme prefix, or nil if no scheme matches.
+func (p *Player) matchSourceResolver(path string) SourceResolver {
+	for scheme, r := range p.sourceResolvers {
+		if strings.HasPrefix(path, scheme) {
+			return r
+		}
+	}
+	return nil
+}
+
 // sourceResult holds the opened stream and optional HTTP metadata.
 type sourceResult struct {
 	body          io.ReadCloser

--- a/player/nav_buffer.go
+++ b/player/nav_buffer.go
@@ -60,31 +60,78 @@ type navBuffer struct {
 // does not send a Content-Length header (e.g. chunked transfer encoding).
 func newNavBuffer(rawURL string) (*navBuffer, int64, error) {
 	ctx, cancel := context.WithCancel(context.Background())
-	req, err := http.NewRequestWithContext(ctx, "GET", rawURL, nil)
+	resp, err := navBufferGet(ctx, rawURL)
 	if err != nil {
 		cancel()
-		return nil, 0, fmt.Errorf("nav buffer request: %w", err)
+		return nil, 0, err
+	}
+
+	b, err := newNavBufferFor(resp, cancel)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	go b.download(resp.Body)
+
+	return b, resp.ContentLength, nil
+}
+
+// newNavBufferSegments is like newNavBuffer for an ordered list of segment
+// URLs whose concatenated bytes form one progressive stream (e.g. an fMP4
+// init segment followed by unencrypted media segments). The total length is
+// unknown up front, so the returned contentLength is always -1.
+func newNavBufferSegments(urls []string) (*navBuffer, int64, error) {
+	if len(urls) == 0 {
+		return nil, 0, fmt.Errorf("nav buffer: no segment urls")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	resp, err := navBufferGet(ctx, urls[0])
+	if err != nil {
+		cancel()
+		return nil, 0, err
+	}
+
+	b, err := newNavBufferFor(resp, cancel)
+	if err != nil {
+		return nil, 0, err
+	}
+	b.total = -1
+
+	go b.downloadSegments(ctx, resp.Body, urls[1:])
+
+	return b, -1, nil
+}
+
+// navBufferGet performs the HTTP GET for a navBuffer download source.
+func navBufferGet(ctx context.Context, rawURL string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", rawURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("nav buffer request: %w", err)
 	}
 	req.Header.Set("User-Agent", "cliamp/1.0 (https://github.com/bjarneo/cliamp)")
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		cancel()
-		return nil, 0, fmt.Errorf("nav buffer connect: %w", err)
+		return nil, fmt.Errorf("nav buffer connect: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
 		resp.Body.Close()
-		cancel()
-		return nil, 0, fmt.Errorf("nav buffer: http status %s", resp.Status)
+		return nil, fmt.Errorf("nav buffer: http status %s", resp.Status)
 	}
+	return resp, nil
+}
+
+// newNavBufferFor builds the file-backed buffer for an opened response.
+// On error the response body is closed and cancel invoked.
+func newNavBufferFor(resp *http.Response, cancel context.CancelFunc) (*navBuffer, error) {
 	file, err := os.CreateTemp("", "cliamp-nav-*")
 	if err != nil {
 		resp.Body.Close()
 		cancel()
-		return nil, 0, fmt.Errorf("nav buffer tempfile: %w", err)
+		return nil, fmt.Errorf("nav buffer tempfile: %w", err)
 	}
 
-	b := &navBuffer{
+	return &navBuffer{
 		total:        resp.ContentLength, // -1 if unknown
 		cancel:       cancel,
 		contentType:  resp.Header.Get("Content-Type"),
@@ -93,26 +140,52 @@ func newNavBuffer(rawURL string) (*navBuffer, int64, error) {
 		file:         file,
 		path:         file.Name(),
 		stallTimeout: readStallTimeout,
-	}
-
-	go b.download(resp.Body)
-
-	return b, resp.ContentLength, nil
+	}, nil
 }
 
 // download reads the HTTP response body in bounded chunks and appends them to
 // the temporary file. It signals blocked Read/Seek calls after each write.
 func (b *navBuffer) download(body io.ReadCloser) {
 	defer close(b.downloadDone)
+	if _, ok := b.copyBody(body, 0); ok {
+		b.finish(nil)
+	}
+}
+
+// downloadSegments appends the first segment's body, then fetches and appends
+// each remaining segment URL in order, so the file holds the segments'
+// concatenated bytes. Records the first error and stops on close.
+func (b *navBuffer) downloadSegments(ctx context.Context, first io.ReadCloser, rest []string) {
+	defer close(b.downloadDone)
+	offset, ok := b.copyBody(first, 0)
+	if !ok {
+		return
+	}
+	for _, u := range rest {
+		resp, err := navBufferGet(ctx, u)
+		if err != nil {
+			b.finish(err)
+			return
+		}
+		if offset, ok = b.copyBody(resp.Body, offset); !ok {
+			return
+		}
+	}
+	b.finish(nil)
+}
+
+// copyBody appends one response body to the temporary file starting at
+// offset. Returns the new offset and whether the caller should continue;
+// on failure the error has already been recorded via finish.
+func (b *navBuffer) copyBody(body io.ReadCloser, offset int64) (int64, bool) {
 	defer body.Close()
 	chunk := make([]byte, navBufferChunkSize)
-	var offset int64
 	for {
 		b.mu.Lock()
 		closed := b.closed
 		b.mu.Unlock()
 		if closed {
-			return
+			return offset, false
 		}
 
 		n, err := body.Read(chunk)
@@ -124,7 +197,7 @@ func (b *navBuffer) download(body io.ReadCloser) {
 				closed := b.closed
 				b.mu.Unlock()
 				if closed || file == nil {
-					return
+					return offset, false
 				}
 
 				wn, writeErr := file.WriteAt(chunk[written:n], offset)
@@ -135,21 +208,20 @@ func (b *navBuffer) download(body io.ReadCloser) {
 				}
 				if writeErr != nil {
 					b.finish(fmt.Errorf("nav buffer tempfile write: %w", writeErr))
-					return
+					return offset, false
 				}
 				if wn == 0 {
 					b.finish(fmt.Errorf("nav buffer tempfile write: %w", io.ErrShortWrite))
-					return
+					return offset, false
 				}
 			}
 		}
 		if err == io.EOF {
-			b.finish(nil)
-			return
+			return offset, true
 		}
 		if err != nil {
 			b.finish(err)
-			return
+			return offset, false
 		}
 	}
 }

--- a/player/nav_buffer_test.go
+++ b/player/nav_buffer_test.go
@@ -359,3 +359,73 @@ func waitForNavBufferCursorLock(t *testing.T, b *navBuffer) {
 		runtime.Gosched()
 	}
 }
+
+func TestNavBufferSegmentsConcatenatesInOrder(t *testing.T) {
+	segments := map[string]string{
+		"/init.mp4": "INIT",
+		"/seg1.m4s": "AAAA",
+		"/seg2.m4s": "BBBBBB",
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, ok := segments[r.URL.Path]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "audio/mp4")
+		_, _ = io.WriteString(w, body)
+	}))
+	defer server.Close()
+
+	nb, contentLen, err := newNavBufferSegments([]string{
+		server.URL + "/init.mp4",
+		server.URL + "/seg1.m4s",
+		server.URL + "/seg2.m4s",
+	})
+	if err != nil {
+		t.Fatalf("newNavBufferSegments: %v", err)
+	}
+	defer nb.Close()
+
+	if contentLen != -1 {
+		t.Errorf("contentLength = %d, want -1 (unknown)", contentLen)
+	}
+	if got := nb.ContentType(); got != "audio/mp4" {
+		t.Errorf("ContentType = %q, want audio/mp4", got)
+	}
+
+	got, err := io.ReadAll(nb.newReader())
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if want := "INITAAAABBBBBB"; string(got) != want {
+		t.Errorf("concatenated bytes = %q, want %q", got, want)
+	}
+}
+
+func TestNavBufferSegmentsSurfacesMidStreamError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/init.mp4" {
+			_, _ = io.WriteString(w, "INIT")
+			return
+		}
+		http.Error(w, "expired", http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	nb, _, err := newNavBufferSegments([]string{server.URL + "/init.mp4", server.URL + "/gone.m4s"})
+	if err != nil {
+		t.Fatalf("newNavBufferSegments: %v", err)
+	}
+	defer nb.Close()
+
+	if _, err := io.ReadAll(nb.newReader()); err == nil {
+		t.Fatal("expected mid-stream segment error to surface on read")
+	}
+}
+
+func TestNavBufferSegmentsRejectsEmptyList(t *testing.T) {
+	if _, _, err := newNavBufferSegments(nil); err == nil {
+		t.Fatal("expected error for empty segment list")
+	}
+}

--- a/player/pipeline.go
+++ b/player/pipeline.go
@@ -159,6 +159,41 @@ func (p *Player) buildPipeline(path string) (*trackPipeline, error) {
 		}, nil
 	}
 
+	// Custom URIs with a registered SourceResolver (e.g. tidal://track/123)
+	// resolve to their actual bytes at play time, so short-lived signed URLs
+	// are always fresh. Segment lists get a concatenating navBuffer; direct
+	// URLs fall through to the normal HTTP handling below.
+	if resolver := p.matchSourceResolver(path); resolver != nil {
+		src, err := resolver(path)
+		if err != nil {
+			return nil, fmt.Errorf("resolve source: %w", err)
+		}
+		if len(src.Segments) > 0 {
+			nb, contentLen, err := newNavBufferSegments(src.Segments)
+			if err != nil {
+				return nil, fmt.Errorf("segment buffer: %w", err)
+			}
+			decoder, format, err := decodeNavFFmpeg(nb, p.sr, p.bitDepth, 0)
+			if err != nil {
+				nb.Close()
+				return nil, fmt.Errorf("decode segments: %w", err)
+			}
+			return &trackPipeline{
+				decoder:       decoder,
+				stream:        decoder,
+				format:        format,
+				seekable:      true, // navFFmpegStreamer.Seek() handles seeking without reconnect
+				path:          path,
+				bytesRead:     &nb.bytesIn,
+				contentLength: contentLen,
+			}, nil
+		}
+		if src.URL == "" {
+			return nil, fmt.Errorf("resolve source: empty result for %s", path)
+		}
+		path = src.URL
+	}
+
 	// For HTTP URLs, pass the ICY metadata callback; for local files, nil.
 	var onMeta func(string)
 	if isURL(path) {

--- a/player/player.go
+++ b/player/player.go
@@ -59,6 +59,7 @@ type Player struct {
 	streamTitle      atomic.Value               // stores string, set by ICY reader callback
 	customFactories  map[string]StreamerFactory // URI scheme prefix -> factory (e.g. "spotify:" -> fn)
 	bufferedURLMatch func(string) bool          // optional: returns true for URLs needing navBuffer pipeline
+	sourceResolvers  map[string]SourceResolver  // URI scheme prefix -> play-time source resolver (e.g. "tidal://")
 
 	streamMetaResolver StreamMetadataResolver // optional: API-based now-playing for streams without ICY
 	metaCancel         context.CancelFunc     // cancels the active metadata poller; guarded by mu
@@ -918,6 +919,32 @@ func (p *Player) RegisterBufferedURLMatcher(match func(string) bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.bufferedURLMatch = match
+}
+
+// ResolvedSource is a playable source produced by a SourceResolver at play
+// time: either a direct HTTP URL, or an ordered list of media segment URLs
+// whose concatenated bytes form one progressive stream (e.g. unencrypted
+// DASH fMP4 segments).
+type ResolvedSource struct {
+	URL      string
+	Segments []string
+}
+
+// SourceResolver turns a custom URI (e.g. "tidal://track/123") into a
+// ResolvedSource when playback starts. Resolving at play time keeps
+// short-lived signed URLs fresh no matter how long a track sat in the queue.
+type SourceResolver func(uri string) (ResolvedSource, error)
+
+// RegisterSourceResolver registers a resolver for a custom URI scheme prefix.
+// Unlike RegisterStreamerFactory, the provider only supplies bytes to fetch;
+// decoding stays in the player's buffered ffmpeg pipeline.
+func (p *Player) RegisterSourceResolver(scheme string, r SourceResolver) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.sourceResolvers == nil {
+		p.sourceResolvers = make(map[string]SourceResolver)
+	}
+	p.sourceResolvers[scheme] = r
 }
 
 // suspendSpeaker suspends the ALSA audio callback goroutine so it blocks

--- a/provider/types.go
+++ b/provider/types.go
@@ -5,6 +5,8 @@
 // via type assertions.
 package provider
 
+import "strconv"
+
 // ArtistInfo describes an artist in a provider's catalog.
 type ArtistInfo struct {
 	ID         string
@@ -29,6 +31,20 @@ type SortType struct {
 	Label string // e.g. "By Name"
 }
 
+// YearFromDate extracts the year from a "YYYY-MM-DD" (or bare "YYYY") date
+// string, as returned by streaming-service APIs. Returns 0 when the string
+// does not start with a 4-digit year.
+func YearFromDate(date string) int {
+	if len(date) < 4 {
+		return 0
+	}
+	y, err := strconv.Atoi(date[:4])
+	if err != nil {
+		return 0
+	}
+	return y
+}
+
 // ProviderMeta key constants used across providers and the UI.
 const (
 	MetaNavidromeID = "navidrome.id"
@@ -36,6 +52,7 @@ const (
 	MetaEmbyID      = "emby.id"
 	MetaNetEaseID   = "netease.id"
 	MetaQobuzID     = "qobuz.id"
+	MetaTidalID     = "tidal.id"
 
 	MetaAudiobookshelfID      = "audiobookshelf.id"
 	MetaAudiobookshelfEpisode = "audiobookshelf.episode"

--- a/provider/types_test.go
+++ b/provider/types_test.go
@@ -1,0 +1,22 @@
+package provider
+
+import "testing"
+
+func TestYearFromDate(t *testing.T) {
+	tests := []struct {
+		in   string
+		want int
+	}{
+		{"2021-05-14", 2021},
+		{"1999", 1999},
+		{"", 0},
+		{"abc", 0},
+		{"20", 0},
+		{"19xy-01-01", 0},
+	}
+	for _, tt := range tests {
+		if got := YearFromDate(tt.in); got != tt.want {
+			t.Errorf("YearFromDate(%q) = %d, want %d", tt.in, got, tt.want)
+		}
+	}
+}

--- a/site/index.html
+++ b/site/index.html
@@ -4,20 +4,20 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>CLIAMP — Terminal Music Player</title>
-<meta name="description" content="A retro terminal music player inspired by Winamp 2.x. Play local files, YouTube, Spotify, Qobuz, Plex, Jellyfin, Emby, Navidrome, SoundCloud, NetEase, and 30,000+ radio stations with a spectrum visualizer and 10-band EQ.">
+<meta name="description" content="A retro terminal music player inspired by Winamp 2.x. Play local files, YouTube, Spotify, Qobuz, Tidal, Plex, Jellyfin, Emby, Navidrome, SoundCloud, NetEase, and 30,000+ radio stations with a spectrum visualizer and 10-band EQ.">
 <link rel="icon" type="image/svg+xml" href="favicon.svg">
 
 <!-- Open Graph -->
 <meta property="og:type" content="website">
 <meta property="og:title" content="CLIAMP — Terminal Music Player">
-<meta property="og:description" content="A retro terminal music player inspired by Winamp 2.x. Play YouTube, Spotify, Qobuz, Plex, Jellyfin, Emby, SoundCloud, NetEase, and 30,000+ radio stations from your terminal with a spectrum visualizer and 10-band EQ.">
+<meta property="og:description" content="A retro terminal music player inspired by Winamp 2.x. Play YouTube, Spotify, Qobuz, Tidal, Plex, Jellyfin, Emby, SoundCloud, NetEase, and 30,000+ radio stations from your terminal with a spectrum visualizer and 10-band EQ.">
 <meta property="og:image" content="https://cliamp.stream/og-image.png">
 <meta property="og:url" content="https://cliamp.stream">
 
 <!-- Twitter Card -->
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="CLIAMP — Terminal Music Player">
-<meta name="twitter:description" content="A retro terminal music player inspired by Winamp 2.x. Play YouTube, Spotify, Qobuz, Plex, Jellyfin, Emby, SoundCloud, NetEase, and 30,000+ radio stations from your terminal with a spectrum visualizer and 10-band EQ.">
+<meta name="twitter:description" content="A retro terminal music player inspired by Winamp 2.x. Play YouTube, Spotify, Qobuz, Tidal, Plex, Jellyfin, Emby, SoundCloud, NetEase, and 30,000+ radio stations from your terminal with a spectrum visualizer and 10-band EQ.">
 <meta name="twitter:image" content="https://cliamp.stream/og-image.png">
 
 <style>
@@ -530,7 +530,7 @@ footer{border-top:1px solid var(--line);background:var(--ink-2);padding:46px 0 5
         <div class="hero-eyebrow"><span class="led"></span>Terminal music player</div>
         <h1 class="hero-word">cli<span>amp</span></h1>
         <p class="hero-sub"><em>Winamp</em> for your shell.</p>
-        <p class="hero-desc">Playlists, a 10-band EQ, visualizers, synced lyrics, remote control, and a Lua plugin system — streaming from <em>Spotify, Qobuz, YouTube Music, Plex, Jellyfin, Emby, Navidrome</em>, and 30,000+ radio stations.</p>
+        <p class="hero-desc">Playlists, a 10-band EQ, visualizers, synced lyrics, remote control, and a Lua plugin system — streaming from <em>Spotify, Qobuz, Tidal, YouTube Music, Plex, Jellyfin, Emby, Navidrome</em>, and 30,000+ radio stations.</p>
         <div class="hero-cta">
           <a href="#install" class="btn btn-go">Install<span class="ar">→</span></a>
           <a href="https://github.com/bjarneo/cliamp" class="btn btn-ghost">Source<span class="ar">↗</span></a>
@@ -634,7 +634,7 @@ footer{border-top:1px solid var(--line);background:var(--ink-2);padding:46px 0 5
 <!-- ═══ TICKER ═══ -->
 <div class="ticker" aria-hidden="true">
   <div class="ticker-track" id="ticker">
-    <span>MP3 · FLAC · OGG · OPUS · WAV · AAC · ALAC · Spotify · Qobuz · YouTube · Plex · Jellyfin · Emby · Navidrome · SoundCloud · NetEase · Bandcamp · Bilibili · RSS / Podcasts · 30k+ Radio Stations · ICY metadata · MPRIS · Lua plugins</span>
+    <span>MP3 · FLAC · OGG · OPUS · WAV · AAC · ALAC · Spotify · Qobuz · Tidal · YouTube · Plex · Jellyfin · Emby · Navidrome · SoundCloud · NetEase · Bandcamp · Bilibili · RSS / Podcasts · 30k+ Radio Stations · ICY metadata · MPRIS · Lua plugins</span>
   </div>
 </div>
 
@@ -699,7 +699,7 @@ footer{border-top:1px solid var(--line);background:var(--ink-2);padding:46px 0 5
     <div class="next-step reveal">
       <div class="next-step-label">Next step · configure providers</div>
       <h3>Run the setup wizard</h3>
-      <p>An interactive TUI walks you through Navidrome, Plex, Jellyfin, Emby, Spotify, Qobuz, NetEase, and YouTube Music. It links to each provider's credential page, validates the connection, and writes the right block to your config file.</p>
+      <p>An interactive TUI walks you through Navidrome, Plex, Jellyfin, Emby, Spotify, Qobuz, Tidal, NetEase, and YouTube Music. It links to each provider's credential page, validates the connection, and writes the right block to your config file.</p>
       <div class="install-box" onclick="copyCmd(this,'cliamp setup')">
         <div class="install-platform">Setup</div>
         <code><span class="prompt">$ </span>cliamp setup</code>
@@ -717,11 +717,12 @@ footer{border-top:1px solid var(--line);background:var(--ink-2);padding:46px 0 5
       <span class="strip-meter"><i></i><i></i><i></i><i></i><i></i></span>
     </div>
     <p class="sources-intro reveal">
-      Stream from everywhere. Every provider runs through the same <em>playlist, EQ, visualizer, and lyrics pipeline</em> — your config follows you across services. Run <code>cliamp setup</code> for an interactive wizard that walks you through Navidrome, Plex, Jellyfin, Emby, Audiobookshelf, Spotify, Qobuz, NetEase, and YouTube Music.
+      Stream from everywhere. Every provider runs through the same <em>playlist, EQ, visualizer, and lyrics pipeline</em> — your config follows you across services. Run <code>cliamp setup</code> for an interactive wizard that walks you through Navidrome, Plex, Jellyfin, Emby, Audiobookshelf, Spotify, Qobuz, Tidal, NetEase, and YouTube Music.
     </p>
     <div class="sources-grid reveal">
       <div class="source" style="--src-color:#1db954"><div class="source-badge">OAuth · cached</div><div class="source-name">Spotify</div><div class="source-desc">Stream your Premium library. Bring your own developer <code>client_id</code> for a private Web API quota; playback is authorized separately. Search with <kbd>Ctrl+F</kbd>; Development Mode paging is automatic. Pre-built Windows releases include Spotify support.</div></div>
       <div class="source" style="--src-color:#c3c9d4"><div class="source-badge">OAuth · lossless</div><div class="source-name">Qobuz</div><div class="source-desc">Opt-in: set <code>[qobuz] enabled = true</code>. Stream lossless FLAC up to 24-bit/192kHz from your subscription. Browse favorites &amp; playlists, search with <kbd>Ctrl+F</kbd>. Sign in once via OAuth in your browser.</div></div>
+      <div class="source" style="--src-color:#33ffee"><div class="source-badge">OAuth · lossless</div><div class="source-name">Tidal</div><div class="source-desc">Opt-in: set <code>[tidal] enabled = true</code>. Stream lossless FLAC (CD quality) from your subscription. Browse favorites &amp; playlists, search with <kbd>Ctrl+F</kbd>. Sign in once by approving a <code>link.tidal.com</code> device code.</div></div>
       <div class="source" style="--src-color:#ff0000"><div class="source-badge">yt-dlp</div><div class="source-name">YouTube</div><div class="source-desc">Search videos with <kbd>Ctrl+F</kbd>, then play, append, or queue from a results list.</div></div>
       <div class="source" style="--src-color:#ff4444"><div class="source-badge">Cookies · OAuth</div><div class="source-name">YT Music</div><div class="source-desc">Browse your playlists and Liked Music directly via browser cookies (zero OAuth setup) or custom Google Cloud credentials. Set <code>cookies_from</code> in your config.</div></div>
       <div class="source" style="--src-color:#e5a00d"><div class="source-badge">Media server</div><div class="source-name">Plex</div><div class="source-desc">Browse albums and stream from your Plex Media Server.</div></div>

--- a/ui/model/command_registry.go
+++ b/ui/model/command_registry.go
@@ -112,6 +112,7 @@ var commandRegistry = []commandSpec{
 	{Mode: commandModeMain, Keys: []string{"E"}, KeyLabel: "E", Label: "Open Emby provider", Keymap: true},
 	{Mode: commandModeMain, Keys: []string{"B"}, KeyLabel: "B", Label: "Open Audiobookshelf provider", Keymap: true},
 	{Mode: commandModeMain, Keys: []string{"Q"}, KeyLabel: "Q", Label: "Open Qobuz provider", Keymap: true},
+	{Mode: commandModeMain, Keys: []string{"T"}, KeyLabel: "T", Label: "Open Tidal provider", Keymap: true},
 	{Mode: commandModeMain, Keys: []string{"ctrl+j"}, KeyLabel: "Ctrl+J", Label: "Jump to time", Keymap: true},
 	{Mode: commandModeMain, Keys: []string{"p"}, KeyLabel: "p", Label: "Playlist manager", Keymap: true},
 	{Mode: commandModeMain, Keys: []string{"ctrl+h"}, KeyLabel: "Ctrl+H", Label: "Toggle album headers", Keymap: true},

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -429,6 +429,8 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 			return m.switchToProvider("netease")
 		case "Q":
 			return m.switchToProvider("qobuz")
+		case "T":
+			return m.switchToProvider("tidal")
 		case "L":
 			return m.switchToProvider("local")
 		case "R":
@@ -795,6 +797,8 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 		return m.switchToProvider("netease")
 	case "Q":
 		return m.switchToProvider("qobuz")
+	case "T":
+		return m.switchToProvider("tidal")
 
 	case "ctrl+h":
 		m.toggleAlbumHeadersManual()

--- a/ui/model/providers.go
+++ b/ui/model/providers.go
@@ -165,6 +165,8 @@ func providerKeyForShortcut(key string) string {
 		return "netease"
 	case "Q":
 		return "qobuz"
+	case "T":
+		return "tidal"
 	case "L":
 		return "local"
 	case "R":


### PR DESCRIPTION
Closes #97.

Adds a Tidal provider — including lossless, which the issue thought out of reach: LOSSLESS tier streams FLAC 16/44.1 as plain signed CDN URLs (Tidal's BTS manifest), so it rides the existing buffer-while-playing + ffmpeg pipeline exactly like Qobuz. No player changes.

## What's in

- `external/tidal/`: OAuth 2.0 device flow (`link.tidal.com` code via the provider sign-in overlay), private-API client (same API python-tidal uses — the official developer API is previews-only) with silent token refresh and atomic credential caching, BTS manifest parsing.
- Quality tiers: `low`/`high` (AAC), `lossless` (FLAC CD, default), `hires`. Tidal ships hi-res as segmented DASH which the pipeline can't consume yet, so `hires` latches to lossless per session after the first DASH response; native DASH playback is the follow-up.
- Provider surface: Favorite Tracks (capped 500), playlists, favorite album/artist browse, catalog search; `T` jump key, `--provider tidal`, `cliamp setup` wizard page, `cliamp tidal reset`.
- Built-in client credentials are config-overridable (`client_id`/`client_secret`) so users can recover from Tidal's periodic key revocations without a release.
- Docs (`docs/tidal.md` + keybindings/configuration/cli), `config.toml.example`, and `site/index.html` updated in sync.
- Consolidations that fell out: `provider.YearFromDate` shared with Qobuz, one `providerCredsCommand` helper for the spotify/qobuz/tidal reset commands.

## Testing

- Table-driven tests: manifest parsing (BTS/DASH/encrypted), hires→lossless fallback, device-flow quality normalization, pagination + 401-refresh against httptest, config parsing, setup wizard body. `make check` and `-race` green.
- The device-authorization endpoint was probed live with the embedded client credentials (Tidal issues a valid device code, so the client ID is currently unrevoked). End-to-end playback testing against a real subscription is in progress on our side.

Streaming only — no download-to-disk for Tidal content, mirroring the approach of long-lived open-source Tidal players.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional Tidal integration for playlists, favorites, artists, albums, search, and playback.
  - Added device-code authentication with cached credentials and credential reset support.
  - Added selectable stream quality, including lossless and high-resolution lossless fallback.
  - Added the `T` keyboard shortcut for switching to Tidal.
  - Added a Tidal playback diagnostic command.
  - Added setup, configuration, website, and usage documentation.

- **Bug Fixes**
  - Improved playback URL handling and automatic token refresh.
  - Standardized release-year metadata parsing across providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->