### PR TITLE
fix(spotify): page search around the Development Mode limit

### DIFF
--- a/docs/spotify.md
+++ b/docs/spotify.md
@@ -32,17 +32,17 @@ To register one:
 
 Run `cliamp`, select Spotify as a provider, and press Enter to sign in. When using your own `client_id`, the browser completes two authorization steps in the same tab: one for Web API access and one for playback. The built-in client path needs one step. Credentials are cached at `~/.config/cliamp/spotify_credentials.json`; subsequent launches refresh silently.
 
-### Newer apps and the search caveat
+### Newer apps and the search page size
 
-Apps registered in Development Mode (the default for anything created on developer.spotify.com after Nov 27, 2024) still work for your library, your playlists, save/follow actions, and OAuth itself. Playback uses its separate authorization. The one specific thing newer apps cannot do is hit Spotify's **catalog endpoints**: `/v1/search` and a handful of related endpoints.
+Apps registered in Development Mode (the default for anything created on developer.spotify.com after Nov 27, 2024) work for your library, your playlists, save/follow actions, OAuth, and search. Playback uses its separate authorization.
 
-You'll see the catalog restriction as `400 "Invalid limit"` whenever you press <kbd>Ctrl+F</kbd> to search Spotify — Spotify [introduced this restriction on Nov 27, 2024](https://developer.spotify.com/blog/2024-11-27-changes-to-the-web-api) and rarely grants Extended Quota Mode to personal/non-commercial apps. Cliamp surfaces a friendlier error explaining what's actually wrong instead of the raw "Invalid limit" message.
+Search does come with one limit: `/v1/search` accepts at most **10 results per request** for a Development Mode app. Asking for more returns `400 "Invalid limit"`, which is exactly what it says and not a sign that search is blocked. Cliamp handles this for you by paging through results 10 at a time with `offset`, so <kbd>Ctrl+F</kbd> returns the full set either way.
 
-If you don't use Spotify search often, your own `client_id` is the better choice — keep it.
+Some other endpoints genuinely are restricted for these apps (`/v1/browse/new-releases` answers `403`, and followed playlists are affected as described in the [Nov 27, 2024 announcement](https://developer.spotify.com/blog/2024-11-27-changes-to-the-web-api)), but `/v1/search` is not among them and Extended Quota Mode is not needed for it.
 
 ### Alternative: built-in shared client ID
 
-If Spotify search is essential to you and your own app hits the dev-mode restriction above, drop the `client_id` line:
+If you would rather not register an app at all, drop the `client_id` line:
 
 ```toml
 [spotify]
@@ -89,7 +89,7 @@ Podcast episodes work like tracks. Press `Ctrl+F` to search Spotify and matching
 - **Re-authenticate**: Run `cliamp spotify reset` to clear stored credentials, then relaunch cliamp and select Spotify to sign in again. (Equivalent to deleting `~/.config/cliamp/spotify_credentials.json` manually.)
 - **Persistent "rate-limited" errors on `/v1/me`**: Your stored auth has expired or been revoked. Cliamp will detect this on most launches and prompt you to sign in again, but if it does not, run `cliamp spotify reset` and re-authenticate. This is *not* a real Spotify rate limit — waiting will not resolve it.
 - **`429 Too Many Requests` on search or playlist loading (using the built-in fallback)**: The built-in `client_id` is shared with every librespot- and spotify-player-based client; when the global pool is busy, Spotify caps requests for everyone using it. Cliamp retries with exponential backoff, but if the errors keep returning the simplest fix is to register your own developer app and set `client_id` in `[spotify]` — your personal app gets its own quota.
-- **"search blocked — your client_id is too new" on <kbd>Ctrl+F</kbd>**: Your registered Spotify Developer app is in Development Mode and can't hit `/v1/search` (Spotify's Nov 27, 2024 change). Everything else on your app — playback, library, playlists, save/follow — still works fine. Either remove `client_id` from `[spotify]` to use the built-in fallback for search, or just don't use Spotify search and keep your own app.
+- **`400 "Invalid limit"` on <kbd>Ctrl+F</kbd>**: Development Mode apps cap `/v1/search` at 10 results per request. Cliamp pages around that automatically, so seeing this error means the cap moved below 10; please open an issue.
 
 ## Requirements
 

--- a/external/spotify/provider.go
+++ b/external/spotify/provider.go
@@ -555,26 +555,104 @@ func (p *SpotifyProvider) webAPIWithBody(ctx context.Context, method, path strin
 	return nil, fmt.Errorf("spotify: web api rate-limited on %s after %d retries (try re-authenticating)", path, maxRetries)
 }
 
-// friendlySearchError rewrites Spotify's misleading 400 "Invalid limit" reply
-// from /v1/search into something a user can act on. Since Nov 27, 2024 Spotify
-// returns this error for developer apps registered in Development Mode — the
-// rest of the API (playback, playlists, library) keeps working, but the
-// catalog endpoints (/v1/search etc.) are blocked. The limit value is fine.
+// devModeSearchLimit is the largest per-request limit /v1/search accepts for an
+// app still in Spotify's Development Mode. Anything above it comes back as
+// 400 "Invalid limit", which reads like a bug in the value we picked but is
+// simply the cap. Measured against a Development Mode app: 10 succeeds, 11 does
+// not, and offset paging past the cap works fine.
+const devModeSearchLimit = 10
+
+// isInvalidLimit reports whether err is Spotify's 400 "Invalid limit" reply,
+// i.e. the app is capped at devModeSearchLimit results per search request.
+func isInvalidLimit(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "400") && strings.Contains(msg, "Invalid limit")
+}
+
+// friendlySearchError turns a failed /v1/search into something actionable.
+// A surviving "Invalid limit" means the cap moved below devModeSearchLimit,
+// since SearchTracks already retries in pages of that size.
 func friendlySearchError(err error) error {
 	if err == nil {
 		return nil
 	}
-	msg := err.Error()
-	if strings.Contains(msg, "400") && strings.Contains(msg, "Invalid limit") {
-		return fmt.Errorf("spotify: search blocked — your client_id is too new. Spotify's Nov 27 2024 change blocks /v1/search for apps in Development Mode (the rest of cliamp still works on your app). Remove client_id from [spotify] in config.toml to use the built-in fallback for search, or apply for Extended Quota Mode")
+	if isInvalidLimit(err) {
+		return fmt.Errorf("spotify: search rejected even a limit of %d; Spotify's cap for Development Mode apps appears to have changed (%w)", devModeSearchLimit, err)
 	}
 	return fmt.Errorf("spotify: search: %w", err)
+}
+
+// spotifySearchPage is one page of /v1/search results.
+type spotifySearchPage struct {
+	Tracks struct {
+		Items []*spotifyItem `json:"items"`
+	} `json:"tracks"`
+	Episodes struct {
+		Items []*spotifyItem `json:"items"`
+	} `json:"episodes"`
+}
+
+// searchPage runs a single /v1/search request.
+//
+// No market parameter: when the request carries a user OAuth token, Spotify
+// implicitly scopes results to the account's country.
+func (p *SpotifyProvider) searchPage(ctx context.Context, query string, limit, offset int) (*spotifySearchPage, error) {
+	q := url.Values{
+		"q":     {query},
+		"type":  {"track,episode"},
+		"limit": {strconv.Itoa(limit)},
+	}
+	if offset > 0 {
+		q.Set("offset", strconv.Itoa(offset))
+	}
+
+	resp, err := p.webAPI(ctx, "GET", "/v1/search", q)
+	if err != nil {
+		return nil, err
+	}
+
+	var page spotifySearchPage
+	if err := decodeBody(resp, &page); err != nil {
+		return nil, fmt.Errorf("spotify: parse search: %w", err)
+	}
+	return &page, nil
+}
+
+// searchPaged collects up to limit results in pages of devModeSearchLimit, for
+// apps that cannot ask for more in one go. A page that fails after the first
+// one keeps whatever was already collected rather than losing the whole search.
+func (p *SpotifyProvider) searchPaged(ctx context.Context, query string, limit int) (*spotifySearchPage, error) {
+	combined := &spotifySearchPage{}
+	for offset := 0; offset < limit; offset += devModeSearchLimit {
+		size := min(devModeSearchLimit, limit-offset)
+		page, err := p.searchPage(ctx, query, size, offset)
+		if err != nil {
+			if offset == 0 {
+				return nil, err
+			}
+			break
+		}
+		combined.Tracks.Items = append(combined.Tracks.Items, page.Tracks.Items...)
+		combined.Episodes.Items = append(combined.Episodes.Items, page.Episodes.Items...)
+		// Both result kinds exhausted, so further pages are empty.
+		if len(page.Tracks.Items) < size && len(page.Episodes.Items) < size {
+			break
+		}
+	}
+	return combined, nil
 }
 
 // SearchTracks searches Spotify for tracks and podcast episodes, returning up
 // to limit results of each. Episodes (e.g. podcasts) are routed through their
 // spotify:episode: URI so they play correctly.
 // limit is clamped to Spotify's accepted range of 1..50.
+//
+// Apps in Development Mode cap /v1/search at devModeSearchLimit results per
+// request, so a rejected limit is retried as several smaller pages instead of
+// being reported as a blocked search.
 func (p *SpotifyProvider) SearchTracks(ctx context.Context, query string, limit int) ([]playlist.Track, error) {
 	if err := p.ensureSession(); err != nil {
 		return nil, err
@@ -586,29 +664,14 @@ func (p *SpotifyProvider) SearchTracks(ctx context.Context, query string, limit 
 		limit = 50
 	}
 
-	// No market parameter: when the request carries a user OAuth token, Spotify
-	// implicitly scopes results to the account's country.
-	q := url.Values{
-		"q":     {query},
-		"type":  {"track,episode"},
-		"limit": {fmt.Sprintf("%d", limit)},
+	// Try the whole thing in one request first: an app with Extended Quota Mode
+	// takes any limit up to 50 and needs no paging.
+	result, err := p.searchPage(ctx, query, limit, 0)
+	if err != nil && isInvalidLimit(err) && limit > devModeSearchLimit {
+		result, err = p.searchPaged(ctx, query, limit)
 	}
-
-	resp, err := p.webAPI(ctx, "GET", "/v1/search", q)
 	if err != nil {
 		return nil, friendlySearchError(err)
-	}
-
-	var result struct {
-		Tracks struct {
-			Items []*spotifyItem `json:"items"`
-		} `json:"tracks"`
-		Episodes struct {
-			Items []*spotifyItem `json:"items"`
-		} `json:"episodes"`
-	}
-	if err := decodeBody(resp, &result); err != nil {
-		return nil, fmt.Errorf("spotify: parse search: %w", err)
 	}
 
 	var tracks []playlist.Track

--- a/external/spotify/search_devmode_test.go
+++ b/external/spotify/search_devmode_test.go
@@ -1,0 +1,118 @@
+//go:build !windows
+
+package spotify
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	"golang.org/x/oauth2"
+)
+
+// devModeSpotify fakes an app in Development Mode: /v1/search rejects any limit
+// above devModeSearchLimit with the same 400 "Invalid limit" the real API
+// returns, and serves offset paging normally. It records every limit it saw.
+func devModeSpotify(t *testing.T, total int) (*SpotifyProvider, *[]int) {
+	t.Helper()
+	var limits []int
+
+	originalTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/v1/search" {
+			return nil, fmt.Errorf("unexpected Spotify API path %q", req.URL.Path)
+		}
+		q := req.URL.Query()
+		limit, _ := strconv.Atoi(q.Get("limit"))
+		offset, _ := strconv.Atoi(q.Get("offset"))
+		limits = append(limits, limit)
+
+		if limit > devModeSearchLimit {
+			return &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Status:     "400 Bad Request",
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"error":{"status":400,"message":"Invalid limit"}}`)),
+				Request:    req,
+			}, nil
+		}
+
+		items := []map[string]any{}
+		for i := offset; i < offset+limit && i < total; i++ {
+			items = append(items, map[string]any{
+				"id":   fmt.Sprintf("t%d", i),
+				"name": fmt.Sprintf("Track %d", i),
+				"type": "track",
+				"uri":  fmt.Sprintf("spotify:track:t%d", i),
+			})
+		}
+		body, _ := json.Marshal(map[string]any{
+			"tracks":   map[string]any{"items": items},
+			"episodes": map[string]any{"items": []any{}},
+		})
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(string(body))),
+			Request:    req,
+		}, nil
+	})
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	sess := &Session{tokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "token"})}
+	return New(sess, "client", 320), &limits
+}
+
+func TestSearchTracksPagesAroundDevModeLimit(t *testing.T) {
+	p, limits := devModeSpotify(t, 100)
+
+	got, err := p.SearchTracks(context.Background(), "radiohead", 25)
+	if err != nil {
+		t.Fatalf("SearchTracks() failed instead of paging around the cap: %v", err)
+	}
+	if len(got) != 25 {
+		t.Errorf("got %d tracks, want 25", len(got))
+	}
+	// One rejected attempt at 25, then pages of 10, 10 and 5.
+	want := []int{25, 10, 10, 5}
+	if fmt.Sprint(*limits) != fmt.Sprint(want) {
+		t.Errorf("requested limits = %v, want %v", *limits, want)
+	}
+}
+
+func TestSearchTracksKeepsSingleRequestWhenLimitFits(t *testing.T) {
+	p, limits := devModeSpotify(t, 100)
+
+	got, err := p.SearchTracks(context.Background(), "radiohead", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 10 {
+		t.Errorf("got %d tracks, want 10", len(got))
+	}
+	if len(*limits) != 1 {
+		t.Errorf("made %d requests, want 1: %v", len(*limits), *limits)
+	}
+}
+
+func TestSearchTracksStopsWhenResultsRunOut(t *testing.T) {
+	p, limits := devModeSpotify(t, 12) // fewer results than asked for
+
+	got, err := p.SearchTracks(context.Background(), "radiohead", 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 12 {
+		t.Errorf("got %d tracks, want 12", len(got))
+	}
+	// 50 rejected, then 10 + 2; the short second page ends the loop.
+	if len(*limits) != 3 {
+		t.Errorf("made %d requests, want 3: %v", len(*limits), *limits)
+	}
+}


### PR DESCRIPTION
Closes #205.

## What is actually wrong

`/v1/search` accepts at most **10 results per request** for an app in Development Mode. Asking for more returns `400 "Invalid limit"`, which is literally true. `SearchTracks` asks for up to 50, so every search from such an app fails.

`friendlySearchError` then reports that 400 as *"search blocked, your client_id is too new"* and advises dropping `client_id` to use the shared built-in one. That advice sends users into the shared client's global rate limit, and it is not needed: search works fine on a Development Mode app.

## Measurements

Against a Development Mode app registered in Aug 2026, using a client credentials token:

| Request | Result |
|---|---|
| `type=track&limit=10` | 200, 10 tracks |
| `type=track&limit=11` / `20` / `50` | 400 `Invalid limit` |
| no `limit` parameter | 200, default page |
| `type=track,episode&limit=10` | 200, 10 tracks + 10 episodes |
| `type=track&limit=10&offset=0/10/20/40` | 200 for every offset |
| `GET /v1/tracks/{id}` | 200 |
| `GET /v1/browse/new-releases` | 403 |

The cap is real but narrow. Offset paging past it works, and neither the `episode` type nor a missing `market` parameter plays a role. Some catalog endpoints genuinely are restricted for these apps, which is probably where the theory in #205 came from, but `/v1/search` is not one of them, and Extended Quota Mode is not required for it.

## The change

`SearchTracks` tries the requested limit first, so an app with Extended Quota Mode keeps its single request for up to 50 results. Only when Spotify rejects the limit does it fall back to pages of `devModeSearchLimit` (10) using `offset`, collecting up to the requested total. A page that fails after the first one keeps what was already collected rather than losing the whole search.

The error message now describes the cap instead of diagnosing a blocked client_id, and `docs/spotify.md` is corrected accordingly.

## Tests

Three tests in `external/spotify/search_devmode_test.go` fake an app in Development Mode (400 above the cap, normal offset paging below it) and assert:

- a request for 25 results yields 25, via limits `[25, 10, 10, 5]`
- a request for 10 stays a single request
- a search that runs out of results early stops paging and returns what exists

Full suite passes (44 packages).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Spotify searches now automatically retrieve results in batches when Development Mode limits requests to 10 results.
  * Larger searches continue across multiple pages and stop gracefully when no additional results are available.
  * Searches preserve results already found if a later request fails.

* **Bug Fixes**
  * Improved handling of Spotify’s “Invalid limit” response with clearer, actionable error messages.

* **Documentation**
  * Updated Spotify setup and troubleshooting guidance to reflect current Development Mode search limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->