### PR TITLE
feat(ipc): report live radio metadata in status

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -959,13 +959,15 @@ func (d *daemon) statusResponse() ipc.Response {
 		if cur.Stream {
 			if title := d.player.StreamTitle(); title != "" {
 				info.StreamTitle = title
-				if title != cur.Title {
-					info.Station = cur.Title
-				}
 				if a, t, ok := strings.Cut(title, " - "); ok {
-					info.Artist, info.Title = a, t
+					if t != "" {
+						info.Artist, info.Title = a, t
+					}
 				} else {
 					info.Title = title
+				}
+				if info.Title != cur.Title {
+					info.Station = cur.Title
 				}
 			}
 		}

--- a/daemon.go
+++ b/daemon.go
@@ -944,6 +944,26 @@ func (d *daemon) handleBands(m ipc.BandsRequestMsg) {
 	reply(m.Reply, ipc.Response{OK: true, Visualizer: d.vis.ModeName(), Bands: bands})
 }
 
+// applyStreamTitle folds a stream's live ICY metadata into info, mirroring the
+// TUI's resolveTrackDisplay: split "Artist - Title", fall back to the raw value,
+// and keep the entry's own title when the tag carries no song.
+func applyStreamTitle(info *ipc.TrackInfo, cur playlist.Track, streamTitle string) {
+	if !cur.Stream || streamTitle == "" {
+		return
+	}
+	info.StreamTitle = streamTitle
+	if a, t, ok := strings.Cut(streamTitle, " - "); ok {
+		if t != "" {
+			info.Artist, info.Title = a, t
+		}
+	} else {
+		info.Title = streamTitle
+	}
+	if info.Title != cur.Title {
+		info.Station = cur.Title
+	}
+}
+
 func (d *daemon) statusResponse() ipc.Response {
 	resp := ipc.Response{OK: true}
 	switch {
@@ -957,19 +977,7 @@ func (d *daemon) statusResponse() ipc.Response {
 	if cur, _ := d.playlist.Current(); cur.Path != "" {
 		info := trackInfo(cur, d.playlist.Index(), d.playlist.QueuePosition(d.playlist.Index()))
 		if cur.Stream {
-			if title := d.player.StreamTitle(); title != "" {
-				info.StreamTitle = title
-				if a, t, ok := strings.Cut(title, " - "); ok {
-					if t != "" {
-						info.Artist, info.Title = a, t
-					}
-				} else {
-					info.Title = title
-				}
-				if info.Title != cur.Title {
-					info.Station = cur.Title
-				}
-			}
+			applyStreamTitle(&info, cur, d.player.StreamTitle())
 		}
 		resp.Track = &info
 	}

--- a/daemon.go
+++ b/daemon.go
@@ -956,6 +956,19 @@ func (d *daemon) statusResponse() ipc.Response {
 	}
 	if cur, _ := d.playlist.Current(); cur.Path != "" {
 		info := trackInfo(cur, d.playlist.Index(), d.playlist.QueuePosition(d.playlist.Index()))
+		if cur.Stream {
+			if title := d.player.StreamTitle(); title != "" {
+				info.StreamTitle = title
+				if title != cur.Title {
+					info.Station = cur.Title
+				}
+				if a, t, ok := strings.Cut(title, " - "); ok {
+					info.Artist, info.Title = a, t
+				} else {
+					info.Title = title
+				}
+			}
+		}
 		resp.Track = &info
 	}
 	pos, dur := d.player.PositionAndDuration()

--- a/daemon_stream_title_test.go
+++ b/daemon_stream_title_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/bjarneo/cliamp/ipc"
+	"github.com/bjarneo/cliamp/playlist"
+)
+
+// TestDaemonStreamTitleFields pins the daemon's IPC contract against the TUI's:
+// same split, same fallbacks, same Station derivation. statusResponse itself
+// needs a live *player.Player, so it calls the extracted helper directly.
+func TestDaemonStreamTitleFields(t *testing.T) {
+	tests := []struct {
+		name        string
+		streamTitle string
+		track       playlist.Track
+		wantTitle   string
+		wantArtist  string
+		wantStation string
+		wantStream  string
+	}{
+		{
+			name:        "artist and title split on separator",
+			streamTitle: "Tycho - Awake",
+			track:       playlist.Track{Title: "NCS Trap Stream", Stream: true},
+			wantTitle:   "Awake",
+			wantArtist:  "Tycho",
+			wantStation: "NCS Trap Stream",
+			wantStream:  "Tycho - Awake",
+		},
+		{
+			name:        "empty title after the separator keeps the station",
+			streamTitle: "Tycho - ",
+			track:       playlist.Track{Title: "Lofi Stream", Stream: true},
+			wantTitle:   "Lofi Stream",
+			wantStream:  "Tycho - ",
+		},
+		{
+			name:        "title-only metadata becomes the title",
+			streamTitle: "Morning Session",
+			track:       playlist.Track{Title: "Lofi Stream", Stream: true},
+			wantTitle:   "Morning Session",
+			wantStation: "Lofi Stream",
+			wantStream:  "Morning Session",
+		},
+		{
+			name:      "no metadata leaves the entry untouched",
+			track:     playlist.Track{Title: "Lofi Stream", Stream: true},
+			wantTitle: "Lofi Stream",
+		},
+		{
+			name:        "non-stream track is never rewritten",
+			streamTitle: "Tycho - Awake",
+			track:       playlist.Track{Title: "Alien Boy", Artist: "Oliver Tree"},
+			wantTitle:   "Alien Boy",
+			wantArtist:  "Oliver Tree",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			info := ipc.TrackInfo{Title: tc.track.Title, Artist: tc.track.Artist}
+			applyStreamTitle(&info, tc.track, tc.streamTitle)
+
+			for _, f := range []struct{ field, got, want string }{
+				{"Title", info.Title, tc.wantTitle},
+				{"Artist", info.Artist, tc.wantArtist},
+				{"Station", info.Station, tc.wantStation},
+				{"StreamTitle", info.StreamTitle, tc.wantStream},
+			} {
+				if f.got != f.want {
+					t.Errorf("%s = %q, want %q", f.field, f.got, f.want)
+				}
+			}
+		})
+	}
+}

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -89,6 +89,25 @@ click-left = cliamp toggle
 click-right = cliamp next
 ```
 
+#### Radio stream metadata
+
+A radio station's playlist entry only knows the station name. While a stream is
+playing, `.track` instead reports the now-playing metadata the station itself
+broadcasts inline — the ICY metadata of the SHOUTcast/Icecast protocol:
+
+| Field | Description |
+|-------|-------------|
+| `title` | Current song, from the ICY tag (the station name before any arrives) |
+| `artist` | Current artist, when the ICY tag uses `"Artist - Title"` |
+| `station` | The station's own name, present only once a song replaces `title` |
+| `stream_title` | The raw, unsplit ICY value |
+
+So a status bar can show the station and the song together:
+
+```sh
+cliamp status --json | jq -r '.track | if .station then "\(.station): \(.artist) - \(.title)" else .title end'
+```
+
 ### Hotkeys (window manager / sxhkd / Hyprland)
 
 Bind your media keys directly to IPC subcommands.

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -105,7 +105,7 @@ broadcasts inline — the ICY metadata of the SHOUTcast/Icecast protocol:
 So a status bar can show the station and the song together:
 
 ```sh
-cliamp status --json | jq -r '.track | if .station then "\(.station): \(.artist) - \(.title)" else .title end'
+cliamp status --json | jq -r '.track | if .station then (if .artist then "\(.station): \(.artist) - \(.title)" else "\(.station): \(.title)" end) else .title end'
 ```
 
 ### Hotkeys (window manager / sxhkd / Hyprland)

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -105,7 +105,7 @@ broadcasts inline — the ICY metadata of the SHOUTcast/Icecast protocol:
 So a status bar can show the station and the song together:
 
 ```sh
-cliamp status --json | jq -r '.track | if .station then (if .artist then "\(.station): \(.artist) - \(.title)" else "\(.station): \(.title)" end) else .title end'
+cliamp status --json | jq -r '(.track // {}) | if .station then (if .artist then "\(.station): \(.artist) - \(.title)" else "\(.station): \(.title)" end) else (.title // "") end'
 ```
 
 ### Hotkeys (window manager / sxhkd / Hyprland)

--- a/ipc/protocol.go
+++ b/ipc/protocol.go
@@ -101,6 +101,8 @@ type TrackInfo struct {
 	Index         int    `json:"index,omitempty"`
 	QueuePosition int    `json:"queue_position,omitempty"`
 	Stream        bool   `json:"stream,omitempty"`
+	StreamTitle   string `json:"stream_title,omitempty"`
+	Station       string `json:"station,omitempty"`
 	Realtime      bool   `json:"realtime,omitempty"`
 	Bookmark      bool   `json:"bookmark,omitempty"`
 	Unplayable    bool   `json:"unplayable,omitempty"`

--- a/ui/model/notifications.go
+++ b/ui/model/notifications.go
@@ -51,7 +51,9 @@ func (m *Model) resolveTrackDisplay(track playlist.Track) (artist, title string)
 	artist, title = track.Artist, track.Title
 	if m.streamTitle != "" && track.Stream {
 		if a, t, ok := strings.Cut(m.streamTitle, " - "); ok {
-			artist, title = a, t
+			if t != "" {
+				artist, title = a, t
+			}
 		} else {
 			title = m.streamTitle
 		}

--- a/ui/model/stream_title_test.go
+++ b/ui/model/stream_title_test.go
@@ -32,6 +32,14 @@ func TestResolveTrackDisplayStreamTitle(t *testing.T) {
 			wantTitle:   "Morning Session",
 		},
 		{
+			// "Artist - " cuts to an empty title; keep the stored one rather than
+			// blanking it. The daemon guards the same case.
+			name:        "icy value with an empty title keeps the station name",
+			streamTitle: "Tycho - ",
+			track:       playlist.Track{Title: "Lofi Stream", Stream: true},
+			wantTitle:   "Lofi Stream",
+		},
+		{
 			name:      "no icy metadata keeps the station name",
 			track:     playlist.Track{Title: "Lofi Stream", Stream: true},
 			wantTitle: "Lofi Stream",

--- a/ui/model/stream_title_test.go
+++ b/ui/model/stream_title_test.go
@@ -1,0 +1,125 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/bjarneo/cliamp/playlist"
+)
+
+// TestResolveTrackDisplayStreamTitle covers the ICY override a radio stream
+// needs: its playlist entry only knows the station name. Audiobookshelf tracks
+// are also Stream: true, so the no-metadata case matters for them too --
+// streamTitle is cleared on every track change, and their own title must stand.
+func TestResolveTrackDisplayStreamTitle(t *testing.T) {
+	tests := []struct {
+		name        string
+		streamTitle string
+		track       playlist.Track
+		wantArtist  string
+		wantTitle   string
+	}{
+		{
+			name:        "icy artist and title split on separator",
+			streamTitle: "Tycho - Awake",
+			track:       playlist.Track{Title: "NCS Trap Stream", Stream: true},
+			wantArtist:  "Tycho",
+			wantTitle:   "Awake",
+		},
+		{
+			name:        "icy value without separator becomes the title",
+			streamTitle: "Morning Session",
+			track:       playlist.Track{Title: "Lofi Stream", Stream: true},
+			wantTitle:   "Morning Session",
+		},
+		{
+			name:      "no icy metadata keeps the station name",
+			track:     playlist.Track{Title: "Lofi Stream", Stream: true},
+			wantTitle: "Lofi Stream",
+		},
+		{
+			// Library providers (Navidrome, Plex, Jellyfin, Emby, Qobuz, NetEase,
+			// Audiobookshelf) are Stream: true too, so they take the same branch
+			// as radio and must keep their own title and author.
+			name: "audiobook stream without icy keeps its own metadata",
+			track: playlist.Track{
+				Title:  "Tortilla Face",
+				Artist: "Bobby Lee & Andrew Santino",
+				Album:  "Bad Friends",
+				Stream: true,
+			},
+			wantArtist: "Bobby Lee & Andrew Santino",
+			wantTitle:  "Tortilla Face",
+		},
+		{
+			// A stale ICY title must never bleed onto a non-stream track.
+			name:        "spotify track ignores a leftover stream title",
+			streamTitle: "Tycho - Awake",
+			track:       playlist.Track{Title: "Alien Boy", Artist: "Oliver Tree"},
+			wantArtist:  "Oliver Tree",
+			wantTitle:   "Alien Boy",
+		},
+		{
+			// " - " in a real track title is not an ICY separator to split on.
+			name:       "spotify remix title keeps its separator",
+			track:      playlist.Track{Title: "Counting - Taiki Nulight Remix", Artist: "Hamdi"},
+			wantArtist: "Hamdi",
+			wantTitle:  "Counting - Taiki Nulight Remix",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := Model{streamTitle: tc.streamTitle}
+			artist, title := m.resolveTrackDisplay(tc.track)
+			if artist != tc.wantArtist || title != tc.wantTitle {
+				t.Errorf("resolveTrackDisplay() = (%q, %q), want (%q, %q)",
+					artist, title, tc.wantArtist, tc.wantTitle)
+			}
+		})
+	}
+}
+
+// TestIPCTrackInfoKeepsAlbum pins the show/book name a podcast or audiobook
+// carries in Album: the stream branch rewrites Title and Artist, so Album has to
+// come through ipcTrackInfo untouched for a client to render "Bad Friends".
+func TestIPCTrackInfoKeepsAlbum(t *testing.T) {
+	tests := []struct {
+		name  string
+		track playlist.Track
+	}{
+		{
+			name: "audiobook keeps the show name",
+			track: playlist.Track{
+				Title:  "Tortilla Face",
+				Artist: "Bobby Lee & Andrew Santino",
+				Album:  "Bad Friends",
+				Path:   "http://abs.example/api/items/x/file/y",
+				Stream: true,
+			},
+		},
+		{
+			name: "spotify keeps the album",
+			track: playlist.Track{
+				Title:  "Alien Boy",
+				Artist: "Oliver Tree",
+				Album:  "Ugly is Beautiful",
+				Path:   "spotify:track:abc123",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			info := ipcTrackInfo(tc.track, 0, 0)
+			for _, f := range []struct{ field, got, want string }{
+				{"Title", info.Title, tc.track.Title},
+				{"Artist", info.Artist, tc.track.Artist},
+				{"Album", info.Album, tc.track.Album},
+			} {
+				if f.got != f.want {
+					t.Errorf("%s = %q, want %q", f.field, f.got, f.want)
+				}
+			}
+		})
+	}
+}

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -1151,6 +1151,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if cur, _ := m.currentPlaybackTrack(); cur.Path != "" {
 			info := ipcTrackInfo(cur, m.playlist.Index(), m.playlist.QueuePosition(m.playlist.Index()))
+			if artist, title := m.resolveTrackDisplay(cur); title != "" {
+				if cur.Stream && title != cur.Title {
+					info.Station = cur.Title
+				}
+				info.Artist, info.Title = artist, title
+			}
+			if cur.Stream {
+				info.StreamTitle = m.streamTitle
+			}
 			resp.Track = &info
 		}
 		resp.Position = m.player.Position().Seconds()


### PR DESCRIPTION
## Summary

For a radio stream, `cliamp status` reported only the station name and no artist, while the TUI displayed the actual song playing. Stations broadcast their now-playing text inline in the audio stream as ICY metadata (the `StreamTitle` field of the SHOUTcast/Icecast protocol), and the UI already polls it — but it never reached the IPC response, because the status handlers build `Track` straight from the playlist entry, and a stream's entry only knows the station name. Any client on the IPC socket (status bars, Waybar, scripts) had no way to show what was playing.

This applies the UI's own resolution (`resolveTrackDisplay`) in both status handlers and adds two `TrackInfo` fields:

- `stream_title` — the raw `StreamTitle` value, unsplit, for clients that would rather parse it themselves
- `station` — the playlist entry's own name, kept because `title`/`artist` get overwritten by the live values, so a client can show station **and** song

`cliamp status`, before and after, on the same station:

    State: playing              State: playing
    Track: NCS Trap Stream      Track: Folded live
    Artist:                     Artist: Ketsa

The same fields in `status --json`, after:

    $ cliamp status --json | jq .track
    {
      "title": "Folded live",
      "artist": "Ketsa",
      "station": "Lofi Stream",
      "stream_title": "Ketsa - Folded live",
      "stream": true
    }

Resolution happens at the status handlers rather than inside `ipcTrackInfo`/`trackInfo`, since only the now-playing track has stream context — search results and queue listings share those helpers and must keep their stored titles. Both the TUI (`ui/model/update.go`) and the headless daemon (`daemon.go`) had the same gap, so both are fixed.

Existing fields are unchanged and the new ones are `omitempty`, so this is additive for existing clients.

### Providers marked `Stream: true`

Radio is not the only source flagged as a stream. Navidrome, Plex, Jellyfin, Emby, Qobuz, NetEase, and Audiobookshelf all set `Stream: true`, so they take the same branch. They are unaffected: `m.streamTitle` is cleared on every track change (`ui/model/playback.go`) and the override requires a non-empty value, so their own title, artist, and album come through untouched. A test pins that.

Local files, Spotify, SoundCloud, and YouTube Music do not set the flag and never enter the branch at all.

## How to test

1. Play a radio station with ICY metadata, e.g. `cliamp http://radio.cliamp.stream/lofi/stream`, and let it connect.
2. From another shell, run `cliamp status`. Confirm `Track:` is the live song and `Artist:` is populated, where before both showed the station name and nothing.
3. Run `cliamp status --json | jq .track` and confirm `station` is the station name and `stream_title` is the raw `"Artist - Title"` value the station broadcast.
4. Before the station sends any metadata, confirm `title` is still the station name and `station`/`stream_title` are absent.
5. Play something from any `Stream: true` library provider you have set up and confirm its own title, artist, and album are reported with no `station` or `stream_title`. Verified here against Audiobookshelf; Navidrome, Plex, Jellyfin, Emby, Qobuz, and NetEase set the same flag and take the same path, but were not exercised directly.
6. Play a local file or a Spotify track and confirm the output is unchanged.
7. Repeat step 3 against `cliamp --daemon` to cover the headless path.
8. Run the `jq` one-liner from the new "Radio stream metadata" section in `docs/headless.md` and confirm it prints `Station: Artist - Title` while a stream is playing, and just the title otherwise.

## Checklist

- [x] `make check` passes
- [x] `docs/` and `site/index.html` updated for user-facing changes

`docs/headless.md` gains a "Radio stream metadata" subsection under the status-bar examples, documenting `title`/`artist`/`station`/`stream_title` for a stream plus a `jq` one-liner that renders station and song together. `site/index.html` needs no change — it does not describe the `status --json` fields.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Status responses now include live stream titles, station names, and parsed artist/title information when available.
  * Streaming metadata is available in JSON output for easier integration and display.
  * Existing album, artist, and title details are preserved for non-streaming content.
  * Empty or unavailable stream metadata no longer replaces existing track information.
  * Stream title parsing supports station and song details while avoiding stale metadata.

* **Documentation**
  * Added guidance and examples for viewing radio stream metadata in JSON status output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->