### PR TITLE
feat(plex): browse server playlists alongside albums

### DIFF
--- a/docs/plex.md
+++ b/docs/plex.md
@@ -44,7 +44,7 @@ Once configured, **Plex** appears as a provider in the cliamp TUI alongside Radi
 
 The provider exposes your server's audio playlists and your music library, grouped under two headers:
 
-```
+```text
 ── Playlists ──
 GOOD
 All Music

--- a/docs/plex.md
+++ b/docs/plex.md
@@ -42,13 +42,19 @@ If you access Plex remotely via `app.plex.tv`, you can still use a direct server
 
 Once configured, **Plex** appears as a provider in the cliamp TUI alongside Radio, Navidrome, Spotify, etc.
 
-The provider exposes your music library as a flat list of albums, labelled:
+The provider exposes your server's audio playlists and your music library, grouped under two headers:
 
 ```
+── Playlists ──
+GOOD
+All Music
+drums
+
+── Albums ──
 Artist - Album Title (Year)
 ```
 
-Select an album to load its tracks, then play as normal.
+Select a playlist or album to load its tracks, then play as normal. Smart playlists are included and resolve to their current contents, so they always reflect the server.
 
 To start cliamp with Plex as the default provider:
 
@@ -64,7 +70,7 @@ provider = "plex"
 
 ## How it works
 
-cliamp calls the Plex HTTP API to enumerate your music libraries and albums. When you select an album, it fetches the track list and constructs authenticated streaming URLs of the form:
+cliamp calls the Plex HTTP API to enumerate your server's audio playlists (`/playlists`) and music library albums. When you select an entry, it fetches the track list (from the playlists items endpoint or the album children endpoint) and constructs authenticated streaming URLs of the form:
 
 ```
 http://<server>:32400/library/parts/<partID>/<timestamp>/file.<ext>?X-Plex-Token=<token>
@@ -86,4 +92,3 @@ Fix: open **System Settings > Privacy & Security > Local Network** and enable ac
 - **No playlist write-back**: cliamp cannot create or modify Plex playlists
 - **Token is long-lived**: store it carefully; it grants full access to your Plex account
 - **Album list is flat**: no artist drill-down; search by scrolling or using cliamp's search
-- **No Plex playlists**: only library albums are exposed (Plex user-created playlists are not yet surfaced)

--- a/external/plex/client.go
+++ b/external/plex/client.go
@@ -231,7 +231,7 @@ func (c *Client) Playlists() ([]Playlist, error) {
 		} `json:"MediaContainer"`
 	}
 	if err := c.get("/playlists", nil, &result); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("plex: list playlists: %w", err)
 	}
 
 	var playlists []Playlist
@@ -274,7 +274,7 @@ func (c *Client) PlaylistTracks(playlistRatingKey string) ([]Track, error) {
 		}
 		var page trackPage
 		if err := c.get("/playlists/"+playlistRatingKey+"/items", params, &page); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("plex: playlist %s items: %w", playlistRatingKey, err)
 		}
 		for _, m := range page.MediaContainer.Metadata {
 			tracks = append(tracks, trackFromJSON(m))

--- a/external/plex/client.go
+++ b/external/plex/client.go
@@ -62,6 +62,15 @@ type Track struct {
 	PartKey     string // relative path, e.g. "/library/parts/67890/1234567890/file.flac"
 }
 
+// Playlist represents a Plex playlist (smart or user-created) of audio tracks.
+type Playlist struct {
+	RatingKey    string
+	Title        string
+	TrackCount   int // leafCount
+	DurationSecs int // duration, converted from milliseconds
+	Smart        bool
+}
+
 // get issues an authenticated GET request and decodes the JSON response into result.
 func (c *Client) get(path string, params url.Values, result any) error {
 	if params == nil {
@@ -202,6 +211,79 @@ func (c *Client) Albums(sectionKey string) ([]Album, error) {
 		}
 	}
 	return albums, nil
+}
+
+// Playlists returns all audio playlists on the server. Smart playlists and
+// user-created playlists are both included; non-audio playlists (video, photo)
+// are filtered out. The Plex JSON API returns playlist entries under
+// MediaContainer.Metadata, each carrying a "type" of "playlist".
+func (c *Client) Playlists() ([]Playlist, error) {
+	var result struct {
+		MediaContainer struct {
+			Metadata []struct {
+				RatingKey    string `json:"ratingKey"`
+				Title        string `json:"title"`
+				Smart        bool   `json:"smart"`
+				PlaylistType string `json:"playlistType"`
+				LeafCount    int    `json:"leafCount"`
+				Duration     int    `json:"duration"`
+			} `json:"Metadata"`
+		} `json:"MediaContainer"`
+	}
+	if err := c.get("/playlists", nil, &result); err != nil {
+		return nil, err
+	}
+
+	var playlists []Playlist
+	for _, m := range result.MediaContainer.Metadata {
+		if m.PlaylistType != "audio" {
+			continue
+		}
+		playlists = append(playlists, Playlist{
+			RatingKey:    m.RatingKey,
+			Title:        m.Title,
+			TrackCount:   m.LeafCount,
+			DurationSecs: m.Duration / 1000,
+			Smart:        m.Smart,
+		})
+	}
+	return playlists, nil
+}
+
+// playlistPageSize is the number of playlist items requested per API call.
+// Playlists can contain tens of thousands of tracks, so a larger page keeps
+// the request count low while staying well under the 10 MB response cap.
+const playlistPageSize = 1000
+
+// PlaylistTracks returns all tracks in the given playlist (identified by its
+// ratingKey). Playlist items share the track JSON shape, so trackFromJSON is
+// reused. Results are paginated with X-Plex-Container-Start / Size.
+func (c *Client) PlaylistTracks(playlistRatingKey string) ([]Track, error) {
+	type trackPage struct {
+		MediaContainer struct {
+			TotalSize int         `json:"totalSize"`
+			Metadata  []trackJSON `json:"Metadata"`
+		} `json:"MediaContainer"`
+	}
+
+	var tracks []Track
+	for offset := 0; ; offset += playlistPageSize {
+		params := url.Values{
+			"X-Plex-Container-Start": {fmt.Sprintf("%d", offset)},
+			"X-Plex-Container-Size":  {fmt.Sprintf("%d", playlistPageSize)},
+		}
+		var page trackPage
+		if err := c.get("/playlists/"+playlistRatingKey+"/items", params, &page); err != nil {
+			return nil, err
+		}
+		for _, m := range page.MediaContainer.Metadata {
+			tracks = append(tracks, trackFromJSON(m))
+		}
+		if offset+playlistPageSize >= page.MediaContainer.TotalSize {
+			break
+		}
+	}
+	return tracks, nil
 }
 
 // Tracks returns all tracks in the given album (identified by its ratingKey).

--- a/external/plex/client_test.go
+++ b/external/plex/client_test.go
@@ -239,6 +239,84 @@ func TestAlbums_Paginates(t *testing.T) {
 	}
 }
 
+func TestPlaylists_FiltersAudio(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/playlists") {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{
+			"MediaContainer": {
+				"Metadata": [
+					{"ratingKey":"1","title":"GOOD","smart":true,"playlistType":"audio","leafCount":3,"duration":600000},
+					{"ratingKey":"2","title":"drums","smart":false,"playlistType":"audio","leafCount":28,"duration":6000000},
+					{"ratingKey":"3","title":"Home Movies","smart":false,"playlistType":"video","leafCount":4,"duration":12000000}
+				]
+			}
+		}`))
+	}))
+	defer srv.Close()
+
+	playlists, err := newTestClient(srv).Playlists()
+	if err != nil {
+		t.Fatalf("Playlists() error: %v", err)
+	}
+	if len(playlists) != 2 {
+		t.Fatalf("expected 2 audio playlists, got %d", len(playlists))
+	}
+	a := playlists[0]
+	if a.RatingKey != "1" || a.Title != "GOOD" || !a.Smart || a.TrackCount != 3 || a.DurationSecs != 600 {
+		t.Errorf("unexpected playlist[0]: %+v", a)
+	}
+	b := playlists[1]
+	if b.RatingKey != "2" || b.Title != "drums" || b.Smart || b.TrackCount != 28 || b.DurationSecs != 6000 {
+		t.Errorf("unexpected playlist[1]: %+v", b)
+	}
+}
+
+func TestPlaylistTracks_Paginates(t *testing.T) {
+	seenStarts := map[string]bool{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/playlists/42/items") {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		start := r.URL.Query().Get("X-Plex-Container-Start")
+		size := r.URL.Query().Get("X-Plex-Container-Size")
+		if size != "1000" {
+			t.Errorf("expected size=1000, got %q", size)
+		}
+		seenStarts[start] = true
+		w.Header().Set("Content-Type", "application/json")
+		switch start {
+		case "0", "":
+			w.Write([]byte(`{"MediaContainer":{"totalSize":1001,"Metadata":[{"ratingKey":"1","title":"One","grandparentTitle":"A","parentTitle":"Al","index":1,"duration":1000,"Media":[{"Part":[{"key":"/library/parts/1/1/one.flac"}]}]}]}}`))
+		case "1000":
+			w.Write([]byte(`{"MediaContainer":{"totalSize":1001,"Metadata":[{"ratingKey":"2","title":"Two","grandparentTitle":"B","parentTitle":"Alb","index":2,"duration":2000,"Media":[{"Part":[{"key":"/library/parts/2/2/two.flac"}]}]}]}}`))
+		default:
+			t.Errorf("unexpected start %q", start)
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer srv.Close()
+
+	tracks, err := newTestClient(srv).PlaylistTracks("42")
+	if err != nil {
+		t.Fatalf("PlaylistTracks() error: %v", err)
+	}
+	if len(tracks) != 2 {
+		t.Fatalf("expected 2 tracks, got %d", len(tracks))
+	}
+	if tracks[0].Title != "One" || tracks[0].PartKey != "/library/parts/1/1/one.flac" {
+		t.Errorf("unexpected tracks[0]: %+v", tracks[0])
+	}
+	if tracks[1].Title != "Two" || tracks[1].ArtistName != "B" || tracks[1].Duration != 2000 {
+		t.Errorf("unexpected tracks[1]: %+v", tracks[1])
+	}
+	if !seenStarts["0"] || !seenStarts["1000"] {
+		t.Errorf("expected pagination to hit starts 0 and 1000, got %v", seenStarts)
+	}
+}
+
 func TestTracks_MapsAllFields(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.HasSuffix(r.URL.Path, "/library/metadata/456/children") {

--- a/external/plex/provider.go
+++ b/external/plex/provider.go
@@ -4,11 +4,21 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 	"sync"
 
 	"github.com/bjarneo/cliamp/config"
 	"github.com/bjarneo/cliamp/playlist"
 	"github.com/bjarneo/cliamp/provider"
+)
+
+// ID prefixes and section labels used to group Plex playlists and albums in
+// the browse view. Playlist IDs are prefixed so they can be told apart from
+// album ratingKeys (both live in the same server-side metadata key space).
+const (
+	prefixPlaylist   = "pl:"
+	sectionAlbums    = "Albums"
+	sectionPlaylists = "Playlists"
 )
 
 // Compile-time interface checks.
@@ -18,8 +28,10 @@ var (
 )
 
 // Provider implements playlist.Provider for a Plex Media Server.
-// Playlists() returns all albums across all music library sections.
-// Tracks() returns the tracks for a given album ratingKey.
+// Playlists() returns server audio playlists (Section "Playlists") followed
+// by albums from all music library sections (Section "Albums").
+// Tracks() returns the tracks for a playlist or album ratingKey; playlist IDs
+// are distinguished by the "pl:" prefix.
 type Provider struct {
 	client        *Client
 	mu            sync.Mutex
@@ -43,9 +55,10 @@ func NewFromConfig(cfg config.PlexConfig) *Provider {
 // Name returns the display name used in the provider selector.
 func (p *Provider) Name() string { return "Plex" }
 
-// Playlists returns all albums across all Plex music library sections.
-// Each album is a PlaylistInfo whose ID is the album's Plex ratingKey.
-// Results are cached after the first successful call.
+// Playlists returns the server's audio playlists first, then all albums
+// across all Plex music library sections, each tagged with its section so the
+// browse view renders them under headers. Results are cached after the first
+// successful call.
 func (p *Provider) Playlists() ([]playlist.PlaylistInfo, error) {
 	p.mu.Lock()
 	if p.playlistCache != nil {
@@ -55,15 +68,26 @@ func (p *Provider) Playlists() ([]playlist.PlaylistInfo, error) {
 	}
 	p.mu.Unlock()
 
+	var lists []playlist.PlaylistInfo
+
+	serverPlaylists, err := p.client.Playlists()
+	if err != nil {
+		return nil, err
+	}
+	for _, pl := range serverPlaylists {
+		lists = append(lists, playlist.PlaylistInfo{
+			ID:           prefixPlaylist + pl.RatingKey,
+			Name:         pl.Title,
+			TrackCount:   pl.TrackCount,
+			DurationSecs: pl.DurationSecs,
+			Section:      sectionPlaylists,
+		})
+	}
+
 	sections, err := p.client.MusicSections()
 	if err != nil {
 		return nil, err
 	}
-	if len(sections) == 0 {
-		return nil, fmt.Errorf("plex: no matching music libraries found on this server")
-	}
-
-	var lists []playlist.PlaylistInfo
 	for _, sec := range sections {
 		albums, err := p.client.Albums(sec.Key)
 		if err != nil {
@@ -78,8 +102,13 @@ func (p *Provider) Playlists() ([]playlist.PlaylistInfo, error) {
 				ID:         a.RatingKey,
 				Name:       name,
 				TrackCount: a.TrackCount,
+				Section:    sectionAlbums,
 			})
 		}
+	}
+
+	if len(lists) == 0 {
+		return nil, fmt.Errorf("plex: no matching music libraries or audio playlists found on this server")
 	}
 
 	p.mu.Lock()
@@ -98,21 +127,31 @@ func (p *Provider) Refresh() {
 	p.mu.Unlock()
 }
 
-// Tracks returns the tracks for the album identified by albumRatingKey.
-// Each track's Path is a complete authenticated HTTP URL ready for the player.
-// Tracks with no streamable part (missing Media/Part data) are silently skipped.
-// Results are cached per albumRatingKey.
-func (p *Provider) Tracks(albumRatingKey string) ([]playlist.Track, error) {
+// Tracks returns the tracks for the playlist or album identified by
+// playlistID. Playlist IDs (prefixed "pl:") load via the server playlists
+// endpoint; album IDs load via the album children endpoint. Each track's Path
+// is a complete authenticated HTTP URL ready for the player. Tracks with no
+// streamable part (missing Media/Part data) are silently skipped. Results are
+// cached per playlistID.
+func (p *Provider) Tracks(playlistID string) ([]playlist.Track, error) {
 	p.mu.Lock()
 	if p.trackCache != nil {
-		if cached, ok := p.trackCache[albumRatingKey]; ok {
+		if cached, ok := p.trackCache[playlistID]; ok {
 			p.mu.Unlock()
 			return slices.Clone(cached), nil
 		}
 	}
 	p.mu.Unlock()
 
-	plexTracks, err := p.client.Tracks(albumRatingKey)
+	var (
+		plexTracks []Track
+		err        error
+	)
+	if strings.HasPrefix(playlistID, prefixPlaylist) {
+		plexTracks, err = p.client.PlaylistTracks(strings.TrimPrefix(playlistID, prefixPlaylist))
+	} else {
+		plexTracks, err = p.client.Tracks(playlistID)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +162,7 @@ func (p *Provider) Tracks(albumRatingKey string) ([]playlist.Track, error) {
 	if p.trackCache == nil {
 		p.trackCache = make(map[string][]playlist.Track)
 	}
-	p.trackCache[albumRatingKey] = tracks
+	p.trackCache[playlistID] = tracks
 	p.mu.Unlock()
 
 	return slices.Clone(tracks), nil

--- a/external/plex/provider.go
+++ b/external/plex/provider.go
@@ -72,7 +72,7 @@ func (p *Provider) Playlists() ([]playlist.PlaylistInfo, error) {
 
 	serverPlaylists, err := p.client.Playlists()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("plex: list playlists: %w", err)
 	}
 	for _, pl := range serverPlaylists {
 		lists = append(lists, playlist.PlaylistInfo{
@@ -131,11 +131,14 @@ func (p *Provider) Refresh() {
 // playlistID. Playlist IDs (prefixed "pl:") load via the server playlists
 // endpoint; album IDs load via the album children endpoint. Each track's Path
 // is a complete authenticated HTTP URL ready for the player. Tracks with no
-// streamable part (missing Media/Part data) are silently skipped. Results are
-// cached per playlistID.
+// streamable part (missing Media/Part data) are silently skipped. Album tracks
+// are cached per album ID; playlist tracks are intentionally not cached so
+// smart playlists always reflect their current server contents.
 func (p *Provider) Tracks(playlistID string) ([]playlist.Track, error) {
+	isPlaylist := strings.HasPrefix(playlistID, prefixPlaylist)
+
 	p.mu.Lock()
-	if p.trackCache != nil {
+	if !isPlaylist && p.trackCache != nil {
 		if cached, ok := p.trackCache[playlistID]; ok {
 			p.mu.Unlock()
 			return slices.Clone(cached), nil
@@ -147,7 +150,7 @@ func (p *Provider) Tracks(playlistID string) ([]playlist.Track, error) {
 		plexTracks []Track
 		err        error
 	)
-	if strings.HasPrefix(playlistID, prefixPlaylist) {
+	if isPlaylist {
 		plexTracks, err = p.client.PlaylistTracks(strings.TrimPrefix(playlistID, prefixPlaylist))
 	} else {
 		plexTracks, err = p.client.Tracks(playlistID)
@@ -158,12 +161,14 @@ func (p *Provider) Tracks(playlistID string) ([]playlist.Track, error) {
 
 	tracks := p.convertTracks(plexTracks, 0)
 
-	p.mu.Lock()
-	if p.trackCache == nil {
-		p.trackCache = make(map[string][]playlist.Track)
+	if !isPlaylist {
+		p.mu.Lock()
+		if p.trackCache == nil {
+			p.trackCache = make(map[string][]playlist.Track)
+		}
+		p.trackCache[playlistID] = tracks
+		p.mu.Unlock()
 	}
-	p.trackCache[playlistID] = tracks
-	p.mu.Unlock()
 
 	return slices.Clone(tracks), nil
 }

--- a/external/plex/provider_test.go
+++ b/external/plex/provider_test.go
@@ -268,6 +268,33 @@ func TestProvider_Tracks_Playlist(t *testing.T) {
 	}
 }
 
+func TestProvider_Tracks_Playlist_NotCached(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/playlists/24872/items"):
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"MediaContainer":{"totalSize":1,"Metadata":[{"ratingKey":"300","title":"Highway to Hell","grandparentTitle":"AC/DC","parentTitle":"Highway to Hell","index":1,"duration":208000,"Media":[{"Part":[{"key":"/library/parts/3/333/HighwayToHell.flac"}]}]}]}}`))
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	p := newProvider(NewClient(srv.URL, "tok"))
+	if _, err := p.Tracks("pl:24872"); err != nil {
+		t.Fatalf("first Tracks() error: %v", err)
+	}
+	if _, err := p.Tracks("pl:24872"); err != nil {
+		t.Fatalf("second Tracks() error: %v", err)
+	}
+	if callCount != 2 {
+		t.Errorf("expected playlist items endpoint called twice (smart playlists not cached), got %d", callCount)
+	}
+}
+
 func TestProvider_Tracks_SkipsMissingPart(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/external/plex/provider_test.go
+++ b/external/plex/provider_test.go
@@ -9,11 +9,34 @@ import (
 	"github.com/bjarneo/cliamp/config"
 )
 
-// sectionsHandler returns a handler that serves a single music section.
+// sectionsHandler returns a handler that serves a single music section
+// plus one audio playlist (and one video playlist that must be filtered out).
 func sectionsHandler(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
+		case strings.HasSuffix(r.URL.Path, "/playlists/24872/items"):
+			w.Write([]byte(`{
+				"MediaContainer": {
+					"totalSize": 1,
+					"Metadata": [
+						{
+							"ratingKey":"300","title":"Highway to Hell","grandparentTitle":"AC/DC",
+							"parentTitle":"Highway to Hell","year":1979,"index":1,"duration":208000,
+							"Media":[{"Part":[{"key":"/library/parts/3/333/HighwayToHell.flac"}]}]
+						}
+					]
+				}
+			}`))
+		case strings.HasSuffix(r.URL.Path, "/playlists"):
+			w.Write([]byte(`{
+				"MediaContainer": {
+					"Metadata": [
+						{"ratingKey":"24872","title":"GOOD","smart":true,"playlistType":"audio","leafCount":3,"duration":600000},
+						{"ratingKey":"9001","title":"Movies","smart":false,"playlistType":"video","leafCount":5,"duration":9000000}
+					]
+				}
+			}`))
 		case strings.HasSuffix(r.URL.Path, "/library/sections"):
 			w.Write([]byte(`{"MediaContainer":{"Directory":[{"key":"3","type":"artist","title":"Music"}]}}`))
 		case strings.HasSuffix(r.URL.Path, "/library/sections/3/all"):
@@ -73,25 +96,45 @@ func TestProvider_Playlists(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Playlists() error: %v", err)
 	}
-	if len(lists) != 2 {
-		t.Fatalf("expected 2 playlists, got %d", len(lists))
+	if len(lists) != 3 {
+		t.Fatalf("expected 3 entries (1 playlist + 2 albums), got %d", len(lists))
 	}
 
-	// Check first album entry
-	if lists[0].ID != "100" {
-		t.Errorf("lists[0].ID = %q, want %q", lists[0].ID, "100")
+	// First entry is the audio playlist, tagged with its section.
+	if lists[0].ID != "pl:24872" {
+		t.Errorf("lists[0].ID = %q, want %q", lists[0].ID, "pl:24872")
 	}
-	if !strings.Contains(lists[0].Name, "Miles Davis") {
-		t.Errorf("lists[0].Name %q missing artist", lists[0].Name)
+	if lists[0].Name != "GOOD" {
+		t.Errorf("lists[0].Name = %q, want %q", lists[0].Name, "GOOD")
 	}
-	if !strings.Contains(lists[0].Name, "Kind of Blue") {
-		t.Errorf("lists[0].Name %q missing album title", lists[0].Name)
+	if lists[0].TrackCount != 3 {
+		t.Errorf("lists[0].TrackCount = %d, want 3", lists[0].TrackCount)
 	}
-	if !strings.Contains(lists[0].Name, "1959") {
-		t.Errorf("lists[0].Name %q missing year", lists[0].Name)
+	if lists[0].DurationSecs != 600 {
+		t.Errorf("lists[0].DurationSecs = %d, want 600", lists[0].DurationSecs)
 	}
-	if lists[0].TrackCount != 5 {
-		t.Errorf("lists[0].TrackCount = %d, want 5", lists[0].TrackCount)
+	if lists[0].Section != "Playlists" {
+		t.Errorf("lists[0].Section = %q, want %q", lists[0].Section, "Playlists")
+	}
+
+	// Then the albums from the music library.
+	if lists[1].ID != "100" {
+		t.Errorf("lists[1].ID = %q, want %q", lists[1].ID, "100")
+	}
+	if !strings.Contains(lists[1].Name, "Miles Davis") {
+		t.Errorf("lists[1].Name %q missing artist", lists[1].Name)
+	}
+	if !strings.Contains(lists[1].Name, "Kind of Blue") {
+		t.Errorf("lists[1].Name %q missing album title", lists[1].Name)
+	}
+	if !strings.Contains(lists[1].Name, "1959") {
+		t.Errorf("lists[1].Name %q missing year", lists[1].Name)
+	}
+	if lists[1].TrackCount != 5 {
+		t.Errorf("lists[1].TrackCount = %d, want 5", lists[1].TrackCount)
+	}
+	if lists[1].Section != "Albums" {
+		t.Errorf("lists[1].Section = %q, want %q", lists[1].Section, "Albums")
 	}
 }
 
@@ -103,6 +146,8 @@ func TestProvider_Playlists_Cached(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
+		case strings.HasSuffix(r.URL.Path, "/playlists"):
+			w.Write([]byte(`{"MediaContainer":{"Metadata":[]}}`))
 		case strings.HasSuffix(r.URL.Path, "/library/sections"):
 			w.Write([]byte(`{"MediaContainer":{"Directory":[{"key":"3","type":"artist","title":"Music"}]}}`))
 		case strings.HasSuffix(r.URL.Path, "/library/sections/3/all"):
@@ -182,6 +227,43 @@ func TestProvider_Tracks(t *testing.T) {
 		t.Errorf("Path %q missing X-Plex-Token", tr.Path)
 	}
 	if !strings.Contains(tr.Path, "/library/parts/1/111/SoWhat.flac") {
+		t.Errorf("Path %q missing part key", tr.Path)
+	}
+}
+
+func TestProvider_Tracks_Playlist(t *testing.T) {
+	srv := httptest.NewServer(sectionsHandler(t))
+	defer srv.Close()
+
+	p := newProvider(NewClient(srv.URL, "tok"))
+	tracks, err := p.Tracks("pl:24872")
+	if err != nil {
+		t.Fatalf("Tracks(pl:...) error: %v", err)
+	}
+	if len(tracks) != 1 {
+		t.Fatalf("expected 1 track, got %d", len(tracks))
+	}
+
+	tr := tracks[0]
+	if tr.Title != "Highway to Hell" {
+		t.Errorf("Title = %q, want %q", tr.Title, "Highway to Hell")
+	}
+	if tr.Artist != "AC/DC" {
+		t.Errorf("Artist = %q, want %q", tr.Artist, "AC/DC")
+	}
+	if tr.Album != "Highway to Hell" {
+		t.Errorf("Album = %q, want %q", tr.Album, "Highway to Hell")
+	}
+	if tr.DurationSecs != 208 {
+		t.Errorf("DurationSecs = %d, want 208", tr.DurationSecs)
+	}
+	if !tr.Stream {
+		t.Error("Stream = false, want true")
+	}
+	if !strings.Contains(tr.Path, "X-Plex-Token=tok") {
+		t.Errorf("Path %q missing X-Plex-Token", tr.Path)
+	}
+	if !strings.Contains(tr.Path, "/library/parts/3/333/HighwayToHell.flac") {
 		t.Errorf("Path %q missing part key", tr.Path)
 	}
 }
@@ -290,6 +372,8 @@ func TestNewFromConfig_LibrariesWired(t *testing.T) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				switch {
+				case strings.HasSuffix(r.URL.Path, "/playlists"):
+					w.Write([]byte(`{"MediaContainer":{"Metadata":[]}}`))
 				case strings.HasSuffix(r.URL.Path, "/library/sections"):
 					w.Write([]byte(`{"MediaContainer":{"Directory":[
 						{"key":"1","type":"artist","title":"Music"},


### PR DESCRIPTION
## Summary

Expose Plex audio playlists (smart and user-created) in the provider browse view. The browse list now shows a **Playlists** section ahead of the existing album list, which now sits under an **Albums** section (using the existing `PlaylistInfo.Section` header mechanism).

## Changes

- **`external/plex/client.go`**
  - `Playlist` struct and `Playlists()` — `GET /playlists`, keeps only `playlistType="audio"` (both smart and manual playlists).
  - `PlaylistTracks(key)` — `GET /playlists/<key>/items`, paginated (`X-Plex-Container-Start/Size`, 1000/page) so smart playlists with tens of thousands of tracks stay well under the 10 MB response cap. Reuses the existing `trackJSON`/`trackFromJSON`.
- **`external/plex/provider.go`**
  - Playlist IDs are prefixed `pl:` so `Tracks()` can route them to the playlists-items endpoint instead of the album children endpoint (both live in the same ratingKey space).
  - `Playlists()` returns playlists first (Section `Playlists`), then albums (Section `Albums`); only errors when both are empty.
- **Tests** — audio filtering, playlist items pagination, field mapping, `pl:` routing, section ordering. Existing album tests preserved and passing.
- **`docs/plex.md`** — document the two browse sections; drop the "No Plex playlists" limitation.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` all pass; `gofmt` clean.
- Manually validated against a live Plex server: all 15 audio playlists appear with correct track counts, and an 18k-track smart playlist loads via pagination with correct streaming URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for discovering Plex audio playlists alongside music albums.
  * Added playlist track loading, including smart playlist contents and paginated results.
  * Playlist and album sections are clearly labeled for easier browsing.

* **Documentation**
  * Updated Plex setup guidance to explain playlist and music library support.
  * Removed the previous limitation stating that Plex playlists were unsupported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->