### PR TITLE
fix: handle capital keybindings from enhanced keyboard events

### DIFF
--- a/ui/model/interaction_test.go
+++ b/ui/model/interaction_test.go
@@ -9,7 +9,135 @@ import (
 
 	"github.com/bjarneo/cliamp/ipc"
 	"github.com/bjarneo/cliamp/playlist"
+	"github.com/bjarneo/cliamp/provider"
 )
+
+type interactionBrowseProvider struct {
+	commandsTestProvider
+}
+
+func (p interactionBrowseProvider) Artists() ([]provider.ArtistInfo, error) { return nil, nil }
+
+func (p interactionBrowseProvider) ArtistAlbums(string) ([]provider.AlbumInfo, error) {
+	return nil, nil
+}
+
+func keybindingTestModel() Model {
+	local := commandsTestProvider{name: "Local"}
+	return Model{
+		playlist: playlist.New(),
+		provider: local,
+		providers: []ProviderEntry{
+			{Key: "local", Name: "Local", Provider: local},
+			{Key: "yt", Name: "YouTube", Provider: commandsTestProvider{name: "YouTube"}},
+		},
+	}
+}
+
+func TestHandleKeyEnhancedShiftYSelectsYouTubeProvider(t *testing.T) {
+	m := keybindingTestModel()
+	msg := tea.KeyPressMsg{Code: 'y', ShiftedCode: 'Y', Mod: tea.ModShift}
+	if got := msg.String(); got != "shift+y" {
+		t.Fatalf("enhanced Shift+Y string = %q, want shift+y", got)
+	}
+
+	m.handleKey(msg)
+
+	if got := m.provider.Name(); got != "YouTube" {
+		t.Fatalf("active provider = %q, want YouTube", got)
+	}
+	if m.lyrics.visible {
+		t.Fatal("lyrics.visible = true after enhanced Shift+Y, want false")
+	}
+}
+
+func TestHandleKeyEnhancedShiftNOpensProviderBrowser(t *testing.T) {
+	browse := interactionBrowseProvider{commandsTestProvider{name: "Navidrome"}}
+	m := keybindingTestModel()
+	m.providers = append(m.providers, ProviderEntry{Key: "navidrome", Name: "Navidrome", Provider: browse})
+	msg := tea.KeyPressMsg{Code: 'n', ShiftedCode: 'N', Mod: tea.ModShift}
+
+	m.handleKey(msg)
+
+	if !m.navBrowser.visible {
+		t.Fatal("navBrowser.visible = false after enhanced Shift+N, want true")
+	}
+	if got := m.navBrowser.prov.Name(); got != "Navidrome" {
+		t.Fatalf("browser provider = %q, want Navidrome", got)
+	}
+}
+
+func TestHandleKeyEnhancedShiftLetterReachesActiveTextInput(t *testing.T) {
+	m := keybindingTestModel()
+	m.search.active = true
+
+	m.handleKey(tea.KeyPressMsg{Code: 'a', ShiftedCode: 'A', Mod: tea.ModShift})
+
+	if got := m.search.query; got != "A" {
+		t.Fatalf("search query = %q, want A", got)
+	}
+}
+
+func TestHandleKeyPreservesExistingLetterRepresentations(t *testing.T) {
+	t.Run("lowercase toggles lyrics", func(t *testing.T) {
+		m := keybindingTestModel()
+		m.handleKey(tea.KeyPressMsg{Code: 'y', Text: "y"})
+
+		if !m.lyrics.visible {
+			t.Fatal("lyrics.visible = false after lowercase y, want true")
+		}
+		if got := m.provider.Name(); got != "Local" {
+			t.Fatalf("active provider = %q, want Local", got)
+		}
+	})
+
+	t.Run("uppercase text selects provider", func(t *testing.T) {
+		m := keybindingTestModel()
+		msg := tea.KeyPressMsg{Code: 'y', ShiftedCode: 'Y', Text: "Y", Mod: tea.ModShift}
+		if got := msg.String(); got != "Y" {
+			t.Fatalf("uppercase text string = %q, want Y", got)
+		}
+
+		m.handleKey(msg)
+
+		if got := m.provider.Name(); got != "YouTube" {
+			t.Fatalf("active provider = %q, want YouTube", got)
+		}
+	})
+}
+
+func TestHandleKeyPreservesUnrelatedModifiedKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  tea.KeyPressMsg
+		want string
+	}{
+		{name: "shifted non-letter", msg: tea.KeyPressMsg{Code: '1', ShiftedCode: '!', Mod: tea.ModShift}, want: "shift+1"},
+		{name: "control shifted letter", msg: tea.KeyPressMsg{Code: 'y', ShiftedCode: 'Y', Mod: tea.ModCtrl | tea.ModShift}, want: "ctrl+shift+y"},
+		{name: "alt shifted letter", msg: tea.KeyPressMsg{Code: 'y', ShiftedCode: 'Y', Mod: tea.ModAlt | tea.ModShift}, want: "alt+shift+y"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := keybindingTestModel()
+			if got := tt.msg.String(); got != tt.want {
+				t.Fatalf("key string = %q, want %q", got, tt.want)
+			}
+			if got := normalizeShiftedLetter(tt.msg).String(); got != tt.want {
+				t.Fatalf("normalized key string = %q, want %q", got, tt.want)
+			}
+
+			m.handleKey(tt.msg)
+
+			if got := m.provider.Name(); got != "Local" {
+				t.Fatalf("active provider = %q, want Local", got)
+			}
+			if m.lyrics.visible || m.navBrowser.visible {
+				t.Fatalf("unexpected action: lyrics.visible=%v navBrowser.visible=%v", m.lyrics.visible, m.navBrowser.visible)
+			}
+		})
+	}
+}
 
 func TestGlobalHelpOpensOverActiveTextInput(t *testing.T) {
 	m := Model{search: searchState{active: true, query: "jazz"}}

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -175,8 +175,20 @@ func (m *Model) providerToBottom() {
 	m.providerMaybeAdjustScroll()
 }
 
+func normalizeShiftedLetter(msg tea.KeyPressMsg) tea.KeyPressMsg {
+	if msg.Text != "" || msg.Mod != tea.ModShift ||
+		msg.Code < 'a' || msg.Code > 'z' ||
+		msg.ShiftedCode < 'A' || msg.ShiftedCode > 'Z' {
+		return msg
+	}
+	msg.Text = string(msg.ShiftedCode)
+	return msg
+}
+
 // handleKey processes a single key press and returns an optional command.
 func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
+	msg = normalizeShiftedLetter(msg)
+
 	if msg.String() == "ctrl+c" {
 		return m.quit()
 	}


### PR DESCRIPTION
## Summary

Normalize enhanced printable Shift+letter events at the start of `Model.handleKey`, before global checks or delegation to overlay handlers, so every existing `msg.String()` switch receives the same uppercase textual representation used by non-enhanced terminals. Use Bubble Tea's structured key fields to recognize an ASCII letter with an uppercase `ShiftedCode` and no usable text, and preserve the original event for lowercase input, non-letter shifted keys, and combinations carrying Ctrl, Alt, or other non-Shift modifiers. Keep the existing shortcut switches and provider mapping unchanged; the normalization belongs at the shared production dispatch boundary rather than in each individual handler.

Capital-letter shortcuts such as `Y` and `N` do not fire for the reporter in MacTerm 1.20.9 with `TERM=xterm-ghostty`, although lowercase shortcuts and shifted shortcuts in another TUI work normally. The thread identifies the concrete mismatch: Bubble Tea's enhanced keyboard reporting can stringify a shifted letter as `shift+y`, while cliamp's dispatch switches match literal uppercase strings such as `Y`. Because `handleKey` forwards the original key message into overlay-specific handlers, the same representation mismatch can affect capital shortcuts in both the main player and nested browsers. The issue is open, unassigned, and has no referenced prior or competing pull request.

Fixes #286

## Screenshots / video

No user-visible surface changes in this PR, so there is nothing to show.

## How to test

1.

## Checklist

- [x] `make check` passes
- [x] `docs/` and `site/index.html` updated for user-facing changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Shift+letter keyboard handling throughout the interface.
  * Shift+Y and Shift+N now correctly support provider selection and browsing.
  * Shifted letters are properly delivered to active text fields.
  * Preserved expected lowercase and uppercase key behavior.
  * Normalized unrelated modified-key input for more consistent handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->