### PR TITLE
security: prevent SSH option injection via URL host

### DIFF
--- a/internal/sshurl/sshurl.go
+++ b/internal/sshurl/sshurl.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"strings"
 )
 
 // Parsed holds the components of an ssh:// URL.
@@ -42,6 +43,12 @@ func Parse(raw string) (Parsed, error) {
 	host := u.Hostname()
 	if u.User != nil {
 		host = u.User.Username() + "@" + host
+	}
+
+	// Reject hostnames that start with - (ssh -o option prefix) or contain =
+	// (= would separate a key/value pair, neither a valid hostname pattern).
+	if strings.HasPrefix(host, "-") || strings.Contains(host, "=") {
+		return Parsed{}, fmt.Errorf("invalid ssh URL %q: host %q contains disallowed characters", raw, host)
 	}
 
 	port := u.Port()

--- a/player/decode.go
+++ b/player/decode.go
@@ -96,6 +96,12 @@ func openSSHSource(path string) (sourceResult, error) {
 		return sourceResult{}, err
 	}
 
+	// Defense-in-depth: reject hosts that start with - or contain =, which would
+	// indicate ssh option injection (e.g. -oProxyCommand=...) injected via the URL host.
+	if strings.HasPrefix(parsed.Host, "-") || strings.Contains(parsed.Host, "=") {
+		return sourceResult{}, fmt.Errorf("invalid ssh URL %q: host %q contains disallowed characters", path, parsed.Host)
+	}
+
 	catCmd := "cat -- " + shellQuoteSSH(parsed.Path)
 	args := parsed.SSHArgs()
 	args = append(args, catCmd)


### PR DESCRIPTION
# Description
The `sshurl.Parse()` function and `openSSHSource()` function in `cliamp` were vulnerable to SSH option injection through the URL host field. Go's `url.Parse` accepts `-oProxyCommand=...` in the host field, which cliamp's `SSHArgs()` function appends bare to the ssh argv, which then allows arbitrary command execution.

This commit adds defense-in-depth validation at two layers:
1. `internal/sshurl/sshurl.go:50` -- Rejects hostnames starting with `-` (the `-o` ssh option prefix) or containing `=` (key-value separator) during URL parsing.
2. `player/decode.go:101` -- Defense-in-depth check in `openSSHSource()` that validates the parsed host after `sshurl.Parse()` returns, rejecting the same disallowed patterns before constructing the ssh command.

On OpenSSH 9.6 and later, an additional `ssh_valid_hostname()` check blocks the destination hostname `cat -- /x` from being accepted. _Check out the release notes for reference: [OpenSSH 9.6](https://www.openssh.org/txt/release-9.6) and [OpenWall Cockpit RCE](https://www.openwall.com/lists/oss-security/2026/04/10/5)._ However, the code-layer validation is still necessary because:
- The `-oProxyCommand=...` option injection itself is not blocked by OpenSSH's hostname check (the option value is still accepted).
- On OpenSSH 9.5 and earlier (the vast deployed base: Ubuntu 22.04/24.04, Debian 12, RHEL/CentOS, macOS), the code-layer validation is the only protection.

Both checks use `strings.HasPrefix(host, "-") || strings.Contains(host, "=")` to catch the injection vector while still preserving legitimate `ssh://host/path` links.

The scope of this PR is limited, as I am not well informed with regards to the intention behind playing media over SSH specifically. Ideally, I also wanted to add a rejection rule for passwords, as allowing password authentication means the SSH URL can potentially be used to connect to machines where the user is expected to interactively authenticate. That makes it harder to strictly enforce the intended non-interactive use of SSH for media playback, and could potentially leave other command-execution paths available depending on how the SSH connection is configured.

I don't want to make that behavioral change without knowing whether password-based SSH URLs are intentional functionality, so I have left that out of this PR.

## Summary
Fixes a local command execution vulnerability where a malicious `ssh://` URL (e.g. from a remote playlist or podcast feed) could inject `-oProxyCommand=...` into the ssh argv via the URL host field. Adds hostname validation at both URL parsing and source-opening layers.

## How to test

1. `make check` passes
2. `cliamp ssh://-oProxyCommand=touch$IFS/tmp/pwned/nonexistent.host/path` no longer spawns a shell; the URL is rejected with an invalid hostname error.
3. Legitimate `ssh://host/path` URLs should still play correctly.

## Checklist

- [x] `make check` passes
- [ ] `docs/` and `site/index.html` updated for user-facing changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SSH URL validation to reject unsafe hostnames beginning with `-` or containing `=`.
  - Prevented malformed SSH hosts from being interpreted as command-line options.
  - SSH connections now fail safely before attempting to start a subprocess when invalid hosts are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->