### PR TITLE
fix(ui): decay visualizer to rest when paused

### DIFF
--- a/ui/model/tick.go
+++ b/ui/model/tick.go
@@ -44,6 +44,20 @@ func (m *Model) visualizerPaused() bool {
 		!m.isOverlayActive() && m.player.IsPlaying() && m.player.IsPaused()
 }
 
+// visualizerSettlingPaused reports whether playback is paused and the
+// visualizer still has spectrum content easing to zero. While true the tick
+// stays above the idle cadence so the bars fall; once settled the model can
+// return to the fully-idle cadence.
+func (m *Model) visualizerSettlingPaused() bool {
+	if m.player == nil || !m.player.IsPaused() || m.isOverlayActive() {
+		return false
+	}
+	if !m.visualizerVisible() {
+		return false
+	}
+	return m.vis.PausedDecayPending(m.visualizerTickContext(time.Time{}))
+}
+
 func (m *Model) visualizerTickContext(now time.Time) ui.VisTickContext {
 	sampled := false
 	samplesRead := 0
@@ -81,6 +95,14 @@ func (m *Model) visualizerTickContext(now time.Time) ui.VisTickContext {
 				return nil
 			}
 			if bands, ok := cache[spec]; ok {
+				return bands
+			}
+			if m.player.IsPaused() {
+				// Paused playback yields no new samples; feed silence so
+				// spectrum content eases down to rest instead of freezing on
+				// the last played frame held in the audio tap.
+				bands := m.vis.Analyze(nil, spec)
+				cache[spec] = bands
 				return bands
 			}
 			buf := m.vis.EnsureSampleBuf(spec.FFTSize)
@@ -161,6 +183,12 @@ func (m *Model) tickInterval() time.Duration {
 		}
 		return ui.TickFast
 	}
+	// Paused visualizer content still easing to rest: run at the fast cadence
+	// so the bars fall smoothly instead of in ~5 fps steps, then drop to idle
+	// once the content has settled.
+	if m.visualizerSettlingPaused() {
+		return ui.TickFast
+	}
 	return max(d, ui.TickFast)
 }
 
@@ -172,6 +200,9 @@ func (m *Model) isFullyIdle() bool {
 		return false
 	}
 	if m.player.IsPlaying() && !m.player.IsPaused() {
+		return false
+	}
+	if m.visualizerSettlingPaused() {
 		return false
 	}
 	if m.isOverlayActive() || m.buffering || m.termTitle.introActive {

--- a/ui/model/tick_test.go
+++ b/ui/model/tick_test.go
@@ -40,8 +40,11 @@ func (f *samplingFakeEngine) SamplesInto(dst []float64) int {
 	if len(dst) == 0 {
 		return 0
 	}
-	dst[0] = 1
-	return 1
+	n := min(512, len(dst))
+	for i := range n {
+		dst[i] = 0.8 * math.Sin(2*math.Pi*1000*float64(i)/float64(f.SampleRate()))
+	}
+	return n
 }
 
 func (f *samplingFakeEngine) StereoSamplesInto(dst [][2]float64) int {
@@ -164,6 +167,68 @@ func TestTickIntervalLowPowerPlayingUsesLowPowerCadence(t *testing.T) {
 
 	if got := m.tickInterval(); got != ui.TickLowPowerPlaying {
 		t.Fatalf("tickInterval() = %v, want %v", got, ui.TickLowPowerPlaying)
+	}
+}
+
+func chargedPausedModel(t *testing.T) (Model, *samplingFakeEngine) {
+	t.Helper()
+	p := &samplingFakeEngine{playbackFakeEngine: &playbackFakeEngine{playing: true}}
+	m := Model{
+		player:   p,
+		vis:      ui.NewVisualizer(float64(p.SampleRate())),
+		playlist: playlist.New(),
+		width:    80,
+		height:   24,
+	}
+	m.recomputeLayout()
+	m.vis.Mode = ui.VisBars
+
+	// Charge the bars through the normal tick path so v.bands is populated,
+	// then pause to leave non-empty spectrum content behind.
+	base := time.Unix(1, 0)
+	for i := range 3 {
+		m.tickVisualizer(base.Add(time.Duration(i+1) * ui.TickFast))
+	}
+	p.paused = true
+	return m, p
+}
+
+// TestTickIntervalPausedSettlingVisualizerUsesFast verifies that pausing with
+// non-empty spectrum content keeps a fast (non-idle) cadence so the bars ease
+// down smoothly instead of freezing or stepping at a few fps, then returns to
+// idle once they settle.
+func TestTickIntervalPausedSettlingVisualizerUsesFast(t *testing.T) {
+	m, _ := chargedPausedModel(t)
+
+	if !m.isOverlayActive() && !m.visualizerSettlingPaused() {
+		t.Fatal("visualizerSettlingPaused() = false with charged paused bars, want true")
+	}
+	if m.isFullyIdle() {
+		t.Fatal("isFullyIdle() = true while paused bars settle, want false")
+	}
+	if got := m.tickInterval(); got != ui.TickFast {
+		t.Fatalf("tickInterval() = %v, want %v while paused bars settle", got, ui.TickFast)
+	}
+}
+
+func TestTickIntervalPausedSettledVisualizerUsesIdle(t *testing.T) {
+	m, _ := chargedPausedModel(t)
+
+	base := time.Unix(1, 0)
+	for i := range 120 {
+		m.tickVisualizer(base.Add(time.Duration(i+1) * ui.TickSlow))
+		if !m.visualizerSettlingPaused() {
+			break
+		}
+	}
+	if m.visualizerSettlingPaused() {
+		t.Fatal("visualizer still settling after decay ticks")
+	}
+	if !m.isFullyIdle() {
+		t.Fatal("isFullyIdle() = false after paused bars settled, want true")
+	}
+	if got := m.tickInterval(); got != ui.TickIdle {
+		t.Fatalf("tickInterval() = %v, want %v after paused bars settle", got, ui.TickIdle)
 	}
 }
 

--- a/ui/vis_classic_peak_test.go
+++ b/ui/vis_classic_peak_test.go
@@ -443,7 +443,7 @@ func TestClassicPeakRenderShowsAttachedCapWhileSettling(t *testing.T) {
 	}
 }
 
-func TestClassicPeakPauseFreezesStateAndClearsAnimationClock(t *testing.T) {
+func TestClassicPeakPausedDecaysBarsAndCapsToRest(t *testing.T) {
 	withPanelWidth(t, 8)
 
 	v := NewVisualizer(44100)
@@ -456,26 +456,41 @@ func TestClassicPeakPauseFreezesStateAndClearsAnimationClock(t *testing.T) {
 	driver.peakVel = repeatedClassicPeakSlice(PanelWidth, 1.1)
 	driver.peakHold = repeatedClassicPeakSlice(PanelWidth, classicPeakApexHold)
 
-	snapshotPeak := append([]float64(nil), driver.peakPos...)
-	snapshotVel := append([]float64(nil), driver.peakVel...)
-	snapshotHold := append([]float64(nil), driver.peakHold...)
+	snapshotBar := append([]float64(nil), driver.barPos...)
 
-	driver.lastTick = time.Now()
-	v.Tick(VisTickContext{Now: time.Now(), Paused: true})
-
-	for i := range driver.peakPos {
-		if driver.peakPos[i] != snapshotPeak[i] {
-			t.Fatalf("paused cap[%d] = %v, want frozen %v", i, driver.peakPos[i], snapshotPeak[i])
-		}
-		if driver.peakVel[i] != snapshotVel[i] {
-			t.Fatalf("paused velocity[%d] = %v, want frozen %v", i, driver.peakVel[i], snapshotVel[i])
-		}
-		if driver.peakHold[i] != snapshotHold[i] {
-			t.Fatalf("paused hold[%d] = %v, want frozen %v", i, driver.peakHold[i], snapshotHold[i])
+	t0 := time.Unix(1, 0)
+	driver.lastTick = t0
+	// Paused ticks empty the bars instead of freezing them at launch height.
+	for i := range 2 {
+		v.Tick(VisTickContext{Now: t0.Add(time.Duration(i+1) * TickSlow), Paused: true})
+	}
+	for i, got := range driver.barPos {
+		if got >= snapshotBar[i] {
+			t.Fatalf("paused bar[%d] = %v after decay, want below %v", i, got, snapshotBar[i])
 		}
 	}
-	if !driver.animating(v) {
-		t.Fatal("animating() = false, want true while caps still airborne")
+
+	// Keep ticking until the airborne caps have fallen and the driver settles.
+	settled := false
+	for i := 2; i < 240; i++ {
+		v.Tick(VisTickContext{Now: t0.Add(time.Duration(i+1) * TickSlow), Paused: true})
+		if !v.PausedDecayPending(VisTickContext{Paused: true}) {
+			settled = true
+			break
+		}
+	}
+	if !settled {
+		t.Fatal("classic peak never settled to rest while paused")
+	}
+	for i, got := range driver.barPos {
+		if got >= pausedDecayEpsilon {
+			t.Fatalf("settled bar[%d] = %v, want below %v", i, got, pausedDecayEpsilon)
+		}
+	}
+	for i, got := range driver.peakPos {
+		if got >= pausedDecayEpsilon {
+			t.Fatalf("settled cap[%d] = %v, want below %v", i, got, pausedDecayEpsilon)
+		}
 	}
 	if got := v.TickInterval(VisTickContext{Paused: true}); got != TickSlow {
 		t.Fatalf("TickInterval(paused) = %v, want %v", got, TickSlow)

--- a/ui/vis_stereo_test.go
+++ b/ui/vis_stereo_test.go
@@ -94,3 +94,56 @@ func TestStereoDriverReadsAndRendersStereoSamples(t *testing.T) {
 		t.Errorf("R field labels = %d, want 1", got)
 	}
 }
+
+func TestStereoPausedDecaysMetersToRest(t *testing.T) {
+	v := NewVisualizer(44100)
+	v.Cols = 48
+	v.Rows = 5
+	activateMode(t, v, VisStereo)
+	driver := v.driverFor(VisStereo).(*stereoDriver)
+
+	// Charge the meters with loud audio first.
+	samples := [][2]float64{{0.9, 0.9}, {-0.9, -0.9}}
+	t0 := time.Unix(1, 0)
+	for i := range 5 {
+		v.Tick(VisTickContext{
+			Now:     t0.Add(time.Duration(i+1) * TickSlow),
+			Playing: true,
+			StereoSamplesInto: func(dst [][2]float64) int {
+				return copy(dst, samples)
+			},
+		})
+	}
+	for c := range 2 {
+		if driver.level[c] < 0.8 {
+			t.Fatalf("level[%d] = %v after charge, want >= 0.8", c, driver.level[c])
+		}
+	}
+
+	// Paused ticks empty both needles and peaks instead of freezing them.
+	settled := false
+	prevLevel := driver.level
+	prevPeak := driver.peak
+	for i := 0; i < 240; i++ {
+		v.Tick(VisTickContext{Now: t0.Add(time.Duration(i+1) * TickSlow), Paused: true})
+		for c := range 2 {
+			if driver.level[c] > prevLevel[c]+1e-9 || driver.peak[c] > prevPeak[c]+1e-9 {
+				t.Fatalf("paused tick %d channel %d level %v->%v or peak %v->%v, want monotonic decay",
+					i, c, prevLevel[c], driver.level[c], prevPeak[c], driver.peak[c])
+			}
+		}
+		prevLevel, prevPeak = driver.level, driver.peak
+		if !v.PausedDecayPending(VisTickContext{Paused: true}) {
+			settled = true
+			break
+		}
+	}
+	if !settled {
+		t.Fatal("stereo meters never settled to rest while paused")
+	}
+	for c := range 2 {
+		if driver.level[c] > stereoEpsilon || driver.peak[c] > stereoEpsilon {
+			t.Fatalf("settled channel %d level=%v peak=%v, want <= %v", c, driver.level[c], driver.peak[c], stereoEpsilon)
+		}
+	}
+}

--- a/ui/visualizer.go
+++ b/ui/visualizer.go
@@ -19,6 +19,9 @@ const (
 	// frame) step like ~1 frame instead of integrating over a huge interval.
 	maxSmoothDtFrames        = 10
 	maxAnimationCatchUpSteps = 4
+	// Band level below which paused spectrum content is treated as fully
+	// decayed to rest, letting the model drop the visualizer to the idle tick.
+	pausedDecayEpsilon = 0.01
 )
 
 var legacySpectrumEdges = [DefaultSpectrumBands + 1]float64{
@@ -876,7 +879,14 @@ func (v *Visualizer) Tick(ctx VisTickContext) {
 	}
 	v.refreshPending = false
 	if ctx.Paused {
-		v.Suspend()
+		// Keep easing the visual down to rest instead of freezing mid-frame.
+		// Drivers already know how to decay when not playing (silent band
+		// analysis, target-zero physics); we just keep ticking until settled.
+		if v.pausedSettled(driver, ctx) {
+			v.Suspend()
+		} else {
+			driver.Tick(v, ctx)
+		}
 		return
 	}
 	if ctx.OverlayActive {
@@ -904,6 +914,42 @@ func (v *Visualizer) resetFrameTiming() {
 	v.lastFrameTick = time.Time{}
 	v.frameElapsed = 0
 	v.frameInterval = 0
+}
+
+// pausedSettled reports whether a paused visualizer has no content left to
+// ease down, so it can freeze at rest. Band-driven modes must empty both the
+// raw and smoothed bands; drivers with their own physics (classic peak/LED,
+// stereo) stay active until their internal animation settles, which they
+// signal with a fast tick interval even when not playing.
+func (v *Visualizer) pausedSettled(driver visModeDriver, ctx VisTickContext) bool {
+	if v == nil || driver == nil {
+		return true
+	}
+	if spec := NormalizeAnalysisSpec(driver.AnalysisSpec(v)); spec.BandCount > 0 {
+		for _, b := range v.bands {
+			if b >= pausedDecayEpsilon {
+				return false
+			}
+		}
+		for _, b := range v.smoothedBands {
+			if b >= pausedDecayEpsilon {
+				return false
+			}
+		}
+	}
+	ctx.Playing = false
+	return driver.TickInterval(v, ctx) >= TickSlow
+}
+
+// PausedDecayPending reports whether a paused visualizer still needs ticks to
+// settle its content to rest. The model uses it to keep the slow tick cadence
+// instead of dropping to fully idle while bars ease down.
+func (v *Visualizer) PausedDecayPending(ctx VisTickContext) bool {
+	driver := v.syncDriverMode()
+	if driver == nil {
+		return false
+	}
+	return !v.pausedSettled(driver, ctx)
 }
 
 func (v *Visualizer) animationSteps(now time.Time, interval time.Duration) uint64 {

--- a/ui/visualizer_driver_test.go
+++ b/ui/visualizer_driver_test.go
@@ -218,6 +218,60 @@ func TestAdvanceSmoothingResizesOnBandCountChange(t *testing.T) {
 	}
 }
 
+func TestPausedBarsDecayToRestThenSuspend(t *testing.T) {
+	withPanelWidth(t, 16)
+
+	v := NewVisualizer(44100)
+	activateMode(t, v, VisBars)
+	v.bands = uniformBands(0.8)
+	v.smoothedBands = append([]float64(nil), v.bands...)
+
+	analyze := func(spec VisAnalysisSpec) []float64 {
+		return v.Analyze(nil, spec)
+	}
+	ctxAt := func(now time.Time) VisTickContext {
+		return VisTickContext{Now: now, Paused: true, Analyze: analyze}
+	}
+
+	prev := append([]float64(nil), v.SmoothedBands()...)
+	settled := false
+	now := time.Unix(1, 0)
+	for i := 0; i < 240; i++ {
+		v.Tick(ctxAt(now.Add(time.Duration(i+1) * TickSlow)))
+		cur := v.SmoothedBands()
+		for b := range len(cur) {
+			if cur[b] > prev[b]+1e-9 {
+				t.Fatalf("paused tick %d band %d rose %v -> %v, want monotonic decay", i, b, prev[b], cur[b])
+			}
+		}
+		prev = append(prev[:0], cur...)
+		if !v.PausedDecayPending(ctxAt(now.Add(time.Duration(i+2) * TickSlow))) {
+			settled = true
+			break
+		}
+	}
+	if !settled {
+		t.Fatal("paused bars never settled to rest")
+	}
+	for i, got := range prev {
+		if got >= pausedDecayEpsilon {
+			t.Fatalf("band %d = %v after decay, want below %v", i, got, pausedDecayEpsilon)
+		}
+	}
+
+	// Once settled, further paused ticks suspend and leave the frame alone.
+	frameBefore := v.Frame()
+	v.Tick(ctxAt(now.Add(10 * time.Second)))
+	if got := v.Frame(); got != frameBefore {
+		t.Fatalf("settled paused tick advanced frame %d -> %d", frameBefore, got)
+	}
+	for i, got := range v.SmoothedBands() {
+		if math.Abs(got-prev[i]) > 1e-9 {
+			t.Fatalf("settled paused tick changed band %d %v -> %v", i, prev[i], got)
+		}
+	}
+}
+
 func TestDefaultDriverTickGatesAnalyzeAtAnalyzeCadence(t *testing.T) {
 	v := NewVisualizer(44100)
 	activateMode(t, v, VisBars)


### PR DESCRIPTION
## Summary

When playback is paused, the visualizer previously froze at its current state — spectrum bars, peak caps, and meters stayed stuck mid-frame. This makes the audio-driven visuals gently decay to empty instead of freezing, then settle to the idle cadence.

## What changed

- **`ui/visualizer.go`** — `Tick()` no longer hard-suspends on pause. It keeps ticking the active driver so the existing non-playing decay runs (silent band analysis + eased smoothing, target-zero physics for classic peak/stereo), and only suspends once the content has fully settled (all bands below an epsilon and no driver physics still animating). Adds `PausedDecayPending()` for the model.
- **`ui/model/tick.go`** — the analyzer feeds silence while paused (the audio tap otherwise replays the frozen last frame, so bands never fell). `isFullyIdle()` stays false while content is settling, and `tickInterval()` runs at the fast cadence during the brief decay so the fall is smooth (~20 FPS), then drops back to `TickIdle` when settled.
- **Tests** — new paused-decay coverage for bars, stereo, and classic peak (the old "paused freezes" test now asserts decay-to-rest), plus model tick-cadence tests for the settling and settled states. Confirmed the existing scope catch-up behavior is unchanged.

## Notes

The paused decay is temporary (a couple of seconds at ≤20 FPS, no FFT happens during pause since the silence gate short-circuits it), so it has no meaningful CPU/RAM impact — long-paused playback still returns to the 1.5s idle cadence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Paused visualizer animations now smoothly decay spectrum bars, peaks, and stereo meters toward rest instead of freezing.
  * Visualizer updates continue at a responsive cadence while paused content settles, then suspend once fully idle.
  * Improved handling of paused playback when no new audio samples are available.

* **Tests**
  * Added coverage confirming paused visualizers decay monotonically and stop updating after settling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->