### PR TITLE
feat(ui): mouse support for playlist, providers, seek and volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ docs/ideas.md
 config.backup.toml
 .env
 .github/workflows/contextowl-changelog.yml
+.cgo-deps/
+/zig-build/

--- a/scripts/build-zig.ps1
+++ b/scripts/build-zig.ps1
@@ -1,0 +1,264 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Reproducible Windows cgo build of cliamp using only zig as the C toolchain.
+
+.DESCRIPTION
+    Provisions a self-contained toolchain under .cgo-deps/ (vendored MSYS2 dev
+    libraries, a minimal pkg-config shim, a source-built libogg with IOVEC
+    support, and libwinpthread-1.dll compiled from zig's bundled winpthreads),
+    then builds the binary and copies the required runtime DLLs next to it.
+
+.PARAMETER Output
+    Path of the built executable. Defaults to <repo>\zig-build\cliamp.exe.
+    Runtime DLLs are copied next to it.
+
+.PARAMETER Test
+    Run the full test suite (go test ./...) in the same environment after building.
+
+.PARAMETER ProvisionOnly
+    Provision .cgo-deps/ without building.
+
+.PARAMETER ForceProvision
+    Re-run provisioning even if the recipe marker matches.
+
+.EXAMPLE
+    pwsh scripts/build-zig.ps1 -Test
+#>
+[CmdletBinding()]
+param(
+    [string]$Output,
+    [switch]$Test,
+    [switch]$ProvisionOnly,
+    [switch]$ForceProvision
+)
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+$RecipeVersion = '2026-08-21.1'
+
+$Root  = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$Deps  = Join-Path $Root '.cgo-deps'
+$Mingw = Join-Path $Deps 'mingw64'
+if (-not $Output) { $Output = Join-Path $Root 'zig-build/cliamp.exe' }
+
+$RepoUrl = 'https://repo.msys2.org/mingw/mingw64'
+$Packages = @(
+    @{ File = 'mingw-w64-x86_64-libogg-1.3.6-1-any.pkg.tar.zst';    Check = 'lib/libogg.dll.a' }
+    @{ File = 'mingw-w64-x86_64-libvorbis-1.3.7-3-any.pkg.tar.zst'; Check = 'lib/libvorbis.dll.a' }
+    @{ File = 'mingw-w64-x86_64-flac-1.5.0-2-any.pkg.tar.zst';      Check = 'bin/libFLAC.dll' }
+    @{ File = 'mingw-w64-x86_64-mpg123-1.33.7-1-any.pkg.tar.zst';   Check = 'lib/libmpg123.dll.a' }
+)
+$OggSourceUrl = 'https://downloads.xiph.org/releases/ogg/libogg-1.3.6.tar.gz'
+$OggSourceDir = Join-Path $Deps 'libogg-1.3.6'
+$ImportLibs   = 'ogg', 'vorbis', 'vorbisenc', 'FLAC', 'mpg123'
+$RuntimeDlls  = 'libogg-0.dll', 'libvorbis-0.dll', 'libvorbisenc-2.dll',
+                'libvorbisfile-3.dll', 'libFLAC.dll', 'libmpg123-0.dll', 'libwinpthread-1.dll'
+
+function Assert-Tool {
+    param([string]$Name, [string]$Hint)
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "Required tool '$Name' not found on PATH. $Hint"
+    }
+}
+
+function Save-File {
+    param([string]$Url, [string]$Dest)
+    New-Item -ItemType Directory -Force -Path (Split-Path $Dest) | Out-Null
+    Write-Host "downloading $(Split-Path $Url -Leaf)"
+    Invoke-WebRequest -UseBasicParsing -Uri $Url -OutFile $Dest
+}
+
+$shimSource = @'
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func main() {
+	exe, err := os.Executable()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	root := filepath.Join(filepath.Dir(filepath.Dir(exe)), "mingw64")
+	root = filepath.ToSlash(root)
+
+	args := os.Args[1:]
+	wantCflags := false
+	wantLibs := false
+	var names []string
+	for _, a := range args {
+		switch {
+		case a == "--cflags":
+			wantCflags = true
+		case a == "--libs":
+			wantLibs = true
+		case strings.HasPrefix(a, "--"):
+		default:
+			names = append(names, a)
+		}
+	}
+
+	libs := map[string][]string{
+		"ogg":       {"ogg"},
+		"vorbis":    {"vorbis", "ogg"},
+		"vorbisenc": {"vorbisenc", "vorbis", "ogg"},
+		"flac":      {"FLAC", "ogg"},
+		"libmpg123": {"mpg123", "shlwapi"},
+	}
+
+	switch {
+	case wantCflags && wantLibs:
+		fmt.Printf("-I%s/include -L%s/lib -logg -lvorbis -lvorbisenc -lFLAC -lmpg123\n", root, root)
+	case wantCflags:
+		fmt.Printf("-I%s/include\n", root)
+	case wantLibs:
+		var seen []string
+		add := func(l string) {
+			for _, s := range seen {
+				if s == l {
+					return
+				}
+			}
+			seen = append(seen, l)
+		}
+		for _, n := range names {
+			for _, l := range libs[n] {
+				add(l)
+			}
+		}
+		out := fmt.Sprintf("-L%s/lib", root)
+		for _, l := range seen {
+			out += " -l" + l
+		}
+		fmt.Println(out)
+	}
+}
+'@
+
+$configTypesH = @'
+#ifndef OGG_CONFIG_TYPES_H
+#define OGG_CONFIG_TYPES_H
+#include <stdint.h>
+typedef int16_t ogg_int16_t;
+typedef uint16_t ogg_uint16_t;
+typedef int32_t ogg_int32_t;
+typedef uint32_t ogg_uint32_t;
+typedef int64_t ogg_int64_t;
+typedef uint64_t ogg_uint64_t;
+#endif
+'@
+
+function Invoke-Provision {
+    $marker = Join-Path $Deps '.provisioned'
+    if ((Test-Path $marker) -and -not $ForceProvision -and
+        (Get-Content $marker -Raw).Trim() -eq $RecipeVersion) {
+        return
+    }
+
+    Assert-Tool 'zig' 'Install zig: https://ziglang.org/download/'
+    Assert-Tool 'tar' 'bsdtar ships with Windows 10+.'
+    New-Item -ItemType Directory -Force -Path $Deps, (Join-Path $Deps 'bin') | Out-Null
+
+    foreach ($pkg in $Packages) {
+        if (Test-Path (Join-Path $Mingw ($pkg.Check -replace '/', '\'))) { continue }
+        $archive = Join-Path $Deps $pkg.File
+        if (-not (Test-Path $archive)) { Save-File "$RepoUrl/$($pkg.File)" $archive }
+        Write-Host "extracting $($pkg.File)"
+        tar -xf $archive -C $Deps
+        if ($LASTEXITCODE -ne 0) { throw "tar failed extracting $($pkg.File)" }
+    }
+
+    $staticArchives = Get-ChildItem (Join-Path $Mingw 'lib') -Filter '*.a' |
+        Where-Object Name -NotLike '*.dll.a'
+    $staticArchives | Remove-Item -Force
+    foreach ($name in $ImportLibs) {
+        $src = Join-Path $Mingw "lib/lib$name.dll.a"
+        $dst = Join-Path $Mingw "lib/$name.lib"
+        if ((Test-Path $src) -and -not (Test-Path $dst)) {
+            Copy-Item $src $dst
+        }
+    }
+
+    Set-Content -Encoding Ascii -Path (Join-Path $Mingw 'include/ogg/config_types.h') -Value $configTypesH
+
+    $shim = Join-Path $Deps 'pkgconfig.go'
+    Set-Content -Encoding Utf8 -Path $shim -Value $shimSource
+    $env:CGO_ENABLED = '0'
+    go build -o (Join-Path $Deps 'bin/pkg-config.exe') $shim
+    if ($LASTEXITCODE -ne 0) { throw 'failed to build pkg-config shim' }
+
+    if (-not (Test-Path $OggSourceDir)) {
+        $tarball = Join-Path $Deps 'libogg-1.3.6.tar.gz'
+        if (-not (Test-Path $tarball)) { Save-File $OggSourceUrl $tarball }
+        tar -xzf $tarball -C $Deps
+        if ($LASTEXITCODE -ne 0) { throw 'tar failed extracting libogg source' }
+    }
+    Write-Host 'compiling libogg from source (IOVEC enabled)'
+    $inc = @("-I$($OggSourceDir -replace '\\','/')/include", "-I$($Mingw -replace '\\','/')/include")
+    $objs = @()
+    foreach ($c in 'framing.c', 'bitwise.c') {
+        $obj = Join-Path $Deps ("$([IO.Path]::GetFileNameWithoutExtension($c)).o")
+        zig cc -target x86_64-windows-gnu -O2 @inc -c (Join-Path $OggSourceDir "src/$c") -o $obj
+        if ($LASTEXITCODE -ne 0) { throw "zig cc failed compiling $c" }
+        $objs += $obj
+    }
+    Remove-Item (Join-Path $Mingw 'lib/ogg.lib') -Force -ErrorAction SilentlyContinue
+    zig ar rcs (Join-Path $Mingw 'lib/ogg.lib') @objs
+    if ($LASTEXITCODE -ne 0) { throw 'zig ar failed building ogg.lib' }
+
+    $pthreadDll = Join-Path $Mingw 'bin/libwinpthread-1.dll'
+    if (-not (Test-Path $pthreadDll)) {
+        $zigHome = Split-Path (Get-Command zig).Source -Parent
+        $wpSrc = Join-Path $zigHome 'lib/libc/mingw/winpthreads'
+        if (-not (Test-Path $wpSrc)) {
+            throw "winpthreads sources not found at '$wpSrc'; check your zig installation layout."
+        }
+        Write-Host 'compiling libwinpthread-1.dll from zig bundled sources'
+        $sources = Get-ChildItem $wpSrc -Filter '*.c' | ForEach-Object { $_.FullName }
+        zig cc -target x86_64-windows-gnu -shared -O2 -DIN_WINPTHREAD -DDLL_EXPORT `
+            -o $pthreadDll @sources
+        if ($LASTEXITCODE -ne 0) { throw 'zig cc failed building libwinpthread-1.dll' }
+    }
+
+    Set-Content -Encoding Ascii -Path $marker -Value $RecipeVersion
+    Write-Host "provisioned $Deps (recipe $RecipeVersion)"
+}
+
+Set-Location $Root
+Invoke-Provision
+if ($ProvisionOnly) { return }
+
+Assert-Tool 'go' 'Install Go: https://go.dev/dl/'
+
+$outDir = Split-Path $Output -Parent
+New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+foreach ($dll in $RuntimeDlls) {
+    Copy-Item (Join-Path $Mingw "bin/$dll") $outDir -Force
+}
+
+$env:PATH = "$Deps/bin;$Mingw/bin;$env:PATH"
+$env:CGO_ENABLED = '1'
+$env:CC = 'zig cc -target x86_64-windows-gnu'
+
+$version = (git describe --tags --always --dirty 2>$null)
+if (-not $version) { $version = 'dev' }
+
+Write-Host "building $Output (version $version)"
+go build -trimpath -ldflags "-s -w -X main.version=$version" -o $Output .
+if ($LASTEXITCODE -ne 0) { throw 'go build failed' }
+
+& $Output --help *> $null
+if ($LASTEXITCODE -ne 0) { throw "smoke test failed: $Output did not respond to --help" }
+Write-Host "ok: $Output"
+
+if ($Test) {
+    go test ./...
+    if ($LASTEXITCODE -ne 0) { throw 'go test failed' }
+}

--- a/ui/model/init.go
+++ b/ui/model/init.go
@@ -46,6 +46,7 @@ func New(p player.Engine, pl *playlist.Playlist, providers []ProviderEntry, defa
 	if luaMgr != nil {
 		m.pluginEmit = &pluginEmitState{}
 	}
+	m.mouseHits = &mouseHitState{}
 	m.termTitle = initialTerminalTitleState()
 	// Select the default provider pill.
 	for i, pe := range providers {

--- a/ui/model/model.go
+++ b/ui/model/model.go
@@ -361,6 +361,10 @@ type Model struct {
 	// snapshot survives Update's value-receiver copy.
 	pluginEmit *pluginEmitState
 
+	// mouseHits accumulates clickable regions while View renders the current
+	// frame. Held behind a pointer for the same reason as pluginEmit.
+	mouseHits *mouseHitState
+
 	// History recorder (nil if config dir unavailable; safe to call when nil)
 	historyStore *history.Store
 

--- a/ui/model/mouse.go
+++ b/ui/model/mouse.go
@@ -1,0 +1,337 @@
+package model
+
+import (
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/bjarneo/cliamp/playlist"
+	"github.com/bjarneo/cliamp/ui"
+)
+
+// hitKind identifies what action a clickable region maps to.
+type hitKind int
+
+const (
+	hitNone        hitKind = iota
+	hitPlaylistRow         // a track row in the main playlist
+	hitProviderRow         // a playlist row inside the provider browser
+	hitSeekBar             // the seek progress bar
+	hitVolumeBar           // the volume bar in the controls row
+	hitBody                // whole body band, used for wheel scrolling
+)
+
+// volumeMaxDB is the top of the volume bar range; the bottom is the engine's
+// configurable volume minimum.
+const volumeMaxDB = 6.0
+
+func clamp01(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}
+
+// hitRegion is a clickable rectangle in panel coordinates: x counted from the
+// frame's left padding edge, y from the first content row of the frame. y1 and
+// x1 are exclusive. idx carries the payload (track index or provider index).
+type hitRegion struct {
+	kind hitKind
+	y0   int
+	y1   int
+	x0   int
+	x1   int
+	idx  int
+}
+
+// mouseHitState accumulates clickable regions while View renders the current
+// frame. It is held behind a pointer so regions survive Update's value
+// receiver copies (same pattern as pluginEmitState).
+type mouseHitState struct {
+	offX, offY int // terminal coords of the panel origin for the last frame
+
+	regions []hitRegion // panel-coord regions for the last frame
+
+	// Scratch filled by section renderers during rendering, converted into
+	// regions by mainSections/renderFullVisualizer once each section's line
+	// offset within the joined content is known.
+	bodyRows []hitRegion // y relative to the body section start
+	seekBar  *hitRegion  // y assigned at flush time (always single-line)
+	volume   *hitRegion  // y assigned at flush time (always single-line)
+}
+
+func (h *mouseHitState) resetFrame() {
+	h.regions = h.regions[:0]
+	h.bodyRows = h.bodyRows[:0]
+	h.seekBar = nil
+	h.volume = nil
+}
+
+// mouseTrackRow records a body row at body-relative line y carrying idx.
+func (m Model) mouseTrackRow(y, idx int, kind hitKind) {
+	if m.mouseHits == nil {
+		return
+	}
+	m.mouseHits.bodyRows = append(m.mouseHits.bodyRows, hitRegion{
+		kind: kind,
+		y0:   y,
+		y1:   y + 1,
+		x0:   0,
+		x1:   ui.PanelWidth,
+		idx:  idx,
+	})
+}
+
+func (m Model) mouseTrackSeekBar(x0, x1 int) {
+	if m.mouseHits == nil {
+		return
+	}
+	m.mouseHits.seekBar = &hitRegion{kind: hitSeekBar, x0: x0, x1: x1}
+}
+
+func (m Model) mouseTrackVolumeBar(x0, x1 int) {
+	if m.mouseHits == nil {
+		return
+	}
+	m.mouseHits.volume = &hitRegion{kind: hitVolumeBar, x0: x0, x1: x1}
+}
+
+// mouseFlushBody converts scratch body rows into frame regions using base as
+// the absolute first content line of the body section and height as the number
+// of lines it occupies. Rows clipped away by FitRect are dropped.
+func (m Model) mouseFlushBody(base, height int) {
+	h := m.mouseHits
+	if h == nil || len(h.bodyRows) == 0 {
+		return
+	}
+	// The coarse body band is registered before individual rows so the
+	// reversed scan in mouseRegionAt resolves clicks to the most specific
+	// region under the cursor.
+	h.regions = append(h.regions, hitRegion{
+		kind: hitBody,
+		y0:   base,
+		y1:   base + height,
+		x0:   0,
+		x1:   ui.PanelWidth,
+	})
+	for _, r := range h.bodyRows {
+		r.y0 += base
+		r.y1 += base
+		if r.y0 >= base+height {
+			continue
+		}
+		if r.y1 > base+height {
+			r.y1 = base + height
+		}
+		h.regions = append(h.regions, r)
+	}
+}
+
+func (m Model) mouseFlushSeekBar(base int) {
+	h := m.mouseHits
+	if h == nil || h.seekBar == nil {
+		return
+	}
+	r := *h.seekBar
+	r.y0 = base
+	r.y1 = base + 1
+	h.regions = append(h.regions, r)
+}
+
+func (m Model) mouseFlushVolume(base int) {
+	h := m.mouseHits
+	if h == nil || h.volume == nil {
+		return
+	}
+	r := *h.volume
+	r.y0 = base
+	r.y1 = base + 1
+	h.regions = append(h.regions, r)
+}
+
+// mousePanelPoint converts terminal coordinates to panel coordinates for the
+// last rendered frame.
+func (m Model) mousePanelPoint(x, y int) (px, py int, ok bool) {
+	if m.mouseHits == nil || m.width <= 0 || m.height <= 0 {
+		return 0, 0, false
+	}
+	px = x - m.mouseHits.offX
+	py = y - m.mouseHits.offY
+	if px < 0 || py < 0 {
+		return 0, 0, false
+	}
+	return px, py, true
+}
+
+// mouseRegionAt returns the most specific region registered under the given
+// terminal coordinates.
+func (m Model) mouseRegionAt(x, y int) (hitRegion, bool) {
+	px, py, ok := m.mousePanelPoint(x, y)
+	if !ok {
+		return hitRegion{}, false
+	}
+	for i := len(m.mouseHits.regions) - 1; i >= 0; i-- {
+		r := m.mouseHits.regions[i]
+		if py >= r.y0 && py < r.y1 && px >= r.x0 && px < r.x1 {
+			return r, true
+		}
+	}
+	return hitRegion{}, false
+}
+
+// handleMouseClick maps a left click onto the regions recorded while
+// rendering the current frame.
+func (m *Model) handleMouseClick(msg tea.MouseClickMsg) tea.Cmd {
+	if m.mouseHits == nil || m.quitting || m.layout.tooSmall() {
+		return nil
+	}
+	if msg.Button != tea.MouseLeft {
+		return nil
+	}
+	r, ok := m.mouseRegionAt(msg.X, msg.Y)
+	if !ok {
+		return nil
+	}
+	switch r.kind {
+	case hitPlaylistRow:
+		return m.clickPlaylistRow(r.idx)
+	case hitProviderRow:
+		return m.clickProviderRow(r.idx)
+	case hitSeekBar:
+		dur := m.cachedDur
+		if dur <= 0 || m.buffering {
+			return nil
+		}
+		frac := clamp01(float64(msg.X-m.mouseHits.offX-r.x0) / float64(max(1, r.x1-r.x0)))
+		target := time.Duration(frac * float64(dur))
+		return m.seekAbsolute(target)
+	case hitVolumeBar:
+		volMin := m.player.VolumeMin()
+		frac := clamp01(float64(msg.X-m.mouseHits.offX-r.x0) / float64(max(1, r.x1-r.x0)))
+		m.player.SetVolume(volMin + frac*(volumeMaxDB-volMin))
+		m.notifyPlayback()
+	case hitBody:
+		// Clicks on empty body padding do nothing; wheel uses this band.
+	}
+	return nil
+}
+
+func (m *Model) clickPlaylistRow(idx int) tea.Cmd {
+	if m.playlist == nil || idx < 0 || idx >= m.playlist.Len() {
+		return nil
+	}
+	// Clicking an already-focused selected row plays it; otherwise select.
+	if m.plCursor == idx && m.focus == focusPlaylist {
+		if m.buffering && m.plCursor == m.playlist.Index() {
+			return nil
+		}
+		m.scrobbleCurrent()
+		m.playlist.SetIndex(m.plCursor)
+		cmd := m.playCurrentTrack()
+		m.notifyPlayback()
+		return cmd
+	}
+	m.focus = focusPlaylist
+	if m.plCursor != idx {
+		m.plCursor = idx
+		m.adjustScroll()
+	}
+	return nil
+}
+
+func (m *Model) clickProviderRow(idx int) tea.Cmd {
+	if m.provider == nil || idx < 0 || idx >= len(m.providerLists) {
+		return nil
+	}
+	if m.provCursor == idx && m.focus == focusProvider {
+		if m.provSignIn {
+			if auth, ok := m.provider.(playlist.Authenticator); ok {
+				m.provSignIn = false
+				m.provLoading = true
+				return authenticateProviderCmd(auth, m.provider.Name(), nextRequest(&m.requests.auth))
+			}
+			return nil
+		}
+		if !m.provLoading {
+			m.provLoading = true
+			m.activeProviderPlaylistID = m.providerLists[idx].ID
+			return m.fetchProviderTracks(m.providerLists[idx].ID)
+		}
+		return nil
+	}
+	m.focus = focusProvider
+	if m.provCursor != idx {
+		m.provCursor = idx
+		m.providerMaybeAdjustScroll()
+	}
+	return nil
+}
+
+// handleMouseWheel scrolls the list occupying the clicked area without
+// wrapping at either end.
+func (m *Model) handleMouseWheel(msg tea.MouseWheelMsg) tea.Cmd {
+	if m.mouseHits == nil || m.quitting || m.layout.tooSmall() {
+		return nil
+	}
+	r, ok := m.mouseRegionAt(msg.X, msg.Y)
+	if !ok {
+		return nil
+	}
+	var providerArea, playlistArea bool
+	switch r.kind {
+	case hitProviderRow:
+		providerArea = true
+	case hitPlaylistRow:
+		playlistArea = true
+	case hitBody:
+		providerArea = m.focus == focusProvider
+		playlistArea = !providerArea
+	}
+	up := msg.Button == tea.MouseWheelUp
+	down := msg.Button == tea.MouseWheelDown
+	if !up && !down {
+		return nil
+	}
+	if providerArea {
+		return m.wheelProvider(down)
+	}
+	if playlistArea {
+		m.wheelPlaylist(down)
+	}
+	return nil
+}
+
+func (m *Model) wheelProvider(down bool) tea.Cmd {
+	if down {
+		if m.provCursor < len(m.providerLists)-1 {
+			m.provCursor++
+			m.providerMaybeAdjustScroll()
+		}
+		return m.maybeLoadCatalogBatch()
+	}
+	if m.provCursor > 0 {
+		m.provCursor--
+		m.providerMaybeAdjustScroll()
+	}
+	return nil
+}
+
+func (m *Model) wheelPlaylist(down bool) {
+	if m.playlist == nil {
+		return
+	}
+	if down {
+		if m.plCursor < m.playlist.Len()-1 {
+			m.plCursor++
+			m.adjustScroll()
+		}
+		return
+	}
+	if m.plCursor > 0 {
+		m.plCursor--
+		m.adjustScroll()
+	}
+}

--- a/ui/model/mouse_test.go
+++ b/ui/model/mouse_test.go
@@ -1,0 +1,267 @@
+package model
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/bjarneo/cliamp/playlist"
+	"github.com/bjarneo/cliamp/ui"
+)
+
+type mouseTestEngine struct {
+	playbackFakeEngine
+	duration    time.Duration
+	seekCalls   []time.Duration
+	volumeCalls []float64
+}
+
+func (e *mouseTestEngine) Seek(d time.Duration) error {
+	e.seekCalls = append(e.seekCalls, d)
+	return nil
+}
+func (e *mouseTestEngine) SetVolume(v float64)     { e.volumeCalls = append(e.volumeCalls, v) }
+func (e *mouseTestEngine) Duration() time.Duration { return e.duration }
+func (e *mouseTestEngine) Seekable() bool          { return e.duration > 0 }
+
+func newMouseTestModel(engine *mouseTestEngine, tracks int) Model {
+	pl := playlist.New()
+	for i := range tracks {
+		pl.Add(playlist.Track{
+			Path:  fmt.Sprintf("/tmp/mouse-%d.mp3", i),
+			Title: fmt.Sprintf("Track %d", i),
+		})
+	}
+	m := Model{
+		player:    engine,
+		playlist:  pl,
+		vis:       ui.NewVisualizer(44100),
+		width:     100,
+		height:    40,
+		focus:     focusPlaylist,
+		mouseHits: &mouseHitState{},
+	}
+	m.recomputeLayout()
+	m.View()
+	return m
+}
+
+func clickAt(m *Model, x, y int) {
+	m.handleMouseClick(tea.MouseClickMsg{X: x, Y: y, Button: tea.MouseLeft})
+}
+
+func wheelAt(m *Model, x, y int, button tea.MouseButton) {
+	m.handleMouseWheel(tea.MouseWheelMsg{X: x, Y: y, Button: button})
+}
+
+func findRegion(m Model, kind hitKind, idx int) hitRegion {
+	for _, r := range m.mouseHits.regions {
+		if r.kind == kind && r.idx == idx {
+			return r
+		}
+	}
+	return hitRegion{}
+}
+
+func TestViewEnablesCellMotionMouse(t *testing.T) {
+	m := newMouseTestModel(&mouseTestEngine{}, 4)
+
+	view := m.View()
+
+	if view.MouseMode != tea.MouseModeCellMotion {
+		t.Fatalf("mouse mode = %v, want MouseModeCellMotion", view.MouseMode)
+	}
+}
+
+func TestClickPlaylistRowSelectsThenPlays(t *testing.T) {
+	engine := &mouseTestEngine{}
+	m := newMouseTestModel(engine, 8)
+
+	r := findRegion(m, hitPlaylistRow, 3)
+	if r.kind != hitPlaylistRow {
+		t.Fatal("no region registered for track 3")
+	}
+	x := m.mouseHits.offX + r.x0 + 1
+	y := m.mouseHits.offY + r.y0
+
+	clickAt(&m, x, y)
+	if m.plCursor != 3 {
+		t.Fatalf("plCursor after first click = %d, want 3", m.plCursor)
+	}
+	if engine.playing {
+		t.Fatal("engine started playing on selection click, want selection only")
+	}
+
+	clickAt(&m, x, y)
+	if !engine.playing {
+		t.Fatal("second click did not start playback")
+	}
+	if got := m.playlist.Index(); got != 3 {
+		t.Fatalf("playing index = %d, want 3", got)
+	}
+	if len(engine.playCalls) != 1 || engine.playCalls[0] != "/tmp/mouse-3.mp3" {
+		t.Fatalf("play calls = %v, want [/tmp/mouse-3.mp3]", engine.playCalls)
+	}
+}
+
+func TestWheelScrollsPlaylistClamped(t *testing.T) {
+	engine := &mouseTestEngine{}
+	m := newMouseTestModel(engine, 8)
+
+	var band hitRegion
+	for _, r := range m.mouseHits.regions {
+		if r.kind == hitBody {
+			band = r
+			break
+		}
+	}
+	if band.kind != hitBody {
+		t.Fatal("no body band registered for wheel scrolling")
+	}
+	x := m.mouseHits.offX + 2
+	y := m.mouseHits.offY + band.y0
+
+	wheelAt(&m, x, y, tea.MouseWheelDown)
+	if m.plCursor != 1 {
+		t.Fatalf("plCursor after wheel down = %d, want 1", m.plCursor)
+	}
+
+	wheelAt(&m, x, y, tea.MouseWheelUp)
+	wheelAt(&m, x, y, tea.MouseWheelUp)
+	if m.plCursor != 0 {
+		t.Fatalf("wheel up wrapped below first row: plCursor = %d, want 0", m.plCursor)
+	}
+
+	for range 20 {
+		wheelAt(&m, x, y, tea.MouseWheelDown)
+	}
+	if want := m.playlist.Len() - 1; m.plCursor != want {
+		t.Fatalf("plCursor after many wheel downs = %d, want %d (clamped)", m.plCursor, want)
+	}
+}
+
+func TestClickSeekBarSeeks(t *testing.T) {
+	engine := &mouseTestEngine{duration: time.Hour}
+	m := newMouseTestModel(engine, 4)
+	m.cachedDur = time.Hour
+
+	r := findRegion(m, hitSeekBar, 0)
+	if r.kind != hitSeekBar {
+		t.Fatal("no seek bar region registered")
+	}
+	x := m.mouseHits.offX + (r.x0+r.x1)/2
+	y := m.mouseHits.offY + r.y0
+
+	clickAt(&m, x, y)
+
+	if len(engine.seekCalls) != 1 {
+		t.Fatalf("seek call count = %d, want 1", len(engine.seekCalls))
+	}
+	got := engine.seekCalls[0]
+	wantMin, wantMax := 29*time.Minute+55*time.Second, 30*time.Minute+5*time.Second
+	if got < wantMin || got > wantMax {
+		t.Fatalf("seek target = %v, want within [%v, %v]", got, wantMin, wantMax)
+	}
+}
+
+func TestClickVolumeBarSetsVolume(t *testing.T) {
+	engine := &mouseTestEngine{}
+	m := newMouseTestModel(engine, 4)
+
+	r := findRegion(m, hitVolumeBar, 0)
+	if r.kind != hitVolumeBar {
+		t.Fatal("no volume bar region registered")
+	}
+
+	clickAt(&m, m.mouseHits.offX+r.x1-1, m.mouseHits.offY+r.y0)
+	if len(engine.volumeCalls) != 1 {
+		t.Fatalf("volume call count = %d, want 1", len(engine.volumeCalls))
+	}
+	barW := r.x1 - r.x0
+	wantVol := -50.0 + float64(barW-1)/float64(barW)*56.0
+	if got := engine.volumeCalls[0]; got < wantVol-0.01 || got > wantVol+0.01 {
+		t.Fatalf("volume at bar end = %v dB, want %v", got, wantVol)
+	}
+
+	engine.volumeCalls = nil
+	clickAt(&m, m.mouseHits.offX+r.x0, m.mouseHits.offY+r.y0)
+	if got := engine.volumeCalls[0]; got != -50.0 {
+		t.Fatalf("volume at bar start = %v dB, want -50", got)
+	}
+}
+
+func TestNoRowRegionsWhileOverlayOpen(t *testing.T) {
+	engine := &mouseTestEngine{}
+	m := newMouseTestModel(engine, 6)
+	m.visPicker.visible = true
+	m.View()
+
+	for _, r := range m.mouseHits.regions {
+		switch r.kind {
+		case hitPlaylistRow, hitProviderRow:
+			t.Fatalf("row region registered while overlay open: kind=%d idx=%d", r.kind, r.idx)
+		}
+	}
+}
+
+func TestUpdateDispatchesMouseClick(t *testing.T) {
+	engine := &mouseTestEngine{}
+	m := newMouseTestModel(engine, 8)
+
+	r := findRegion(m, hitPlaylistRow, 2)
+	out, _ := m.Update(tea.MouseClickMsg{
+		X:      m.mouseHits.offX + 1,
+		Y:      m.mouseHits.offY + r.y0,
+		Button: tea.MouseLeft,
+	})
+	next := out.(Model)
+
+	if next.plCursor != 2 {
+		t.Fatalf("plCursor after Update click = %d, want 2", next.plCursor)
+	}
+}
+
+func TestProviderRowsResolveSearchFilterIndices(t *testing.T) {
+	playlists := []playlist.PlaylistInfo{
+		{ID: "a", Name: "Alpha"},
+		{ID: "b", Name: "Beta"},
+		{ID: "c", Name: "Gamma"},
+	}
+	m := keybindingTestModel()
+	m.player = &mouseTestEngine{}
+	m.providerLists = playlists
+	m.provCursor = 1
+	m.width, m.height = 100, 40
+	m.focus = focusProvider
+	m.mouseHits = &mouseHitState{}
+	m.recomputeLayout()
+	m.View()
+
+	rows := 0
+	for _, r := range m.mouseHits.regions {
+		if r.kind == hitProviderRow {
+			rows++
+			if r.idx < 0 || r.idx >= len(playlists) {
+				t.Fatalf("provider row region index out of range: %d", r.idx)
+			}
+		}
+	}
+	if rows == 0 {
+		t.Fatal("no provider row regions registered")
+	}
+
+	// Clicking a provider row selects it without loading tracks.
+	target := -1
+	for _, r := range m.mouseHits.regions {
+		if r.kind == hitProviderRow && r.idx != m.provCursor {
+			target = r.idx
+			break
+		}
+	}
+	clickAt(&m, m.mouseHits.offX+1, m.mouseHits.offY+findRegion(m, hitProviderRow, target).y0)
+	if m.provCursor != target {
+		t.Fatalf("provCursor after click = %d, want %d", m.provCursor, target)
+	}
+}

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -61,6 +61,24 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.adjustScroll()
 		return m, cmd
 
+	case tea.MouseClickMsg:
+		cmd := m.handleMouseClick(msg)
+		if m.quitting {
+			return m, tea.Quit
+		}
+		m.applyHeightMode()
+		m.adjustScroll()
+		return m, cmd
+
+	case tea.MouseWheelMsg:
+		cmd := m.handleMouseWheel(msg)
+		if m.quitting {
+			return m, tea.Quit
+		}
+		m.applyHeightMode()
+		m.adjustScroll()
+		return m, cmd
+
 	case autoPlayMsg:
 		if m.playlist.Len() > 0 && !m.player.IsPlaying() {
 			cmd := m.playCurrentTrack()

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -115,6 +115,9 @@ func (m Model) View() tea.View {
 	if m.quitting {
 		return tea.NewView("")
 	}
+	if m.mouseHits != nil {
+		m.mouseHits.resetFrame()
+	}
 	m.recomputeLayout()
 	if m.layout.tooSmall() {
 		content := fmt.Sprintf("Terminal too small. Resize to at least 40x10 (current: %dx%d).", m.width, m.height)
@@ -158,6 +161,7 @@ func (m Model) View() tea.View {
 	}
 	view.AltScreen = true
 	view.WindowTitle = currentTerminalTitle(m.termTitle, m.width, m.terminalTitleValues())
+	view.MouseMode = tea.MouseModeCellMotion
 	return view
 }
 
@@ -168,69 +172,76 @@ func trimTrailingEmpty(sections []string) []string {
 	return sections
 }
 
+// mainSections assembles the vertical stack of frame sections. While joining,
+// it converts renderer-recorded scratch regions into frame coordinates by
+// tracking the running line offset of each section.
 func (m Model) mainSections(playlist string, includeTransient, contentFirst bool) []string {
 	var sections []string
+	line := 0
+	put := func(sec string, tag hitKind) {
+		switch tag {
+		case hitSeekBar:
+			m.mouseFlushSeekBar(line)
+		case hitVolumeBar:
+			m.mouseFlushVolume(line)
+		}
+		sections = append(sections, sec)
+		line += strings.Count(sec, "\n") + 1
+	}
 	if contentFirst {
 		if m.layout.tier == layoutMinimal {
-			sections = []string{
-				m.renderTrackInfo(),
-				m.renderTimeStatus(),
-				m.renderSeekBar(),
-				m.renderPlaylistHeader(),
-			}
+			put(m.renderTrackInfo(), hitNone)
+			put(m.renderTimeStatus(), hitNone)
+			put(m.renderSeekBar(), hitSeekBar)
+			put(m.renderPlaylistHeader(), hitNone)
 		} else {
-			sections = []string{
-				m.renderTitle(),
-				m.renderTrackInfo(),
-				m.renderTimeStatus(),
-				m.renderSeekBar(),
-				m.renderPlaylistHeader(),
-			}
+			put(m.renderTitle(), hitNone)
+			put(m.renderTrackInfo(), hitNone)
+			put(m.renderTimeStatus(), hitNone)
+			put(m.renderSeekBar(), hitSeekBar)
+			put(m.renderPlaylistHeader(), hitNone)
 		}
 	} else {
 		switch m.layout.tier {
 		case layoutCompact:
-			sections = []string{
-				m.renderTitle(),
-				m.renderTrackInfo(),
-				m.renderTimeStatus(),
-				m.renderSpectrum(),
-				m.renderSeekBar(),
-				m.renderCompactControls(),
-				m.renderCompactSource(),
-				m.renderPlaylistHeader(),
-			}
+			put(m.renderTitle(), hitNone)
+			put(m.renderTrackInfo(), hitNone)
+			put(m.renderTimeStatus(), hitNone)
+			put(m.renderSpectrum(), hitNone)
+			put(m.renderSeekBar(), hitSeekBar)
+			put(m.renderCompactControls(), hitNone)
+			put(m.renderCompactSource(), hitNone)
+			put(m.renderPlaylistHeader(), hitNone)
 		case layoutMinimal:
-			sections = []string{
-				m.renderTrackInfo(),
-				m.renderTimeStatus(),
-				m.renderSeekBar(),
-				m.renderPlaylistHeader(),
-			}
+			put(m.renderTrackInfo(), hitNone)
+			put(m.renderTimeStatus(), hitNone)
+			put(m.renderSeekBar(), hitSeekBar)
+			put(m.renderPlaylistHeader(), hitNone)
 		default:
-			sections = []string{
-				m.renderTitle(),
-				m.renderTrackInfo(),
-				m.renderTimeStatus(),
-				"",
-				m.renderSpectrum(),
-				m.renderSeekBar(),
-				m.renderControls(),
-			}
+			put(m.renderTitle(), hitNone)
+			put(m.renderTrackInfo(), hitNone)
+			put(m.renderTimeStatus(), hitNone)
+			put("", hitNone)
+			put(m.renderSpectrum(), hitNone)
+			put(m.renderSeekBar(), hitSeekBar)
+			put(m.renderControls(), hitVolumeBar)
 			if source := m.renderProviderPill(); source != "" {
-				sections = append(sections, source)
+				put(source, hitNone)
 			}
-			sections = append(sections, m.renderPlaylistHeader())
+			put(m.renderPlaylistHeader(), hitNone)
 		}
 	}
 	if playlist != "" {
-		sections = append(sections, playlist)
+		m.mouseFlushBody(line, strings.Count(playlist, "\n")+1)
+		put(playlist, hitNone)
 	}
-	sections = append(sections, "", m.renderTierHelp(), m.renderBottomStatus())
+	put("", hitNone)
+	put(m.renderTierHelp(), hitNone)
+	put(m.renderBottomStatus(), hitNone)
 
 	if includeTransient {
-		if line := m.renderTransient(); line != "" {
-			sections = append(sections, line)
+		if transient := m.renderTransient(); transient != "" {
+			put(transient, hitNone)
 		}
 	}
 
@@ -309,6 +320,11 @@ func (m Model) centerFrame(frame string) string {
 	frameH := lipgloss.Height(frame)
 	padLeft := max(0, (m.width-frameW)/2)
 	padTop := max(0, (m.height-frameH)/2)
+
+	if m.mouseHits != nil {
+		m.mouseHits.offX = padLeft + m.layout.paddingH
+		m.mouseHits.offY = padTop + m.layout.paddingV
+	}
 
 	if padLeft == 0 {
 		return strings.Repeat("\n", padTop) + frame
@@ -450,6 +466,14 @@ func (m Model) renderFullVisualizer() string {
 		helpKey("V", "Exit ") + helpKey("v", "Mode:"+m.vis.ModeName()+" ") + helpKey("Spc", "▶❚❚ ") + helpKey("<>", "Trk ") + helpKey("+-", "Vol ") + helpKey("?", "Keys"),
 	}
 
+	line := 0
+	for i, sec := range sections {
+		if i == 4 {
+			m.mouseFlushSeekBar(line)
+		}
+		line += strings.Count(sec, "\n") + 1
+	}
+
 	return strings.Join(sections, "\n")
 }
 
@@ -498,6 +522,7 @@ func (m Model) renderSeekBar() string {
 	} else {
 		b.WriteString(seekDimStyle.Render(strings.Repeat("━", w-fullCells)))
 	}
+	m.mouseTrackSeekBar(0, w)
 	return b.String()
 }
 
@@ -528,7 +553,7 @@ func (m Model) renderControls() string {
 
 	vol := m.player.Volume()
 	volMin := m.player.VolumeMin()
-	frac := max(0, min(1, (vol-volMin)/(6-volMin)))
+	frac := max(0, min(1, (vol-volMin)/(volumeMaxDB-volMin)))
 	dbStr := fmt.Sprintf(" %+.0fdB", vol)
 	monoStr := ""
 	if m.player.Mono() {
@@ -550,6 +575,7 @@ func (m Model) renderControls() string {
 	rightW := lipgloss.Width(right)
 	gap := max(1, ui.PanelWidth-leftW-rightW)
 
+	m.mouseTrackVolumeBar(leftW+gap+volLabelW, leftW+gap+volLabelW+barW)
 	return left + strings.Repeat(" ", gap) + right
 }
 
@@ -690,6 +716,7 @@ func (m Model) renderProviderList() string {
 					idx := m.provSearch.results[j]
 					p := m.providerLists[idx]
 					prefix, style := m.providerRowStyle(p, j == m.provSearch.cursor)
+					m.mouseTrackRow(len(lines), idx, hitProviderRow)
 					lines = append(lines, style.Render(playlistLabel(prefix, p)))
 				}
 				lines = append(lines, dimStyle.Render(fmt.Sprintf("  %d/%d playlists", len(m.provSearch.results), len(m.providerLists))))
@@ -758,6 +785,7 @@ func (m Model) renderProviderList() string {
 			}
 
 			prefix, style := m.providerRowStyle(p, j == m.provCursor)
+			m.mouseTrackRow(len(lines), j, hitProviderRow)
 			lines = append(lines, style.Render(playlistLabel(prefix, p)))
 		}
 	}
@@ -902,6 +930,7 @@ func (m Model) renderPlaylist() string {
 			padding := max(1, ui.PanelWidth-lipgloss.Width(line)-durationLen)
 			line += strings.Repeat(" ", padding) + dimStyle.Render(duration)
 		}
+		m.mouseTrackRow(len(lines), i, hitPlaylistRow)
 		lines = append(lines, line)
 	}
 


### PR DESCRIPTION
## Summary
- Adds phase-1 mouse support to the TUI: click-to-select playlist/provider rows (clicking an already-selected row plays it, mirroring Enter), seek-bar and volume-bar click handling, and wheel scrolling that matches keyboard navigation semantics (clamped, no wrap; provider wheel-down loads catalog batches).
- Includes `scripts/build-zig.ps1`, a reproducible Windows cgo builder that uses zig as the only C toolchain.

## How it works
- Renderers record clickable regions into a per-frame scratch state (`mouseHitState`, pointer field on `Model` like `pluginEmit`).
- `mainSections` tracks the running line offset of each section and resolves scratch regions into absolute frame coordinates; the visualizer's centered frame records its offsets so clicks inside it map correctly.
- `View()` enables `tea.MouseModeCellMotion`; `Update` dispatches `tea.MouseClickMsg` / `tea.MouseWheelMsg` with the same post-processing as key presses.
- Seek clicks require a known duration and are ignored while buffering, matching keyboard seek behavior. Volume maps continuously over [-50, +6] dB.

## Builder script notes (Windows cgo without MinGW)
- MSYS2 libogg packages ship with IOVEC disabled, but xlab/vorbis-go references `ogg_stream_iovecin` at link time, so the script compiles libogg 1.3.6 from source instead.
- `libFLAC.dll` depends on `libwinpthread-1.dll`, which current MSYS2 winpthreads packages no longer ship as a DLL; the script builds it from zig's bundled winpthreads sources.
- A minimal pkg-config shim answers only `--cflags`/`--libs`; everything is vendored under gitignored `.cgo-deps/`.

## Testing
- New `ui/model/mouse_test.go`: MouseMode enabled, select-then-play, clamped wheel scrolling, seek-to-position accuracy (~30min target +-5s on a 60-min track), volume endpoints (-50 exact / +6 computed), no row hits while overlays are open, Update dispatch wiring, provider search-filter index resolution.
- Full `go test ./...` passes, including under the zig/cgo environment produced by `scripts/build-zig.ps1 -Test`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mouse interaction support for selecting and playing playlist tracks.
  * Added clickable seek and volume controls.
  * Added mouse-wheel scrolling for playlists and provider lists.
  * Added interactive provider playlist and catalog loading.
  * Added a reproducible Windows build setup through PowerShell.

* **Bug Fixes**
  * Prevented scrolling beyond available playlist and provider content.
  * Suppressed background row interactions while overlays are open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->