### PR TITLE
feat: add nix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,23 @@ The formula pulls in all required runtime libraries automatically.
 yay -S cliamp
 ```
 
+**Nix**
+
+```sh
+nix run github:bjarneo/cliamp
+```
+
+For a declarative NixOS configuration, add `github:bjarneo/cliamp` as a flake
+input and install its default package:
+
+```nix
+inputs.cliamp.url = "github:bjarneo/cliamp";
+
+environment.systemPackages = [
+  inputs.cliamp.packages.${pkgs.stdenv.hostPlatform.system}.default
+];
+```
+
 **Go**
 
 ```sh

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787135253,
+        "narHash": "sha256-RD2kNWCG+Bjo6h+JVjWVNntZs2GtRoeY2xHjts/FNkA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,43 @@
+{
+  description = "A retro terminal music player inspired by Winamp";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+      version =
+        if self ? shortRev then
+          self.shortRev
+        else if self ? dirtyShortRev then
+          self.dirtyShortRev
+        else
+          "dev";
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          cliamp = pkgs.callPackage ./nix/package.nix { inherit version; };
+        in
+        {
+          inherit cliamp;
+          default = cliamp;
+        }
+      );
+
+      apps = forAllSystems (system: {
+        default = {
+          type = "app";
+          program = nixpkgs.lib.getExe self.packages.${system}.default;
+          meta.description = "Run cliamp";
+        };
+      });
+    };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,57 @@
+{
+  alsa-lib,
+  buildGoModule,
+  ffmpeg-headless,
+  flac,
+  lib,
+  libogg,
+  libvorbis,
+  makeWrapper,
+  mpg123,
+  pkg-config,
+  version ? "dev",
+  yt-dlp,
+}:
+
+buildGoModule {
+  pname = "cliamp";
+  inherit version;
+
+  src = lib.cleanSource ../.;
+  vendorHash = "sha256-/c2MOMnG8twpr2/9plFanXkJwoIYNwC0mPksTklIcRw=";
+
+  nativeBuildInputs = [
+    makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    alsa-lib
+    flac
+    libogg
+    libvorbis
+    mpg123
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=main.version=${version}"
+  ];
+
+  postInstall = ''
+    wrapProgram "$out/bin/cliamp" \
+      --prefix PATH : ${lib.makeBinPath [
+        ffmpeg-headless
+        yt-dlp
+      ]}
+  '';
+
+  meta = {
+    description = "Retro terminal music player inspired by Winamp";
+    homepage = "https://github.com/bjarneo/cliamp";
+    license = lib.licenses.mit;
+    mainProgram = "cliamp";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/site/index.html
+++ b/site/index.html
@@ -682,6 +682,11 @@ footer{border-top:1px solid var(--line);background:var(--ink-2);padding:46px 0 5
         <code><span class="prompt">$ </span>yay -S cliamp</code>
         <span class="copied-msg">COPIED</span>
       </div>
+      <div class="install-box" onclick="copyCmd(this,'nix run github:bjarneo/cliamp')">
+        <div class="install-platform">Nix</div>
+        <code><span class="prompt">$ </span>nix run github:bjarneo/cliamp</code>
+        <span class="copied-msg">COPIED</span>
+      </div>
       <div class="install-box" onclick="copyCmd(this,'go install github.com/bjarneo/cliamp@latest')">
         <div class="install-platform">Go</div>
         <code><span class="prompt">$ </span>go install github.com/bjarneo/cliamp@latest</code>


### PR DESCRIPTION
## Summary

This PR adds support for Nix (via `nix run` and a `nix flake` for NixOS installs).

No functionality has been changed; I've just added an additional installation option for those of us not using an Arch-based system and want to more easily bundle this into a declarative NixOS configuration.

For what it's worth, this is mostly a convenience for those of us using NixOS -- I'm currently running `cliamp` via a local NixOS configuration setup that pulls the most recent binary from GH, but the updates I've made here are much nicer than my current local version.

Figured I'd throw the PR up there and see if it's something you're interested in!

## Screenshots / video

N/A

## How to test

1. With `nix` package manager installed, run `nix run github:bjarneo/cliamp` and see the application launch and function as expected

(I fully understand that you may not have `nix` or `NixOS` configured anywhere, but I have gone through the testing procedure myself, so take that for whatever a random stranger on the internet telling you he tested his code is worth 😅)

## Checklist

- [x] `make check` passes
- [x] `docs/` and `site/index.html` updated for user-facing changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Nix package support for installing and running the application.
  * Added a `nix run` command and declarative NixOS configuration guidance.
  * Added Nix installation instructions to the documentation.
  * Added a copyable Nix installation command to the website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->