### PR TITLE
fix(player): decode live streams off the speaker mutex

### DIFF
--- a/player/decode.go
+++ b/player/decode.go
@@ -207,9 +207,12 @@ func openSource(path string, onMeta func(string)) (sourceResult, error) {
 	}
 
 	// Guard the body with a stall timeout so a stalled/half-open live stream
-	// cannot park a Read forever. Slow reads are moved off the speaker callback
-	// by livePrefetchStreamer; this timeout handles a connection that stops
-	// making progress entirely.
+	// can't park a Read forever. Close() cancels the request, so this also
+	// cleans up the context. Jitter in a live-but-slow connection (data
+	// arriving in small delayed bursts, well under streamStallTimeout) is
+	// handled further up the chain by livePrefetchStreamer, which decodes
+	// off the audio-callback goroutine so this Read never blocks the
+	// speaker's mutex — see its doc comment for the full rationale.
 	var body io.ReadCloser = &stallReader{rc: resp.Body, cancel: cancel, timeout: streamStallTimeout}
 
 	// Wrap in ICY reader if the server provides a metaint interval.

--- a/player/pipeline.go
+++ b/player/pipeline.go
@@ -34,7 +34,10 @@ type trackPipeline struct {
 	// clobbering a newer manual selection.
 	gaplessToken uint64
 
-	live         bool
+	live bool
+
+	// livePrefetch is set when stream is wrapped in a livePrefetchStreamer
+	// (live/non-seekable HTTP sources). close() stops its fill goroutine.
 	livePrefetch *livePrefetchStreamer
 }
 


### PR DESCRIPTION
Fixes #339

## Problem

Live (non-seekable) HTTP streams — internet radio — decode synchronously inside the beep speaker's audio callback, which holds `speaker`'s global mutex for the duration of the call. When the network delivers data slower than real-time playback needs (small, delayed chunks — common on long-lived Icecast/CDN connections, well under `streamStallTimeout`), that blocking `Read()` holds the mutex for the same duration. Every UI operation that needs it (`PositionAndDuration()` on every tick, pause, volume, seek) freezes along with the audio. See #339 for the full root-cause writeup and log evidence from a reproduced session.

## Fix

`livePrefetchStreamer` (new, `player/live_prefetch.go`) wraps the decode chain for live/non-seekable HTTP sources. It runs the actual `Stream()` calls in a dedicated goroutine, writing finished samples into a ring buffer sized for a few seconds of audio. The `Stream()` method actually registered with `speaker` only ever copies from that buffer and never blocks: on underrun (buffer empty, source not keeping up) it returns silence for the requested length rather than waiting.

This trades a brief audio glitch for never holding `speaker.Lock()` on network I/O — the glitch is unavoidable (the data genuinely hasn't arrived yet), but the UI no longer freezes with it.

Wired in only where it's needed: `buildPipeline` wraps the stream with `livePrefetchStreamer` when `!seekable` (the existing flag that's already true only for live HTTP sources). Buffered/seekable sources (Navidrome, etc.) are untouched — `navBuffer` already gives them equivalent decoupling via its own background download goroutine.

`trackPipeline.close()` closes the prefetcher to stop its fill goroutine, mirroring how `decoder.Close()` is already handled.

## Testing

- Added `player/live_prefetch_test.go`: never-blocks-under-stall, real samples delivered once decoded, EOF propagation after drain, `Err()` propagation, and `Close()` stopping the fill goroutine promptly.
- `go test ./...` and `go test -race ./player/...` both pass.
- `go vet ./...` and `gofmt -l .` clean.
- Manually verified against the live production stream used to diagnose the issue: before the fix, `speaker.Lock()` wait times matched network read stall durations 1:1 (up to ~900ms) with visible UI/audio freezes; after, the same session ran without freezes (instrumented debug logging removed from this PR — this was a throwaway verification build).

## Scope note

Not claiming this eliminates every possible glitch on a sustained-too-slow connection — that's a real network/server limitation and some audio interruption is unavoidable there. This fixes the part that shouldn't happen regardless: the UI (and by extension all playback control) freezing along with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified audio playback behavior for stalled requests and delayed live-stream data.
  * Added context around live-stream prefetching, including how it applies to non-seekable streams and is stopped during shutdown.
* **No User-Facing Changes**
  * These updates improve technical clarity without changing playback functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->