### PR TITLE
test(sshurl): add regression tests for SSH option-injection fix (#325)

### DIFF
--- a/internal/sshurl/sshurl_test.go
+++ b/internal/sshurl/sshurl_test.go
@@ -49,6 +49,16 @@ func TestParse(t *testing.T) {
 			input:   "ssh://myhost",
 			wantErr: true,
 		},
+		{
+			name:    "host with ssh option injection is rejected",
+			input:   "ssh://-oProxyCommand=command/path/to/music",
+			wantErr: true,
+		},
+		{
+			name:    "host containing equals is rejected",
+			input:   "ssh://ho=st/path/to/music",
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

The SSH option-injection fix in #325 landed without regression tests. This adds two table-driven cases to `TestParse` so the guard can't silently regress:

- **`host with ssh option injection is rejected`** — `ssh://-oProxyCommand=command/path/to/music`. Without the guard, Go's `url.Parse` returns `-oProxyCommand=command` as the host, which `SSHArgs()` appends bare to the ssh argv, where ssh interprets it as an option → arbitrary command execution. `Parse` must return an error.
- **`host containing equals is rejected`** — `ssh://ho=st/path/to/music`, covering the `=` branch of the same guard.

No production code changes; this is test-only.

## Screenshots / video

N/A — no UI changes.

## How to test

1. `go test -race ./internal/sshurl/`
2. Both new subcases (`TestParse/host_with_ssh_option_injection_is_rejected`, `TestParse/host_containing_equals_is_rejected`) pass; reverting the guard in `sshurl.go` makes them fail.

## Checklist

- [x] `make check` passes — ran `gofmt -l`, `go vet`, and `go test -race ./internal/sshurl/` locally (Go 1.27); change is test-only, full suite runs in CI
- [x] `docs/` and `site/index.html` updated for user-facing changes — N/A (no user-facing change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SSH URLs with hosts beginning with `-` or containing `=` are now rejected, preventing potentially unsafe SSH option injection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->