### PR TITLE
fix(ui): avoid stale preloads by clearing preload more often

### DIFF
--- a/ui/model/interaction_test.go
+++ b/ui/model/interaction_test.go
@@ -189,7 +189,12 @@ func TestUndoRestoresClearedQueue(t *testing.T) {
 	p.Add(playlist.Track{Title: "One"}, playlist.Track{Title: "Two"})
 	p.Queue(0)
 	p.Queue(1)
-	m := Model{playlist: p, plVisible: 1, queue: queueOverlay{visible: true, cursor: 1, scroll: 1}}
+	m := Model{
+		player:    &playbackFakeEngine{},
+		playlist:  p,
+		plVisible: 1,
+		queue:     queueOverlay{visible: true, cursor: 1, scroll: 1},
+	}
 
 	m.handleQueueKey(tea.KeyPressMsg{Text: "c"})
 	if got := p.QueueLen(); got != 0 {

--- a/ui/model/ipc_extended.go
+++ b/ui/model/ipc_extended.go
@@ -94,6 +94,7 @@ func (m *Model) handleIPCQueue(request ipc.QueueRequestMsg) tea.Cmd {
 		m.playlist.Queue(request.Index)
 		m.normalizeQueueOverlay()
 		request.Reply <- m.ipcQueueResponse()
+		return m.rearmPreload()
 	case "queue.remove":
 		if request.Index == m.playlist.Index() {
 			m.player.Stop()
@@ -105,6 +106,7 @@ func (m *Model) handleIPCQueue(request ipc.QueueRequestMsg) tea.Cmd {
 		}
 		m.normalizeQueueOverlay()
 		request.Reply <- m.ipcQueueResponse()
+		return m.rearmPreload()
 	case "queue.move":
 		if !m.playlist.Move(request.Index, request.To) {
 			request.Reply <- ipc.Response{OK: false, Error: "invalid queue move"}
@@ -112,6 +114,7 @@ func (m *Model) handleIPCQueue(request ipc.QueueRequestMsg) tea.Cmd {
 		}
 		m.normalizeQueueOverlay()
 		request.Reply <- m.ipcQueueResponse()
+		return m.rearmPreload()
 	case "queue.clear":
 		m.player.Stop()
 		m.replacePlaylist(nil)

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -193,8 +193,7 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 		return m.quit()
 	}
 	if msg.String() == "ctrl+z" {
-		m.undoPlaylistMutation()
-		return nil
+		return m.undoPlaylistMutation()
 	}
 	if msg.String() == "ctrl+k" && !m.keymap.visible {
 		if m.fullVis {
@@ -657,16 +656,14 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 		if err := m.configSaver.Save("repeat", fmt.Sprintf("%q", m.playlist.Repeat().String())); err != nil {
 			m.status.Errorf(statusTTLDefault, "Config save failed: %s", err)
 		}
-		m.player.ClearPreload()
-		return m.preloadNext()
+		return m.rearmPreload()
 
 	case "z":
 		m.playlist.ToggleShuffle()
 		if err := m.configSaver.Save("shuffle", fmt.Sprintf("%v", m.playlist.Shuffled())); err != nil {
 			m.status.Errorf(statusTTLDefault, "Config save failed: %s", err)
 		}
-		m.player.ClearPreload()
-		return m.preloadNext()
+		return m.rearmPreload()
 
 	case "tab":
 		m.focus = m.nextMainFocus(m.focus)
@@ -694,6 +691,7 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 				m.playlist.Queue(m.plCursor)
 			}
 			m.normalizeQueueOverlay()
+			return m.rearmPreload()
 		}
 
 	case "w":
@@ -1392,6 +1390,7 @@ func (m *Model) handleSearchKey(msg tea.KeyPressMsg) tea.Cmd {
 				m.playlist.Queue(idx)
 			}
 			m.normalizeQueueOverlay()
+			return m.rearmPreload()
 		}
 
 	case tea.KeyUp:
@@ -2666,34 +2665,54 @@ func (m *Model) handleQueueKey(msg tea.KeyPressMsg) tea.Cmd {
 		}
 		m.normalizeQueueOverlay()
 	case "shift+up":
+		moved := false
 		if m.queue.cursor > 0 {
 			if m.playlist.MoveQueue(m.queue.cursor, m.queue.cursor-1) {
 				m.queue.cursor--
+				moved = true
 			}
 		}
 		m.normalizeQueueOverlay()
+		if moved {
+			return m.rearmPreload()
+		}
 	case "shift+down":
+		moved := false
 		if m.queue.cursor < qLen-1 {
 			if m.playlist.MoveQueue(m.queue.cursor, m.queue.cursor+1) {
 				m.queue.cursor++
+				moved = true
 			}
 		}
 		m.normalizeQueueOverlay()
+		if moved {
+			return m.rearmPreload()
+		}
 	case "d":
+		removed := false
 		if qLen > 0 {
 			m.playlistUndo = playlistUndo{active: true, snapshot: m.playlist.Snapshot()}
 			m.playlist.RemoveQueueAt(m.queue.cursor)
+			removed = true
 			m.status.Show("Removed queued track (Ctrl+Z to undo)", statusTTLDefault)
 		}
 		m.normalizeQueueOverlay()
+		if removed {
+			return m.rearmPreload()
+		}
 	case "c":
+		cleared := false
 		if qLen > 0 {
 			m.playlistUndo = playlistUndo{active: true, snapshot: m.playlist.Snapshot()}
 			m.playlist.ClearQueue()
+			cleared = true
 			m.normalizeQueueOverlay()
 			m.status.Show("Cleared queue (Ctrl+Z to undo)", statusTTLDefault)
 		}
 		m.queue.visible = false
+		if cleared {
+			return m.rearmPreload()
+		}
 	case "esc", "A":
 		m.queue.visible = false
 	}

--- a/ui/model/keys_nav.go
+++ b/ui/model/keys_nav.go
@@ -451,6 +451,7 @@ func (m *Model) handleNavTrackListKey(msg tea.KeyPressMsg) tea.Cmd {
 				m.notifyPlayback()
 				return cmd
 			}
+			return m.rearmPreload()
 		}
 	case "esc", "h", "left", "backspace":
 		// Navigate back one level depending on the mode and how we got here.

--- a/ui/model/playback.go
+++ b/ui/model/playback.go
@@ -194,7 +194,7 @@ func (m *Model) queueAlbumNext(album playlist.Track, tracks []playlist.Track) te
 		m.notifyPlayback()
 		return cmd
 	}
-	return nil
+	return m.rearmPreload()
 }
 
 // closeNetSearch fully resets the net search overlay and restores focus,
@@ -250,7 +250,7 @@ func (m *Model) queueTrackNext(track playlist.Track) tea.Cmd {
 		m.notifyPlayback()
 		return cmd
 	}
-	return nil
+	return m.rearmPreload()
 }
 
 // removeSelectedFromPlaylist removes the track at the current playlist cursor.
@@ -330,21 +330,21 @@ func (m *Model) removeSelectedFromPlaylist() {
 	m.notifyPlayback()
 }
 
-func (m *Model) undoPlaylistMutation() {
+func (m *Model) undoPlaylistMutation() tea.Cmd {
 	undo := m.playlistUndo
 	if !undo.active {
 		m.status.Warning("Nothing to undo", statusTTLShort)
-		return
+		return nil
 	}
 	if undo.persisted {
 		saver := m.localSaver()
 		if saver == nil {
 			m.status.Warning("Undo unavailable", statusTTLDefault)
-			return
+			return nil
 		}
 		if err := saver.SavePlaylist(undo.loaded, cloneTracks(undo.saved)); err != nil {
 			m.status.Errorf(statusTTLDefault, "Undo failed: %s", err)
-			return
+			return nil
 		}
 	}
 	m.playlist.Restore(undo.snapshot)
@@ -355,6 +355,7 @@ func (m *Model) undoPlaylistMutation() {
 	}
 	m.adjustScroll()
 	m.status.Show("Restored previous playlist state", statusTTLDefault)
+	return m.rearmPreload()
 }
 
 // playTrack plays a track, using async HTTP for streams and sync I/O for local files.

--- a/ui/model/playback_test.go
+++ b/ui/model/playback_test.go
@@ -527,3 +527,33 @@ func TestGaplessAdvanceRefreshesLyricsAndArtwork(t *testing.T) {
 		t.Fatal("lyrics.loading = false, want true for new track fetch")
 	}
 }
+
+func TestQueueToggleRearmsGaplessPreload(t *testing.T) {
+	player := &playbackFakeEngine{playing: true}
+	p := playlist.New()
+	p.Replace([]playlist.Track{
+		{Title: "Playing", Path: "a.mp3", DurationSecs: 180},
+		{Title: "Order next", Path: "b.mp3", DurationSecs: 180},
+		{Title: "Queued", Path: "c.mp3", DurationSecs: 180},
+	})
+	m := Model{
+		player:   player,
+		playlist: p,
+		plCursor: 2,
+	}
+
+	cmd := m.handleKey(tea.KeyPressMsg{Text: "a"})
+	if cmd == nil {
+		t.Fatal("handleKey(a) = nil, want preload command")
+	}
+	if got := p.QueueLen(); got != 1 {
+		t.Fatalf("QueueLen() = %d, want 1", got)
+	}
+	if player.clearPreloadCalls != 1 {
+		t.Fatalf("ClearPreload calls = %d, want 1", player.clearPreloadCalls)
+	}
+	cmd()
+	if len(player.preloadCalls) != 1 || player.preloadCalls[0] != "c.mp3" {
+		t.Fatalf("preloadCalls = %v, want [c.mp3] (queued track, not order-next b.mp3)", player.preloadCalls)
+	}
+}

--- a/ui/model/preload.go
+++ b/ui/model/preload.go
@@ -22,6 +22,16 @@ const streamPreloadLeadTime = 3 * time.Second
 // takes 3-10 seconds, so we start preloading much earlier.
 const ytdlPreloadLeadTime = 15 * time.Second
 
+// rearmPreload discards any armed gapless pipeline and re-arms from the
+// current playlist state. Call after any change that alters which track
+// plays next.
+func (m *Model) rearmPreload() tea.Cmd {
+	nextRequest(&m.requests.preload)
+	m.preloading = false
+	m.player.ClearPreload()
+	return m.preloadNext()
+}
+
 // preloadNext looks ahead in the playlist and preloads the next track for
 // gapless transition. Errors are silently ignored — playback falls back to
 // non-gapless if preloading fails.

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -1050,8 +1050,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if err := m.configSaver.Save("shuffle", fmt.Sprintf("%v", shuffled)); err != nil {
 			m.status.Errorf(statusTTLDefault, "Config save failed: %s", err)
 		}
-		m.player.ClearPreload()
-		cmd := m.preloadNext()
+		cmd := m.rearmPreload()
 		if msg.Reply != nil {
 			msg.Reply <- ipc.Response{OK: true, Shuffle: &shuffled}
 		}
@@ -1072,8 +1071,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if err := m.configSaver.Save("repeat", fmt.Sprintf("%q", mode.String())); err != nil {
 			m.status.Errorf(statusTTLDefault, "Config save failed: %s", err)
 		}
-		m.player.ClearPreload()
-		cmd := m.preloadNext()
+		cmd := m.rearmPreload()
 		if msg.Reply != nil {
 			msg.Reply <- ipc.Response{OK: true, Repeat: mode.String()}
 		}


### PR DESCRIPTION
## Summary

- Fixes an issue where certain queued tracks would not play correctly unless specific UI actions were taken
- Extracts the `m.playlist.ClearPreload()` -> `return m.preloadNext()` that's repeated throughout and gives it a name
- Actions that mutate playlist / queue state (such as adding a track to the queue) now bust the preload cache

I will admit this is the brute force method, so let me know if you see a better path forward and I can take another stab at it. I also can file an issue if you prefer we go that route.

## How to test

1. Play a track
2. Queue a second track that's not the next track in the playlist
3. Don't seek, shuffle, etc.
4. Wait for the track to end
5. Hear the audio for the queued track

## Checklist

- [x] `make check` passes
- [x] `docs/` and `site/index.html` updated for user-facing changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gapless playback after queue, playlist, shuffle, repeat, and search-result changes.
  * Preloading now refreshes correctly when tracks are added, removed, reordered, or restored with undo.
  * Fixed queueing behavior during active playback to preload the intended next track.
  * Improved playback recovery after undoing playlist changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->