### PR TITLE
feat: add Mixcloud provider, with genre browsing, creator collections, and resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Docs on contextowl.co](https://contextowl.co/uploads/_brand/badge-docs.svg)](https://contextowl.co)
 
-A retro terminal music player inspired by Winamp. Play local files, streams, podcasts, YouTube, YouTube Music, SoundCloud, Bilibili, Spotify, NetEase Cloud Music, Xiaoyuzhou (小宇宙), Navidrome, Plex, Jellyfin, and Audiobookshelf with a spectrum visualizer, parametric EQ, and playlist management.
+A retro terminal music player inspired by Winamp. Play local files, streams, podcasts, YouTube, YouTube Music, SoundCloud, Mixcloud, Bilibili, Spotify, NetEase Cloud Music, Xiaoyuzhou (小宇宙), Navidrome, Plex, Jellyfin, and Audiobookshelf with a spectrum visualizer, parametric EQ, and playlist management.
 
 **[cliamp.stream](https://cliamp.stream)** · **[docs](https://whiterose.org.contextowl.co/docs/cliamp)**
 
@@ -84,7 +84,7 @@ Download from [GitHub Releases](https://github.com/bjarneo/cliamp/releases/lates
 **Optional runtime dependencies** (all platforms, all install methods):
 
 - [ffmpeg](https://ffmpeg.org/) — for AAC, ALAC, Opus, and WMA playback
-- [yt-dlp](https://github.com/yt-dlp/yt-dlp) — for YouTube, YouTube Music, SoundCloud, Bandcamp, Bilibili, and NetEase Cloud Music
+- [yt-dlp](https://github.com/yt-dlp/yt-dlp) — for YouTube, YouTube Music, SoundCloud, Mixcloud, Bandcamp, Bilibili, and NetEase Cloud Music
 
 On macOS: `brew install ffmpeg yt-dlp`. On Linux, use your distribution's package manager.
 
@@ -106,13 +106,17 @@ cliamp https://example.com/stream  # play a URL
 
 Press `Ctrl+K` to see all keybindings.
 
-**Configure remote providers** (Navidrome, Plex, Jellyfin, Audiobookshelf, Spotify, YouTube Music, NetEase Cloud Music) with the interactive wizard:
+**Configure remote providers** (Navidrome, Plex, Jellyfin, Audiobookshelf, Spotify, Mixcloud, YouTube Music, NetEase Cloud Music) with the interactive wizard:
 
 ```sh
 cliamp setup
 ```
 
-It walks you through each provider, validates the connection, and writes the right block to your config file (`~/.config/cliamp/config.toml`, or `%APPDATA%\cliamp\config.toml` on Windows when `HOME` is unset). See [docs/cli.md](docs/cli.md#setup-wizard) for details.
+It walks you through each provider and writes the right block to your config file (`~/.config/cliamp/config.toml`, or `%APPDATA%\cliamp\config.toml` on Windows when `HOME` is unset). Supported server connections are validated during setup; Mixcloud's optional browser-session or OAuth credentials are checked later, when used. See [docs/cli.md](docs/cli.md#setup-wizard) for details.
+
+The [Mixcloud provider guide](docs/mixcloud.md) covers its complete discovery,
+account, creator/show, genre search and local genre-favorite features, along
+with authentication, signed-in playback, resume/seeking and limitations.
 
 ## Radio
 
@@ -185,7 +189,7 @@ Or without Make: `go build -o cliamp .`
 **Optional runtime dependencies:**
 
 - [ffmpeg](https://ffmpeg.org/) — for AAC, ALAC, Opus, and WMA playback
-- [yt-dlp](https://github.com/yt-dlp/yt-dlp) — for YouTube, SoundCloud, Bandcamp, Bilibili, and NetEase Cloud Music
+- [yt-dlp](https://github.com/yt-dlp/yt-dlp) — for YouTube, SoundCloud, Mixcloud, Bandcamp, Bilibili, and NetEase Cloud Music
 
 ## Docs
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -1,7 +1,8 @@
 // Package cmd implements interactive subcommands invoked from the CLI.
 // setup.go contains the provider onboarding wizard reachable via
 // `cliamp setup`. It walks the user through configuring each remote
-// provider (Navidrome, Plex, Jellyfin, Spotify, Qobuz, Tidal, NetEase, YouTube Music),
+// provider (Navidrome, Plex, Jellyfin, Spotify, Qobuz, Tidal, Mixcloud,
+// NetEase, YouTube Music),
 // validates the connection where possible, and writes the resulting
 // TOML section to ~/.config/cliamp/config.toml.
 //
@@ -28,6 +29,7 @@ import (
 	"github.com/bjarneo/cliamp/external/audiobookshelf"
 	"github.com/bjarneo/cliamp/external/emby"
 	"github.com/bjarneo/cliamp/external/jellyfin"
+	"github.com/bjarneo/cliamp/external/mixcloud"
 	"github.com/bjarneo/cliamp/external/navidrome"
 	"github.com/bjarneo/cliamp/external/netease"
 	"github.com/bjarneo/cliamp/external/plex"
@@ -88,14 +90,15 @@ type pickerOption struct {
 // Picker keys are stored in the values map alongside real field keys; the
 // leading underscore distinguishes them from TOML field names.
 const (
-	keyJellyfinAuth   = "_auth"
-	keyEmbyAuth       = "_emby_auth"
-	keyABSAuth        = "_abs_auth"
-	keyNetEaseBrowser = "_netease_browser"
-	keyYTMusicMode    = "_mode"
-	keySpotifyMode    = "_spotify_mode"
-	keyQobuzQuality   = "_qobuz_quality"
-	keyTidalQuality   = "_tidal_quality"
+	keyJellyfinAuth    = "_auth"
+	keyEmbyAuth        = "_emby_auth"
+	keyABSAuth         = "_abs_auth"
+	keyNetEaseBrowser  = "_netease_browser"
+	keyYTMusicMode     = "_mode"
+	keySpotifyMode     = "_spotify_mode"
+	keyQobuzQuality    = "_qobuz_quality"
+	keyTidalQuality    = "_tidal_quality"
+	keyMixcloudBrowser = "_mixcloud_browser"
 )
 
 func providers() []providerSpec {
@@ -457,6 +460,88 @@ func providers() []providerSpec {
 			},
 		},
 		{
+			key:     "mixcloud",
+			name:    "Mixcloud",
+			section: "mixcloud",
+			intro: []string{
+				"Browse and play Mixcloud shows through its public API and yt-dlp.",
+				"A username adds your public library, following stream, and creators.",
+				"An optional developer access token adds /me and Listen Later.",
+				"Choose browser cookies for subscriber-only or signed-in playback.",
+				"Docs: cliamp.stream → docs/mixcloud.md",
+			},
+			picker: &pickerSpec{
+				key:   keyMixcloudBrowser,
+				label: "Playback session",
+				options: []pickerOption{
+					{value: "none", label: "Public shows only (no browser cookies)"},
+					{value: "chrome", label: "Chrome"},
+					{value: "safari", label: "Safari"},
+					{value: "firefox", label: "Firefox"},
+					{value: "brave", label: "Brave"},
+					{value: "edge", label: "Edge"},
+					{value: "chromium", label: "Chromium"},
+					{value: "opera", label: "Opera"},
+					{value: "vivaldi", label: "Vivaldi"},
+					{value: "whale", label: "Whale"},
+					{value: "custom", label: "Custom browser/profile"},
+				},
+			},
+			fields: []fieldSpec{
+				{key: "username", label: "Mixcloud username (optional)", help: "adds account views and followed creators"},
+				{key: "access_token", label: "Developer API access token (optional)", help: "enables /me and Listen Later", secret: true},
+				{key: "cookies_from", label: "Custom browser/profile", help: "e.g. chrome:Profile 1, firefox:default-release", required: true,
+					onlyIf: func(v map[string]string) bool { return v[keyMixcloudBrowser] == "custom" }},
+				{key: "styles", label: "Music styles (optional)", help: "comma-separated; blank uses cliamp defaults"},
+				{key: "max_items", label: "Items per view", help: fmt.Sprintf("%d-%d", mixcloud.MinItems, mixcloud.MaxItemsLimit), defaultV: strconv.Itoa(mixcloud.DefaultMaxItems)},
+				{key: "stream_creators", label: "Creators in Stream", help: fmt.Sprintf("%d-%d", mixcloud.MinItems, mixcloud.MaxStreamCreators), defaultV: strconv.Itoa(mixcloud.DefaultStreamCreators)},
+			},
+			extraValidate: func(v map[string]string) error {
+				limits := []struct {
+					key, label string
+					max        int
+				}{
+					{key: "max_items", label: "items per view", max: mixcloud.MaxItemsLimit},
+					{key: "stream_creators", label: "stream creators", max: mixcloud.MaxStreamCreators},
+				}
+				for _, field := range limits {
+					n, err := strconv.Atoi(strings.TrimSpace(v[field.key]))
+					if err != nil {
+						return fmt.Errorf("%s must be a number", field.label)
+					}
+					if n < mixcloud.MinItems || n > field.max {
+						return fmt.Errorf("%s is outside its supported range", field.label)
+					}
+				}
+				return nil
+			},
+			body: func(v map[string]string) string {
+				lines := []string{"enabled = true"}
+				if username := strings.TrimSpace(v["username"]); username != "" {
+					lines = append(lines, fmt.Sprintf("username = %q", username))
+				}
+				if token := strings.TrimSpace(v["access_token"]); token != "" {
+					lines = append(lines, fmt.Sprintf("access_token = %q", token))
+				}
+				if browser := mixcloudCookiesFrom(v); browser != "" {
+					lines = append(lines, fmt.Sprintf("cookies_from = %q", browser))
+				}
+				if styles := setupStringList(v["styles"]); styles != "" {
+					lines = append(lines, "styles = "+styles)
+				}
+				maxItems := strings.TrimSpace(v["max_items"])
+				if maxItems == "" {
+					maxItems = strconv.Itoa(mixcloud.DefaultMaxItems)
+				}
+				streamCreators := strings.TrimSpace(v["stream_creators"])
+				if streamCreators == "" {
+					streamCreators = strconv.Itoa(mixcloud.DefaultStreamCreators)
+				}
+				lines = append(lines, "max_items = "+maxItems, "stream_creators = "+streamCreators)
+				return strings.Join(lines, "\n")
+			},
+		},
+		{
 			key:     "ytmusic",
 			name:    "YouTube Music",
 			section: "ytmusic",
@@ -515,6 +600,30 @@ func netEaseCookiesFrom(v map[string]string) string {
 		return strings.TrimSpace(v["cookies_from"])
 	}
 	return picked
+}
+
+func mixcloudCookiesFrom(v map[string]string) string {
+	picked := strings.TrimSpace(v[keyMixcloudBrowser])
+	if picked == "" || picked == "none" {
+		return ""
+	}
+	if picked == "custom" {
+		return strings.TrimSpace(v["cookies_from"])
+	}
+	return picked
+}
+
+func setupStringList(value string) string {
+	var quoted []string
+	for _, part := range strings.Split(value, ",") {
+		if part = strings.TrimSpace(part); part != "" {
+			quoted = append(quoted, strconv.Quote(part))
+		}
+	}
+	if len(quoted) == 0 {
+		return ""
+	}
+	return "[" + strings.Join(quoted, ", ") + "]"
 }
 
 // ----- Bubbletea model ----------------------------------------------------

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -310,6 +310,65 @@ func TestTidalSetupBody(t *testing.T) {
 	}
 }
 
+func TestMixcloudSetupBody(t *testing.T) {
+	var spec providerSpec
+	for _, p := range providers() {
+		if p.section == "mixcloud" {
+			spec = p
+			break
+		}
+	}
+	if spec.section == "" {
+		t.Fatal("mixcloud spec missing")
+	}
+	values := map[string]string{
+		keyMixcloudBrowser: "firefox",
+		"username":         "alice",
+		"access_token":     "token",
+		"styles":           "ambient, deep-house",
+		"max_items":        " 75 ",
+		"stream_creators":  "15",
+	}
+	if err := spec.extraValidate(values); err != nil {
+		t.Fatalf("extraValidate: %v", err)
+	}
+	body := spec.body(values)
+	for _, want := range []string{
+		"enabled = true", `username = "alice"`, `access_token = "token"`,
+		`cookies_from = "firefox"`, `styles = ["ambient", "deep-house"]`,
+		"max_items = 75", "stream_creators = 15",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body missing %q: %q", want, body)
+		}
+	}
+	publicOnly := spec.body(map[string]string{
+		keyMixcloudBrowser: "none",
+		"max_items":        "100",
+		"stream_creators":  "20",
+	})
+	if strings.Contains(publicOnly, "cookies_from") {
+		t.Fatalf("public-only session must not write cookies_from: %q", publicOnly)
+	}
+	custom := spec.body(map[string]string{
+		keyMixcloudBrowser: "custom",
+		"cookies_from":     "chrome:Profile 1",
+		"max_items":        "100",
+		"stream_creators":  "20",
+	})
+	if !strings.Contains(custom, `cookies_from = "chrome:Profile 1"`) {
+		t.Fatalf("custom browser/profile was not written: %q", custom)
+	}
+	if spec.validate != nil {
+		t.Fatal("mixcloud setup should not claim a live validation probe")
+	}
+
+	err := spec.extraValidate(map[string]string{"max_items": "bad", "stream_creators": "also bad"})
+	if err == nil || !strings.Contains(err.Error(), "items per view") {
+		t.Fatalf("validation order error = %v, want items per view first", err)
+	}
+}
+
 func TestNetEasePickerSelectionFiltersFields(t *testing.T) {
 	base := newSetupModel()
 	neteaseIdx := -1

--- a/commands.go
+++ b/commands.go
@@ -34,7 +34,7 @@ func buildApp() *cli.Command {
 		&cli.BoolFlag{Name: "no-mono", Usage: "disable mono output"},
 		&cli.BoolFlag{Name: "auto-play", Usage: "start playback immediately"},
 		&cli.BoolFlag{Name: "simplified", Usage: "simplified playback view (no visualizer or playlist)"},
-		&cli.StringFlag{Name: "provider", Usage: "default provider: radio, navidrome, plex, jellyfin, emby, spotify, qobuz, tidal, soundcloud, netease, audiobookshelf, abs, yt, youtube, ytmusic"},
+		&cli.StringFlag{Name: "provider", Usage: "default provider: radio, navidrome, plex, jellyfin, emby, spotify, qobuz, tidal, soundcloud, mixcloud, netease, audiobookshelf, abs, yt, youtube, ytmusic"},
 		&cli.StringFlag{Name: "start-theme", Usage: "UI theme name"},
 		&cli.StringFlag{Name: "visualizer", Usage: "visualizer mode"},
 		&cli.BoolFlag{Name: "visualizer-60fps", Usage: "render visualizer at 60 FPS (higher CPU use)"},
@@ -162,10 +162,10 @@ func overridesFromFlags(c *cli.Command) (config.Overrides, error) {
 			v = "audiobookshelf"
 		}
 		switch v {
-		case "radio", "navidrome", "spotify", "qobuz", "tidal", "plex", "jellyfin", "emby", "audiobookshelf", "soundcloud", "netease", "yt", "youtube", "ytmusic":
+		case "radio", "navidrome", "spotify", "qobuz", "tidal", "plex", "jellyfin", "emby", "audiobookshelf", "soundcloud", "mixcloud", "netease", "yt", "youtube", "ytmusic":
 			ov.Provider = &v
 		default:
-			return ov, fmt.Errorf("--provider must be radio, navidrome, spotify, qobuz, tidal, plex, jellyfin, emby, audiobookshelf, soundcloud, netease, yt, youtube, or ytmusic (got %q)", v)
+			return ov, fmt.Errorf("--provider must be radio, navidrome, spotify, qobuz, tidal, plex, jellyfin, emby, audiobookshelf, soundcloud, mixcloud, netease, yt, youtube, or ytmusic (got %q)", v)
 		}
 	}
 	if c.IsSet("start-theme") {

--- a/config.toml.example
+++ b/config.toml.example
@@ -43,7 +43,7 @@ eq_preset = "Flat"
 # Saved Custom curve; applied when eq_preset is "Custom" or empty
 eq = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 
-# Default provider on startup: "radio", "navidrome", "spotify", "qobuz", "tidal", "plex", "jellyfin", "emby", "soundcloud", "netease", "audiobookshelf", or a YouTube provider
+# Default provider on startup: "radio", "navidrome", "spotify", "qobuz", "tidal", "plex", "jellyfin", "emby", "soundcloud", "mixcloud", "netease", "audiobookshelf", or a YouTube provider
 # provider = "radio"
 
 # Simplified mode: artist/title and time strip without a visualizer or playlist.
@@ -159,6 +159,24 @@ eq = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 # enabled = true
 # user = "yourname"
 # cookies_from = "firefox"   # chrome, brave, edge, opera, safari, vivaldi…
+
+# ---
+# Mixcloud (optional, opt-in)
+# Public discovery, show search, the live genre catalogue, genre/tag search,
+# creator jumps, and Latest/Popular charts work with enabled=true. Set username
+# for your following stream, profile activity, uploads, read-only show favorites,
+# listening history, collections, and followed-creator browsing. A developer
+# OAuth access_token makes /me the account identity and adds Listen Later.
+# cookies_from is used by yt-dlp for signed-in playback only. styles is the
+# local genre-favorites list; toggle it with [f] in Mixcloud's Genres browser.
+# [mixcloud]
+# enabled = true
+# username = "yourname"
+# access_token = "${MIXCLOUD_ACCESS_TOKEN}"
+# cookies_from = "firefox"   # chrome, brave, edge, chromium, opera, safari, vivaldi, whale…
+# styles = ["ambient", "deep-house", "house", "jazz", "techno"]
+# max_items = 100
+# stream_creators = 20
 
 # ---
 # NetEase Cloud Music (optional, opt-in)

--- a/config/config.go
+++ b/config/config.go
@@ -199,6 +199,24 @@ type SoundCloudConfig struct {
 // IsSet reports whether the SoundCloud provider should be shown.
 func (s SoundCloudConfig) IsSet() bool { return s.Enabled }
 
+// MixcloudConfig holds settings for the Mixcloud provider. Public discovery
+// works with only enabled=true. Username adds public account views; an access
+// token adds /me and Listen Later; browser cookies are used only by yt-dlp for
+// playback that needs the listener's signed-in Mixcloud session.
+type MixcloudConfig struct {
+	Enabled        bool
+	Username       string
+	AccessToken    string
+	CookiesFrom    string
+	Styles         []string
+	StylesSet      bool // distinguishes omitted styles (defaults) from an explicit empty list
+	MaxItems       int
+	StreamCreators int
+}
+
+// IsSet reports whether the Mixcloud provider should be shown.
+func (m MixcloudConfig) IsSet() bool { return m.Enabled }
+
 // NetEaseConfig holds settings for the NetEase Cloud Music provider.
 // The provider is opt-in and can reuse an existing browser session through
 // yt-dlp's --cookies-from-browser support.
@@ -284,7 +302,7 @@ type Config struct {
 	Speed            float64                      // playback speed ratio: 0.25–2.0 (default 1.0)
 	AutoPlay         bool                         // start playback automatically on launch (radio streams, CLI tracks)
 	SeekStepLarge    int                          // seconds for Shift+Left/Right seek jumps
-	Provider         string                       // default provider: "radio", "navidrome", "spotify", "qobuz", "tidal", "plex", "jellyfin", "emby", "audiobookshelf", "soundcloud", "netease", "ytmusic" (default "radio")
+	Provider         string                       // default provider: "radio", "navidrome", "spotify", "qobuz", "tidal", "plex", "jellyfin", "emby", "audiobookshelf", "soundcloud", "mixcloud", "netease", "ytmusic" (default "radio")
 	Theme            string                       // theme name, or "" for ANSI default
 	Visualizer       string                       // visualizer mode name, or "" for default (Bars)
 	SampleRate       int                          // output sample rate: 22050, 44100, 48000, 96000, 192000
@@ -307,6 +325,7 @@ type Config struct {
 	Emby             EmbyConfig                   // optional Emby server credentials
 	Audiobookshelf   AudiobookshelfConfig         // optional Audiobookshelf server credentials
 	SoundCloud       SoundCloudConfig             // SoundCloud provider (opt-in via enabled = true)
+	Mixcloud         MixcloudConfig               // Mixcloud provider (opt-in via enabled = true)
 	NetEase          NetEaseConfig                // NetEase Cloud Music provider (opt-in via enabled = true)
 	Plugins          map[string]map[string]string // per-plugin config from [plugins.*] sections
 	LogLevel         string                       // log level: debug, info, warn, error (default "info")
@@ -480,6 +499,28 @@ func Load() (Config, error) {
 				cfg.SoundCloud.User = parseString(val)
 			case "cookies_from":
 				cfg.SoundCloud.CookiesFrom = strings.TrimSpace(parseString(val))
+			}
+		case "mixcloud":
+			switch key {
+			case "enabled":
+				cfg.Mixcloud.Enabled = strings.ToLower(val) == "true"
+			case "username":
+				cfg.Mixcloud.Username = strings.TrimSpace(parseString(val))
+			case "access_token":
+				cfg.Mixcloud.AccessToken = strings.TrimSpace(parseString(val))
+			case "cookies_from":
+				cfg.Mixcloud.CookiesFrom = strings.TrimSpace(parseString(val))
+			case "styles":
+				cfg.Mixcloud.Styles = parseStringSlice(val)
+				cfg.Mixcloud.StylesSet = true
+			case "max_items":
+				if v, err := strconv.Atoi(val); err == nil {
+					cfg.Mixcloud.MaxItems = v
+				}
+			case "stream_creators":
+				if v, err := strconv.Atoi(val); err == nil {
+					cfg.Mixcloud.StreamCreators = v
+				}
 			}
 		case "netease":
 			switch key {
@@ -700,72 +741,93 @@ func Save(key, value string) error {
 // in-place, or appends it after the [navidrome] section if not present.
 // If no [navidrome] section exists, one is appended along with the key.
 func SaveNavidromeSort(sortType string) error {
+	return saveSectionValue("navidrome", "browse_sort", strconv.Quote(sortType))
+}
+
+// SaveMixcloudStyles persists the selected discovery styles in the [mixcloud]
+// section without disturbing other provider settings or comments.
+func SaveMixcloudStyles(styles []string) error {
+	quoted := make([]string, 0, len(styles))
+	for _, style := range styles {
+		quoted = append(quoted, strconv.Quote(style))
+	}
+	return saveSectionValue("mixcloud", "styles", "["+strings.Join(quoted, ", ")+"]")
+}
+
+func saveSectionValue(section, key, value string) error {
 	path, err := configPath()
 	if err != nil {
-		return err
+		return fmt.Errorf("resolve config path: %w", err)
 	}
 
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return err
+		return fmt.Errorf("create config directory: %w", err)
 	}
 
-	line := fmt.Sprintf("browse_sort = %q", sortType)
+	line := fmt.Sprintf("%s = %s", key, value)
 
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if !errors.Is(err, fs.ErrNotExist) {
-			return err
+			return fmt.Errorf("read config: %w", err)
 		}
 		// No file: create with section + key.
-		return fileutil.WriteFileAtomic(path, []byte("[navidrome]\n"+line+"\n"), 0o600)
+		if err := fileutil.WriteFileAtomic(path, []byte("["+section+"]\n"+line+"\n"), 0o600); err != nil {
+			return fmt.Errorf("write config: %w", err)
+		}
+		return nil
 	}
 
 	lines := strings.Split(string(data), "\n")
 
-	// Try to replace an existing browse_sort inside [navidrome].
-	inNavidrome := false
+	// Try to replace the existing key inside the requested section.
+	inSection := false
 	for i, l := range lines {
 		trimmed := strings.TrimSpace(l)
 		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
-			inNavidrome = strings.ToLower(trimmed[1:len(trimmed)-1]) == "navidrome"
+			inSection = strings.EqualFold(trimmed[1:len(trimmed)-1], section)
 			continue
 		}
-		if inNavidrome {
+		if inSection {
 			k, _, ok := strings.Cut(trimmed, "=")
-			if ok && strings.TrimSpace(k) == "browse_sort" {
+			if ok && strings.TrimSpace(k) == key {
 				lines[i] = line
-				return fileutil.WriteFileAtomic(path, []byte(strings.Join(lines, "\n")), 0o600)
+				if err := fileutil.WriteFileAtomic(path, []byte(strings.Join(lines, "\n")), 0o600); err != nil {
+					return fmt.Errorf("write config: %w", err)
+				}
+				return nil
 			}
 		}
 	}
 
-	// Key not found: append after the last line in the [navidrome] section,
-	// or append a new [navidrome] section at the end.
-	inNavidrome = false
+	// Key not found: append after the last line in the requested section, or
+	// append a new section at the end.
+	inSection = false
 	insertAt := -1
 	for i, l := range lines {
 		trimmed := strings.TrimSpace(l)
 		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
-			if inNavidrome && insertAt >= 0 {
-				break // we've moved past [navidrome]
+			if inSection && insertAt >= 0 {
+				break
 			}
-			inNavidrome = strings.ToLower(trimmed[1:len(trimmed)-1]) == "navidrome"
+			inSection = strings.EqualFold(trimmed[1:len(trimmed)-1], section)
 		}
-		if inNavidrome {
+		if inSection {
 			insertAt = i
 		}
 	}
 
 	if insertAt >= 0 {
-		// Insert after the last line we saw inside [navidrome].
 		tail := append([]string{line}, lines[insertAt+1:]...)
 		lines = append(lines[:insertAt+1], tail...)
 	} else {
-		// No [navidrome] section found: append one.
-		lines = append(lines, "[navidrome]", line)
+		lines = append(lines, "["+section+"]", line)
 	}
 
-	return fileutil.WriteFileAtomic(path, []byte(strings.Join(lines, "\n")), 0o600)
+	if err := fileutil.WriteFileAtomic(path, []byte(strings.Join(lines, "\n")), 0o600); err != nil {
+		return fmt.Errorf("write config: %w", err)
+	}
+	return nil
 }
 
 // PlayerConfig is the subset of player controls needed to apply config.

--- a/config/mixcloud_test.go
+++ b/config/mixcloud_test.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestLoadMixcloudConfig(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CLIAMP_TEST_MIXCLOUD_TOKEN", "secret-token")
+	path := filepath.Join(os.Getenv("HOME"), ".config", "cliamp", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data := []byte(`
+[mixcloud]
+enabled = true
+username = "alice"
+access_token = "${CLIAMP_TEST_MIXCLOUD_TOKEN}"
+cookies_from = "firefox"
+styles = ["ambient", "deep-house"]
+max_items = 75
+stream_creators = 15
+`)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.Mixcloud.IsSet() || cfg.Mixcloud.Username != "alice" || cfg.Mixcloud.AccessToken != "secret-token" || cfg.Mixcloud.CookiesFrom != "firefox" {
+		t.Fatalf("Mixcloud config = %+v", cfg.Mixcloud)
+	}
+	if !slices.Equal(cfg.Mixcloud.Styles, []string{"ambient", "deep-house"}) || cfg.Mixcloud.MaxItems != 75 || cfg.Mixcloud.StreamCreators != 15 {
+		t.Fatalf("Mixcloud limits/styles = %+v", cfg.Mixcloud)
+	}
+	if !cfg.Mixcloud.StylesSet {
+		t.Fatal("explicit Mixcloud styles were not distinguished from defaults")
+	}
+}
+
+func TestLoadExplicitEmptyMixcloudStyles(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	path := filepath.Join(os.Getenv("HOME"), ".config", "cliamp", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("[mixcloud]\nenabled = true\nstyles = []\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.Mixcloud.StylesSet || len(cfg.Mixcloud.Styles) != 0 {
+		t.Fatalf("explicit empty styles = %+v", cfg.Mixcloud)
+	}
+}
+
+func TestMixcloudDisabledByDefault(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Mixcloud.IsSet() {
+		t.Fatal("Mixcloud should be opt-in")
+	}
+}

--- a/config/saver_test.go
+++ b/config/saver_test.go
@@ -198,3 +198,37 @@ func TestSaveFuncDelegates(t *testing.T) {
 		t.Errorf("config should contain 'test_key = 123':\n%s", got)
 	}
 }
+
+func TestSaveMixcloudStylesReplacesOnlyMixcloudStyles(t *testing.T) {
+	home := withHome(t)
+	dir := filepath.Join(home, ".config", "cliamp")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	initial := "# keep\n[mixcloud]\nenabled = true\nstyles = [\"ambient\"] # old\nusername = \"alice\"\n[other]\nstyles = [\"untouched\"]\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(initial), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if err := SaveMixcloudStyles([]string{"deep-house", "drum-bass"}); err != nil {
+		t.Fatalf("SaveMixcloudStyles: %v", err)
+	}
+	got := readConfig(t, home)
+	if !strings.Contains(got, `styles = ["deep-house", "drum-bass"]`) {
+		t.Fatalf("updated Mixcloud styles missing:\n%s", got)
+	}
+	if !strings.Contains(got, "[other]\nstyles = [\"untouched\"]") || !strings.Contains(got, "# keep") || !strings.Contains(got, `username = "alice"`) {
+		t.Fatalf("unrelated config changed:\n%s", got)
+	}
+}
+
+func TestSaveMixcloudStylesCreatesSection(t *testing.T) {
+	home := withHome(t)
+	if err := SaveMixcloudStyles([]string{"house"}); err != nil {
+		t.Fatalf("SaveMixcloudStyles: %v", err)
+	}
+	got := readConfig(t, home)
+	if !strings.Contains(got, "[mixcloud]") || !strings.Contains(got, `styles = ["house"]`) {
+		t.Fatalf("Mixcloud section missing:\n%s", got)
+	}
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -142,7 +142,7 @@ CLI flags override config file values for the current session only. They are not
 
 ## Setup wizard
 
-Configure remote providers (Navidrome, Plex, Jellyfin, Emby, Spotify, Qobuz, Tidal, NetEase, Audiobookshelf, YouTube Music) through a small TUI. Each provider page links to where to find the required credentials, validates the connection live where the provider supports it (media servers like Navidrome, Plex, Jellyfin, Emby, and Audiobookshelf), and writes the resulting `[provider]` block to `~/.config/cliamp/config.toml` without disturbing the rest of the file. OAuth providers (Spotify, Qobuz, Tidal) authenticate later, interactively in the player.
+Configure remote providers (Navidrome, Plex, Jellyfin, Emby, Spotify, Qobuz, Tidal, Mixcloud, NetEase, Audiobookshelf, YouTube Music) through a small TUI. Each provider page links to where to find the required credentials and writes the resulting `[provider]` block to `~/.config/cliamp/config.toml` without disturbing the rest of the file. Supported server connections are validated during setup. OAuth providers (Spotify, Qobuz, Tidal) authenticate later in the player; Mixcloud's optional browser-session or OAuth credentials are checked when used.
 
 ```sh
 cliamp setup

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,12 +1,12 @@
 # Configuration
 
-For remote providers (Navidrome, Plex, Jellyfin, Emby, Spotify, Qobuz, Tidal, NetEase, Audiobookshelf, YouTube Music), the fastest path is the interactive wizard:
+For remote providers (Navidrome, Plex, Jellyfin, Emby, Spotify, Qobuz, Tidal, Mixcloud, NetEase, Audiobookshelf, YouTube Music), the fastest path is the interactive wizard:
 
 ```sh
 cliamp setup
 ```
 
-It writes the right TOML block without touching the rest of your config, and validates server credentials live where the provider supports it (Navidrome, Plex, Jellyfin, Emby). OAuth providers such as Spotify, Qobuz, and Tidal sign in later, interactively in the player — Tidal via a `link.tidal.com` device code. See [cli.md](cli.md#setup-wizard) for details.
+It writes the right TOML block without touching the rest of your config and validates server credentials live where the provider supports it (Navidrome, Plex, Jellyfin, Emby). OAuth providers such as Spotify, Qobuz, and Tidal sign in later in the player — Tidal via a `link.tidal.com` device code. Mixcloud's optional browser-session or OAuth credentials are checked when used. See [cli.md](cli.md#setup-wizard) for details.
 
 ## Config directory
 
@@ -147,6 +147,9 @@ client_id = "${YTMUSIC_CLIENT_ID}"
 client_secret = "${YTMUSIC_CLIENT_SECRET}"
 # Optional: resolve full playlists from list= URLs (default true). Set to false to strip playlist params.
 # expand_playlist = true
+
+[mixcloud]
+access_token = "${MIXCLOUD_ACCESS_TOKEN}"
 ```
 
 Rules:
@@ -164,7 +167,7 @@ Set which provider to start with:
 provider = "radio"
 ```
 
-Valid values: `radio` (default), `navidrome`, `spotify`, `plex`, `jellyfin`, `emby`, `qobuz`, `tidal`, `soundcloud`, `netease`, `audiobookshelf`, `yt`, `youtube`, `ytmusic`.
+Valid values: `radio` (default), `navidrome`, `spotify`, `plex`, `jellyfin`, `emby`, `qobuz`, `tidal`, `soundcloud`, `mixcloud`, `netease`, `audiobookshelf`, `yt`, `youtube`, `ytmusic`.
 
 You can also override from the CLI: `cliamp --provider jellyfin`.
 
@@ -207,6 +210,43 @@ cookies_from = "firefox"   # or chrome, chromium, brave, edge, opera, safari, vi
 With cookies set, yt-dlp can stream subscriber-gated tracks (SoundCloud Go+) and access private likes/playlists your account is authorized for. The same cookies also apply to the player's yt-dlp invocations, so playback uses your signed-in session.
 
 Requires `yt-dlp` on `PATH`.
+
+## Mixcloud
+
+Mixcloud is opt-in. Public recent releases, popular shows, global show browsing,
+the live category catalogue, Latest/Popular genre charts, genre/tag search,
+native show search, direct creator jumps, and playback need no account:
+
+```toml
+[mixcloud]
+enabled = true
+```
+
+Add `username` for your following stream, activity, uploads, read-only show
+favorites, listening history, collections, and followed-creator browsing. An
+optional developer `access_token` makes `/me/` the account identity and adds
+Listen Later; `cookies_from` gives yt-dlp your signed-in browser session for
+playback that requires it.
+
+```toml
+[mixcloud]
+enabled = true
+username = "yourname"
+access_token = "${MIXCLOUD_ACCESS_TOKEN}"
+cookies_from = "firefox"
+styles = ["ambient", "deep-house", "jazz", "techno"]
+max_items = 100
+stream_creators = 20
+```
+
+The `styles` list is also the provider's local genre-favorites list. In the
+**Genres** browser, `/` filters and searches the full tag catalogue, while `f`
+atomically adds or removes a style and refreshes its Latest/Popular provider
+rows. These favorites do not modify the Mixcloud website account.
+
+See [mixcloud.md](mixcloud.md) for the complete feature matrix, provider-pane
+inventory, navigation and keybindings, favorite terminology, OAuth-token setup,
+signed-in playback, resume/seeking, and upstream limitations.
 
 ## NetEase Cloud Music
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -75,14 +75,14 @@ active when the picker opened. While typing a filter, `Enter` finishes it and
 | Key | Action |
 |---|---|
 | `f` | Toggle bookmark ★ on selected track (or favorite radio station in radio browser) |
-| `Ctrl+F` | Search — active provider's native search (Spotify, Qobuz, Tidal, Navidrome, Jellyfin, Emby, Plex, Audiobookshelf, NetEase, Local) or YouTube fallback. Available from playlist and provider-browser views. |
+| `Ctrl+F` | Search — active provider's native search (Spotify, Qobuz, Tidal, Navidrome, Jellyfin, Emby, Plex, Audiobookshelf, Mixcloud, NetEase, Local) or YouTube fallback. Available from playlist and provider-browser views. |
 | `u` | Load URL (stream/playlist) |
 | `y` | Show or close lyrics |
 | `r` | Retry lyrics lookup while lyrics are open |
 | `i` | Show track metadata (`↑`/`↓` scrolls) |
 | `Ctrl+S` | Save track to `~/Music/cliamp` |
 | `w` | Write the highlighted track to a local playlist |
-| `N` | Open the active provider browser when available |
+| `N` | Open the active provider browser; on a selected Mixcloud show, jump directly to that creator's Uploads/Favorites |
 | `L` | Browse local playlists (with cliamp radio) |
 | `R` | Open radio provider |
 | `S` | Open Spotify provider |
@@ -91,6 +91,7 @@ active when the picker opened. While typing a filter, `Enter` finishes it and
 | `E` | Open Emby provider |
 | `Y` | Open YouTube provider |
 | `C` | Open SoundCloud provider |
+| `X` | Open Mixcloud provider |
 | `M` | Open NetEase provider |
 | `Q` | Open Qobuz provider |
 | `T` | Open Tidal provider |
@@ -145,22 +146,27 @@ Shift-letter keys are reserved for provider switching, so playlist-manager track
 
 ## Provider browser (`N` key)
 
-When you press `N` to drill into a provider (Navidrome, Plex, Jellyfin, Emby, Audiobookshelf, Spotify, Qobuz, Tidal, YouTube Music), the album/artist/track screens use:
+When you press `N` to drill into a provider (Navidrome, Plex, Jellyfin, Emby, Audiobookshelf, Spotify, Qobuz, Tidal, Mixcloud, YouTube Music), the album/artist/track screens use:
 
 | Key | Action |
 |---|---|
 | `↑` `↓` / `j` `k` | Move cursor (wraps top↔bottom) |
 | `←` `→` / `h` `l` | Back / drill in |
-| `/` | Filter the visible list (search bar appears under the title) |
+| `/` | Filter the visible list; while filtering Mixcloud's Genres list, `Enter` searches the full server-side genre/tag catalogue |
+| `f` | In Mixcloud's Genres list, favorite/unfavorite the highlighted genre locally and update `[mixcloud].styles` |
 | `Enter` | Open (artists/albums) · play the highlighted track and queue the rest of the visible list |
 | `R` | Replace the queue with all visible tracks (start from the top, confirm when non-empty) |
 | `a` | Append all visible tracks to the queue |
 | `q` | Queue the highlighted track to play next |
 | `s` | Cycle album sort (album list only) |
-| `S` `N` `P` `J` `E` `Y` `C` `M` `Q` `T` `L` | Quick-switch to that provider without going back through the main pane. `R` replaces the queue on the track screen. |
+| `S` `N` `P` `J` `E` `Y` `C` `X` `M` `Q` `T` `L` | Quick-switch to that provider without going back through the main pane. `R` replaces the queue on the track screen. |
 | `Esc` `b` | Walk back one level / close the browser |
 
-The header shows a source breadcrumb such as `Navidrome / Miles Davis / Kind of Blue / Tracks`, so the current provider and drill-down location remain visible. Track rows show right-aligned durations when the provider returns them.
+Mixcloud's browser menu contains **By Show**, **By Creator**, **By Creator / Show**, and **Genres**. Genre favorites produce Latest/Popular rows in the provider pane and show-sort menu; they do not modify the Mixcloud website account. The header shows a source breadcrumb such as `Navidrome / Miles Davis / Kind of Blue / Tracks`, so the current provider and drill-down location remain visible. Track rows show right-aligned durations when the provider returns them.
+
+For Mixcloud, selecting a Show, a creator's Uploads/Favorites collection, or a
+genre's Latest/Popular view replaces the main playlist and closes the browser.
+An empty result leaves the current playlist and browser unchanged.
 
 ## Provider playlist list
 
@@ -173,12 +179,12 @@ The playlists pane (visible when focus is on a provider — Spotify, Navidrome, 
 | `Enter` | Load the highlighted playlist's tracks into the queue |
 | `/` | Filter the playlist list |
 | `Ctrl+F` | Online/server search (Spotify/Navidrome/NetEase/etc.'s own search) |
-| `Ctrl+R` | Refresh — re-pull the playlist list from the provider |
-| `S` `N` `P` `J` `E` `Y` `C` `M` `Q` `L` `R` | Switch to that provider |
+| `Ctrl+R` | Refresh — re-pull the playlist list from the provider; for Mixcloud, also clear the cached `/me/` identity |
+| `S` `N` `P` `J` `E` `Y` `C` `X` `M` `Q` `L` `R` | Switch to that provider |
 | `Tab` | Switch focus to EQ |
 | `Esc` `b` | Back to the playlist pane |
 
-Playlist rows show `Name · N tracks · 1h 23m` when the provider returns track counts and total duration. The header identifies the scope as `Provider / Playlists`. The currently loaded playlist is marked with a `▶` prefix. Spotify groups its playlists under section headers (`── library ──`, `── your playlists ──`, `── followed playlists ──`).
+Playlist rows show `Name · N tracks · 1h 23m` when the provider returns track counts and total duration. The header identifies the scope as `Provider / Playlists`. The currently loaded playlist is marked with a `▶` prefix. Spotify groups its playlists under section headers (`── library ──`, `── your playlists ──`, `── followed playlists ──`). For configured accounts, Mixcloud places Your Mixcloud first (Stream, then Favorites), followed by its Browse shortcuts, public collections, Discover charts, and each locally favorited genre's Latest/Popular pair under Music Styles. Backing out of a provider-pane Browse shortcut returns directly to the provider pane.
 
 ## Search results overlays
 
@@ -204,7 +210,7 @@ This applies to:
 - `/` file browser filter
 - `Ctrl+F` when the active provider is Local (your saved playlists)
 
-Other `Ctrl+F` providers (Spotify, Qobuz, Tidal, Navidrome, Jellyfin, Emby, Plex, Audiobookshelf, NetEase, YouTube) send your query to their own search API, so matching there follows each service's rules.
+Other `Ctrl+F` providers (Spotify, Qobuz, Tidal, Navidrome, Jellyfin, Emby, Plex, Audiobookshelf, Mixcloud, NetEase, YouTube) send your query to their own search API, so matching there follows each service's rules.
 
 ## General
 

--- a/docs/mixcloud.md
+++ b/docs/mixcloud.md
@@ -1,0 +1,368 @@
+# Mixcloud Integration
+
+cliamp supports [Mixcloud](https://www.mixcloud.com) as an opt-in provider. It
+uses Mixcloud's public JSON API for catalog metadata and the existing
+`yt-dlp`/FFmpeg pipeline for playback, so `yt-dlp` and `ffmpeg` must be on
+`PATH`.
+
+## Feature summary
+
+| Feature | Requirement | Where to use it |
+|---|---|---|
+| Direct Mixcloud show URL playback | `yt-dlp`; the provider does not need to be enabled | Pass the URL to `cliamp` or press `u` |
+| Recent releases, popular shows, show browsing and show search | `[mixcloud] enabled = true` | Provider pane, `N`, or `Ctrl+F` |
+| Live category catalogue and Latest/Popular genre charts | Provider enabled | **Genres** in the provider pane or `N` browser |
+| Genre/tag search and local genre favorites | Provider enabled and a writable config file | `/`, `Enter`, and `f` in **Genres** |
+| Public profile activity, uploads, show favorites, listening history and collections | Public profile `username`, or an `access_token` | **Your Mixcloud** and **Collections** sections |
+| Following stream and followed-creator browser | Public profile `username`, or an `access_token` | **Stream (Following Releases)** and **Creators** |
+| Jump from a highlighted show to that creator's Uploads/Favorites | Provider enabled; no configured account is required for the jump | Press `N` on a Mixcloud show |
+| Listen Later | Developer OAuth `access_token` | **Your Mixcloud** section |
+| Signed-in or subscriber-gated playback | `cookies_from` for a supported browser containing the Mixcloud session | Playback through yt-dlp |
+| Exclusive-show warning | Provider enabled | An `[E]` suffix on show rows |
+| Resume and seek-by-restart for finite shows | A successfully playable finite Mixcloud show | Normal cliamp seek keys and clean-exit resume |
+
+The provider does not implement Mixcloud write actions such as following a
+creator, favoriting or reposting a show, editing a collection, or uploading.
+The **Favorites** lists are therefore read-only. Genre favorites are a separate,
+local cliamp feature described below.
+
+## Setup
+
+Run the setup wizard and select **Mixcloud**:
+
+```sh
+cliamp setup
+```
+
+For public discovery, no account is required. The smallest manual
+configuration is:
+
+```toml
+[mixcloud]
+enabled = true
+```
+
+Add your public username to expose account-based views:
+
+```toml
+[mixcloud]
+enabled = true
+username = "your-mixcloud-username"
+```
+
+Use the username segment from your public profile URL, not an email address or
+an unrelated display label. Preserve its spelling when copying it from
+`https://www.mixcloud.com/<username>/`.
+
+To open Mixcloud at startup, also set the top-level provider option:
+
+```toml
+provider = "mixcloud"
+```
+
+## Provider pane
+
+Press `X` to switch directly to Mixcloud. The provider pane is grouped into the
+following sections.
+
+| Section | Entry | Behaviour |
+|---|---|---|
+| **Your Mixcloud** | **Stream (Following Releases)** | Merges recent uploads from followed creators; see [Limits and tuning](#limits-and-tuning) |
+| **Your Mixcloud** | **Favorites** | Reads the configured public account, or the token owner's `/me/` connections |
+| **Your Mixcloud** | **Creators** | Lists the configured account and followed creators, then separates each creator's **Uploads** and **Favorites** |
+| **Your Mixcloud** | **Uploads**, **Profile Activity**, **Listening History** | Reads the configured public account, or the token owner's `/me/` connections |
+| **Your Mixcloud** | **Listen Later** | Appears only when `access_token` is set |
+| **Browse** | **Shows** | Opens the global show catalogue with Recent Releases, Popular, and every configured style as sort modes |
+| **Browse** | **Genres** | Loads Mixcloud's current category catalogue, displays local favorite state, and opens Latest or Popular shows for a category |
+| **Collections** | One row per collection | Reads every collection returned for the account and shows its API track count |
+| **Discover** | **Recent Releases**, **Popular** | Global public discovery; no account required |
+| **Music Styles** | `<Style> — Latest`, `<Style> — Popular` | One pair for every entry in `[mixcloud].styles` |
+
+For configured accounts, **Your Mixcloud** is the first section and prioritizes
+**Stream** followed by **Favorites**, then **Creators** immediately below them.
+Public-only and degraded-account views begin with **Browse** and omit
+**Creators** from the provider pane. The hierarchy rows are shortcuts: backing
+out of their top-level Shows, Creators, or Genres list returns directly to this
+provider pane.
+
+Selecting an individual **Show**, a creator's **Uploads** or **Favorites**, or
+a genre's **Latest** or **Popular** view loads those results into the main
+playlist and closes the provider browser. Empty results leave the existing
+playlist and browser intact and show a warning.
+
+`Ctrl+R` reloads the provider lists and clears the cached `/me/` identity. Show,
+category, collection and account results are otherwise fetched from Mixcloud
+when opened rather than retained as an expiring audio-URL cache.
+
+If account resolution or collection loading fails—for example because of a
+mistyped username, expired token, or API rate limit—cliamp shows a warning and
+temporarily omits **Your Mixcloud** and **Collections**. Public **Browse**,
+**Discover**, and **Music Styles** entries remain available, so an account-side
+problem does not make the entire provider appear broken.
+
+## Hierarchical browsing and controls
+
+Pressing `N` with no recognized Mixcloud show selected opens the normal provider
+browser. Mixcloud exposes four routes:
+
+- **By Show** browses the global show catalogue. Press `s` to cycle Recent
+  Releases, Popular, and the Latest/Popular view for each configured style.
+- **By Creator** selects a creator and combines that creator's Uploads and
+  Favorites into a track list.
+- **By Creator / Show** selects a creator, then loads an explicit **Uploads**
+  or **Favorites** collection into the main playlist.
+- **Genres** browses and searches categories before loading Latest or Popular
+  into the main playlist.
+
+The creator list contains the configured account and followed creators. Both
+creator routes require `username` or `access_token`; **By Show** and **Genres**
+are public. Breadcrumbs use the Mixcloud terms **Creator** and **Show** so the
+current route remains visible.
+
+When a Mixcloud show is highlighted in the main playlist, `N` changes to
+**Browse creator** and jumps straight to that show's creator and their separate
+Uploads/Favorites choices. This works even if that creator is not followed.
+`Esc` returns to the normal browse menu from this shortcut; press `Esc` again to
+return to the originating playlist. Browsing opened through **Shows**,
+**Creators**, **Genres**, or the normal `N` menu uses one-level-at-a-time back
+navigation.
+
+| Key | Mixcloud action |
+|---|---|
+| `X` | Open the Mixcloud provider |
+| `N` | Open the browse menu, or jump from the highlighted Mixcloud show to its creator |
+| `Ctrl+F` | Search Mixcloud shows from the provider pane or provider browser |
+| `/` | Filter the currently visible creator, show, genre, sort, or track list |
+| `Enter` while filtering **Genres** | Replace the local category filter with a server-side Mixcloud tag search |
+| `f` in the **Genres** list | Add or remove the highlighted genre from local Mixcloud favorites |
+| `s` in the global show list | Cycle Recent, Popular and configured-style show views |
+| `Enter` / `→` / `l` | Drill in; on a track row, play it and queue the remaining visible rows |
+| `a` | Append all visible browser tracks to the queue |
+| `q` on a browser track | Queue the highlighted show to play next |
+| `R` on browser tracks | Replace the queue with all visible shows, with confirmation when needed |
+| `Esc` / `←` / `h` / `b` | Walk back one level or close the browser |
+| `Ctrl+R` in the provider pane | Refresh Mixcloud lists and account identity |
+| `u` | Paste a Mixcloud show URL |
+| `Ctrl+S` | Save/download the currently playing show through cliamp's normal track-save flow |
+
+Search and browse result lists retain cliamp's normal filtering, append, play,
+queue-next and replace-queue behaviour.
+
+## Genre browsing and favorites
+
+**Genres** is loaded from Mixcloud's current public category catalogue. Each
+row shows `★` when the genre is in `[mixcloud].styles` and `☆` when it is not.
+Category groups returned by Mixcloud, such as Music or Talk, are displayed next
+to the category name.
+
+Typing after `/` immediately filters the loaded catalogue by category name or
+group. Pressing `Enter` submits the same text to Mixcloud's tag search, which
+can find categories beyond the initial catalogue. Selecting any category or
+search result offers **Latest** and **Popular** show lists.
+
+Press `f` on a genre to toggle its star. cliamp then:
+
+1. atomically rewrites only `styles` in the `[mixcloud]` config section;
+2. preserves the other Mixcloud settings, comments and unrelated sections;
+3. updates the in-memory favorite state; and
+4. refreshes the **Music Styles** provider rows, adding or removing that
+   genre's Latest/Popular pair.
+
+No access token is required because this is a local cliamp preference. It does
+not favorite anything on the Mixcloud website. A failed config write leaves the
+previous UI and config state unchanged.
+
+The default styles are ambient, chillout, deep house, disco, drum and bass,
+electronica, funk, hip-hop, house, jazz, reggae, soul, techno, trance, and
+world. Override them with Mixcloud genre slugs:
+
+```toml
+[mixcloud]
+enabled = true
+styles = ["ambient", "balearic", "deep-house", "jazz"]
+```
+
+Omit `styles` to use the defaults. Set `styles = []` to start with no favorited
+genres and no **Music Styles** rows; the live **Genres** catalogue remains
+available, so styles can be added again with `f`. Values are normalized to
+lowercase hyphenated slugs and duplicates are removed.
+
+### Favorite terminology
+
+Mixcloud exposes several similarly named concepts:
+
+- **Your Mixcloud / Favorites** reads shows favorited by the configured account.
+- **Creator / Favorites** reads a selected creator's public show favorites.
+- `f` on a show in cliamp's main playlist toggles a local cliamp track bookmark.
+- `f` inside **Genres** toggles a local Mixcloud style in `[mixcloud].styles`.
+
+None of these controls writes a show favorite back to Mixcloud.
+
+## Account identity and authentication
+
+Mixcloud permits public API reads without authentication. cliamp supports four
+separate levels of configuration:
+
+| Configuration | Purpose |
+|---|---|
+| `enabled = true` | Public discovery, shows, genres, genre/tag search and show search |
+| `username` | Public account connections: following, activity, uploads, show favorites, listening history and collections |
+| `access_token` | Resolves the authorized user through `/me/` and adds Listen Later |
+| `cookies_from` | Gives yt-dlp a signed-in browser session for playback only |
+
+If both `username` and `access_token` are configured, the access-token owner's
+`/me/` identity is the source of truth for all account views. This prevents a
+stale or different public username from mixing two accounts in one menu.
+
+Browser cookies do not authenticate the JSON API, reveal private library data,
+or replace a developer token. Consequently, cliamp has no generic "logged in"
+badge for cookie playback: the cookies are read only when yt-dlp starts a show.
+
+## Access token and Listen Later
+
+A developer OAuth access token enables `/me/` account resolution and the
+read-only **Listen Later** view:
+
+```toml
+[mixcloud]
+enabled = true
+access_token = "${MIXCLOUD_ACCESS_TOKEN}"
+```
+
+Create an application and obtain a token through Mixcloud's browser-based
+OAuth flow as described in the [official API documentation](https://www.mixcloud.com/developers/).
+cliamp does not ask for or store the application client secret. Treat the
+access token as a secret; environment interpolation keeps it out of
+`config.toml`.
+
+The access token is used for API metadata only. It is never appended to
+playable show URLs or passed to yt-dlp. Although Mixcloud's API offers write
+endpoints for following, favoriting, reposting and Listen Later, cliamp does not
+call them.
+
+## Signed-in playback
+
+Public shows normally play without authentication. To give yt-dlp the same
+Mixcloud session as your browser—for subscriber-only or otherwise gated
+content—configure a browser cookie source:
+
+```toml
+[mixcloud]
+enabled = true
+username = "your-mixcloud-username"
+cookies_from = "firefox" # brave, chrome, chromium, edge, firefox, opera, safari, vivaldi, whale
+```
+
+`cookies_from` is passed to yt-dlp's `--cookies-from-browser` option. Custom
+profiles such as `chrome:Profile 1` or `firefox:default-release` are also
+accepted when supported by the installed yt-dlp version. Run `yt-dlp --help`
+and inspect `--cookies-from-browser` for its current list.
+
+Arc is not currently exposed as a separate yt-dlp cookie source. Choose a
+supported browser where you are also signed in to Mixcloud. On macOS, an
+`Operation not permitted` error while reading `~/Library` means the terminal
+app launching cliamp needs Full Disk Access; restart that terminal after
+granting it.
+
+cliamp selects yt-dlp cookies by service URL. Mixcloud can therefore use a
+different browser or profile from SoundCloud, NetEase, or YouTube without one
+provider overriding another's session.
+
+Shows that Mixcloud flags as exclusive display an `[E]` suffix in cliamp's UI.
+The marker is presentation-only, so it is not written into exported
+playlists, IPC output, or Now Playing metadata. It is a warning rather than an
+automatic skip: a signed-in listener may be entitled through a subscription,
+while another account will receive Mixcloud's restricted-show error when
+playback begins. cliamp cannot determine entitlement from the public metadata,
+so it does not filter these rows out.
+
+## Direct URLs and playback metadata
+
+Direct show URLs work wherever cliamp accepts a URL, even when the provider is
+not enabled:
+
+```sh
+cliamp https://www.mixcloud.com/creator/show-name/
+```
+
+Inside the TUI, press `u` and paste the same URL. Provider-generated queue
+entries also store stable `https://www.mixcloud.com/<creator>/<show>/` page
+URLs. yt-dlp resolves the current media URL only when playback starts, so an
+idle or long queue does not retain expired CDN URLs.
+
+Mixcloud tracks carry the show title, creator, duration, publication year,
+category tags and the best image URL returned by the API. cliamp uses the
+available fields in its normal track rows, metadata view, IPC and desktop media
+integration.
+
+## Resume and seeking
+
+When cliamp exits cleanly during a finite Mixcloud show, it saves the current
+position. The next time that exact show is played—even when cliamp originally
+opened it in the provider browser—it restarts the yt-dlp/FFmpeg pipeline at the
+saved position. Live shows and failed/unstarted playback are not recorded.
+
+Seeking and resume can take a few seconds because they start a replacement
+pipeline rather than moving an in-memory decoder. Multiple rapid seek presses
+are combined before the restart.
+
+Mixcloud's website and official widget limit fast-forwards and rewinds for some
+listener accounts. cliamp does not call that widget seek operation: it restarts
+the same playable media and asks FFmpeg to discard input up to the target
+timestamp. The website's seek allowance is therefore not available to cliamp,
+and a large jump may take longer while the replacement pipeline catches up.
+See [Mixcloud's playback-limits article](https://help.mixcloud.com/hc/en-us/articles/360004054059-Why-are-there-limits-for-rewinds-and-fast-forwards)
+and the [`seek` result in its Widget API](https://www.mixcloud.com/developers/widget/).
+
+If Mixcloud, yt-dlp, or FFmpeg cannot build the replacement, cliamp restores
+the existing pipeline and continues from its previous position instead of
+leaving the player silent.
+
+## Configuration reference
+
+| Key | Default | Meaning |
+|---|---|---|
+| `enabled` | `false` | Registers the Mixcloud provider |
+| `username` | empty | Public profile URL username used for account views when no token is set |
+| `access_token` | empty | Developer OAuth token used for `/me/` and Listen Later |
+| `cookies_from` | empty | Browser/profile passed to yt-dlp for signed-in playback |
+| `styles` | cliamp's default style list | Local genre favorites; each produces Latest and Popular provider rows and show sort modes |
+| `max_items` | `100` | Maximum shows, creators or collections returned per view; setup accepts 1–500, manual values at or below zero use the default, and larger values are capped at 500 |
+| `stream_creators` | `20` | Maximum followed creators sampled for the following stream; setup accepts 1–100, manual values at or below zero use the default, and larger values are capped at 100 |
+
+A complete example is:
+
+```toml
+provider = "mixcloud"
+
+[mixcloud]
+enabled = true
+username = "your-mixcloud-username"
+access_token = "${MIXCLOUD_ACCESS_TOKEN}"
+cookies_from = "firefox"
+styles = ["chillout", "deep-house", "drum-bass", "electronica", "house", "techno"]
+max_items = 100
+stream_creators = 20
+```
+
+## Limits and tuning
+
+The API does not expose Mixcloud's exact personalized website home feed.
+**Stream (Following Releases)** is therefore a transparent approximation: it
+fetches the first `stream_creators` followed accounts, merges their newest
+uploads, sorts by publication time, removes duplicates, and returns at most
+`max_items` shows. Lower the values if you encounter API rate limits; cliamp
+preserves Mixcloud's `Retry-After` value in the error shown to the user.
+
+Mixcloud explicitly does not provide audio streams through its JSON API. The
+official playback mechanism for third-party sites is the visible web widget.
+Terminal playback therefore depends on yt-dlp's Mixcloud extractor, which is
+not a Mixcloud-supported API and can break when the website changes. Keep
+yt-dlp current and use this integration only where permitted by Mixcloud's
+terms and the rights attached to the content.
+
+The current cliamp provider contract has no generic UI for Mixcloud write
+actions such as follow, show favorite, repost, Listen Later mutation, upload,
+comment, or collection editing. Mixcloud Live is not exposed. Show search uses
+Mixcloud's cloudcast search; creator discovery comes from followed creators and
+selected-show jumps, while genre discovery uses the category and tag APIs.

--- a/docs/provider-development.md
+++ b/docs/provider-development.md
@@ -7,9 +7,12 @@ discovers capabilities at runtime via type assertions and enables features
 accordingly.
 
 See the existing providers for reference:
+
 - `external/navidrome/`: Subsonic API, browsing, scrobbling
 - `external/plex/`: Plex Media Server, search, album tracks
 - `external/spotify/`: Spotify, search, playlist management, custom streaming
+- `external/mixcloud/`: public catalog, browse-entry shortcuts, creator jumps,
+  genre search and local genre favorites
 - `external/radio/`: internet radio, favorites
 - `external/local/`: local TOML playlist files
 - `external/audiobookshelf/`: Audiobookshelf, sectioned playlists, resume
@@ -38,6 +41,11 @@ interfaces are defined in `provider/interfaces.go`.
 |---|---|---|
 | `Searcher` | Track search overlay | `SearchTracks(ctx, query, limit)` |
 | `ArtistBrowser` | Hierarchical artist browsing | `Artists()`, `ArtistAlbums(id)` |
+| `TrackArtistResolver` | Jump from a highlighted provider track to its artist/creator with `N` | `ArtistForTrack(track)` |
+| `BrowseEntryProvider` | Add non-playable shortcuts into the provider playlist pane | `BrowseEntries()`; each entry can set `AfterID`, `AfterSection`, and `OpenInPlaylist` |
+| `GenreBrowser` | Hierarchical category browsing with provider-defined sort views | `Genres()`, `GenreSortTypes()`, `GenreTracks(genreID, sortType)` |
+| `GenreFavoriteToggler` | Favorite/unfavorite categories with `f` in the genre browser | `ToggleGenreFavorite(genreID)` |
+| `GenreSearcher` | Search beyond the initially loaded category catalogue | `SearchGenres(ctx, query, limit)` |
 | `AlbumBrowser` | Paginated album browsing with sort | `AlbumList(sort, offset, size)`, `AlbumSortTypes()` |
 | `AlbumTrackLoader` | Album track listing | `AlbumTracks(albumID)` |
 | `PlaybackReporter` | Playback reporting at track start and finish | `CanReportPlayback(track)`, `ReportNowPlaying(track, position, canSeek) error`, `ReportScrobble(track, elapsed, duration, canSeek) error` |
@@ -187,7 +195,18 @@ users can set it as their default.
 You don't need to touch the UI code. Based on which interfaces your provider
 implements, the UI will automatically:
 
-- Show the browse overlay ("N") if any registered provider implements `ArtistBrowser` or `AlbumBrowser`
+- Show the browse overlay (`N`) if any registered provider implements
+  `ArtistBrowser`, `AlbumBrowser`, or `GenreBrowser`
+- Add `BrowseEntryProvider` routes to the provider pane without exposing them
+  as playable playlists to IPC or other provider consumers. `AfterID` places a
+  route after one list item, with `AfterSection` as its section-level fallback.
+  A route extending a missing section is omitted. `OpenInPlaylist` makes its
+  non-empty final result replace the main playlist instead of opening the
+  browser's track screen
+- Jump from a highlighted track to its artist/creator when the originating
+  provider implements both `TrackArtistResolver` and `ArtistBrowser`
+- Add genre lists and sort views for `GenreBrowser`, the `f` action for
+  `GenreFavoriteToggler`, and provider-side category search for `GenreSearcher`
 - Show the search overlay ("F") if any registered provider implements `Searcher`
 - Enable add-to-playlist in search results if the searched provider implements `PlaylistWriter`
 - Report playback at track start and finish if `PlaybackReporter` is implemented, logging any failure the provider returns

--- a/docs/soundcloud.md
+++ b/docs/soundcloud.md
@@ -50,7 +50,9 @@ cookies_from = "firefox"   # also: chrome, chromium, brave, edge, opera, safari,
 
 cliamp passes `--cookies-from-browser <name>` to every yt-dlp invocation — search, browse, and playback. As long as you're signed into SoundCloud in that browser (no need to keep it open), yt-dlp acts as logged-in-you and can access content your account is authorized for.
 
-This is the same mechanism `[ytmusic] cookies_from` uses. If you set both, the last one to initialize wins for the playback path; in practice users have one default browser they're signed into multiple sites with, so this is fine.
+This is the same mechanism `[ytmusic] cookies_from` uses. Cookie sources are
+selected by service, so SoundCloud and YouTube can use different browsers or
+profiles in the same cliamp process.
 
 ## CLI
 

--- a/docs/yt-dlp.md
+++ b/docs/yt-dlp.md
@@ -1,10 +1,11 @@
-# YouTube, SoundCloud, NetEase, Bandcamp and Bilibili
+# YouTube, SoundCloud, Mixcloud, NetEase, Bandcamp and Bilibili
 
-Play from YouTube, SoundCloud, NetEase, Bandcamp, and Bilibili URLs if [yt-dlp](https://github.com/yt-dlp/yt-dlp) is installed:
+Play from YouTube, SoundCloud, Mixcloud, NetEase, Bandcamp, and Bilibili URLs if [yt-dlp](https://github.com/yt-dlp/yt-dlp) is installed:
 
 ```sh
 cliamp https://www.youtube.com/watch?v=dQw4w9WgXcQ
 cliamp https://soundcloud.com/artist/track
+cliamp https://www.mixcloud.com/creator/show-name/
 cliamp 'https://music.163.com/#/song?id=1973665667'
 cliamp https://artist.bandcamp.com/album/name
 cliamp https://www.bilibili.com/video/BV1xxxxxxxxx
@@ -24,7 +25,7 @@ cliamp search "never gonna give you up"       # search YouTube
 cliamp search-sc "lofi beats"                  # search SoundCloud
 ```
 
-Inside the TUI, press `Ctrl+F` to search the active provider — YouTube when you're on YouTube/YT-Music, SoundCloud when you're on SoundCloud, and NetEase when you're on NetEase. SoundCloud and NetEase also have dedicated provider docs covering signed-in playback: [SoundCloud](soundcloud.md), [NetEase](netease.md).
+Inside the TUI, press `Ctrl+F` to search the active provider — YouTube when you're on YouTube/YT-Music, SoundCloud when you're on SoundCloud, Mixcloud when you're on Mixcloud, and NetEase when you're on NetEase. These providers have dedicated docs covering signed-in playback: [SoundCloud](soundcloud.md), [Mixcloud](mixcloud.md), [NetEase](netease.md).
 
 ## Disclaimer
 

--- a/external/mixcloud/client.go
+++ b/external/mixcloud/client.go
@@ -1,0 +1,261 @@
+package mixcloud
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultAPIBase = "https://api.mixcloud.com"
+	apiPageSize    = 50
+	maxAPIPageSize = 100
+	maxErrorBody   = 1 << 20
+)
+
+// APIError is returned for a non-successful response from Mixcloud.
+// RetryAfter is populated for rate-limit responses when Mixcloud supplies it.
+type APIError struct {
+	StatusCode int
+	Type       string
+	Message    string
+	RetryAfter time.Duration
+}
+
+func (e *APIError) Error() string {
+	if e == nil {
+		return "mixcloud: API error"
+	}
+	msg := strings.TrimSpace(e.Message)
+	if msg == "" {
+		msg = http.StatusText(e.StatusCode)
+	}
+	if e.RetryAfter > 0 {
+		return fmt.Sprintf("mixcloud: API returned %d: %s (retry after %s)", e.StatusCode, msg, e.RetryAfter)
+	}
+	return fmt.Sprintf("mixcloud: API returned %d: %s", e.StatusCode, msg)
+}
+
+type client struct {
+	baseURL     string
+	accessToken string
+	httpClient  *http.Client
+}
+
+func newClient(accessToken string) *client {
+	return &client{
+		baseURL:     defaultAPIBase,
+		accessToken: strings.TrimSpace(accessToken),
+		httpClient:  &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func (c *client) requestURL(apiPath string, query url.Values) (string, error) {
+	if c == nil {
+		return "", errors.New("mixcloud: nil API client")
+	}
+	if !validAPIPath(apiPath) {
+		return "", fmt.Errorf("mixcloud: invalid API path %q", apiPath)
+	}
+	u, err := url.Parse(strings.TrimRight(c.baseURL, "/") + apiPath)
+	if err != nil {
+		return "", fmt.Errorf("mixcloud: build API URL: %w", err)
+	}
+	q := u.Query()
+	for key, values := range query {
+		for _, value := range values {
+			q.Add(key, value)
+		}
+	}
+	if c.accessToken != "" {
+		q.Set("access_token", c.accessToken)
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+func (c *client) getJSON(ctx context.Context, apiPath string, query url.Values, dst any) error {
+	requestURL, err := c.requestURL(apiPath, query)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return fmt.Errorf("mixcloud: create request for %s: %w", apiPath, err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "cliamp-mixcloud/1")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("mixcloud: GET %s: %w", apiPath, redactRequestURL(err, apiPath))
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return decodeAPIError(resp)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
+		return fmt.Errorf("mixcloud: decode %s: %w", apiPath, err)
+	}
+	return nil
+}
+
+// redactRequestURL prevents net/http's *url.Error from including an OAuth
+// token embedded in the query string while retaining errors.Is/errors.As
+// behavior for the underlying transport or context error.
+func redactRequestURL(err error, safeURL string) error {
+	var urlErr *url.Error
+	if !errors.As(err, &urlErr) {
+		return err
+	}
+	redacted := *urlErr
+	redacted.URL = safeURL
+	return &redacted
+}
+
+func decodeAPIError(resp *http.Response) error {
+	var envelope apiErrorEnvelope
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxErrorBody)).Decode(&envelope); err != nil && !errors.Is(err, io.EOF) {
+		return fmt.Errorf("mixcloud: API returned %s: decode error response: %w", resp.Status, err)
+	}
+	retrySeconds := envelope.Error.RetryAfter
+	if header := strings.TrimSpace(resp.Header.Get("Retry-After")); header != "" {
+		if n, err := strconv.Atoi(header); err == nil && n >= 0 {
+			retrySeconds = n
+		}
+	}
+	return &APIError{
+		StatusCode: resp.StatusCode,
+		Type:       envelope.Error.Type,
+		Message:    envelope.Error.Message,
+		RetryAfter: time.Duration(retrySeconds) * time.Second,
+	}
+}
+
+func pageQuery(offset, limit int) url.Values {
+	q := make(url.Values)
+	q.Set("offset", strconv.Itoa(max(offset, 0)))
+	q.Set("limit", strconv.Itoa(max(limit, 1)))
+	return q
+}
+
+func (c *client) cloudcastPage(ctx context.Context, apiPath string, offset, limit int) ([]apiCloudcast, bool, error) {
+	var page apiPage[apiCloudcast]
+	if err := c.getJSON(ctx, apiPath, pageQuery(offset, min(max(limit, 1), maxAPIPageSize)), &page); err != nil {
+		return nil, false, err
+	}
+	return page.Data, page.Paging.Next != "", nil
+}
+
+func (c *client) cloudcasts(ctx context.Context, apiPath string, limit int) ([]apiCloudcast, error) {
+	return pagedItems[apiCloudcast](ctx, c, apiPath, limit)
+}
+
+func (c *client) categories(ctx context.Context) ([]apiCategory, error) {
+	var page apiPage[apiCategory]
+	if err := c.getJSON(ctx, "/categories/", nil, &page); err != nil {
+		return nil, err
+	}
+	return page.Data, nil
+}
+
+func (c *client) users(ctx context.Context, apiPath string, limit int) ([]apiUser, error) {
+	return pagedItems[apiUser](ctx, c, apiPath, limit)
+}
+
+func (c *client) playlists(ctx context.Context, apiPath string, limit int) ([]apiPlaylist, error) {
+	return pagedItems[apiPlaylist](ctx, c, apiPath, limit)
+}
+
+func (c *client) activities(ctx context.Context, apiPath string, limit int) ([]apiActivity, error) {
+	return pagedItems[apiActivity](ctx, c, apiPath, limit)
+}
+
+func pagedItems[T any](ctx context.Context, c *client, apiPath string, limit int) ([]T, error) {
+	limit = max(limit, 1)
+	items := make([]T, 0, min(limit, apiPageSize))
+	for offset := 0; len(items) < limit; {
+		var page apiPage[T]
+		pageLimit := min(apiPageSize, limit-len(items))
+		if err := c.getJSON(ctx, apiPath, pageQuery(offset, pageLimit), &page); err != nil {
+			return nil, err
+		}
+		items = append(items, page.Data...)
+		if len(items) > limit {
+			items = items[:limit]
+			break
+		}
+		if page.Paging.Next == "" || len(page.Data) == 0 {
+			break
+		}
+		offset += len(page.Data)
+	}
+	return items, nil
+}
+
+func (c *client) cloudcast(ctx context.Context, key string) (apiCloudcast, error) {
+	var item apiCloudcast
+	if err := c.getJSON(ctx, ensureTrailingSlash(key), nil, &item); err != nil {
+		return apiCloudcast{}, err
+	}
+	return item, nil
+}
+
+func (c *client) user(ctx context.Context, key string) (apiUser, error) {
+	var item apiUser
+	if err := c.getJSON(ctx, ensureTrailingSlash(key), nil, &item); err != nil {
+		return apiUser{}, err
+	}
+	return item, nil
+}
+
+func (c *client) searchCloudcasts(ctx context.Context, query string, limit int) ([]apiCloudcast, error) {
+	q := pageQuery(0, min(max(limit, 1), maxAPIPageSize))
+	q.Set("q", query)
+	q.Set("type", "cloudcast")
+	var page apiPage[apiCloudcast]
+	if err := c.getJSON(ctx, "/search/", q, &page); err != nil {
+		return nil, err
+	}
+	return page.Data, nil
+}
+
+func (c *client) searchTags(ctx context.Context, query string, limit int) ([]apiTag, error) {
+	q := pageQuery(0, min(max(limit, 1), maxAPIPageSize))
+	q.Set("q", query)
+	q.Set("type", "tag")
+	var page apiPage[apiTag]
+	if err := c.getJSON(ctx, "/search/", q, &page); err != nil {
+		return nil, err
+	}
+	return page.Data, nil
+}
+
+func ensureTrailingSlash(s string) string {
+	s = "/" + strings.Trim(s, "/") + "/"
+	return s
+}
+
+func validAPIPath(apiPath string) bool {
+	if !strings.HasPrefix(apiPath, "/") || strings.Contains(apiPath, "://") || strings.ContainsAny(apiPath, "?#") {
+		return false
+	}
+	for _, segment := range strings.Split(apiPath, "/") {
+		if segment == "." || segment == ".." {
+			return false
+		}
+	}
+	return true
+}
+
+func validAPIKey(key string) bool {
+	return strings.TrimSpace(key) == key && key != "" && validAPIPath(key)
+}

--- a/external/mixcloud/client_test.go
+++ b/external/mixcloud/client_test.go
@@ -1,0 +1,181 @@
+package mixcloud
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func testClient(server *httptest.Server, token string) *client {
+	c := newClient(token)
+	c.baseURL = server.URL
+	c.httpClient = server.Client()
+	return c
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, value any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		t.Fatalf("encode response: %v", err)
+	}
+}
+
+func TestClientAddsTokenAndPaginates(t *testing.T) {
+	var offsets []int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("access_token"); got != "secret-token" {
+			t.Errorf("access_token = %q", got)
+		}
+		offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+		offsets = append(offsets, offset)
+		page := apiPage[apiCloudcast]{Data: []apiCloudcast{{Key: "/user/show-" + strconv.Itoa(offset) + "/"}}}
+		if offset == 0 {
+			page.Paging.Next = serverURLPlaceholder
+		}
+		writeJSON(t, w, page)
+	}))
+	defer server.Close()
+
+	items, err := testClient(server, "secret-token").cloudcasts(context.Background(), "/shows/", 2)
+	if err != nil {
+		t.Fatalf("cloudcasts: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("items = %d, want 2", len(items))
+	}
+	if len(offsets) != 2 || offsets[0] != 0 || offsets[1] != 1 {
+		t.Fatalf("offsets = %v, want [0 1]", offsets)
+	}
+}
+
+func TestClientCapsItemsWhenAPIExceedsRequestedLimit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, apiPage[apiCloudcast]{Data: []apiCloudcast{
+			{Key: "/user/one/"},
+			{Key: "/user/two/"},
+			{Key: "/user/three/"},
+		}})
+	}))
+	defer server.Close()
+
+	items, err := testClient(server, "").cloudcasts(context.Background(), "/shows/", 2)
+	if err != nil {
+		t.Fatalf("cloudcasts: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("items = %d, want requested limit 2", len(items))
+	}
+}
+
+func TestClientLoadsCategories(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/categories/" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		writeJSON(t, w, map[string]any{"data": []any{
+			map[string]any{"slug": "deep-house", "name": "Deep House", "format": "music"},
+		}})
+	}))
+	defer server.Close()
+
+	categories, err := testClient(server, "").categories(context.Background())
+	if err != nil {
+		t.Fatalf("categories: %v", err)
+	}
+	if len(categories) != 1 || categories[0].Slug != "deep-house" || categories[0].Format != "music" {
+		t.Fatalf("categories = %+v", categories)
+	}
+}
+
+func TestClientSearchesTags(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/search/" || r.URL.Query().Get("type") != "tag" || r.URL.Query().Get("q") != "acid techno" {
+			t.Errorf("request = %s?%s", r.URL.Path, r.URL.RawQuery)
+		}
+		writeJSON(t, w, map[string]any{"data": []any{
+			map[string]any{"key": "/genres/acid-techno/", "name": "Acid Techno"},
+		}})
+	}))
+	defer server.Close()
+
+	tags, err := testClient(server, "").searchTags(context.Background(), "acid techno", 20)
+	if err != nil {
+		t.Fatalf("searchTags: %v", err)
+	}
+	if len(tags) != 1 || tags[0].Key != "/genres/acid-techno/" {
+		t.Fatalf("tags = %+v", tags)
+	}
+}
+
+const serverURLPlaceholder = "https://api.mixcloud.com/next/"
+
+func TestClientPreservesCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := testClient(server, "").searchCloudcasts(ctx, "ambient", 10)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+}
+
+func TestClientReturnsStructuredRateLimit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "17")
+		w.WriteHeader(http.StatusForbidden)
+		writeJSON(t, w, map[string]any{"error": map[string]any{
+			"type": "RateLimitException", "message": "slow down", "retry_after": 9,
+		}})
+	}))
+	defer server.Close()
+
+	_, err := testClient(server, "").searchCloudcasts(context.Background(), "house", 5)
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error = %T %v, want *APIError", err, err)
+	}
+	if apiErr.StatusCode != http.StatusForbidden || apiErr.RetryAfter != 17*time.Second {
+		t.Fatalf("APIError = %+v", apiErr)
+	}
+}
+
+func TestRequestURLRejectsExternalPath(t *testing.T) {
+	c := newClient("")
+	if _, err := c.requestURL("https://attacker.example/", nil); err == nil {
+		t.Fatal("requestURL accepted absolute external URL")
+	}
+	if _, err := c.requestURL("/users/../me/", nil); err == nil {
+		t.Fatal("requestURL accepted a traversal path")
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+func TestClientRedactsTokenFromTransportError(t *testing.T) {
+	sentinel := errors.New("network unavailable")
+	c := newClient("top-secret-token")
+	c.httpClient = &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return nil, sentinel
+	})}
+
+	_, err := c.searchCloudcasts(context.Background(), "house", 5)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("error = %v, want wrapped transport error", err)
+	}
+	if strings.Contains(err.Error(), "top-secret-token") || strings.Contains(err.Error(), "access_token") {
+		t.Fatalf("error leaked credentials: %v", err)
+	}
+}

--- a/external/mixcloud/live_test.go
+++ b/external/mixcloud/live_test.go
@@ -1,0 +1,102 @@
+package mixcloud
+
+import (
+	"net/url"
+	"os"
+	"slices"
+	"testing"
+
+	"github.com/bjarneo/cliamp/playlist"
+	"github.com/bjarneo/cliamp/provider"
+)
+
+// TestLivePublicAPI is opt-in so ordinary and offline test runs remain
+// deterministic. It catches drift in Mixcloud's public discover/detail
+// response shapes without requiring an account or storing credentials.
+func TestLivePublicAPI(t *testing.T) {
+	if os.Getenv("CLIAMP_LIVE_MIXCLOUD") != "1" {
+		t.Skip("set CLIAMP_LIVE_MIXCLOUD=1 to exercise api.mixcloud.com")
+	}
+
+	p := NewFromConfig(Config{Enabled: true, MaxItems: 3, Styles: []string{"house"}})
+	tracks, err := p.Tracks(recentID)
+	if err != nil {
+		t.Fatalf("recent releases: %v", err)
+	}
+	if len(tracks) == 0 {
+		t.Fatal("recent releases returned no shows")
+	}
+	for _, track := range tracks {
+		u, err := url.Parse(track.Path)
+		if err != nil || u.Hostname() != "www.mixcloud.com" {
+			t.Fatalf("unexpected playback URL %q: %v", track.Path, err)
+		}
+		if track.Meta(provider.MetaMixcloudKey) == "" || track.Title == "" {
+			t.Fatalf("incomplete live show mapping: %+v", track)
+		}
+	}
+
+	detail, err := p.AlbumTracks(tracks[0].Meta(provider.MetaMixcloudKey))
+	if err != nil {
+		t.Fatalf("show detail: %v", err)
+	}
+	if len(detail) != 1 || detail[0].Path == "" {
+		t.Fatalf("show detail mapping = %+v", detail)
+	}
+
+	creator := tracks[0].Meta(provider.MetaMixcloudCreator)
+	if creator == "" {
+		t.Fatalf("recent show has no creator metadata: %+v", tracks[0])
+	}
+	collections, err := p.ArtistAlbums(creator)
+	if err != nil {
+		t.Fatalf("creator collections: %v", err)
+	}
+	if len(collections) != 2 || collections[0].Name != "Uploads" || collections[1].Name != "Favorites" {
+		t.Fatalf("creator collections = %+v", collections)
+	}
+	for _, collection := range collections {
+		if _, err := p.AlbumTracks(collection.ID); err != nil {
+			t.Fatalf("creator %s: %v", collection.Name, err)
+		}
+	}
+}
+
+// TestLivePublicAccount is opt-in and uses only a public Mixcloud username.
+// It verifies the account connections used by cliamp without reading browser
+// cookies or requiring a developer token.
+func TestLivePublicAccount(t *testing.T) {
+	if os.Getenv("CLIAMP_LIVE_MIXCLOUD") != "1" {
+		t.Skip("set CLIAMP_LIVE_MIXCLOUD=1 to exercise api.mixcloud.com")
+	}
+	username := os.Getenv("CLIAMP_LIVE_MIXCLOUD_USER")
+	if username == "" {
+		t.Skip("set CLIAMP_LIVE_MIXCLOUD_USER to a public profile username")
+	}
+
+	p := NewFromConfig(Config{
+		Enabled:        true,
+		Username:       username,
+		StylesSet:      true,
+		MaxItems:       3,
+		StreamCreators: 2,
+	})
+	lists, err := p.Playlists()
+	if err != nil {
+		t.Fatalf("account playlists: %v", err)
+	}
+	wantLists := []string{streamID, activityID, uploadsID, favoritesID, listensID}
+	for _, id := range wantLists {
+		if !slices.ContainsFunc(lists, func(item playlist.PlaylistInfo) bool { return item.ID == id }) {
+			t.Errorf("account playlists omit %q: %+v", id, lists)
+		}
+	}
+	for _, id := range wantLists {
+		if _, err := p.Tracks(id); err != nil {
+			t.Errorf("account view %q: %v", id, err)
+		}
+	}
+	if _, err := p.Artists(); err != nil {
+		t.Errorf("followed creators: %v", err)
+	}
+}

--- a/external/mixcloud/provider.go
+++ b/external/mixcloud/provider.go
@@ -1,0 +1,947 @@
+// Package mixcloud implements Mixcloud catalog browsing through the public
+// REST API and playback through cliamp's existing yt-dlp pipeline.
+package mixcloud
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"slices"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+
+	"github.com/bjarneo/cliamp/playlist"
+	"github.com/bjarneo/cliamp/provider"
+	"github.com/bjarneo/cliamp/resolve"
+)
+
+const (
+	browseShowsID      = "mixcloud:browse:shows"
+	browseCreatorsID   = "mixcloud:browse:creators"
+	browseGenresID     = "mixcloud:browse:genres"
+	recentID           = "discover:latest"
+	popularID          = "discover:popular"
+	streamID           = "account:stream"
+	activityID         = "account:activity"
+	uploadsID          = "account:uploads"
+	favoritesID        = "account:favorites"
+	listensID          = "account:listens"
+	listenLaterID      = "account:listen-later"
+	collectionPrefix   = "collection:"
+	stylePrefix        = "style:"
+	creatorUploadsID   = "creator:uploads:"
+	creatorFavoritesID = "creator:favorites:"
+	streamConcurrency  = 6
+	accountSection     = "Your Mixcloud"
+)
+
+// Setup and provider limits are exported so the onboarding UI and runtime
+// normalization cannot drift apart.
+const (
+	MinItems              = 1
+	DefaultMaxItems       = 100
+	MaxItemsLimit         = 500
+	DefaultStreamCreators = 20
+	MaxStreamCreators     = 100
+)
+
+var (
+	_ playlist.Provider             = (*Provider)(nil)
+	_ playlist.Refresher            = (*Provider)(nil)
+	_ provider.Searcher             = (*Provider)(nil)
+	_ provider.ArtistBrowser        = (*Provider)(nil)
+	_ provider.TrackArtistResolver  = (*Provider)(nil)
+	_ provider.BrowseEntryProvider  = (*Provider)(nil)
+	_ provider.AlbumBrowser         = (*Provider)(nil)
+	_ provider.AlbumTrackLoader     = (*Provider)(nil)
+	_ provider.BrowseLabeler        = (*Provider)(nil)
+	_ provider.GenreBrowser         = (*Provider)(nil)
+	_ provider.GenreFavoriteToggler = (*Provider)(nil)
+	_ provider.GenreSearcher        = (*Provider)(nil)
+)
+
+// DefaultStyles seeds useful music-style discovery when styles is omitted.
+var DefaultStyles = []string{
+	"ambient", "chillout", "deep-house", "disco", "drum-bass",
+	"electronica", "funk", "hip-hop", "house", "jazz", "reggae",
+	"soul", "techno", "trance", "world",
+}
+
+// Config holds settings for the Mixcloud provider.
+type Config struct {
+	Enabled        bool
+	Username       string
+	AccessToken    string
+	CookiesFrom    string
+	Styles         []string
+	StylesSet      bool
+	MaxItems       int
+	StreamCreators int
+	SaveStyles     func([]string) error
+}
+
+// IsSet reports whether Mixcloud should be registered.
+func (c Config) IsSet() bool { return c.Enabled }
+
+// Provider exposes Mixcloud shows as cliamp tracks. It deliberately stores
+// stable Mixcloud page URLs rather than extracted media URLs; yt-dlp resolves
+// the current stream only when playback begins, so queue entries do not expire.
+type Provider struct {
+	client         *client
+	username       string
+	styles         []string
+	maxItems       int
+	streamCreators int
+	saveStyles     func([]string) error
+
+	mu               sync.Mutex
+	resolvedUsername string
+}
+
+// NewFromConfig returns nil unless Mixcloud is explicitly enabled.
+func NewFromConfig(cfg Config) *Provider {
+	if !cfg.Enabled {
+		return nil
+	}
+	resolve.SetYTDLCookiesForHost("mixcloud.com", cfg.CookiesFrom)
+	maxItems := cfg.MaxItems
+	if maxItems <= 0 {
+		maxItems = DefaultMaxItems
+	}
+	maxItems = min(maxItems, MaxItemsLimit)
+	streamCreators := cfg.StreamCreators
+	if streamCreators <= 0 {
+		streamCreators = DefaultStreamCreators
+	}
+	streamCreators = min(streamCreators, MaxStreamCreators)
+
+	styles := normalizeStyles(cfg.Styles)
+	if len(styles) == 0 && !cfg.StylesSet {
+		styles = slices.Clone(DefaultStyles)
+	}
+	return &Provider{
+		client:         newClient(cfg.AccessToken),
+		username:       strings.TrimSpace(cfg.Username),
+		styles:         styles,
+		maxItems:       maxItems,
+		streamCreators: streamCreators,
+		saveStyles:     cfg.SaveStyles,
+	}
+}
+
+func (p *Provider) Name() string { return "Mixcloud" }
+
+// BrowseEntries makes the same show, creator, and genre routes available from the
+// provider pane that users can otherwise reach through the N browser.
+func (p *Provider) BrowseEntries() []provider.BrowseEntry {
+	return []provider.BrowseEntry{
+		{
+			ID: browseCreatorsID, Name: "Creators", Section: accountSection,
+			Mode: provider.BrowseArtistAlbums, AfterID: favoritesID,
+			AfterSection: accountSection, OpenInPlaylist: true,
+		},
+		{
+			ID: browseShowsID, Name: "Shows", Section: "Browse",
+			Mode: provider.BrowseAlbums, AfterSection: accountSection, OpenInPlaylist: true,
+		},
+		{
+			ID: browseGenresID, Name: "Genres", Section: "Browse",
+			Mode: provider.BrowseGenres, AfterSection: accountSection, OpenInPlaylist: true,
+		},
+	}
+}
+
+// Refresh clears account identity discovered through /me/. Catalog and track
+// pages are intentionally not cached, so subsequent loads always fetch fresh
+// releases and retain no expiring audio URLs.
+func (p *Provider) Refresh() {
+	p.mu.Lock()
+	p.resolvedUsername = ""
+	p.mu.Unlock()
+}
+
+// Playlists returns discovery views, account views, Mixcloud collections, and
+// latest/popular views for each configured music style.
+func (p *Provider) Playlists() ([]playlist.PlaylistInfo, error) {
+	publicLists := []playlist.PlaylistInfo{
+		{ID: recentID, Name: "Recent Releases", Section: "Discover"},
+		{ID: popularID, Name: "Popular", Section: "Discover"},
+	}
+	styleLists := p.stylePlaylists()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if !p.hasAccount() {
+		return append(publicLists, styleLists...), nil
+	}
+
+	username, err := p.accountUsername(ctx)
+	if err != nil {
+		return append(publicLists, styleLists...), fmt.Errorf("mixcloud: account views unavailable: %w", err)
+	}
+	collections, err := p.client.playlists(ctx, p.accountConnection(username, "playlists"), p.maxItems)
+	if err != nil {
+		return append(publicLists, styleLists...), fmt.Errorf("mixcloud: account views unavailable: list collections: %w", err)
+	}
+
+	lists := []playlist.PlaylistInfo{
+		{ID: streamID, Name: "Stream (Following Releases)", Section: accountSection},
+		{ID: favoritesID, Name: "Favorites", Section: accountSection},
+		{ID: uploadsID, Name: "Uploads", Section: accountSection},
+		{ID: activityID, Name: "Profile Activity", Section: accountSection},
+		{ID: listensID, Name: "Listening History", Section: accountSection},
+	}
+	if p.client.accessToken != "" {
+		lists = append(lists, playlist.PlaylistInfo{ID: listenLaterID, Name: "Listen Later", Section: accountSection})
+	}
+	for _, collection := range collections {
+		lists = append(lists, playlist.PlaylistInfo{
+			ID:         collectionPrefix + collection.Key,
+			Name:       collection.Name,
+			TrackCount: collection.CloudcastCount,
+			Section:    "Collections",
+		})
+	}
+	lists = append(lists, publicLists...)
+	return append(lists, styleLists...), nil
+}
+
+func (p *Provider) stylePlaylists() []playlist.PlaylistInfo {
+	var lists []playlist.PlaylistInfo
+	for _, style := range p.styleSnapshot() {
+		label := styleLabel(style)
+		lists = append(lists,
+			playlist.PlaylistInfo{ID: stylePrefix + style + ":latest", Name: label + " — Latest", Section: "Music Styles"},
+			playlist.PlaylistInfo{ID: stylePrefix + style + ":popular", Name: label + " — Popular", Section: "Music Styles"},
+		)
+	}
+	return lists
+}
+
+// Tracks loads shows from one of the synthetic or account playlist views.
+func (p *Provider) Tracks(playlistID string) ([]playlist.Track, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	var (
+		shows []apiCloudcast
+		err   error
+	)
+	switch playlistID {
+	case recentID:
+		shows, err = p.client.cloudcasts(ctx, "/discover/all/latest/", p.maxItems)
+	case popularID:
+		shows, err = p.client.cloudcasts(ctx, "/discover/all/popular/", p.maxItems)
+	case streamID:
+		shows, err = p.followingStream(ctx)
+	case activityID:
+		shows, err = p.profileActivity(ctx)
+	case uploadsID:
+		shows, err = p.accountCloudcasts(ctx, "cloudcasts")
+	case favoritesID:
+		shows, err = p.accountCloudcasts(ctx, "favorites")
+	case listensID:
+		shows, err = p.accountCloudcasts(ctx, "listens")
+	case listenLaterID:
+		if p.client.accessToken == "" {
+			return nil, errors.New("mixcloud: Listen Later requires an access_token")
+		}
+		shows, err = p.client.cloudcasts(ctx, "/me/listen-later/", p.maxItems)
+	default:
+		switch {
+		case strings.HasPrefix(playlistID, collectionPrefix):
+			key := strings.TrimPrefix(playlistID, collectionPrefix)
+			if !validAPIKey(key) || !strings.Contains(key, "/playlists/") {
+				return nil, fmt.Errorf("mixcloud: invalid collection key %q", key)
+			}
+			shows, err = p.client.cloudcasts(ctx, ensureTrailingSlash(key)+"cloudcasts/", p.maxItems)
+		case strings.HasPrefix(playlistID, stylePrefix):
+			style, order, ok := parseStyleID(playlistID)
+			if !ok {
+				return nil, fmt.Errorf("mixcloud: invalid style playlist %q", playlistID)
+			}
+			shows, err = p.client.cloudcasts(ctx, discoverPath(style, order), p.maxItems)
+		default:
+			return nil, fmt.Errorf("mixcloud: unknown playlist %q", playlistID)
+		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("mixcloud: load playlist %q: %w", playlistID, err)
+	}
+	return tracksFromCloudcasts(shows), nil
+}
+
+func (p *Provider) SearchTracks(ctx context.Context, query string, limit int) ([]playlist.Track, error) {
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("mixcloud: search shows: %w", err)
+	}
+	shows, err := p.client.searchCloudcasts(ctx, q, limit)
+	if err != nil {
+		return nil, fmt.Errorf("mixcloud: search shows: %w", err)
+	}
+	return tracksFromCloudcasts(shows), nil
+}
+
+// Artists lists the configured account followed creators. Without account
+// configuration there is no meaningful finite creator list, so it is empty.
+func (p *Provider) Artists() ([]provider.ArtistInfo, error) {
+	if !p.hasAccount() {
+		return nil, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	username, err := p.accountUsername(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("mixcloud: resolve account for creators: %w", err)
+	}
+	users, err := p.client.users(ctx, p.accountConnection(username, "following"), p.maxItems)
+	if err != nil {
+		return nil, fmt.Errorf("mixcloud: list followed creators: %w", err)
+	}
+	artists := make([]provider.ArtistInfo, 0, len(users)+1)
+	if username != "" {
+		artists = append(artists, provider.ArtistInfo{ID: username, Name: username})
+	}
+	for _, user := range users {
+		name := user.Name
+		if name == "" {
+			name = user.Username
+		}
+		artists = append(artists, provider.ArtistInfo{ID: user.Username, Name: name, AlbumCount: user.CloudcastCount})
+	}
+	return dedupeArtists(artists), nil
+}
+
+func (p *Provider) ArtistAlbums(artistID string) ([]provider.AlbumInfo, error) {
+	username := strings.TrimSpace(artistID)
+	if !validUsername(username) {
+		return nil, fmt.Errorf("mixcloud: invalid creator username %q", artistID)
+	}
+	return []provider.AlbumInfo{
+		{ID: creatorCollectionID(creatorUploadsID, username), Name: "Uploads", Artist: username, ArtistID: username},
+		{ID: creatorCollectionID(creatorFavoritesID, username), Name: "Favorites", Artist: username, ArtistID: username},
+	}, nil
+}
+
+// ArtistForTrack resolves a Mixcloud show back to its owning creator so the UI
+// can jump directly from a selected show to that creator's Uploads/Favorites.
+func (p *Provider) ArtistForTrack(track playlist.Track) (provider.ArtistInfo, bool) {
+	username := strings.TrimSpace(track.Meta(provider.MetaMixcloudCreator))
+	if !validUsername(username) {
+		return provider.ArtistInfo{}, false
+	}
+	name := strings.TrimSpace(track.Artist)
+	if name == "" {
+		name = username
+	}
+	return provider.ArtistInfo{ID: username, Name: name}, true
+}
+
+func (p *Provider) AlbumList(sortType string, offset, size int) ([]provider.AlbumInfo, error) {
+	if size <= 0 {
+		size = 50
+	}
+	apiPath, ok := p.albumSortPath(sortType)
+	if !ok {
+		return nil, fmt.Errorf("mixcloud: unknown show sort %q", sortType)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	shows, _, err := p.client.cloudcastPage(ctx, apiPath, offset, size)
+	if err != nil {
+		return nil, fmt.Errorf("mixcloud: list shows: %w", err)
+	}
+	return albumsFromCloudcasts(shows), nil
+}
+
+func (p *Provider) AlbumSortTypes() []provider.SortType {
+	sorts := []provider.SortType{{ID: "latest", Label: "Recent Releases"}, {ID: "popular", Label: "Popular"}}
+	for _, style := range p.styleSnapshot() {
+		label := styleLabel(style)
+		sorts = append(sorts,
+			provider.SortType{ID: stylePrefix + style + ":latest", Label: label + " — Latest"},
+			provider.SortType{ID: stylePrefix + style + ":popular", Label: label + " — Popular"},
+		)
+	}
+	return sorts
+}
+
+func (p *Provider) DefaultAlbumSort() string { return "latest" }
+
+// Genres returns Mixcloud's current public category catalogue, marking the
+// entries pinned in config. Configured styles missing from the live catalogue
+// are retained so a temporary API change never makes a favorite unreachable.
+func (p *Provider) Genres() ([]provider.GenreInfo, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	categories, err := p.client.categories(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("mixcloud: list genres: %w", err)
+	}
+
+	favorites := p.styleSnapshot()
+	favoriteSet := make(map[string]bool, len(favorites))
+	for _, style := range favorites {
+		favoriteSet[style] = true
+	}
+	genres := make([]provider.GenreInfo, 0, len(categories)+len(favorites))
+	seen := make(map[string]bool, len(categories)+len(favorites))
+	for _, category := range categories {
+		id := canonicalStyle(category.Slug)
+		name := strings.TrimSpace(category.Name)
+		if id == "" || name == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		genres = append(genres, provider.GenreInfo{
+			ID:       id,
+			Name:     name,
+			Group:    styleLabel(category.Format),
+			Favorite: favoriteSet[id],
+		})
+	}
+	for _, style := range favorites {
+		if seen[style] {
+			continue
+		}
+		genres = append(genres, provider.GenreInfo{ID: style, Name: styleLabel(style), Group: "Music", Favorite: true})
+	}
+	return genres, nil
+}
+
+func (p *Provider) GenreSortTypes() []provider.SortType {
+	return []provider.SortType{{ID: "latest", Label: "Latest"}, {ID: "popular", Label: "Popular"}}
+}
+
+func (p *Provider) SearchGenres(ctx context.Context, query string, limit int) ([]provider.GenreInfo, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("mixcloud: search genres: %w", err)
+	}
+	tags, err := p.client.searchTags(ctx, query, limit)
+	if err != nil {
+		return nil, fmt.Errorf("mixcloud: search genres: %w", err)
+	}
+	favoriteSet := make(map[string]bool)
+	for _, style := range p.styleSnapshot() {
+		favoriteSet[style] = true
+	}
+	genres := make([]provider.GenreInfo, 0, len(tags))
+	seen := make(map[string]bool, len(tags))
+	for _, tag := range tags {
+		id := styleFromTagKey(tag.Key)
+		if id == "" {
+			id = canonicalStyle(tag.Name)
+		}
+		name := strings.TrimSpace(tag.Name)
+		if id == "" || name == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		genres = append(genres, provider.GenreInfo{ID: id, Name: name, Favorite: favoriteSet[id]})
+	}
+	return genres, nil
+}
+
+func (p *Provider) GenreTracks(genreID, sortType string) ([]playlist.Track, error) {
+	genreID = canonicalStyle(genreID)
+	if genreID == "" || (sortType != "latest" && sortType != "popular") {
+		return nil, fmt.Errorf("mixcloud: invalid genre browse %q/%q", genreID, sortType)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	shows, err := p.client.cloudcasts(ctx, discoverPath(genreID, sortType), p.maxItems)
+	if err != nil {
+		return nil, fmt.Errorf("mixcloud: browse genre %q: %w", genreID, err)
+	}
+	return tracksFromCloudcasts(shows), nil
+}
+
+// ToggleGenreFavorite updates both the live provider menu and the configured
+// [mixcloud].styles list. Persistence happens before the in-memory change so a
+// failed atomic write cannot make the UI disagree with disk.
+func (p *Provider) ToggleGenreFavorite(genreID string) (bool, error) {
+	genreID = canonicalStyle(genreID)
+	if genreID == "" {
+		return false, errors.New("mixcloud: invalid genre")
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	next := slices.Clone(p.styles)
+	favorite := !slices.Contains(next, genreID)
+	if favorite {
+		next = append(next, genreID)
+	} else {
+		next = slices.DeleteFunc(next, func(style string) bool { return style == genreID })
+	}
+	if p.saveStyles != nil {
+		if err := p.saveStyles(next); err != nil {
+			return !favorite, fmt.Errorf("mixcloud: save genre favorites: %w", err)
+		}
+	}
+	p.styles = next
+	return favorite, nil
+}
+
+func (p *Provider) styleSnapshot() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return slices.Clone(p.styles)
+}
+
+func (p *Provider) AlbumTracks(albumID string) ([]playlist.Track, error) {
+	if username, connection, ok := parseCreatorCollectionID(albumID); ok {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		shows, err := p.client.cloudcasts(ctx, userPath(username, connection), p.maxItems)
+		if err != nil {
+			return nil, fmt.Errorf("mixcloud: load creator %q %s: %w", username, connection, err)
+		}
+		tracks := tracksFromCloudcasts(shows)
+		label := "Uploads"
+		if connection == "favorites" {
+			label = "Favorites"
+		}
+		for i := range tracks {
+			tracks[i].Album = label
+		}
+		return tracks, nil
+	}
+	if !validAPIKey(albumID) {
+		return nil, fmt.Errorf("mixcloud: invalid show key %q", albumID)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	show, err := p.client.cloudcast(ctx, albumID)
+	if err != nil {
+		return nil, fmt.Errorf("mixcloud: load show: %w", err)
+	}
+	track := trackFromCloudcast(show)
+	if track.Path == "" {
+		return nil, errors.New("mixcloud: show returned no playback URL or key")
+	}
+	return []playlist.Track{track}, nil
+}
+
+func (p *Provider) BrowseLabels() (artist, album string) { return "Creator", "Show" }
+
+func (p *Provider) hasAccount() bool {
+	return p.username != "" || p.client.accessToken != ""
+}
+
+func (p *Provider) accountUsername(ctx context.Context) (string, error) {
+	// An access token makes /me the source of truth. This keeps account views
+	// internally consistent when a configured public username is stale or
+	// belongs to a different account than the token.
+	if p.client.accessToken == "" && p.username != "" {
+		return p.username, nil
+	}
+	p.mu.Lock()
+	username := p.resolvedUsername
+	p.mu.Unlock()
+	if username != "" {
+		return username, nil
+	}
+	if p.client.accessToken == "" {
+		return "", errors.New("mixcloud: username or access_token is required for account views")
+	}
+	me, err := p.client.user(ctx, "/me/")
+	if err != nil {
+		return "", fmt.Errorf("mixcloud: resolve access-token account: %w", err)
+	}
+	if me.Username == "" {
+		return "", errors.New("mixcloud: /me/ returned no username")
+	}
+	p.mu.Lock()
+	p.resolvedUsername = me.Username
+	p.mu.Unlock()
+	return me.Username, nil
+}
+
+func (p *Provider) accountConnection(username, connection string) string {
+	if p.client.accessToken != "" {
+		return "/me/" + strings.Trim(connection, "/") + "/"
+	}
+	return userPath(username, connection)
+}
+
+func (p *Provider) accountCloudcasts(ctx context.Context, connection string) ([]apiCloudcast, error) {
+	username, err := p.accountUsername(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return p.client.cloudcasts(ctx, p.accountConnection(username, connection), p.maxItems)
+}
+
+func (p *Provider) profileActivity(ctx context.Context) ([]apiCloudcast, error) {
+	username, err := p.accountUsername(ctx)
+	if err != nil {
+		return nil, err
+	}
+	activities, err := p.client.activities(ctx, p.accountConnection(username, "feed"), p.maxItems)
+	if err != nil {
+		return nil, err
+	}
+	var shows []apiCloudcast
+	for _, activity := range activities {
+		shows = append(shows, activity.Cloudcasts...)
+	}
+	return dedupeCloudcasts(shows, p.maxItems), nil
+}
+
+// followingStream approximates Mixcloud's website stream using the documented
+// API: fetch followed creators, then merge each creator's newest uploads.
+func (p *Provider) followingStream(ctx context.Context) ([]apiCloudcast, error) {
+	username, err := p.accountUsername(ctx)
+	if err != nil {
+		return nil, err
+	}
+	users, err := p.client.users(ctx, p.accountConnection(username, "following"), p.streamCreators)
+	if err != nil {
+		return nil, fmt.Errorf("mixcloud: load followed creators for stream: %w", err)
+	}
+	if len(users) == 0 {
+		return nil, nil
+	}
+	perCreator := max(2, (p.maxItems+len(users)-1)/len(users))
+
+	type result struct {
+		shows []apiCloudcast
+		err   error
+	}
+	results := make(chan result, len(users))
+	sem := make(chan struct{}, streamConcurrency)
+	var wg sync.WaitGroup
+	for _, user := range users {
+		if user.Username == "" {
+			continue
+		}
+		wg.Add(1)
+		go func(username string) {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				results <- result{err: ctx.Err()}
+				return
+			}
+			defer func() { <-sem }()
+			shows, err := p.client.cloudcasts(ctx, userPath(username, "cloudcasts"), perCreator)
+			results <- result{shows: shows, err: err}
+		}(user.Username)
+	}
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	var (
+		shows    []apiCloudcast
+		firstErr error
+	)
+	for result := range results {
+		if result.err != nil {
+			if errors.Is(result.err, context.Canceled) || errors.Is(result.err, context.DeadlineExceeded) {
+				return nil, result.err
+			}
+			var apiErr *APIError
+			if errors.As(result.err, &apiErr) && apiErr.StatusCode == 404 {
+				// A followed creator may have disappeared between listing and
+				// loading. Treat only that expected race as an empty source.
+				continue
+			}
+			if firstErr == nil {
+				firstErr = result.err
+			}
+			continue
+		}
+		shows = append(shows, result.shows...)
+	}
+	if firstErr != nil {
+		return nil, fmt.Errorf("mixcloud: build following stream: %w", firstErr)
+	}
+	sort.SliceStable(shows, func(i, j int) bool { return shows[i].CreatedTime.After(shows[j].CreatedTime) })
+	return dedupeCloudcasts(shows, p.maxItems), nil
+}
+
+func (p *Provider) albumSortPath(sortType string) (string, bool) {
+	switch sortType {
+	case "", "latest":
+		return "/discover/all/latest/", true
+	case "popular":
+		return "/discover/all/popular/", true
+	default:
+		style, order, ok := parseStyleID(sortType)
+		if !ok {
+			return "", false
+		}
+		return discoverPath(style, order), true
+	}
+}
+
+func tracksFromCloudcasts(shows []apiCloudcast) []playlist.Track {
+	tracks := make([]playlist.Track, 0, len(shows))
+	for _, show := range shows {
+		track := trackFromCloudcast(show)
+		if track.Path != "" {
+			tracks = append(tracks, track)
+		}
+	}
+	return tracks
+}
+
+func trackFromCloudcast(show apiCloudcast) playlist.Track {
+	pageURL := mixcloudPageURL(show.URL)
+	if pageURL == "" && validAPIKey(show.Key) {
+		pageURL = "https://www.mixcloud.com" + ensureTrailingSlash(show.Key)
+	}
+	artist := show.User.Name
+	if artist == "" {
+		artist = show.User.Username
+	}
+	year := 0
+	if !show.CreatedTime.IsZero() {
+		year = show.CreatedTime.Year()
+	}
+	meta := map[string]string{provider.MetaMixcloudKey: show.Key}
+	if validUsername(show.User.Username) {
+		meta[provider.MetaMixcloudCreator] = show.User.Username
+	}
+	if show.IsExclusive {
+		meta[provider.MetaMixcloudExclusive] = "true"
+	}
+	return playlist.Track{
+		Path:         pageURL,
+		Title:        show.Name,
+		Artist:       artist,
+		Genre:        tagNames(show.Tags),
+		Year:         year,
+		Stream:       true,
+		DurationSecs: show.AudioLength,
+		AlbumArtURL:  bestPicture(show.Pictures),
+		ProviderMeta: meta,
+	}
+}
+
+func mixcloudPageURL(rawURL string) string {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || u.Scheme != "https" || (u.Hostname() != "mixcloud.com" && u.Hostname() != "www.mixcloud.com") {
+		return ""
+	}
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
+}
+
+func albumsFromCloudcasts(shows []apiCloudcast) []provider.AlbumInfo {
+	albums := make([]provider.AlbumInfo, 0, len(shows))
+	for _, show := range shows {
+		if !validAPIKey(show.Key) {
+			continue
+		}
+		artist := show.User.Name
+		if artist == "" {
+			artist = show.User.Username
+		}
+		year := 0
+		if !show.CreatedTime.IsZero() {
+			year = show.CreatedTime.Year()
+		}
+		albums = append(albums, provider.AlbumInfo{
+			ID:         show.Key,
+			Name:       show.Name,
+			Artist:     artist,
+			ArtistID:   show.User.Username,
+			Year:       year,
+			TrackCount: 1,
+			Genre:      tagNames(show.Tags),
+			Restricted: show.IsExclusive,
+		})
+	}
+	return albums
+}
+
+func tagNames(tags []apiTag) string {
+	names := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		if name := strings.TrimSpace(tag.Name); name != "" {
+			names = append(names, name)
+		}
+	}
+	return strings.Join(names, ", ")
+}
+
+func bestPicture(pictures apiPictures) string {
+	if pictures.ExtraLarge != "" {
+		return pictures.ExtraLarge
+	}
+	if pictures.Large != "" {
+		return pictures.Large
+	}
+	return pictures.Medium
+}
+
+func userPath(username, connection string) string {
+	return "/" + url.PathEscape(strings.TrimSpace(username)) + "/" + strings.Trim(connection, "/") + "/"
+}
+
+func validUsername(username string) bool {
+	return username != "" && strings.TrimSpace(username) == username && !strings.ContainsAny(username, "/?#")
+}
+
+func creatorCollectionID(prefix, username string) string {
+	return prefix + url.PathEscape(username)
+}
+
+func parseCreatorCollectionID(id string) (username, connection string, ok bool) {
+	var encoded string
+	switch {
+	case strings.HasPrefix(id, creatorUploadsID):
+		encoded = strings.TrimPrefix(id, creatorUploadsID)
+		connection = "cloudcasts"
+	case strings.HasPrefix(id, creatorFavoritesID):
+		encoded = strings.TrimPrefix(id, creatorFavoritesID)
+		connection = "favorites"
+	default:
+		return "", "", false
+	}
+	username, err := url.PathUnescape(encoded)
+	if err != nil || !validUsername(username) {
+		return "", "", false
+	}
+	return username, connection, true
+}
+
+func discoverPath(style, order string) string {
+	return "/discover/" + url.PathEscape(style) + "/" + order + "/"
+}
+
+func parseStyleID(id string) (style, order string, ok bool) {
+	if !strings.HasPrefix(id, stylePrefix) {
+		return "", "", false
+	}
+	rest := strings.TrimPrefix(id, stylePrefix)
+	style, order, ok = strings.Cut(rest, ":")
+	if !ok || normalizeStyle(style) != style || (order != "latest" && order != "popular") {
+		return "", "", false
+	}
+	return style, order, true
+}
+
+func normalizeStyles(styles []string) []string {
+	out := make([]string, 0, len(styles))
+	seen := make(map[string]bool)
+	for _, value := range styles {
+		style := canonicalStyle(value)
+		if style == "" || seen[style] {
+			continue
+		}
+		seen[style] = true
+		out = append(out, style)
+	}
+	return out
+}
+
+func canonicalStyle(value string) string {
+	style := normalizeStyle(value)
+	switch style {
+	case "drum-and-bass":
+		return "drum-bass"
+	case "r-b", "r-and-b":
+		return "rb"
+	default:
+		return style
+	}
+}
+
+func styleFromTagKey(key string) string {
+	const prefix = "/genres/"
+	if !strings.HasPrefix(key, prefix) || !strings.HasSuffix(key, "/") {
+		return ""
+	}
+	style := strings.TrimSuffix(strings.TrimPrefix(key, prefix), "/")
+	if strings.Contains(style, "/") || canonicalStyle(style) != style {
+		return ""
+	}
+	return style
+}
+
+func normalizeStyle(value string) string {
+	var b strings.Builder
+	lastDash := false
+	for _, r := range strings.ToLower(strings.TrimSpace(value)) {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			b.WriteRune(r)
+			lastDash = false
+		case !lastDash && b.Len() > 0:
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+func styleLabel(style string) string {
+	parts := strings.Split(style, "-")
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		runes := []rune(part)
+		runes[0] = unicode.ToUpper(runes[0])
+		parts[i] = string(runes)
+	}
+	return strings.Join(parts, " ")
+}
+
+func dedupeCloudcasts(shows []apiCloudcast, limit int) []apiCloudcast {
+	out := make([]apiCloudcast, 0, min(len(shows), limit))
+	seen := make(map[string]bool)
+	for _, show := range shows {
+		key := show.Key
+		if key == "" {
+			key = show.URL
+		}
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, show)
+		if len(out) == limit {
+			break
+		}
+	}
+	return out
+}
+
+func dedupeArtists(artists []provider.ArtistInfo) []provider.ArtistInfo {
+	out := make([]provider.ArtistInfo, 0, len(artists))
+	seen := make(map[string]bool)
+	for _, artist := range artists {
+		key := strings.ToLower(artist.ID)
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, artist)
+	}
+	return out
+}

--- a/external/mixcloud/provider_test.go
+++ b/external/mixcloud/provider_test.go
@@ -1,0 +1,540 @@
+package mixcloud
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bjarneo/cliamp/playlist"
+	"github.com/bjarneo/cliamp/provider"
+)
+
+func providerWithServer(t *testing.T, cfg Config, handler http.HandlerFunc) (*Provider, *httptest.Server) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	p := NewFromConfig(cfg)
+	if p == nil {
+		server.Close()
+		t.Fatal("NewFromConfig returned nil")
+	}
+	p.client.baseURL = server.URL
+	p.client.httpClient = server.Client()
+	return p, server
+}
+
+func offlineProvider(t *testing.T, cfg Config) *Provider {
+	t.Helper()
+	p, server := providerWithServer(t, cfg, func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected request: %s", r.URL.Path)
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	})
+	t.Cleanup(server.Close)
+	return p
+}
+
+func TestNewFromConfigAndStyles(t *testing.T) {
+	if NewFromConfig(Config{}) != nil {
+		t.Fatal("disabled provider should be nil")
+	}
+	p := NewFromConfig(Config{Enabled: true, Styles: []string{" Deep House ", "deep-house", "Drum & Bass"}})
+	if got, want := p.styles, []string{"deep-house", "drum-bass"}; !slices.Equal(got, want) {
+		t.Fatalf("styles = %v, want %v", got, want)
+	}
+	if p.maxItems != DefaultMaxItems || p.streamCreators != DefaultStreamCreators {
+		t.Fatalf("defaults = max %d stream %d", p.maxItems, p.streamCreators)
+	}
+}
+
+func TestExplicitEmptyStylesDoNotRestoreDefaults(t *testing.T) {
+	p := NewFromConfig(Config{Enabled: true, StylesSet: true})
+	if got := p.styleSnapshot(); len(got) != 0 {
+		t.Fatalf("explicit empty styles = %v, want none", got)
+	}
+}
+
+func TestPublicPlaylistsNeedNoNetwork(t *testing.T) {
+	p := offlineProvider(t, Config{Enabled: true, Styles: []string{"house"}})
+	lists, err := p.Playlists()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]bool{recentID: true, popularID: true, "style:house:latest": true, "style:house:popular": true}
+	for _, item := range lists {
+		delete(want, item.ID)
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing playlist IDs: %v", want)
+	}
+}
+
+func TestBrowseEntriesExposeShowsCreatorsAndGenres(t *testing.T) {
+	p := NewFromConfig(Config{Enabled: true, Username: "alice"})
+	entries := p.BrowseEntries()
+	if len(entries) != 3 {
+		t.Fatalf("browse entries = %d, want 3", len(entries))
+	}
+	if entries[0].ID != browseCreatorsID || entries[0].Name != "Creators" || entries[0].Section != accountSection || entries[0].Mode != provider.BrowseArtistAlbums {
+		t.Fatalf("creators entry = %+v", entries[0])
+	}
+	if entries[1].ID != browseShowsID || entries[1].Name != "Shows" || entries[1].Mode != provider.BrowseAlbums {
+		t.Fatalf("shows entry = %+v", entries[1])
+	}
+	if entries[2].ID != browseGenresID || entries[2].Name != "Genres" || entries[2].Mode != provider.BrowseGenres {
+		t.Fatalf("genres entry = %+v", entries[2])
+	}
+	for _, entry := range entries {
+		if entry.AfterSection != accountSection || !entry.OpenInPlaylist {
+			t.Fatalf("browse entry placement/leaf behavior = %+v", entry)
+		}
+	}
+	if entries[0].AfterID != favoritesID {
+		t.Fatalf("creators placement = %+v, want immediately after Favorites", entries[0])
+	}
+
+	publicEntries := NewFromConfig(Config{Enabled: true}).BrowseEntries()
+	if len(publicEntries) != 3 || publicEntries[0].ID != browseCreatorsID || !publicEntries[0].OpenInPlaylist {
+		t.Fatalf("public browse capabilities = %+v, want config-independent creator behavior", publicEntries)
+	}
+}
+
+func TestGenresLoadLiveCategoriesAndPersistFavorites(t *testing.T) {
+	var saved []string
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/categories/":
+			writeJSON(t, w, map[string]any{"data": []any{
+				map[string]any{"slug": "house", "name": "House", "format": "music"},
+				map[string]any{"slug": "technology", "name": "Technology", "format": "talk"},
+			}})
+		case "/discover/technology/popular/":
+			writeJSON(t, w, map[string]any{"data": []any{map[string]any{
+				"key": "/creator/tech-show/", "name": "Tech Show", "user": map[string]any{"username": "creator"},
+			}}})
+		case "/search/":
+			if r.URL.Query().Get("type") != "tag" {
+				t.Errorf("search type = %q", r.URL.Query().Get("type"))
+			}
+			writeJSON(t, w, map[string]any{"data": []any{
+				map[string]any{"key": "/genres/acid-techno/", "name": "Acid Techno"},
+			}})
+		default:
+			http.NotFound(w, r)
+		}
+	}
+	p, server := providerWithServer(t, Config{
+		Enabled: true,
+		Styles:  []string{"house", "deep-house"},
+		SaveStyles: func(styles []string) error {
+			saved = slices.Clone(styles)
+			return nil
+		},
+	}, handler)
+	defer server.Close()
+
+	genres, err := p.Genres()
+	if err != nil {
+		t.Fatalf("Genres: %v", err)
+	}
+	if len(genres) != 3 {
+		t.Fatalf("genres = %+v, want two live categories plus configured deep-house", genres)
+	}
+	if !genres[0].Favorite || genres[0].Name != "House" || genres[0].Group != "Music" {
+		t.Fatalf("house genre = %+v", genres[0])
+	}
+	if genres[1].Favorite || genres[1].Group != "Talk" {
+		t.Fatalf("technology genre = %+v", genres[1])
+	}
+	if !genres[2].Favorite || genres[2].ID != "deep-house" {
+		t.Fatalf("configured-only genre = %+v", genres[2])
+	}
+
+	favorite, err := p.ToggleGenreFavorite("technology")
+	if err != nil || !favorite {
+		t.Fatalf("ToggleGenreFavorite = %v, %v", favorite, err)
+	}
+	if !slices.Equal(saved, []string{"house", "deep-house", "technology"}) {
+		t.Fatalf("saved styles = %v", saved)
+	}
+	tracks, err := p.GenreTracks("technology", "popular")
+	if err != nil || len(tracks) != 1 || tracks[0].Title != "Tech Show" {
+		t.Fatalf("GenreTracks = %+v, %v", tracks, err)
+	}
+	results, err := p.SearchGenres(context.Background(), "acid techno", 20)
+	if err != nil || len(results) != 1 || results[0].ID != "acid-techno" || results[0].Name != "Acid Techno" {
+		t.Fatalf("SearchGenres = %+v, %v", results, err)
+	}
+}
+
+func TestGenreFavoriteSaveFailureKeepsProviderState(t *testing.T) {
+	p := NewFromConfig(Config{
+		Enabled: true,
+		Styles:  []string{"house"},
+		SaveStyles: func([]string) error {
+			return errors.New("disk full")
+		},
+	})
+	if favorite, err := p.ToggleGenreFavorite("techno"); err == nil || favorite || !strings.Contains(err.Error(), "save genre favorites") {
+		t.Fatalf("ToggleGenreFavorite = %v, %v, want failed and unchanged", favorite, err)
+	}
+	if got := p.styleSnapshot(); !slices.Equal(got, []string{"house"}) {
+		t.Fatalf("styles after failed save = %v", got)
+	}
+}
+
+func TestTracksMapsCapturedMixcloudFields(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/discover/all/latest/" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		writeJSON(t, w, map[string]any{"data": []any{map[string]any{
+			"key":          "/spartacus/cinematic-soundscapes/",
+			"url":          "https://www.mixcloud.com/spartacus/cinematic-soundscapes/",
+			"name":         "Cinematic Soundscapes",
+			"created_time": "2014-09-10T14:42:03Z",
+			"audio_length": 2631,
+			"tags":         []any{map[string]any{"name": "Chillout"}, map[string]any{"name": "Soundtrack"}},
+			"pictures":     map[string]any{"extra_large": "https://img.example/show.jpg"},
+			"user":         map[string]any{"name": "Spartacus", "username": "spartacus"},
+		}}})
+	}
+	p, server := providerWithServer(t, Config{Enabled: true, MaxItems: 1}, handler)
+	defer server.Close()
+
+	tracks, err := p.Tracks(recentID)
+	if err != nil {
+		t.Fatalf("Tracks: %v", err)
+	}
+	if len(tracks) != 1 {
+		t.Fatalf("tracks = %d", len(tracks))
+	}
+	track := tracks[0]
+	if track.Path != "https://www.mixcloud.com/spartacus/cinematic-soundscapes/" || !track.Stream {
+		t.Fatalf("stable playback URL mapping = %+v", track)
+	}
+	if track.Title != "Cinematic Soundscapes" || track.Artist != "Spartacus" || track.DurationSecs != 2631 || track.Year != 2014 {
+		t.Fatalf("metadata mapping = %+v", track)
+	}
+	if track.Genre != "Chillout, Soundtrack" || track.AlbumArtURL != "https://img.example/show.jpg" {
+		t.Fatalf("rich metadata mapping = %+v", track)
+	}
+	if track.Meta(provider.MetaMixcloudKey) != "/spartacus/cinematic-soundscapes/" {
+		t.Fatalf("mixcloud key = %q", track.Meta(provider.MetaMixcloudKey))
+	}
+	if track.Meta(provider.MetaMixcloudCreator) != "spartacus" {
+		t.Fatalf("mixcloud creator = %q", track.Meta(provider.MetaMixcloudCreator))
+	}
+}
+
+func TestExclusiveShowsKeepCleanMetadataAndAreNotSkipped(t *testing.T) {
+	show := apiCloudcast{
+		Key:         "/creator/members-only/",
+		URL:         "https://www.mixcloud.com/creator/members-only/",
+		Name:        "Members Only",
+		User:        apiUser{Name: "Creator", Username: "creator"},
+		IsExclusive: true,
+	}
+
+	track := trackFromCloudcast(show)
+	if track.Title != "Members Only" {
+		t.Fatalf("exclusive track title = %q", track.Title)
+	}
+	if track.Unplayable {
+		t.Fatal("exclusive show was marked unplayable before session entitlement was checked")
+	}
+	if track.Meta(provider.MetaMixcloudExclusive) != "true" {
+		t.Fatalf("exclusive metadata = %q", track.Meta(provider.MetaMixcloudExclusive))
+	}
+	albums := albumsFromCloudcasts([]apiCloudcast{show})
+	if len(albums) != 1 || albums[0].Name != "Members Only" || !albums[0].Restricted {
+		t.Fatalf("exclusive show browse metadata = %+v", albums)
+	}
+}
+
+func TestAccountPlaylistErrorsPreservePublicDiscovery(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     Config
+		failure string
+		status  int
+	}{
+		{
+			name:    "invalid configured username",
+			cfg:     Config{Enabled: true, Username: "missing", Styles: []string{"house"}},
+			failure: "/missing/playlists/",
+			status:  http.StatusNotFound,
+		},
+		{
+			name:    "invalid access token",
+			cfg:     Config{Enabled: true, AccessToken: "expired", Styles: []string{"house"}},
+			failure: "/me/",
+			status:  http.StatusUnauthorized,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, server := providerWithServer(t, tt.cfg, func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != tt.failure {
+					t.Errorf("path = %q, want %q", r.URL.Path, tt.failure)
+				}
+				w.WriteHeader(tt.status)
+				writeJSON(t, w, map[string]any{"error": map[string]any{"message": "User does not exist."}})
+			})
+			defer server.Close()
+
+			lists, err := p.Playlists()
+			if err == nil || !strings.Contains(err.Error(), "account views unavailable") {
+				t.Fatalf("Playlists error = %v, want account warning", err)
+			}
+			for _, id := range []string{recentID, popularID, "style:house:latest", "style:house:popular"} {
+				if !slices.ContainsFunc(lists, func(item playlist.PlaylistInfo) bool { return item.ID == id }) {
+					t.Errorf("public lists omit %q: %+v", id, lists)
+				}
+			}
+			if slices.ContainsFunc(lists, func(item playlist.PlaylistInfo) bool { return item.ID == streamID }) {
+				t.Fatalf("unavailable account view included: %+v", lists)
+			}
+		})
+	}
+}
+
+func TestSearchPreservesCanceledContext(t *testing.T) {
+	p := NewFromConfig(Config{Enabled: true})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := p.SearchTracks(ctx, "house", 10)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if !strings.Contains(err.Error(), "search shows") {
+		t.Fatalf("error = %v, want search operation context", err)
+	}
+	_, err = p.SearchGenres(ctx, "house", 10)
+	if !errors.Is(err, context.Canceled) || !strings.Contains(err.Error(), "search genres") {
+		t.Fatalf("genre search error = %v, want wrapped context.Canceled", err)
+	}
+}
+
+func TestTracksWrapsPlaylistOperation(t *testing.T) {
+	p, server := providerWithServer(t, Config{Enabled: true}, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	defer server.Close()
+
+	_, err := p.Tracks(recentID)
+	if err == nil || !strings.Contains(err.Error(), `load playlist "discover:latest"`) {
+		t.Fatalf("Tracks error = %v, want playlist operation context", err)
+	}
+}
+
+func TestAccountPlaylistsUseMeWithToken(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("access_token") != "token" {
+			t.Errorf("missing access token")
+		}
+		switch r.URL.Path {
+		case "/me/":
+			writeJSON(t, w, map[string]any{"username": "token-owner", "name": "Token Owner"})
+		case "/me/playlists/":
+			writeJSON(t, w, map[string]any{"data": []any{map[string]any{
+				"key": "/token-owner/playlists/late-night/", "name": "Late Night", "cloudcast_count": 12,
+			}}})
+		case "/me/following/":
+			writeJSON(t, w, map[string]any{"data": []any{}})
+		default:
+			http.NotFound(w, r)
+		}
+	}
+	p, server := providerWithServer(t, Config{Enabled: true, Username: "alice", AccessToken: "token", Styles: []string{"house"}}, handler)
+	defer server.Close()
+
+	lists, err := p.Playlists()
+	if err != nil {
+		t.Fatalf("Playlists: %v", err)
+	}
+	wantPrefix := []string{streamID, favoritesID, uploadsID, activityID, listensID, listenLaterID}
+	if len(lists) < len(wantPrefix) {
+		t.Fatalf("account lists = %+v", lists)
+	}
+	for i, id := range wantPrefix {
+		if lists[i].ID != id || lists[i].Section != accountSection {
+			t.Fatalf("account list %d = %+v, want %q in %q", i, lists[i], id, accountSection)
+		}
+	}
+	var collectionFound, listenLaterFound bool
+	for _, item := range lists {
+		collectionFound = collectionFound || item.ID == "collection:/token-owner/playlists/late-night/" && item.TrackCount == 12
+		listenLaterFound = listenLaterFound || item.ID == listenLaterID
+	}
+	if !collectionFound || !listenLaterFound {
+		t.Fatalf("collection=%v listen-later=%v lists=%v", collectionFound, listenLaterFound, lists)
+	}
+	artists, err := p.Artists()
+	if err != nil {
+		t.Fatalf("Artists: %v", err)
+	}
+	if len(artists) != 1 || artists[0].ID != "token-owner" {
+		t.Fatalf("token-backed account identity = %+v, want token owner", artists)
+	}
+}
+
+func TestFollowingStreamMergesNewestAndDeduplicates(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/alice/following/":
+			writeJSON(t, w, map[string]any{"data": []any{
+				map[string]any{"username": "one"}, map[string]any{"username": "two"},
+			}})
+		case "/one/cloudcasts/":
+			writeJSON(t, w, map[string]any{"data": []any{
+				map[string]any{"key": "/one/old/", "name": "Old", "created_time": "2026-01-01T00:00:00Z", "user": map[string]any{"username": "one"}},
+				map[string]any{"key": "/shared/show/", "name": "Shared", "created_time": "2026-03-01T00:00:00Z", "user": map[string]any{"username": "shared"}},
+			}})
+		case "/two/cloudcasts/":
+			writeJSON(t, w, map[string]any{"data": []any{
+				map[string]any{"key": "/two/new/", "name": "New", "created_time": "2026-04-01T00:00:00Z", "user": map[string]any{"username": "two"}},
+				map[string]any{"key": "/shared/show/", "name": "Shared", "created_time": "2026-03-01T00:00:00Z", "user": map[string]any{"username": "shared"}},
+			}})
+		default:
+			http.NotFound(w, r)
+		}
+	}
+	p, server := providerWithServer(t, Config{Enabled: true, Username: "alice", MaxItems: 10, StreamCreators: 2}, handler)
+	defer server.Close()
+
+	tracks, err := p.Tracks(streamID)
+	if err != nil {
+		t.Fatalf("Tracks(stream): %v", err)
+	}
+	if len(tracks) != 3 {
+		t.Fatalf("tracks = %d, want 3 merged and deduplicated shows", len(tracks))
+	}
+	if got := []string{tracks[0].Title, tracks[1].Title, tracks[2].Title}; !slices.Equal(got, []string{"New", "Shared", "Old"}) {
+		t.Fatalf("titles = %v", got)
+	}
+}
+
+func TestFollowingStreamPreservesPartialRateLimit(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/alice/following/":
+			writeJSON(t, w, map[string]any{"data": []any{
+				map[string]any{"username": "working"}, map[string]any{"username": "limited"},
+			}})
+		case "/working/cloudcasts/":
+			writeJSON(t, w, map[string]any{"data": []any{
+				map[string]any{"key": "/working/show/", "name": "Show", "user": map[string]any{"username": "working"}},
+			}})
+		case "/limited/cloudcasts/":
+			w.Header().Set("Retry-After", "12")
+			w.WriteHeader(http.StatusForbidden)
+			writeJSON(t, w, map[string]any{"error": map[string]any{"type": "RateLimitException", "message": "slow down"}})
+		default:
+			http.NotFound(w, r)
+		}
+	}
+	p, server := providerWithServer(t, Config{Enabled: true, Username: "alice", MaxItems: 10, StreamCreators: 2}, handler)
+	defer server.Close()
+
+	_, err := p.Tracks(streamID)
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.RetryAfter != 12*time.Second {
+		t.Fatalf("error = %T %v, want preserved rate limit", err, err)
+	}
+}
+
+func TestProviderRejectsMalformedRecordsAndKeys(t *testing.T) {
+	if got := tracksFromCloudcasts([]apiCloudcast{{Name: "missing identity"}}); len(got) != 0 {
+		t.Fatalf("tracks = %v, want malformed item omitted", got)
+	}
+	if got := albumsFromCloudcasts([]apiCloudcast{{Key: "/user/../show/"}}); len(got) != 0 {
+		t.Fatalf("albums = %v, want malformed item omitted", got)
+	}
+
+	p := NewFromConfig(Config{Enabled: true})
+	if _, err := p.Tracks("collection:/user/../private/"); err == nil {
+		t.Fatal("collection traversal key was accepted")
+	}
+	if _, err := p.AlbumTracks("https://attacker.example/show/"); err == nil {
+		t.Fatal("external show key was accepted")
+	}
+}
+
+func TestCreatorBrowserSeparatesUploadsAndFavorites(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/creator/cloudcasts/":
+			writeJSON(t, w, map[string]any{"data": []any{map[string]any{
+				"key": "/creator/upload/", "name": "Own Show", "user": map[string]any{"username": "creator"},
+			}}})
+		case "/creator/favorites/":
+			writeJSON(t, w, map[string]any{"data": []any{map[string]any{
+				"key": "/someone/favorite/", "name": "Saved Show", "user": map[string]any{"username": "someone"},
+			}}})
+		default:
+			http.NotFound(w, r)
+		}
+	}
+	p, server := providerWithServer(t, Config{Enabled: true, MaxItems: 20}, handler)
+	defer server.Close()
+
+	collections, err := p.ArtistAlbums("creator")
+	if err != nil {
+		t.Fatalf("ArtistAlbums: %v", err)
+	}
+	if len(collections) != 2 || collections[0].Name != "Uploads" || collections[1].Name != "Favorites" {
+		t.Fatalf("creator collections = %+v", collections)
+	}
+
+	uploads, err := p.AlbumTracks(collections[0].ID)
+	if err != nil {
+		t.Fatalf("uploads: %v", err)
+	}
+	favorites, err := p.AlbumTracks(collections[1].ID)
+	if err != nil {
+		t.Fatalf("favorites: %v", err)
+	}
+	if len(uploads) != 1 || uploads[0].Title != "Own Show" || uploads[0].Album != "Uploads" {
+		t.Fatalf("upload tracks = %+v", uploads)
+	}
+	if len(favorites) != 1 || favorites[0].Title != "Saved Show" || favorites[0].Album != "Favorites" {
+		t.Fatalf("favorite tracks = %+v", favorites)
+	}
+}
+
+func TestArtistForTrackUsesOwningCreator(t *testing.T) {
+	p := NewFromConfig(Config{Enabled: true})
+	track := trackFromCloudcast(apiCloudcast{
+		Key:  "/owner/show/",
+		Name: "Show",
+		User: apiUser{Username: "owner", Name: "Owner Name"},
+	})
+	artist, ok := p.ArtistForTrack(track)
+	if !ok || artist.ID != "owner" || artist.Name != "Owner Name" {
+		t.Fatalf("ArtistForTrack = %+v, %v", artist, ok)
+	}
+	if _, ok := p.ArtistForTrack(playlist.Track{Title: "Local"}); ok {
+		t.Fatal("ArtistForTrack claimed a non-Mixcloud track")
+	}
+}
+
+func TestStyleAlbumSortAndLabels(t *testing.T) {
+	p := NewFromConfig(Config{Enabled: true, Styles: []string{"deep house"}})
+	artist, album := p.BrowseLabels()
+	if artist != "Creator" || album != "Show" {
+		t.Fatalf("labels = %q %q", artist, album)
+	}
+	sorts := p.AlbumSortTypes()
+	if !slices.ContainsFunc(sorts, func(item provider.SortType) bool {
+		return item.ID == "style:deep-house:popular" && strings.Contains(item.Label, "Deep House")
+	}) {
+		t.Fatalf("style sort missing: %v", sorts)
+	}
+	if _, ok := p.albumSortPath("deep-house:latest"); ok {
+		t.Fatal("sort without style: prefix was accepted")
+	}
+}

--- a/external/mixcloud/types.go
+++ b/external/mixcloud/types.go
@@ -1,0 +1,76 @@
+package mixcloud
+
+import "time"
+
+type apiPage[T any] struct {
+	Data   []T       `json:"data"`
+	Paging apiPaging `json:"paging"`
+	Name   string    `json:"name"`
+}
+
+type apiPaging struct {
+	Next string `json:"next"`
+}
+
+type apiPictures struct {
+	Medium     string `json:"medium"`
+	Large      string `json:"large"`
+	ExtraLarge string `json:"extra_large"`
+}
+
+type apiUser struct {
+	Key            string      `json:"key"`
+	URL            string      `json:"url"`
+	Name           string      `json:"name"`
+	Username       string      `json:"username"`
+	CloudcastCount int         `json:"cloudcast_count"`
+	Pictures       apiPictures `json:"pictures"`
+}
+
+type apiTag struct {
+	Key  string `json:"key"`
+	URL  string `json:"url"`
+	Name string `json:"name"`
+}
+
+type apiCategory struct {
+	Key    string `json:"key"`
+	URL    string `json:"url"`
+	Slug   string `json:"slug"`
+	Name   string `json:"name"`
+	Format string `json:"format"`
+}
+
+type apiCloudcast struct {
+	Key         string      `json:"key"`
+	URL         string      `json:"url"`
+	Name        string      `json:"name"`
+	Tags        []apiTag    `json:"tags"`
+	CreatedTime time.Time   `json:"created_time"`
+	UpdatedTime time.Time   `json:"updated_time"`
+	AudioLength int         `json:"audio_length"`
+	Pictures    apiPictures `json:"pictures"`
+	User        apiUser     `json:"user"`
+	IsExclusive bool        `json:"is_exclusive"`
+}
+
+type apiPlaylist struct {
+	Key            string  `json:"key"`
+	URL            string  `json:"url"`
+	Name           string  `json:"name"`
+	CloudcastCount int     `json:"cloudcast_count"`
+	Owner          apiUser `json:"owner"`
+}
+
+type apiActivity struct {
+	Cloudcasts  []apiCloudcast `json:"cloudcasts"`
+	CreatedTime time.Time      `json:"created_time"`
+}
+
+type apiErrorEnvelope struct {
+	Error struct {
+		Type       string `json:"type"`
+		Message    string `json:"message"`
+		RetryAfter int    `json:"retry_after"`
+	} `json:"error"`
+}

--- a/external/netease/provider.go
+++ b/external/netease/provider.go
@@ -84,16 +84,14 @@ type Provider struct {
 }
 
 // NewFromConfig returns a provider, or nil when NetEase is not enabled.
-// Sets resolve's yt-dlp cookies as a side effect when CookiesFrom is non-empty
-// so URL resolution uses the same signed-in browser session.
+// Registers NetEase's yt-dlp cookie source so resolution and playback use the
+// same signed-in browser session without affecting other providers.
 func NewFromConfig(cfg Config) *Provider {
 	if !cfg.Enabled {
 		return nil
 	}
 	cfg.CookiesFrom = strings.TrimSpace(cfg.CookiesFrom)
-	if cfg.CookiesFrom != "" {
-		resolve.SetYTDLCookiesFrom(cfg.CookiesFrom)
-	}
+	resolve.SetYTDLCookiesForHost("music.163.com", cfg.CookiesFrom)
 	return New(cfg)
 }
 

--- a/external/soundcloud/provider.go
+++ b/external/soundcloud/provider.go
@@ -58,16 +58,13 @@ var defaultBrowse = []playlist.PlaylistInfo{
 }
 
 // NewFromConfig returns a provider, or nil when SoundCloud is not enabled.
-// Sets resolve's yt-dlp cookies as a side effect when CookiesFrom is non-empty
-// so any yt-dlp invocation (search, browse, playback) uses the user's
-// signed-in session.
+// Registers SoundCloud's yt-dlp cookie source so search, browse, and playback
+// use the user's signed-in session without affecting other providers.
 func NewFromConfig(cfg Config) *Provider {
 	if !cfg.Enabled {
 		return nil
 	}
-	if cfg.CookiesFrom != "" {
-		resolve.SetYTDLCookiesFrom(cfg.CookiesFrom)
-	}
+	resolve.SetYTDLCookiesForHost("soundcloud.com", cfg.CookiesFrom)
 	return &Provider{user: strings.TrimSpace(cfg.User)}
 }
 

--- a/external/soundcloud/provider_test.go
+++ b/external/soundcloud/provider_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bjarneo/cliamp/internal/ytdlcookies"
 	"github.com/bjarneo/cliamp/resolve"
 )
 
@@ -133,14 +134,10 @@ func TestConfigIsSet(t *testing.T) {
 }
 
 func TestNewFromConfigPropagatesCookies(t *testing.T) {
-	t.Cleanup(func() { resolve.SetYTDLCookiesFrom("") })
-
-	resolve.SetYTDLCookiesFrom("") // baseline
+	t.Cleanup(func() { resolve.SetYTDLCookiesForHost("soundcloud.com", "") })
 
 	NewFromConfig(Config{Enabled: true, CookiesFrom: "firefox"})
-	// The exported getter is internal; we verify by side effect: a subsequent
-	// resolve call would emit --cookies-from-browser firefox. We can't easily
-	// invoke yt-dlp from a unit test, so the smoke test is that the setter
-	// accepts our value without panic and the constructor succeeds.
-	// (Full plumbing is exercised manually; resolve.ytdlCookiesFrom is private.)
+	if got := ytdlcookies.ForURL("https://soundcloud.com/user/tracks"); got != "firefox" {
+		t.Errorf("SoundCloud cookie source = %q, want firefox", got)
+	}
 }

--- a/external/ytmusic/cookie_provider_test.go
+++ b/external/ytmusic/cookie_provider_test.go
@@ -408,11 +408,11 @@ func TestCookieProviderSearchTracksHonorsCancellation(t *testing.T) {
 	}
 }
 
-func TestNewCookieProvidersDoesNotMutateGlobalCookies(t *testing.T) {
+func TestNewCookieProvidersDoesNotMutateOtherHostCookies(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping Unix shell script test on Windows")
 	}
-	t.Cleanup(func() { resolve.SetYTDLCookiesFrom("") })
+	t.Cleanup(func() { resolve.SetYTDLCookiesForHost("soundcloud.com", "") })
 
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "ytdlp_args.log")
@@ -425,23 +425,22 @@ func TestNewCookieProvidersDoesNotMutateGlobalCookies(t *testing.T) {
 
 	t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	// Baseline global cookie configured by another provider (e.g. SoundCloud)
-	resolve.SetYTDLCookiesFrom("firefox")
+	// Configure a cookie source for another provider.
+	resolve.SetYTDLCookiesForHost("soundcloud.com", "firefox")
 
-	// Initializing YouTube Music cookie providers should NOT overwrite global cookies
+	// Initializing YouTube Music cookie providers must not affect SoundCloud.
 	_ = NewCookieProviders("chrome")
 	_ = NewCookieProvider("chrome", KindMusic)
 
-	// Caller relying on global cookies (e.g. SoundCloud) should still get firefox
 	_, _ = resolve.ResolveYTDLBatch("https://soundcloud.com/user/tracks", 0, 0)
 	logged, err := os.ReadFile(logFile)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(string(logged), "--cookies-from-browser firefox") {
-		t.Errorf("expected global cookies 'firefox' to remain unchanged, got: %s", string(logged))
+		t.Errorf("expected SoundCloud cookies 'firefox' to remain unchanged, got: %s", string(logged))
 	}
 	if strings.Contains(string(logged), "--cookies-from-browser chrome") {
-		t.Errorf("global cookies was corrupted with 'chrome': %s", string(logged))
+		t.Errorf("SoundCloud cookies were replaced with 'chrome': %s", string(logged))
 	}
 }

--- a/internal/ytdlcookies/cookies.go
+++ b/internal/ytdlcookies/cookies.go
@@ -1,0 +1,69 @@
+// Package ytdlcookies stores browser cookie sources for yt-dlp-backed hosts.
+package ytdlcookies
+
+import (
+	"net/url"
+	"strings"
+	"sync"
+)
+
+var (
+	mu     sync.RWMutex
+	byHost = make(map[string]string)
+)
+
+// SetForHost associates a browser cookie source with a URL host. Passing an
+// empty browser removes the association.
+func SetForHost(host, browser string) {
+	host = normalizeHost(host)
+	if host == "" {
+		return
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	browser = strings.TrimSpace(browser)
+	if browser == "" {
+		delete(byHost, host)
+		return
+	}
+	byHost[host] = browser
+}
+
+// ForURL returns the browser cookie source associated with rawURL. yt-dlp
+// search prefixes are mapped to the service host they query.
+func ForURL(rawURL string) string {
+	host := hostForURL(rawURL)
+	if host == "" {
+		return ""
+	}
+
+	mu.RLock()
+	defer mu.RUnlock()
+	return byHost[host]
+}
+
+func hostForURL(rawURL string) string {
+	rawURL = strings.TrimSpace(rawURL)
+	lower := strings.ToLower(rawURL)
+	switch {
+	case strings.HasPrefix(lower, "scsearch"):
+		return "soundcloud.com"
+	case strings.HasPrefix(lower, "ytsearch"):
+		return "youtube.com"
+	}
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	return normalizeHost(u.Hostname())
+}
+
+func normalizeHost(host string) string {
+	host = strings.ToLower(strings.TrimSpace(host))
+	host = strings.TrimPrefix(host, "www.")
+	host = strings.TrimPrefix(host, "m.")
+	return host
+}

--- a/internal/ytdlcookies/cookies_test.go
+++ b/internal/ytdlcookies/cookies_test.go
@@ -1,0 +1,51 @@
+package ytdlcookies
+
+import "testing"
+
+func TestForURLSelectsCookiesByHost(t *testing.T) {
+	SetForHost("mixcloud.com", "firefox")
+	SetForHost("music.163.com", "chrome")
+	t.Cleanup(func() {
+		SetForHost("mixcloud.com", "")
+		SetForHost("music.163.com", "")
+	})
+
+	tests := []struct {
+		url  string
+		want string
+	}{
+		{url: "https://www.mixcloud.com/creator/show/", want: "firefox"},
+		{url: "https://music.163.com/#/song?id=1", want: "chrome"},
+		{url: "https://example.com/track", want: ""},
+	}
+	for _, test := range tests {
+		if got := ForURL(test.url); got != test.want {
+			t.Errorf("ForURL(%q) = %q, want %q", test.url, got, test.want)
+		}
+	}
+}
+
+func TestForURLMapsYTDLSearchPrefixes(t *testing.T) {
+	SetForHost("soundcloud.com", "firefox")
+	SetForHost("youtube.com", "chrome")
+	t.Cleanup(func() {
+		SetForHost("soundcloud.com", "")
+		SetForHost("youtube.com", "")
+	})
+
+	if got := ForURL("scsearch10:ambient"); got != "firefox" {
+		t.Errorf("ForURL(scsearch) = %q, want firefox", got)
+	}
+	if got := ForURL("ytsearch10:ambient"); got != "chrome" {
+		t.Errorf("ForURL(ytsearch) = %q, want chrome", got)
+	}
+}
+
+func TestSetForHostEmptyBrowserRemovesSelection(t *testing.T) {
+	SetForHost("mixcloud.com", "firefox")
+	SetForHost("mixcloud.com", "")
+
+	if got := ForURL("https://mixcloud.com/creator/show/"); got != "" {
+		t.Errorf("ForURL() = %q after removal, want empty", got)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/bjarneo/cliamp/external/emby"
 	"github.com/bjarneo/cliamp/external/jellyfin"
 	"github.com/bjarneo/cliamp/external/local"
+	"github.com/bjarneo/cliamp/external/mixcloud"
 	"github.com/bjarneo/cliamp/external/navidrome"
 	"github.com/bjarneo/cliamp/external/netease"
 	"github.com/bjarneo/cliamp/external/plex"
@@ -127,13 +128,21 @@ func run(overrides config.Overrides, positional []string, daemon, visualizer60FP
 		User:        cfg.SoundCloud.User,
 		CookiesFrom: cfg.SoundCloud.CookiesFrom,
 	}); scProv != nil {
-		// Provider constructors configure resolve-side yt-dlp cookies. Mirror
-		// cookies_from onto the player so streaming yt-dlp invocations use the
-		// same browser session. Last write wins when multiple providers set it.
-		if cfg.SoundCloud.CookiesFrom != "" {
-			player.SetYTDLCookiesFrom(cfg.SoundCloud.CookiesFrom)
-		}
 		providers = append(providers, model.ProviderEntry{Key: "soundcloud", Name: "SoundCloud", Provider: scProv})
+	}
+
+	if mcProv := mixcloud.NewFromConfig(mixcloud.Config{
+		Enabled:        cfg.Mixcloud.Enabled,
+		Username:       cfg.Mixcloud.Username,
+		AccessToken:    cfg.Mixcloud.AccessToken,
+		CookiesFrom:    cfg.Mixcloud.CookiesFrom,
+		Styles:         cfg.Mixcloud.Styles,
+		StylesSet:      cfg.Mixcloud.StylesSet,
+		MaxItems:       cfg.Mixcloud.MaxItems,
+		StreamCreators: cfg.Mixcloud.StreamCreators,
+		SaveStyles:     config.SaveMixcloudStyles,
+	}); mcProv != nil {
+		providers = append(providers, model.ProviderEntry{Key: "mixcloud", Name: "Mixcloud", Provider: mcProv})
 	}
 
 	if neProv := netease.NewFromConfig(netease.Config{
@@ -141,9 +150,6 @@ func run(overrides config.Overrides, positional []string, daemon, visualizer60FP
 		CookiesFrom: cfg.NetEase.CookiesFrom,
 		UserID:      cfg.NetEase.UserID,
 	}); neProv != nil {
-		if cfg.NetEase.CookiesFrom != "" {
-			player.SetYTDLCookiesFrom(cfg.NetEase.CookiesFrom)
-		}
 		providers = append(providers, model.ProviderEntry{Key: "netease", Name: "NetEase", Provider: neProv})
 	}
 
@@ -159,7 +165,9 @@ func run(overrides config.Overrides, positional []string, daemon, visualizer60FP
 		explicitOAuth := strings.TrimSpace(cfg.YouTubeMusic.ClientID) != "" && strings.TrimSpace(cfg.YouTubeMusic.ClientSecret) != ""
 		hasCookies := strings.TrimSpace(cfg.YouTubeMusic.CookiesFrom) != ""
 		if hasCookies {
-			player.SetYTDLCookiesFrom(cfg.YouTubeMusic.CookiesFrom)
+			for _, host := range []string{"youtube.com", "youtu.be", "music.youtube.com"} {
+				resolve.SetYTDLCookiesForHost(host, cfg.YouTubeMusic.CookiesFrom)
+			}
 		}
 
 		ytClientID, ytClientSecret := cfg.YouTubeMusic.ResolveCredentials(ytmusic.FallbackCredentials)
@@ -445,8 +453,11 @@ func run(overrides config.Overrides, positional []string, daemon, visualizer60FP
 		m.SetSimplified(true)
 	}
 
-	if !defaultRadio && len(positional) > 0 {
-		if rs := resume.Load(); rs.Path != "" && rs.PositionSec > 0 {
+	if rs := resume.Load(); rs.Path != "" && rs.PositionSec > 0 {
+		// Mixcloud is commonly opened from its provider browser rather than a
+		// positional URL. Arm only that provider's browser-started resume while
+		// preserving cliamp's existing positional-file behavior elsewhere.
+		if playlist.IsMixcloudURL(rs.Path) || (!defaultRadio && len(positional) > 0) {
 			m.SetResume(rs.Path, rs.PositionSec)
 		}
 	}

--- a/player/player.go
+++ b/player/player.go
@@ -537,6 +537,7 @@ func (p *Player) SeekYTDL(d time.Duration) error {
 	// Build pipeline WITHOUT speaker lock (this is the slow part — spawns yt-dlp).
 	tp, err := p.buildYTDLPipeline(cur.path, startSec)
 	if err != nil {
+		p.restoreYTDLSeekSource(cur, gen)
 		return fmt.Errorf("yt-dlp seek: %w", err)
 	}
 	tp.knownDuration = cur.knownDuration
@@ -565,6 +566,24 @@ func (p *Player) SeekYTDL(d time.Duration) error {
 	// Clean up old pipelines async to avoid blocking on process wait.
 	go closePipelines(old, oldNext)
 	return nil
+}
+
+// restoreYTDLSeekSource puts the original stream back after a replacement
+// pipeline fails to start. The generation and current-pipeline checks prevent
+// an obsolete seek from overwriting a newer seek or track change.
+func (p *Player) restoreYTDLSeekSource(cur *trackPipeline, gen int64) {
+	if cur == nil || p.seekGen.Load() != gen {
+		return
+	}
+	speaker.Lock()
+	p.mu.Lock()
+	stillCurrent := p.current == cur && p.seekGen.Load() == gen
+	if stillCurrent {
+		p.gapless.Replace(cur.stream)
+		p.gaplessAdvance.Store(false)
+	}
+	p.mu.Unlock()
+	speaker.Unlock()
 }
 
 // IsYTDLSeek reports whether the current track uses yt-dlp seek-by-restart.

--- a/player/player_test.go
+++ b/player/player_test.go
@@ -47,6 +47,37 @@ func TestSetVolumeClamps(t *testing.T) {
 	}
 }
 
+func TestRestoreYTDLSeekSource(t *testing.T) {
+	original := newPlaybackTestDecoder()
+	replacement := newPlaybackTestDecoder()
+	cur := &trackPipeline{decoder: original, stream: original, ytdlSeek: true}
+	p := &Player{gapless: &gaplessStreamer{}, current: cur}
+	p.gapless.Replace(nil) // SeekYTDL mutes playback while rebuilding.
+	p.gaplessAdvance.Store(true)
+
+	p.restoreYTDLSeekSource(cur, 0)
+
+	p.gapless.mu.Lock()
+	got := p.gapless.current
+	p.gapless.mu.Unlock()
+	if got != original {
+		t.Fatal("failed seek did not restore the original stream")
+	}
+	if p.GaplessAdvanced() {
+		t.Fatal("failed seek retained a stale gapless-advance notification")
+	}
+
+	p.gapless.Replace(replacement)
+	p.seekGen.Add(1)
+	p.restoreYTDLSeekSource(cur, 0)
+	p.gapless.mu.Lock()
+	got = p.gapless.current
+	p.gapless.mu.Unlock()
+	if got != replacement {
+		t.Fatal("stale failed seek overwrote a newer stream")
+	}
+}
+
 func TestSetVolumeMinClamps(t *testing.T) {
 	p := newTestPlayer()
 

--- a/player/ytdl.go
+++ b/player/ytdl.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	"github.com/gopxl/beep/v2"
+
+	"github.com/bjarneo/cliamp/internal/ytdlcookies"
 )
 
 // pipeBufSize is the buffer size for audio pipe readers (yt-dlp, ffmpeg).
@@ -28,20 +30,17 @@ const ytdlPipeTimeout = 30 * time.Second
 // when the process is slow to flush and exit.
 const ytdlCauseGrace = 3 * time.Second
 
-// ytdlCookiesFrom is the browser name for --cookies-from-browser (e.g. "chrome").
-// Set via SetYTDLCookiesFrom at startup.
-var ytdlCookiesFrom string
-
-// SetYTDLCookiesFrom configures yt-dlp to use cookies from the given browser
-// for YouTube Music playback (e.g. "chrome", "firefox", "brave").
-func SetYTDLCookiesFrom(browser string) {
-	ytdlCookiesFrom = browser
-}
-
 // YTDLPAvailable reports whether yt-dlp is installed and on PATH.
 func YTDLPAvailable() bool {
 	_, err := exec.LookPath("yt-dlp")
 	return err == nil
+}
+
+func appendYTDLCookieArgs(args []string, pageURL string) []string {
+	if browser := ytdlcookies.ForURL(pageURL); browser != "" {
+		return append(args, "--cookies-from-browser", browser)
+	}
+	return args
 }
 
 // probeYTDLDuration runs a quick yt-dlp --print duration to obtain
@@ -50,9 +49,7 @@ func probeYTDLDuration(pageURL string) time.Duration {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	args := []string{"--skip-download", "--no-playlist", "--socket-timeout", "10", "--print", "duration"}
-	if ytdlCookiesFrom != "" {
-		args = append(args, "--cookies-from-browser", ytdlCookiesFrom)
-	}
+	args = appendYTDLCookieArgs(args, pageURL)
 	args = append(args, pageURL)
 	cmd := exec.CommandContext(ctx, "yt-dlp", args...)
 	// WaitDelay ensures cmd.Output() doesn't hang indefinitely if the
@@ -316,9 +313,7 @@ func decodeYTDLPipe(pageURL string, sr beep.SampleRate, bitDepth, startSec int) 
 		"--socket-timeout", "15",
 		"-o", "-",
 	}
-	if ytdlCookiesFrom != "" {
-		ytdlArgs = append(ytdlArgs, "--cookies-from-browser", ytdlCookiesFrom)
-	}
+	ytdlArgs = appendYTDLCookieArgs(ytdlArgs, pageURL)
 	ytdlArgs = append(ytdlArgs, pageURL)
 	ytdlCmd := exec.Command("yt-dlp", ytdlArgs...)
 	ytdlCmd.Stdout = pw

--- a/player/ytdl_cookies_test.go
+++ b/player/ytdl_cookies_test.go
@@ -1,0 +1,42 @@
+package player
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/bjarneo/cliamp/internal/ytdlcookies"
+)
+
+func TestAppendYTDLCookieArgsSelectsBrowserByURLHost(t *testing.T) {
+	ytdlcookies.SetForHost("mixcloud.com", "firefox")
+	ytdlcookies.SetForHost("music.163.com", "chrome")
+	t.Cleanup(func() {
+		ytdlcookies.SetForHost("mixcloud.com", "")
+		ytdlcookies.SetForHost("music.163.com", "")
+	})
+
+	tests := []struct {
+		url  string
+		want []string
+	}{
+		{
+			url:  "https://www.mixcloud.com/creator/show/",
+			want: []string{"yt-dlp", "--cookies-from-browser", "firefox"},
+		},
+		{
+			url:  "https://music.163.com/#/song?id=1",
+			want: []string{"yt-dlp", "--cookies-from-browser", "chrome"},
+		},
+		{
+			url:  "https://example.com/track",
+			want: []string{"yt-dlp"},
+		},
+	}
+
+	for _, test := range tests {
+		got := appendYTDLCookieArgs([]string{"yt-dlp"}, test.url)
+		if !slices.Equal(got, test.want) {
+			t.Errorf("appendYTDLCookieArgs(%q) = %v, want %v", test.url, got, test.want)
+		}
+	}
+}

--- a/playlist/playlist.go
+++ b/playlist/playlist.go
@@ -185,6 +185,21 @@ func IsYouTubeMusicURL(path string) bool {
 	return host == "music.youtube.com"
 }
 
+// IsMixcloudURL reports whether path is a Mixcloud website URL.
+func IsMixcloudURL(path string) bool {
+	if !IsURL(path) {
+		return false
+	}
+	u, err := url.Parse(path)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	host = strings.TrimPrefix(host, "www.")
+	host = strings.TrimPrefix(host, "m.")
+	return host == "mixcloud.com"
+}
+
 // IsYTDL reports whether the URL points to a site supported by yt-dlp
 // (YouTube, SoundCloud, Bandcamp, ytsearch: protocol, etc.).
 func IsYTDL(path string) bool {
@@ -207,6 +222,7 @@ func IsYTDL(path string) bool {
 	host = strings.TrimPrefix(host, "m.")
 	switch host {
 	case "soundcloud.com",
+		"mixcloud.com",
 		"bandcamp.com",
 		"music.163.com",
 		"bilibili.com",

--- a/playlist/url_test.go
+++ b/playlist/url_test.go
@@ -180,6 +180,8 @@ func TestIsYTDL(t *testing.T) {
 		{"scsearch5:multi result query", true},
 		// SoundCloud
 		{"https://soundcloud.com/artist/track", true},
+		// Mixcloud
+		{"https://www.mixcloud.com/artist/show/", true},
 		// Bandcamp
 		{"https://bandcamp.com/album", true},
 		{"https://artist.bandcamp.com/album/name", true},
@@ -199,6 +201,27 @@ func TestIsYTDL(t *testing.T) {
 		t.Run(tt.path, func(t *testing.T) {
 			if got := IsYTDL(tt.path); got != tt.want {
 				t.Errorf("IsYTDL(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsMixcloudURL(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"https://www.mixcloud.com/creator/show/", true},
+		{"https://m.mixcloud.com/creator/show/", true},
+		{"https://mixcloud.com/creator/show/", true},
+		{"https://notmixcloud.com/creator/show/", false},
+		{"https://mixcloud.com.example/creator/show/", false},
+		{"/local/mixcloud.com/show.mp3", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			if got := IsMixcloudURL(tt.path); got != tt.want {
+				t.Errorf("IsMixcloudURL(%q) = %v, want %v", tt.path, got, tt.want)
 			}
 		})
 	}

--- a/provider/interfaces.go
+++ b/provider/interfaces.go
@@ -21,6 +21,71 @@ type ArtistBrowser interface {
 	ArtistAlbums(artistID string) ([]AlbumInfo, error)
 }
 
+// TrackArtistResolver lets the UI jump from a provider-originated track to
+// that track's artist in the hierarchical browser. It should return false for
+// tracks the provider does not recognize.
+type TrackArtistResolver interface {
+	ArtistForTrack(track playlist.Track) (ArtistInfo, bool)
+}
+
+// BrowseMode identifies a useful entry point into the hierarchical provider
+// browser. Providers can expose these routes alongside their playlist pane
+// through BrowseEntryProvider without representing them as playable lists.
+type BrowseMode uint8
+
+const (
+	BrowseAlbums BrowseMode = iota + 1
+	BrowseArtists
+	BrowseArtistAlbums
+	BrowseGenres
+)
+
+// BrowseEntry is a provider-pane shortcut into the hierarchical browser.
+type BrowseEntry struct {
+	ID      string
+	Name    string
+	Section string
+	Mode    BrowseMode
+	// AfterID places this entry group immediately after a provider list item.
+	// AfterSection is used as a fallback when the item is absent.
+	AfterID string
+	// AfterSection places this entry group after the last provider list in the
+	// named section. If that section is absent and Section == AfterSection, the
+	// entry is omitted rather than creating a section with no provider content.
+	// Other entries with a missing anchor remain at the top.
+	AfterSection string
+	// OpenInPlaylist makes the route's final track result replace the main
+	// playlist and close the browser instead of opening its track screen.
+	OpenInPlaylist bool
+}
+
+// BrowseEntryProvider is implemented by providers that want their principal
+// hierarchical browse routes advertised in the provider playlist pane.
+type BrowseEntryProvider interface {
+	BrowseEntries() []BrowseEntry
+}
+
+// GenreBrowser is implemented by providers that expose a category catalogue.
+type GenreBrowser interface {
+	Genres() ([]GenreInfo, error)
+	GenreSortTypes() []SortType
+	GenreTracks(genreID, sortType string) ([]playlist.Track, error)
+}
+
+// GenreFavoriteToggler is implemented by genre browsers that can persist
+// favorite state in provider-specific configuration or on the remote service.
+type GenreFavoriteToggler interface {
+	ToggleGenreFavorite(genreID string) (favorite bool, err error)
+}
+
+// GenreSearcher extends GenreBrowser with provider-side catalogue search.
+// It is useful when the browsable category list is only a curated subset of
+// the provider's full tag or genre catalogue.
+type GenreSearcher interface {
+	GenreBrowser
+	SearchGenres(ctx context.Context, query string, limit int) ([]GenreInfo, error)
+}
+
 // AlbumBrowser is implemented by providers that support paginated album
 // listing with configurable sort order.
 type AlbumBrowser interface {

--- a/provider/types.go
+++ b/provider/types.go
@@ -23,6 +23,18 @@ type AlbumInfo struct {
 	Year       int
 	TrackCount int
 	Genre      string
+	// Restricted is presentation metadata for provider items that may require
+	// account access. It must not be folded into Name or persisted metadata.
+	Restricted bool
+}
+
+// GenreInfo describes a provider category and whether it is pinned as a
+// favorite. Group is optional (for example "Music" or "Talk").
+type GenreInfo struct {
+	ID       string
+	Name     string
+	Group    string
+	Favorite bool
 }
 
 // SortType describes one sort option for album listing.
@@ -53,6 +65,13 @@ const (
 	MetaNetEaseID   = "netease.id"
 	MetaQobuzID     = "qobuz.id"
 	MetaTidalID     = "tidal.id"
+	MetaMixcloudKey = "mixcloud.key"
+	// MetaMixcloudCreator is the profile username that owns a Mixcloud show.
+	MetaMixcloudCreator = "mixcloud.creator"
+	// MetaMixcloudExclusive marks a show that Mixcloud may restrict to
+	// signed-in users or subscribers. The viewer's entitlement is resolved
+	// only during playback, so it is informational rather than Unplayable.
+	MetaMixcloudExclusive = "mixcloud.exclusive"
 
 	MetaAudiobookshelfID      = "audiobookshelf.id"
 	MetaAudiobookshelfEpisode = "audiobookshelf.episode"

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -21,9 +21,9 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
+	"github.com/bjarneo/cliamp/internal/ytdlcookies"
 	"github.com/bjarneo/cliamp/player"
 	"github.com/bjarneo/cliamp/playlist"
 
@@ -35,21 +35,10 @@ import (
 // Default true preserves backward compatibility.
 var ExpandYTPlaylist = true
 
-// ytdlCookiesFromVal stores the browser name passed to yt-dlp's
-// --cookies-from-browser flag. atomic.Value allows lock-free reads on the
-// resolve hot path while permitting late binding from main.go.
-var ytdlCookiesFromVal atomic.Value
-
-// SetYTDLCookiesFrom configures yt-dlp to use cookies from the given browser
-// (e.g. "firefox", "chrome", "brave") for any --flat-playlist resolution.
-// Pass an empty string to disable.
-func SetYTDLCookiesFrom(browser string) {
-	ytdlCookiesFromVal.Store(browser)
-}
-
-func ytdlCookiesFrom() string {
-	v, _ := ytdlCookiesFromVal.Load().(string)
-	return v
+// SetYTDLCookiesForHost configures yt-dlp to use browser cookies when
+// resolving or playing URLs for host. Passing an empty browser disables it.
+func SetYTDLCookiesForHost(host, browser string) {
+	ytdlcookies.SetForHost(host, browser)
 }
 
 // httpClient is used for feed and M3U resolution. It has a generous but
@@ -609,7 +598,7 @@ func resolveYouTube(pageURL string) ([]playlist.Track, error) {
 // ResolveYTDLBatch fetches tracks starting at offset `start`.
 // If count > 0, fetches at most `count` items; if count == 0, fetches all remaining.
 // If an optional browser is provided, cookies from that browser are used;
-// otherwise, the globally configured yt-dlp cookies browser is used.
+// otherwise, the cookie source configured for pageURL's host is used.
 func ResolveYTDLBatch(pageURL string, start, count int, browser ...string) ([]playlist.Track, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -677,7 +666,7 @@ func resolveYTDLRangePageContext(ctx context.Context, pageURL string, start, end
 		b = strings.TrimSpace(browser[0])
 	}
 	if b == "" {
-		b = ytdlCookiesFrom()
+		b = ytdlcookies.ForURL(pageURL)
 	}
 	if b != "" {
 		args = append(args, "--cookies-from-browser", b)
@@ -761,12 +750,17 @@ func DownloadYTDL(pageURL, saveDir string) (string, error) {
 	}
 
 	outTemplate := filepath.Join(saveDir, "%(artist,uploader)s - %(title)s.%(ext)s")
-	cmd := exec.Command("yt-dlp",
+	args := []string{
 		"-f", "bestaudio[protocol=https]/bestaudio[protocol=http]/bestaudio",
 		"--no-playlist",
 		"--print-json",
 		"-o", outTemplate,
-		pageURL)
+	}
+	if browser := ytdlcookies.ForURL(pageURL); browser != "" {
+		args = append(args, "--cookies-from-browser", browser)
+	}
+	args = append(args, pageURL)
+	cmd := exec.Command("yt-dlp", args...)
 	var stderr strings.Builder
 	cmd.Stderr = &stderr
 	stdout, err := cmd.Output()

--- a/resolve/resolve_test.go
+++ b/resolve/resolve_test.go
@@ -273,7 +273,7 @@ func TestResolveYTDLBatchCookieSelection(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping Unix shell script test on Windows")
 	}
-	t.Cleanup(func() { SetYTDLCookiesFrom("") })
+	t.Cleanup(func() { SetYTDLCookiesForHost("example.com", "") })
 
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "ytdlp_args.log")
@@ -286,8 +286,8 @@ func TestResolveYTDLBatchCookieSelection(t *testing.T) {
 
 	t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	// 1. Fallback to global cookies when explicit browser is empty
-	SetYTDLCookiesFrom("firefox")
+	// 1. Fall back to cookies configured for the URL's host.
+	SetYTDLCookiesForHost("example.com", "firefox")
 	_, _ = ResolveYTDLBatch("https://example.com/playlist", 0, 0)
 
 	logged, err := os.ReadFile(logFile)
@@ -295,10 +295,10 @@ func TestResolveYTDLBatchCookieSelection(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !strings.Contains(string(logged), "--cookies-from-browser firefox") {
-		t.Errorf("expected global cookies 'firefox' in args, got: %s", string(logged))
+		t.Errorf("expected host cookies 'firefox' in args, got: %s", string(logged))
 	}
 
-	// 2. Explicit browser overrides global cookies
+	// 2. An explicit browser overrides the host cookie source.
 	_, _ = ResolveYTDLBatch("https://example.com/playlist", 0, 0, "chrome")
 	logged, err = os.ReadFile(logFile)
 	if err != nil {
@@ -308,7 +308,7 @@ func TestResolveYTDLBatchCookieSelection(t *testing.T) {
 		t.Errorf("expected explicit browser 'chrome' in args, got: %s", string(logged))
 	}
 	if strings.Contains(string(logged), "--cookies-from-browser firefox") {
-		t.Errorf("did not expect fallback cookies 'firefox' in args, got: %s", string(logged))
+		t.Errorf("did not expect host cookies 'firefox' in args, got: %s", string(logged))
 	}
 }
 

--- a/resolve/ytdl_playlists.go
+++ b/resolve/ytdl_playlists.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bjarneo/cliamp/internal/ytdlcookies"
 	"github.com/bjarneo/cliamp/playlist"
 )
 
@@ -91,7 +92,7 @@ func parseYTDLPlaylistFeed(r io.Reader) ([]playlist.PlaylistInfo, error) {
 
 // FetchUserPlaylists invokes yt-dlp to scrape user playlists from
 // https://www.youtube.com/feed/playlists using the specified browser session.
-// If browser is empty, the globally configured yt-dlp cookies browser is used.
+// If browser is empty, the cookie source configured for YouTube is used.
 func FetchUserPlaylists(browser string) ([]playlist.PlaylistInfo, error) {
 	if _, err := exec.LookPath("yt-dlp"); err != nil {
 		return nil, fmt.Errorf("yt-dlp not found in PATH — see https://github.com/yt-dlp/yt-dlp#installation")
@@ -103,7 +104,7 @@ func FetchUserPlaylists(browser string) ([]playlist.PlaylistInfo, error) {
 	args := []string{"--flat-playlist", "-j", "--socket-timeout", "15"}
 	b := strings.TrimSpace(browser)
 	if b == "" {
-		b = ytdlCookiesFrom()
+		b = ytdlcookies.ForURL("https://www.youtube.com/feed/playlists")
 	}
 	if b != "" {
 		args = append(args, "--cookies-from-browser", b)

--- a/site/index.html
+++ b/site/index.html
@@ -4,20 +4,20 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>CLIAMP — Terminal Music Player</title>
-<meta name="description" content="A retro terminal music player inspired by Winamp 2.x. Play local files, YouTube, Spotify, Qobuz, Tidal, Plex, Jellyfin, Emby, Navidrome, SoundCloud, NetEase, and 30,000+ radio stations with a spectrum visualizer and 10-band EQ.">
+<meta name="description" content="A retro terminal music player inspired by Winamp 2.x. Play local files, YouTube, Spotify, Qobuz, Tidal, Plex, Jellyfin, Emby, Navidrome, SoundCloud, Mixcloud, NetEase, and 30,000+ radio stations with a spectrum visualizer and 10-band EQ.">
 <link rel="icon" type="image/svg+xml" href="favicon.svg">
 
 <!-- Open Graph -->
 <meta property="og:type" content="website">
 <meta property="og:title" content="CLIAMP — Terminal Music Player">
-<meta property="og:description" content="A retro terminal music player inspired by Winamp 2.x. Play YouTube, Spotify, Qobuz, Tidal, Plex, Jellyfin, Emby, SoundCloud, NetEase, and 30,000+ radio stations from your terminal with a spectrum visualizer and 10-band EQ.">
+<meta property="og:description" content="A retro terminal music player inspired by Winamp 2.x. Play YouTube, Spotify, Qobuz, Tidal, Plex, Jellyfin, Emby, SoundCloud, Mixcloud, NetEase, and 30,000+ radio stations from your terminal with a spectrum visualizer and 10-band EQ.">
 <meta property="og:image" content="https://cliamp.stream/og-image.png">
 <meta property="og:url" content="https://cliamp.stream">
 
 <!-- Twitter Card -->
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="CLIAMP — Terminal Music Player">
-<meta name="twitter:description" content="A retro terminal music player inspired by Winamp 2.x. Play YouTube, Spotify, Qobuz, Tidal, Plex, Jellyfin, Emby, SoundCloud, NetEase, and 30,000+ radio stations from your terminal with a spectrum visualizer and 10-band EQ.">
+<meta name="twitter:description" content="A retro terminal music player inspired by Winamp 2.x. Play YouTube, Spotify, Qobuz, Tidal, Plex, Jellyfin, Emby, SoundCloud, Mixcloud, NetEase, and 30,000+ radio stations from your terminal with a spectrum visualizer and 10-band EQ.">
 <meta name="twitter:image" content="https://cliamp.stream/og-image.png">
 
 <style>
@@ -634,7 +634,7 @@ footer{border-top:1px solid var(--line);background:var(--ink-2);padding:46px 0 5
 <!-- ═══ TICKER ═══ -->
 <div class="ticker" aria-hidden="true">
   <div class="ticker-track" id="ticker">
-    <span>MP3 · FLAC · OGG · OPUS · WAV · AAC · ALAC · Spotify · Qobuz · Tidal · YouTube · Plex · Jellyfin · Emby · Navidrome · SoundCloud · NetEase · Bandcamp · Bilibili · RSS / Podcasts · 30k+ Radio Stations · ICY metadata · MPRIS · Lua plugins</span>
+    <span>MP3 · FLAC · OGG · OPUS · WAV · AAC · ALAC · Spotify · Qobuz · Tidal · YouTube · Plex · Jellyfin · Emby · Navidrome · SoundCloud · Mixcloud · NetEase · Bandcamp · Bilibili · RSS / Podcasts · 30k+ Radio Stations · ICY metadata · MPRIS · Lua plugins</span>
   </div>
 </div>
 
@@ -699,7 +699,7 @@ footer{border-top:1px solid var(--line);background:var(--ink-2);padding:46px 0 5
     <div class="next-step reveal">
       <div class="next-step-label">Next step · configure providers</div>
       <h3>Run the setup wizard</h3>
-      <p>An interactive TUI walks you through Navidrome, Plex, Jellyfin, Emby, Spotify, Qobuz, Tidal, NetEase, and YouTube Music. It links to each provider's credential page, validates the connection, and writes the right block to your config file.</p>
+      <p>An interactive TUI walks you through Navidrome, Plex, Jellyfin, Emby, Spotify, Qobuz, Tidal, Mixcloud, NetEase, and YouTube Music. It links to each provider's credential page and writes the right block to your config file. Supported server connections are validated during setup; Mixcloud's optional browser-session or OAuth credentials are checked later, when used.</p>
       <div class="install-box" onclick="copyCmd(this,'cliamp setup')">
         <div class="install-platform">Setup</div>
         <code><span class="prompt">$ </span>cliamp setup</code>
@@ -717,7 +717,7 @@ footer{border-top:1px solid var(--line);background:var(--ink-2);padding:46px 0 5
       <span class="strip-meter"><i></i><i></i><i></i><i></i><i></i></span>
     </div>
     <p class="sources-intro reveal">
-      Stream from everywhere. Every provider runs through the same <em>playlist, EQ, visualizer, and lyrics pipeline</em> — your config follows you across services. Run <code>cliamp setup</code> for an interactive wizard that walks you through Navidrome, Plex, Jellyfin, Emby, Audiobookshelf, Spotify, Qobuz, Tidal, NetEase, and YouTube Music.
+      Stream from everywhere. Every provider runs through the same <em>playlist, EQ, visualizer, and lyrics pipeline</em> — your config follows you across services. Run <code>cliamp setup</code> for an interactive wizard that walks you through Navidrome, Plex, Jellyfin, Emby, Audiobookshelf, Spotify, Qobuz, Tidal, Mixcloud, NetEase, and YouTube Music.
     </p>
     <div class="sources-grid reveal">
       <div class="source" style="--src-color:#1db954"><div class="source-badge">OAuth · cached</div><div class="source-name">Spotify</div><div class="source-desc">Stream your Premium library. Bring your own developer <code>client_id</code> for a private Web API quota; playback is authorized separately. Search with <kbd>Ctrl+F</kbd>; Development Mode paging is automatic. Pre-built Windows releases include Spotify support.</div></div>
@@ -731,6 +731,7 @@ footer{border-top:1px solid var(--line);background:var(--ink-2);padding:46px 0 5
       <div class="source" style="--src-color:#2ecc71"><div class="source-badge">Subsonic API</div><div class="source-name">Navidrome</div><div class="source-desc">Browse your self-hosted library with synced lyrics.</div></div>
       <div class="source" style="--src-color:#3c873a"><div class="source-badge">Media server</div><div class="source-name">Audiobookshelf</div><div class="source-desc">Audiobooks and podcasts from your own server, with synced listening position and resume.</div></div>
       <div class="source" style="--src-color:#ff7700"><div class="source-badge">Provider · yt-dlp</div><div class="source-name">SoundCloud</div><div class="source-desc">Opt-in: set <code>[soundcloud] enabled = true</code>. Search with <kbd>Ctrl+F</kbd>, browse curated genre playlists, or add <code>user</code> for your profile. <code>cookies_from</code> unlocks Go+ tracks via your browser session.</div></div>
+      <div class="source" style="--src-color:#5000ff"><div class="source-badge">Public API · yt-dlp</div><div class="source-name">Mixcloud</div><div class="source-desc">Opt-in: set <code>[mixcloud] enabled = true</code>. Account-first Stream, Favorites and followed Creators, recent and popular shows, collections, creator Uploads/Favorites, native show search, live genre/tag discovery, locally favorited style charts, restricted-show warnings, and resume. Press <kbd>Shift+X</kbd> to open; browser cookies support signed-in playback.</div></div>
       <div class="source" style="--src-color:#d33a31"><div class="source-badge">Provider · yt-dlp</div><div class="source-name">NetEase</div><div class="source-desc">Opt-in: run <code>cliamp setup</code> after signing in at <code>music.163.com</code>, then choose your browser. Browse liked songs, account playlists, saved playlists, and charts with browser-cookie playback.</div></div>
       <div class="source" style="--src-color:#629aa9"><div class="source-badge">yt-dlp</div><div class="source-name">Bandcamp</div><div class="source-desc">Paste any Bandcamp URL and it just plays.</div></div>
       <div class="source" style="--src-color:#00a1d6"><div class="source-badge">yt-dlp</div><div class="source-name">Bilibili</div><div class="source-desc">Audio tracks from Bilibili videos via yt-dlp.</div></div>

--- a/ui/model/audiobookshelf_resume_test.go
+++ b/ui/model/audiobookshelf_resume_test.go
@@ -140,6 +140,33 @@ func TestApplyTracksResume(t *testing.T) {
 	}
 }
 
+func TestTracksLoadedResumeKeepsCursorVisible(t *testing.T) {
+	tracks := make([]playlist.Track, 40)
+	for i := range tracks {
+		tracks[i] = playlist.Track{Path: "https://abs/chapter", Title: "Chapter"}
+	}
+	prov := &resumeProv{}
+	m := Model{
+		player:   &playbackFakeEngine{},
+		playlist: playlist.New(),
+		provider: prov,
+	}
+	m.requests.tracks = 1
+
+	updated, _ := m.Update(tracksLoadedMsg{
+		tracks:       tracks,
+		providerName: prov.Name(),
+		resumeIdx:    30,
+		resumeOffset: 90 * time.Second,
+		gen:          1,
+	})
+	got := updated.(Model)
+	visible := got.effectivePlaylistVisible()
+	if got.plCursor != 30 || got.plScroll == 0 || got.plCursor-got.plScroll >= visible {
+		t.Fatalf("resume viewport = cursor:%d scroll:%d visible:%d", got.plCursor, got.plScroll, visible)
+	}
+}
+
 // progressProv records interim progress reports.
 type progressProv struct {
 	plainProv

--- a/ui/model/command_registry.go
+++ b/ui/model/command_registry.go
@@ -5,6 +5,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 
+	"github.com/bjarneo/cliamp/provider"
 	"github.com/bjarneo/cliamp/ui"
 )
 
@@ -55,10 +56,12 @@ type commandSpec struct {
 	Keys        []string // Bubbletea KeyPressMsg.String values.
 	KeyLabel    string   // Human-readable key label.
 	Label       string
+	LabelFor    func(Model) string
 	Enabled     func(Model) bool
 	Destructive bool
 	Keymap      bool
 	ContextHelp bool
+	Prominent   bool
 	Primary     bool
 	Cancel      bool
 	Help        bool
@@ -66,6 +69,13 @@ type commandSpec struct {
 
 func (c commandSpec) enabled(m Model) bool {
 	return c.Enabled == nil || c.Enabled(m)
+}
+
+func (c commandSpec) label(m Model) string {
+	if c.LabelFor != nil {
+		return c.LabelFor(m)
+	}
+	return c.Label
 }
 
 // commandRegistry deliberately lists every core-reserved key, including text
@@ -100,13 +110,19 @@ var commandRegistry = []commandSpec{
 	{Mode: commandModeMain, Keys: []string{"x"}, KeyLabel: "x", Label: "Remove selected track from playlist", Destructive: true, Keymap: true},
 	{Mode: commandModeMain, Keys: []string{"w"}, KeyLabel: "w", Label: "Write selected track/selection to playlist", Keymap: true},
 	{Mode: commandModeMain, Keys: []string{"o"}, KeyLabel: "o", Label: "Open file browser", Keymap: true},
-	{Mode: commandModeMain, Keys: []string{"N"}, KeyLabel: "N", Label: "Provider browser", Keymap: true},
+	{Mode: commandModeMain | commandModeProvider, Keys: []string{"N"}, KeyLabel: "N", Label: "Browse provider", LabelFor: func(m Model) string {
+		if _, ok := m.selectedTrackArtistBrowserTarget(); ok {
+			return "Browse creator"
+		}
+		return "Browse provider"
+	}, Enabled: func(m Model) bool { return m.canOpenProviderBrowser() }, Keymap: true, ContextHelp: true, Prominent: true},
 	{Mode: commandModeMain, Keys: []string{"L"}, KeyLabel: "L", Label: "Browse local playlists", Keymap: true},
 	{Mode: commandModeMain, Keys: []string{"R"}, KeyLabel: "R", Label: "Open radio provider", Keymap: true},
 	{Mode: commandModeMain, Keys: []string{"S"}, KeyLabel: "S", Label: "Open Spotify provider", Keymap: true},
 	{Mode: commandModeMain, Keys: []string{"P"}, KeyLabel: "P", Label: "Open Plex provider", Keymap: true},
 	{Mode: commandModeMain, Keys: []string{"Y"}, KeyLabel: "Y", Label: "Open YouTube provider", Keymap: true},
 	{Mode: commandModeMain, Keys: []string{"C"}, KeyLabel: "C", Label: "Open SoundCloud provider", Keymap: true},
+	{Mode: commandModeMain, Keys: []string{"X"}, KeyLabel: "X", Label: "Open Mixcloud provider", Keymap: true},
 	{Mode: commandModeMain, Keys: []string{"M"}, KeyLabel: "M", Label: "Open NetEase provider", Keymap: true},
 	{Mode: commandModeMain, Keys: []string{"J"}, KeyLabel: "J", Label: "Open Jellyfin provider", Keymap: true},
 	{Mode: commandModeMain, Keys: []string{"E"}, KeyLabel: "E", Label: "Open Emby provider", Keymap: true},
@@ -140,7 +156,12 @@ var commandRegistry = []commandSpec{
 	// from the global keymap, where they would be misleading outside a field.
 	{Mode: commandModeKeymapSearch | commandModeFileBrowserSearch | commandModeNavSearch | commandModePlaylistManagerInput | commandModePlaylistPickerInput | commandModeSearch | commandModeNetSearch | commandModeSpotSearch | commandModeJump | commandModeURL | commandModeThemePickerFilter | commandModeVisPickerFilter | commandModeProviderSearch, Keys: []string{"left", "right", "home", "end", "ctrl+a", "ctrl+e", "backspace", "delete", "ctrl+w", "ctrl+u"}, KeyLabel: "Text editor", Label: "Move cursor and delete text"},
 
-	{Mode: commandModeProvider, Keys: []string{"enter"}, KeyLabel: "Enter", Label: "Load", ContextHelp: true, Primary: true},
+	{Mode: commandModeProvider, Keys: []string{"enter"}, KeyLabel: "Enter", Label: "Load", LabelFor: func(m Model) string {
+		if m.selectedProviderListIsBrowseEntry() {
+			return "Open"
+		}
+		return "Load"
+	}, ContextHelp: true, Primary: true},
 	{Mode: commandModeProvider, Keys: []string{"esc", "backspace", "b"}, KeyLabel: "Esc", Label: "Back", ContextHelp: true, Cancel: true},
 	{Mode: commandModeEQ, Keys: []string{"up", "down"}, KeyLabel: "Up Down", Label: "Gain", ContextHelp: true},
 	{Mode: commandModeSpeed, Keys: []string{"left", "right"}, KeyLabel: "Left Right", Label: "Speed", ContextHelp: true},
@@ -151,6 +172,16 @@ var commandRegistry = []commandSpec{
 	{Mode: commandModeKeymapSearch | commandModeFileBrowserSearch | commandModeNavSearch | commandModePlaylistManagerInput | commandModePlaylistPickerInput | commandModeSearch | commandModeNetSearch | commandModeSpotSearch | commandModeJump | commandModeURL | commandModeProviderSearch, Keys: []string{"enter"}, KeyLabel: "Enter", Label: "Confirm", ContextHelp: true, Primary: true},
 	{Mode: commandModeNavBrowser | commandModePlaylistManager | commandModePlaylistPicker | commandModeQueue | commandModeDevicePicker | commandModeProviderSearch, Keys: []string{"up", "down", "k", "j"}, KeyLabel: "Up Down", Label: "Navigate", ContextHelp: true},
 	{Mode: commandModeFileBrowser | commandModeNavBrowser | commandModePlaylistManager | commandModePlaylistPicker | commandModeDevicePicker, Keys: []string{"enter"}, KeyLabel: "Enter", Label: "Select", ContextHelp: true, Primary: true},
+	{Mode: commandModeNavBrowser, Keys: []string{"/"}, KeyLabel: "/", Label: "Filter", ContextHelp: true, Enabled: func(m Model) bool { return m.navBrowser.mode != navBrowseModeMenu }},
+	{Mode: commandModeNavBrowser, Keys: []string{"f"}, KeyLabel: "f", Label: "Favorite genre", LabelFor: func(m Model) string {
+		if genre, ok := m.selectedNavGenre(); ok && genre.Favorite {
+			return "Unfavorite genre"
+		}
+		return "Favorite genre"
+	}, ContextHelp: true, Enabled: func(m Model) bool {
+		_, canFavorite := m.navBrowser.prov.(provider.GenreFavoriteToggler)
+		return canFavorite && m.navBrowser.mode == navBrowseModeByGenre && m.navBrowser.screen == navBrowseScreenList && !m.navBrowser.loading
+	}},
 	{Mode: commandModeKeymap, Keys: []string{"/"}, KeyLabel: "/", Label: "Filter", ContextHelp: true, Primary: true},
 	{Mode: commandModeThemePicker, Keys: []string{"esc"}, KeyLabel: "Esc", Label: "Cancel preview", ContextHelp: true, Cancel: true},
 	{Mode: commandModeThemePicker, Keys: []string{"enter"}, KeyLabel: "Enter", Label: "Apply theme", ContextHelp: true, Primary: true},
@@ -165,7 +196,7 @@ var commandRegistry = []commandSpec{
 	{Mode: commandModeQueue, Keys: []string{"d"}, KeyLabel: "d", Label: "Remove", Destructive: true, ContextHelp: true, Primary: true, Enabled: func(m Model) bool { return m.playlist != nil && m.playlist.QueueLen() > 0 }},
 	{Mode: commandModeQueue, Keys: []string{"c"}, KeyLabel: "c", Label: "Clear", Destructive: true, ContextHelp: true},
 	{Mode: commandModeFileBrowser, Keys: []string{"R"}, KeyLabel: "R", Label: "Replace queue", Destructive: true, ContextHelp: true},
-	{Mode: commandModeNavBrowser, Keys: []string{"R"}, KeyLabel: "R", Label: "Replace queue", Destructive: true, ContextHelp: true},
+	{Mode: commandModeNavBrowser, Keys: []string{"R"}, KeyLabel: "R", Label: "Replace queue", Destructive: true, ContextHelp: true, Enabled: func(m Model) bool { return m.navView() == navViewTracks }},
 	{Mode: commandModeLyrics, Keys: []string{"r"}, KeyLabel: "r", Label: "Retry", ContextHelp: true, Primary: true, Enabled: func(m Model) bool { return !m.lyrics.loading && (m.lyrics.err != nil || len(m.lyrics.lines) == 0) }},
 	{Mode: commandModeLyrics, Keys: []string{"esc"}, KeyLabel: "Esc", Label: "Close", ContextHelp: true, Cancel: true},
 	{Mode: commandModeInfo, Keys: []string{"esc"}, KeyLabel: "Esc", Label: "Close", ContextHelp: true, Cancel: true},
@@ -175,7 +206,7 @@ var commandRegistry = []commandSpec{
 }
 
 func (m Model) commandHelp(mode commandMode) string {
-	var cancel, primary, help, optional []commandSpec
+	var cancel, primary, help, prominent, optional []commandSpec
 	for _, command := range commandRegistry {
 		if !command.ContextHelp || command.Mode&mode == 0 || !command.enabled(m) {
 			continue
@@ -187,6 +218,8 @@ func (m Model) commandHelp(mode commandMode) string {
 			primary = append(primary, command)
 		case command.Help:
 			help = append(help, command)
+		case command.Prominent:
+			prominent = append(prominent, command)
 		default:
 			optional = append(optional, command)
 		}
@@ -205,8 +238,9 @@ func (m Model) commandHelp(mode commandMode) string {
 	if len(help) > 0 {
 		ordered = append(ordered, help[0])
 	}
+	ordered = append(ordered, prominent...)
 	ordered = append(ordered, optional...)
-	return renderCommandHelp(ordered, m.helpWidth())
+	return renderCommandHelp(ordered, m.helpWidth(), m)
 }
 
 func (m Model) helpWidth() int {
@@ -219,14 +253,14 @@ func (m Model) helpWidth() int {
 	return 80
 }
 
-func renderCommandHelp(commands []commandSpec, width int) string {
+func renderCommandHelp(commands []commandSpec, width int, m Model) string {
 	if width <= 0 {
 		return ""
 	}
 	narrow := width < 48
 	var b strings.Builder
 	for _, command := range commands {
-		label := command.Label
+		label := command.label(m)
 		if narrow {
 			switch {
 			case command.Cancel:

--- a/ui/model/command_registry_test.go
+++ b/ui/model/command_registry_test.go
@@ -78,3 +78,56 @@ func TestReservedKeysComeFromCommandRegistry(t *testing.T) {
 		}
 	}
 }
+
+func TestMixcloudShortcutRegistryEntry(t *testing.T) {
+	for _, command := range commandRegistry {
+		if len(command.Keys) == 1 && command.Keys[0] == "X" && command.Mode&commandModeMain != 0 {
+			if command.KeyLabel != "X" || command.Label != "Open Mixcloud provider" || !command.Keymap {
+				t.Fatalf("Mixcloud command = %+v", command)
+			}
+			return
+		}
+	}
+	t.Fatal("Mixcloud shortcut is missing from the command registry")
+}
+
+func TestContextHelpAdvertisesProviderBrowsing(t *testing.T) {
+	oldPanelWidth := ui.PanelWidth
+	ui.PanelWidth = 80
+	t.Cleanup(func() { ui.PanelWidth = oldPanelWidth })
+
+	browse := trackArtistBrowseProvider{interactionBrowseProvider{commandsTestProvider{name: "Mixcloud"}}}
+	m := keybindingTestModel()
+	m.provider = browse
+	m.providers = append(m.providers, ProviderEntry{Key: "mixcloud", Name: "Mixcloud", Provider: browse})
+	m.playlist.Add(playlist.Track{
+		Title: "A Show", Artist: "Creator",
+		ProviderMeta: map[string]string{"test.creator": "creator"},
+	})
+	m.focus = focusPlaylist
+	if help := m.commandHelp(commandModeMain); !strings.Contains(help, "N") || !strings.Contains(help, "Browse creator") {
+		t.Fatalf("playlist help does not advertise creator browse: %q", help)
+	}
+
+	m.focus = focusProvider
+	paneBrowse := providerPaneBrowseProvider{interactionBrowseProvider{commandsTestProvider{name: "Mixcloud"}}}
+	m.provider = paneBrowse
+	m.providerLists = providerListsWithBrowse(paneBrowse, nil)
+	if help := m.commandHelp(commandModeProvider); !strings.Contains(help, "N") || !strings.Contains(help, "Browse provider") || !strings.Contains(help, "Open") {
+		t.Fatalf("provider help does not advertise provider browse: %q", help)
+	}
+
+	// A browse-capable provider elsewhere in the registry must not advertise
+	// its browser while a provider without pane routes is being viewed.
+	m.provider = commandsTestProvider{name: "Spotify"}
+	if help := m.commandHelp(commandModeProvider); strings.Contains(help, "Browse provider") {
+		t.Fatalf("Spotify provider help advertises another provider's browser: %q", help)
+	}
+
+	// Outside the provider pane, a highlighted Mixcloud show may still expose
+	// its direct creator jump even if another provider is active.
+	m.focus = focusPlaylist
+	if help := m.commandHelp(commandModeMain); !strings.Contains(help, "Browse creator") {
+		t.Fatalf("selected Mixcloud show lost its creator browse action: %q", help)
+	}
+}

--- a/ui/model/commands.go
+++ b/ui/model/commands.go
@@ -160,6 +160,13 @@ type navTracksLoadedMsg struct {
 	err    error
 }
 
+// navGenresLoadedMsg carries the category list from a provider genre browser.
+type navGenresLoadedMsg struct {
+	genres []provider.GenreInfo
+	gen    uint64
+	err    error
+}
+
 // provAuthDoneMsg signals that interactive provider authentication completed.
 type provAuthDoneMsg struct {
 	providerName string
@@ -384,6 +391,29 @@ func fetchNavAlbumTracksCmd(l provider.AlbumTrackLoader, albumID string, gen uin
 	return func() tea.Msg {
 		tracks, err := l.AlbumTracks(albumID)
 		return navTracksLoadedMsg{tracks: tracks, gen: gen, err: err}
+	}
+}
+
+func fetchNavGenresCmd(b provider.GenreBrowser, gen uint64) tea.Cmd {
+	return func() tea.Msg {
+		genres, err := b.Genres()
+		return navGenresLoadedMsg{genres: genres, gen: gen, err: err}
+	}
+}
+
+func fetchNavGenreTracksCmd(b provider.GenreBrowser, genreID, sortType string, gen uint64) tea.Cmd {
+	return func() tea.Msg {
+		tracks, err := b.GenreTracks(genreID, sortType)
+		return navTracksLoadedMsg{tracks: tracks, gen: gen, err: err}
+	}
+}
+
+func fetchNavGenreSearchCmd(s provider.GenreSearcher, query string, gen uint64) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		genres, err := s.SearchGenres(ctx, query, 100)
+		return navGenresLoadedMsg{genres: genres, gen: gen, err: err}
 	}
 }
 

--- a/ui/model/genre_browser_test.go
+++ b/ui/model/genre_browser_test.go
@@ -1,0 +1,272 @@
+package model
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/bjarneo/cliamp/playlist"
+	"github.com/bjarneo/cliamp/provider"
+)
+
+type genreBrowserProvider struct {
+	genres []provider.GenreInfo
+	styles []string
+	tracks []playlist.Track
+	search []provider.GenreInfo
+}
+
+func (p *genreBrowserProvider) Name() string { return "Genres" }
+func (p *genreBrowserProvider) Playlists() ([]playlist.PlaylistInfo, error) {
+	lists := make([]playlist.PlaylistInfo, 0, len(p.styles))
+	for _, style := range p.styles {
+		lists = append(lists, playlist.PlaylistInfo{ID: "style:" + style, Name: style, Section: "Styles"})
+	}
+	return lists, nil
+}
+func (p *genreBrowserProvider) Tracks(string) ([]playlist.Track, error) { return nil, nil }
+func (p *genreBrowserProvider) Genres() ([]provider.GenreInfo, error) {
+	return slices.Clone(p.genres), nil
+}
+func (p *genreBrowserProvider) GenreSortTypes() []provider.SortType {
+	return []provider.SortType{{ID: "latest", Label: "Latest"}, {ID: "popular", Label: "Popular"}}
+}
+func (p *genreBrowserProvider) GenreTracks(genreID, sortType string) ([]playlist.Track, error) {
+	return slices.Clone(p.tracks), nil
+}
+func (p *genreBrowserProvider) ToggleGenreFavorite(genreID string) (bool, error) {
+	favorite := !slices.Contains(p.styles, genreID)
+	if favorite {
+		p.styles = append(p.styles, genreID)
+	} else {
+		p.styles = slices.DeleteFunc(p.styles, func(style string) bool { return style == genreID })
+	}
+	for i := range p.genres {
+		if p.genres[i].ID == genreID {
+			p.genres[i].Favorite = favorite
+		}
+	}
+	return favorite, nil
+}
+func (p *genreBrowserProvider) SearchGenres(context.Context, string, int) ([]provider.GenreInfo, error) {
+	return slices.Clone(p.search), nil
+}
+func (p *genreBrowserProvider) BrowseEntries() []provider.BrowseEntry {
+	return []provider.BrowseEntry{{
+		ID: "browse:genres", Name: "Genres", Section: "Browse",
+		Mode: provider.BrowseGenres, OpenInPlaylist: true,
+	}}
+}
+
+// Compile-time guard against accidentally changing the capability used here.
+var _ provider.GenreBrowser = (*genreBrowserProvider)(nil)
+var _ provider.GenreFavoriteToggler = (*genreBrowserProvider)(nil)
+var _ provider.GenreSearcher = (*genreBrowserProvider)(nil)
+var _ playlist.Provider = (*genreBrowserProvider)(nil)
+
+type readOnlyGenreProvider struct {
+	genres []provider.GenreInfo
+}
+
+func (p *readOnlyGenreProvider) Name() string { return "Read-only genres" }
+func (p *readOnlyGenreProvider) Playlists() ([]playlist.PlaylistInfo, error) {
+	return nil, nil
+}
+func (p *readOnlyGenreProvider) Tracks(string) ([]playlist.Track, error) { return nil, nil }
+func (p *readOnlyGenreProvider) Genres() ([]provider.GenreInfo, error) {
+	return slices.Clone(p.genres), nil
+}
+func (p *readOnlyGenreProvider) GenreSortTypes() []provider.SortType {
+	return []provider.SortType{{ID: "latest", Label: "Latest"}}
+}
+func (p *readOnlyGenreProvider) GenreTracks(string, string) ([]playlist.Track, error) {
+	return nil, nil
+}
+
+var _ provider.GenreBrowser = (*readOnlyGenreProvider)(nil)
+var _ playlist.Provider = (*readOnlyGenreProvider)(nil)
+
+func TestGenreBrowserFiltersFavoritesAndRefreshesProviderLists(t *testing.T) {
+	p := &genreBrowserProvider{
+		genres: []provider.GenreInfo{
+			{ID: "house", Name: "House", Group: "Music", Favorite: true},
+			{ID: "technology", Name: "Technology", Group: "Talk"},
+		},
+		styles: []string{"house"},
+	}
+	m := Model{
+		provider:  p,
+		playlist:  playlist.New(),
+		plVisible: 10,
+		navBrowser: navBrowserState{
+			prov:    p,
+			visible: true,
+			mode:    navBrowseModeByGenre,
+			screen:  navBrowseScreenList,
+			genres:  slices.Clone(p.genres),
+			search:  "tech",
+		},
+	}
+	m.navUpdateSearch()
+	if !slices.Equal(m.navBrowser.searchIdx, []int{1}) {
+		t.Fatalf("genre filter indices = %v, want [1]", m.navBrowser.searchIdx)
+	}
+
+	cmd := m.handleNavBrowserKey(tea.KeyPressMsg{Text: "f"})
+	if !m.navBrowser.genres[1].Favorite || !slices.Equal(p.styles, []string{"house", "technology"}) {
+		t.Fatalf("favorite state = ui:%v provider:%v", m.navBrowser.genres[1].Favorite, p.styles)
+	}
+	if cmd == nil {
+		t.Fatal("favorite did not request an immediate provider-menu refresh")
+	}
+	msg, ok := cmd().(playlistsLoadedMsg)
+	if !ok || len(msg.playlists) != 2 {
+		t.Fatalf("refresh message = %#v", msg)
+	}
+	if got := m.renderNavBody(); got == "" {
+		t.Fatal("genre browser rendered an empty body")
+	}
+}
+
+func TestGenreBrowserDrillsIntoLatestAndPopular(t *testing.T) {
+	p := &genreBrowserProvider{
+		genres: []provider.GenreInfo{{ID: "deep-house", Name: "Deep House", Favorite: true}},
+		tracks: []playlist.Track{{Title: "A Show", Path: "https://example.com/show"}},
+	}
+	m := Model{
+		player:   &playbackFakeEngine{},
+		playlist: playlist.New(),
+		navBrowser: navBrowserState{
+			prov:           p,
+			visible:        true,
+			mode:           navBrowseModeByGenre,
+			screen:         navBrowseScreenList,
+			genres:         slices.Clone(p.genres),
+			openInPlaylist: true,
+		},
+	}
+
+	if cmd := m.handleNavBrowserKey(tea.KeyPressMsg{Code: tea.KeyEnter}); cmd != nil {
+		t.Fatal("genre selection unexpectedly performed network I/O")
+	}
+	if m.navBrowser.screen != navBrowseScreenAlbums || len(m.navBrowser.genreSorts) != 2 {
+		t.Fatalf("genre sort screen = %v, sorts=%v", m.navBrowser.screen, m.navBrowser.genreSorts)
+	}
+	m.navBrowser.cursor = 1
+	cmd := m.handleNavBrowserKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("Popular selection returned no track-loading command")
+	}
+	if m.navBrowser.cursor != 1 || m.navBrowser.selGenreSort.ID != "popular" {
+		t.Fatalf("genre selection moved while loading: %+v", m.navBrowser)
+	}
+	msg := cmd().(navTracksLoadedMsg)
+	if len(msg.tracks) != 1 || msg.tracks[0].Title != "A Show" {
+		t.Fatalf("genre tracks = %+v", msg.tracks)
+	}
+	updated, _ := m.Update(msg)
+	got := updated.(Model)
+	if got.navBrowser.visible || got.navBrowser.selGenreSort.ID != "popular" {
+		t.Fatalf("genre browser remained open after loading a playable leaf: %+v", got.navBrowser)
+	}
+	if got.focus != focusPlaylist || got.playlist.Len() != 1 || got.plCursor != 0 {
+		t.Fatalf("main playlist state = focus:%v len:%d cursor:%d", got.focus, got.playlist.Len(), got.plCursor)
+	}
+}
+
+func TestGenreBrowseEntryAppearsInProviderPaneAndNavMenu(t *testing.T) {
+	p := &genreBrowserProvider{}
+	lists := providerListsWithBrowse(p, nil)
+	if len(lists) != 1 || lists[0].ID != "browse:genres" {
+		t.Fatalf("provider lists = %+v", lists)
+	}
+	m := Model{navBrowser: navBrowserState{prov: p}}
+	menu := m.navMenuItems()
+	if len(menu) != 4 || menu[3].mode != provider.BrowseGenres {
+		t.Fatalf("nav menu = %+v", menu)
+	}
+}
+
+func TestGenreBrowseEntriesAreUniqueAndGenreOnlyProvidersCanBrowse(t *testing.T) {
+	p := &genreBrowserProvider{}
+	lists := providerListsWithBrowse(p, []playlist.PlaylistInfo{{ID: "browse:genres", Name: "Playable collision"}})
+	if len(lists) != 1 || lists[0].Name != "Playable collision" {
+		t.Fatalf("playable-list collision was not preserved: %+v", lists)
+	}
+
+	duplicateEntries := duplicateGenreEntriesProvider{genreBrowserProvider: p}
+	lists = providerListsWithBrowse(duplicateEntries, nil)
+	if len(lists) != 1 {
+		t.Fatalf("duplicate browse entries = %+v, want one", lists)
+	}
+
+	readOnly := &readOnlyGenreProvider{}
+	if !providerSupportsBrowse(readOnly) {
+		t.Fatal("genre-only provider was not recognized as browsable")
+	}
+	m := Model{provider: readOnly, providers: []ProviderEntry{{Provider: readOnly}}}
+	if got := m.findBrowseProvider(); got != readOnly {
+		t.Fatalf("findBrowseProvider() = %T, want read-only genre provider", got)
+	}
+}
+
+type duplicateGenreEntriesProvider struct {
+	*genreBrowserProvider
+}
+
+func (p duplicateGenreEntriesProvider) BrowseEntries() []provider.BrowseEntry {
+	entry := provider.BrowseEntry{ID: "browse:genres", Name: "Genres", Mode: provider.BrowseGenres}
+	return []provider.BrowseEntry{entry, entry}
+}
+
+func TestReadOnlyGenreBrowserDoesNotAdvertiseFavorite(t *testing.T) {
+	p := &readOnlyGenreProvider{genres: []provider.GenreInfo{{ID: "house", Name: "House"}}}
+	m := Model{
+		playlist: playlist.New(),
+		navBrowser: navBrowserState{
+			prov:    p,
+			visible: true,
+			mode:    navBrowseModeByGenre,
+			screen:  navBrowseScreenList,
+			genres:  slices.Clone(p.genres),
+		},
+	}
+	if help := m.commandHelp(commandModeNavBrowser); strings.Contains(help, "Favorite genre") {
+		t.Fatalf("read-only genre browser advertised favorite action: %q", help)
+	}
+	if cmd := m.handleNavBrowserKey(tea.KeyPressMsg{Text: "f"}); cmd != nil {
+		t.Fatal("read-only genre browser handled favorite action")
+	}
+}
+
+func TestGenreFilterEnterSearchesFullProviderCatalogue(t *testing.T) {
+	p := &genreBrowserProvider{search: []provider.GenreInfo{{ID: "acid-techno", Name: "Acid Techno", Group: "Tag"}}}
+	m := Model{
+		playlist: playlist.New(),
+		navBrowser: navBrowserState{
+			prov:      p,
+			visible:   true,
+			mode:      navBrowseModeByGenre,
+			screen:    navBrowseScreenList,
+			searching: true,
+			search:    "acid techno",
+		},
+	}
+
+	cmd := m.handleNavBrowserKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd == nil || !m.navBrowser.loading || m.navBrowser.genreQuery != "acid techno" || m.navBrowser.search != "" {
+		t.Fatalf("remote genre search state = %+v, cmd nil=%v", m.navBrowser, cmd == nil)
+	}
+	msg := cmd().(navGenresLoadedMsg)
+	updated, _ := m.Update(msg)
+	got := updated.(Model)
+	if len(got.navBrowser.genres) != 1 || got.navBrowser.genres[0].ID != "acid-techno" {
+		t.Fatalf("remote genre results = %+v", got.navBrowser.genres)
+	}
+	if breadcrumb := got.navBreadcrumb(); breadcrumb != "Genres / Genres / Search: acid techno" {
+		t.Fatalf("search breadcrumb = %q", breadcrumb)
+	}
+}

--- a/ui/model/inline_overlays.go
+++ b/ui/model/inline_overlays.go
@@ -99,7 +99,7 @@ func (m Model) renderSpotSearchResults(budget int) string {
 			lines = append(lines, dimStyle.Render(labeledSeparator("", row.Section)))
 			continue
 		}
-		label := truncate(fmt.Sprintf("%s - %s", row.Track.Artist, row.Track.Title), ui.PanelWidth-8)
+		label := truncate(trackViewName(row.Track), ui.PanelWidth-8)
 		lines = append(lines, cursorLine(label, row.Index == m.spotSearch.cursor))
 	}
 	return strings.Join(padLines(lines, budget, len(lines)), "\n")
@@ -119,7 +119,7 @@ func (m Model) renderTrackRowsBody(tracks []playlist.Track, cursor, scroll, budg
 			continue
 		}
 		i, t := row.Index, row.Track
-		label := formatTrackRow(i+1, t.DisplayName()+trackAlbumSuffix(t, m.showAlbumHeaders), t.DurationSecs)
+		label := formatTrackRow(i+1, trackViewName(t)+trackAlbumSuffix(t, m.showAlbumHeaders), t.DurationSecs)
 		lines = append(lines, cursorLine(label, i == cursor))
 	}
 	return bodyLines(lines, budget)
@@ -292,7 +292,7 @@ func (m Model) renderQueueBody() string {
 	tracks := m.playlist.QueueWindow(start, budget)
 	items := make([]string, len(tracks))
 	for i, t := range tracks {
-		items[i] = fmt.Sprintf("%d. %s", start+i+1, truncate(t.DisplayName(), ui.PanelWidth-8))
+		items[i] = fmt.Sprintf("%d. %s", start+i+1, truncate(trackViewName(t), ui.PanelWidth-8))
 	}
 	return windowList(items, m.queue.cursor-start, 0, budget)
 }
@@ -485,7 +485,7 @@ func (m Model) renderNetSearchBody() string {
 	}
 	items := make([]string, len(m.netSearch.results))
 	for i, t := range m.netSearch.results {
-		items[i] = truncate(t.DisplayName(), ui.PanelWidth-8)
+		items[i] = truncate(trackViewName(t), ui.PanelWidth-8)
 	}
 	return windowList(items, m.netSearch.cursor, m.netSearch.scroll, budget)
 }

--- a/ui/model/inline_overlays_nav.go
+++ b/ui/model/inline_overlays_nav.go
@@ -18,6 +18,8 @@ const (
 	navViewArtists
 	navViewAlbums
 	navViewTracks
+	navViewGenres
+	navViewGenreSorts
 )
 
 // navView collapses the nav browser's mode + screen into the list actually
@@ -43,6 +45,15 @@ func (m Model) navView() navViewKind {
 		default:
 			return navViewArtists
 		}
+	case navBrowseModeByGenre:
+		switch m.navBrowser.screen {
+		case navBrowseScreenAlbums:
+			return navViewGenreSorts
+		case navBrowseScreenTracks:
+			return navViewTracks
+		default:
+			return navViewGenres
+		}
 	default:
 		return navViewMenu
 	}
@@ -67,6 +78,10 @@ func (m Model) navHeaderLine() string {
 		return sepHeaderN(m.navBreadcrumb(), m.navBrowser.cursor+1, len(m.navBrowser.albums))
 	case navViewTracks:
 		return sepHeaderN(m.navBreadcrumb(), m.navBrowser.cursor+1, len(m.navBrowser.tracks))
+	case navViewGenres:
+		return sepHeaderN(m.navBreadcrumb(), m.navBrowser.cursor+1, len(m.navBrowser.genres))
+	case navViewGenreSorts:
+		return sepHeaderN(m.navBreadcrumb(), m.navBrowser.cursor+1, len(m.navBrowser.genreSorts))
 	default:
 		return sepHeader(m.navBreadcrumb())
 	}
@@ -98,7 +113,11 @@ func (m Model) renderNavBody() string {
 		}
 		items := m.navScrollItems(len(m.navBrowser.artists), func(i int) string {
 			a := m.navBrowser.artists[i]
-			return truncate(fmt.Sprintf("%s (%d %s)", a.Name, a.AlbumCount, labels.albumsLower()), ui.PanelWidth-6)
+			name := a.Name
+			if a.AlbumCount > 0 {
+				name = fmt.Sprintf("%s (%d %s)", name, a.AlbumCount, labels.albumsLower())
+			}
+			return truncate(name, ui.PanelWidth-6)
 		})
 		return strings.Join(items, "\n")
 	case navViewAlbums:
@@ -113,16 +132,52 @@ func (m Model) renderNavBody() string {
 		}
 		items := m.navScrollItems(len(m.navBrowser.albums), func(i int) string {
 			a := m.navBrowser.albums[i]
+			name := albumViewName(a)
 			if a.Year > 0 {
-				return truncate(fmt.Sprintf("%s — %s (%d)", a.Name, a.Artist, a.Year), ui.PanelWidth-6)
+				return truncate(fmt.Sprintf("%s — %s (%d)", name, a.Artist, a.Year), ui.PanelWidth-6)
 			}
-			return truncate(fmt.Sprintf("%s — %s", a.Name, a.Artist), ui.PanelWidth-6)
+			return truncate(fmt.Sprintf("%s — %s", name, a.Artist), ui.PanelWidth-6)
 		})
 		return strings.Join(items, "\n")
 	case navViewTracks:
 		return m.renderNavTrackBody(budget)
+	case navViewGenres:
+		if m.navBrowser.loading && len(m.navBrowser.genres) == 0 {
+			return bodyLines([]string{loadingLine("Loading genres…")}, budget)
+		}
+		if m.navBrowser.search != "" && len(m.navBrowser.searchIdx) == 0 {
+			return bodyMessage("No matches.", budget)
+		}
+		if len(m.navBrowser.genres) == 0 {
+			return bodyMessage("No genres found.", budget)
+		}
+		items := m.navScrollItems(len(m.navBrowser.genres), func(i int) string {
+			genre := m.navBrowser.genres[i]
+			mark := "☆ "
+			if genre.Favorite {
+				mark = "★ "
+			}
+			label := mark + genre.Name
+			if genre.Group != "" && !strings.EqualFold(genre.Group, "music") {
+				label += " — " + genre.Group
+			}
+			return truncate(label, ui.PanelWidth-6)
+		})
+		return strings.Join(items, "\n")
+	case navViewGenreSorts:
+		if len(m.navBrowser.genreSorts) == 0 {
+			return bodyMessage("No genre views found.", budget)
+		}
+		items := m.navScrollItems(len(m.navBrowser.genreSorts), func(i int) string {
+			return truncate(m.navBrowser.genreSorts[i].Label, ui.PanelWidth-6)
+		})
+		return strings.Join(items, "\n")
 	default:
-		items := []string{"By " + labels.album, "By " + labels.artist, "By " + labels.artist + " / " + labels.album}
+		menu := m.navMenuItems()
+		items := make([]string, len(menu))
+		for i := range menu {
+			items[i] = menu[i].label
+		}
 		return windowList(items, m.navBrowser.cursor, 0, budget)
 	}
 }
@@ -141,7 +196,7 @@ func (m Model) renderNavTrackBody(budget int) string {
 	if m.navBrowser.search != "" {
 		items := m.navScrollItems(len(m.navBrowser.tracks), func(i int) string {
 			t := m.navBrowser.tracks[i]
-			return formatTrackRow(i+1, t.DisplayName()+trackAlbumSuffix(t, m.showAlbumHeaders), t.DurationSecs)
+			return formatTrackRow(i+1, trackViewName(t)+trackAlbumSuffix(t, m.showAlbumHeaders), t.DurationSecs)
 		})
 		return strings.Join(items, "\n")
 	}

--- a/ui/model/interaction_test.go
+++ b/ui/model/interaction_test.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 
@@ -22,10 +23,107 @@ func (p interactionBrowseProvider) ArtistAlbums(string) ([]provider.AlbumInfo, e
 	return nil, nil
 }
 
+type trackArtistBrowseProvider struct {
+	interactionBrowseProvider
+}
+
+type providerPaneBrowseProvider struct {
+	interactionBrowseProvider
+}
+
+type positionedBrowseProvider struct {
+	providerPaneBrowseProvider
+}
+
+type sharedModeBrowseProvider struct {
+	providerPaneBrowseProvider
+}
+
+type favoriteBrowseProvider struct {
+	commandsTestProvider
+}
+
+func (p favoriteBrowseProvider) BrowseEntries() []provider.BrowseEntry {
+	return []provider.BrowseEntry{{ID: "browse:shows", Name: "Shows", Section: "Browse", Mode: provider.BrowseAlbums}}
+}
+
+func (p favoriteBrowseProvider) ToggleFavorite(string) (bool, string, error) {
+	return true, "Recent Releases", nil
+}
+
+func (p providerPaneBrowseProvider) BrowseEntries() []provider.BrowseEntry {
+	return []provider.BrowseEntry{
+		{ID: "browse:shows", Name: "Shows", Section: "Browse", Mode: provider.BrowseAlbums},
+		{ID: "browse:creators", Name: "Creators", Section: "Browse", Mode: provider.BrowseArtistAlbums},
+		{ID: "browse:genres", Name: "Genres", Section: "Browse", Mode: provider.BrowseGenres},
+	}
+}
+
+func (p providerPaneBrowseProvider) AlbumList(string, int, int) ([]provider.AlbumInfo, error) {
+	return nil, nil
+}
+
+func (p providerPaneBrowseProvider) AlbumSortTypes() []provider.SortType {
+	return []provider.SortType{{ID: "latest", Label: "Latest"}}
+}
+
+func (p providerPaneBrowseProvider) DefaultAlbumSort() string { return "latest" }
+
+func (p providerPaneBrowseProvider) Genres() ([]provider.GenreInfo, error) { return nil, nil }
+
+func (p providerPaneBrowseProvider) GenreSortTypes() []provider.SortType {
+	return []provider.SortType{{ID: "latest", Label: "Latest"}, {ID: "popular", Label: "Popular"}}
+}
+
+func (p providerPaneBrowseProvider) GenreTracks(string, string) ([]playlist.Track, error) {
+	return []playlist.Track{{Title: "Show", Path: "https://example.com/show"}}, nil
+}
+
+func (p providerPaneBrowseProvider) AlbumTracks(string) ([]playlist.Track, error) {
+	return []playlist.Track{{Title: "Show", Path: "https://example.com/show"}}, nil
+}
+
+func (p positionedBrowseProvider) BrowseEntries() []provider.BrowseEntry {
+	return []provider.BrowseEntry{
+		{
+			ID: "browse:creators", Name: "Creators", Section: "Library",
+			Mode: provider.BrowseArtistAlbums, AfterID: "favorites",
+			AfterSection: "Library", OpenInPlaylist: true,
+		},
+		{
+			ID: "browse:shows", Name: "Shows", Section: "Browse",
+			Mode: provider.BrowseAlbums, AfterSection: "Library", OpenInPlaylist: true,
+		},
+		{
+			ID: "browse:genres", Name: "Genres", Section: "Browse",
+			Mode: provider.BrowseGenres, AfterSection: "Library", OpenInPlaylist: true,
+		},
+	}
+}
+
+func (p sharedModeBrowseProvider) BrowseEntries() []provider.BrowseEntry {
+	return []provider.BrowseEntry{
+		{ID: "browse:preview", Name: "Preview", Section: "Browse", Mode: provider.BrowseAlbums},
+		{ID: "browse:play", Name: "Play", Section: "Browse", Mode: provider.BrowseAlbums, OpenInPlaylist: true},
+	}
+}
+
+func (p trackArtistBrowseProvider) ArtistForTrack(track playlist.Track) (provider.ArtistInfo, bool) {
+	if track.Meta("test.creator") == "" {
+		return provider.ArtistInfo{}, false
+	}
+	return provider.ArtistInfo{ID: track.Meta("test.creator"), Name: track.Artist}, true
+}
+
+func (p trackArtistBrowseProvider) ArtistAlbums(artistID string) ([]provider.AlbumInfo, error) {
+	return []provider.AlbumInfo{{ID: "uploads:" + artistID, Name: "Uploads"}}, nil
+}
+
 func keybindingTestModel() Model {
 	local := commandsTestProvider{name: "Local"}
 	return Model{
 		playlist: playlist.New(),
+		player:   &playbackFakeEngine{},
 		provider: local,
 		providers: []ProviderEntry{
 			{Key: "local", Name: "Local", Provider: local},
@@ -54,6 +152,7 @@ func TestHandleKeyEnhancedShiftYSelectsYouTubeProvider(t *testing.T) {
 func TestHandleKeyEnhancedShiftNOpensProviderBrowser(t *testing.T) {
 	browse := interactionBrowseProvider{commandsTestProvider{name: "Navidrome"}}
 	m := keybindingTestModel()
+	m.provider = browse
 	m.providers = append(m.providers, ProviderEntry{Key: "navidrome", Name: "Navidrome", Provider: browse})
 	msg := tea.KeyPressMsg{Code: 'n', ShiftedCode: 'N', Mod: tea.ModShift}
 
@@ -64,6 +163,440 @@ func TestHandleKeyEnhancedShiftNOpensProviderBrowser(t *testing.T) {
 	}
 	if got := m.navBrowser.prov.Name(); got != "Navidrome" {
 		t.Fatalf("browser provider = %q, want Navidrome", got)
+	}
+}
+
+func TestProviderPaneShiftNDoesNotOpenAnotherProviderBrowser(t *testing.T) {
+	mixcloud := providerPaneBrowseProvider{interactionBrowseProvider{commandsTestProvider{name: "Mixcloud"}}}
+	spotify := commandsTestProvider{name: "Spotify"}
+	m := keybindingTestModel()
+	m.focus = focusProvider
+	m.provider = spotify
+	m.providers = append(m.providers,
+		ProviderEntry{Key: "spotify", Name: "Spotify", Provider: spotify},
+		ProviderEntry{Key: "mixcloud", Name: "Mixcloud", Provider: mixcloud},
+	)
+
+	m.handleKey(tea.KeyPressMsg{Code: 'n', ShiftedCode: 'N', Mod: tea.ModShift})
+
+	if m.navBrowser.visible {
+		t.Fatalf("Spotify provider pane opened %q browser", m.navBrowser.prov.Name())
+	}
+	m.focus = focusPlaylist
+	m.handleKey(tea.KeyPressMsg{Code: 'n', ShiftedCode: 'N', Mod: tea.ModShift})
+	if m.navBrowser.visible {
+		t.Fatalf("Spotify playlist opened %q browser", m.navBrowser.prov.Name())
+	}
+
+	m.focus = focusProvider
+	m.provider = mixcloud
+	m.handleKey(tea.KeyPressMsg{Code: 'n', ShiftedCode: 'N', Mod: tea.ModShift})
+	if !m.navBrowser.visible || m.navBrowser.prov == nil || m.navBrowser.prov.Name() != "Mixcloud" {
+		t.Fatalf("Mixcloud provider pane did not open its own browser: %+v", m.navBrowser)
+	}
+}
+
+func TestShiftNOnProviderTrackJumpsToItsArtist(t *testing.T) {
+	browse := trackArtistBrowseProvider{interactionBrowseProvider{commandsTestProvider{name: "Mixcloud"}}}
+	m := keybindingTestModel()
+	m.provider = browse
+	m.providers = append(m.providers, ProviderEntry{Key: "mixcloud", Name: "Mixcloud", Provider: browse})
+	m.focus = focusPlaylist
+	m.playlist.Add(playlist.Track{
+		Title: "A Show", Artist: "Creator Name",
+		ProviderMeta: map[string]string{"test.creator": "creator"},
+	})
+	m.plCursor = 0
+
+	cmd := m.handleKey(tea.KeyPressMsg{Code: 'n', ShiftedCode: 'N', Text: "N", Mod: tea.ModShift})
+	if cmd == nil {
+		t.Fatal("Shift+N returned no artist-load command")
+	}
+	if !m.navBrowser.visible || m.navBrowser.mode != navBrowseModeByArtistAlbum || m.navBrowser.screen != navBrowseScreenAlbums {
+		t.Fatalf("nav state = %+v", m.navBrowser)
+	}
+	if !m.navBrowser.directTrackJump {
+		t.Fatal("directTrackJump = false after selected-track creator jump")
+	}
+	if m.navBrowser.selArtist.ID != "creator" || m.navBrowser.selArtist.Name != "Creator Name" {
+		t.Fatalf("selected artist = %+v", m.navBrowser.selArtist)
+	}
+	msg, ok := cmd().(navAlbumsLoadedMsg)
+	if !ok || len(msg.albums) != 1 || msg.albums[0].Name != "Uploads" {
+		t.Fatalf("artist load message = %#v", msg)
+	}
+}
+
+func TestEscFromDirectTrackCreatorReturnsToPlaylist(t *testing.T) {
+	browse := trackArtistBrowseProvider{interactionBrowseProvider{commandsTestProvider{name: "Mixcloud"}}}
+	m := keybindingTestModel()
+	m.provider = browse
+	m.providers = append(m.providers, ProviderEntry{Key: "mixcloud", Name: "Mixcloud", Provider: browse})
+	m.focus = focusPlaylist
+	m.playlist.Add(playlist.Track{
+		Title: "A Show", Artist: "Creator Name",
+		ProviderMeta: map[string]string{"test.creator": "creator"},
+	})
+
+	if cmd, ok := m.openSelectedTrackArtistBrowser(); !ok || cmd == nil {
+		t.Fatal("selected-track creator browser did not open")
+	}
+	m.handleNavBrowserKey(tea.KeyPressMsg{Code: tea.KeyEscape})
+
+	if m.navBrowser.visible {
+		t.Fatalf("nav browser = %+v, want closed after backing out of a direct creator jump", m.navBrowser)
+	}
+	if m.navBrowser.directTrackJump {
+		t.Fatal("directTrackJump remained set after returning to the playlist")
+	}
+}
+
+func TestProviderPaneBrowseEntryOpensCreatorHierarchy(t *testing.T) {
+	browse := providerPaneBrowseProvider{interactionBrowseProvider{commandsTestProvider{name: "Mixcloud"}}}
+	lists := providerListsWithBrowse(browse, []playlist.PlaylistInfo{{ID: "recent", Name: "Recent Releases", Section: "Discover"}})
+	if len(lists) != 4 || lists[0].Name != "Shows" || lists[1].Name != "Creators" || lists[2].Name != "Genres" || lists[3].Name != "Recent Releases" {
+		t.Fatalf("decorated provider lists = %+v", lists)
+	}
+
+	m := keybindingTestModel()
+	m.provider = browse
+	m.providerLists = lists
+	cmd := m.openProviderList(1)
+	if cmd == nil {
+		t.Fatal("Creators entry returned no artist-load command")
+	}
+	if !m.navBrowser.visible || m.navBrowser.mode != navBrowseModeByArtistAlbum || m.navBrowser.screen != navBrowseScreenList {
+		t.Fatalf("nav state = %+v", m.navBrowser)
+	}
+	if _, ok := cmd().(navArtistsLoadedMsg); !ok {
+		t.Fatalf("Creators command returned %T, want navArtistsLoadedMsg", cmd())
+	}
+}
+
+func TestProviderPaneBrowseEntryBackReturnsToProviderList(t *testing.T) {
+	browse := providerPaneBrowseProvider{interactionBrowseProvider{commandsTestProvider{name: "Mixcloud"}}}
+	lists := providerListsWithBrowse(browse, nil)
+
+	for _, tt := range []struct {
+		name  string
+		index int
+		mode  navBrowseModeType
+	}{
+		{name: "shows", index: 0, mode: navBrowseModeByAlbum},
+		{name: "creators", index: 1, mode: navBrowseModeByArtistAlbum},
+		{name: "genres", index: 2, mode: navBrowseModeByGenre},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			m := keybindingTestModel()
+			m.provider = browse
+			m.providerLists = lists
+
+			if cmd := m.openProviderList(tt.index); cmd == nil {
+				t.Fatalf("openProviderList(%d) returned no load command", tt.index)
+			}
+			if !m.navBrowser.visible || !m.navBrowser.fromProvList || m.navBrowser.mode != tt.mode {
+				t.Fatalf("opened nav state = %+v", m.navBrowser)
+			}
+
+			m.handleNavBrowserKey(tea.KeyPressMsg{Code: tea.KeyLeft})
+			if m.navBrowser.visible || m.navBrowser.fromProvList {
+				t.Fatalf("nav state after Back = %+v, want provider list", m.navBrowser)
+			}
+		})
+	}
+}
+
+func TestProviderPaneCreatorMultiLevelBackReturnsToProviderList(t *testing.T) {
+	browse := providerPaneBrowseProvider{interactionBrowseProvider{commandsTestProvider{name: "Mixcloud"}}}
+	m := keybindingTestModel()
+	m.provider = browse
+	m.providerLists = providerListsWithBrowse(browse, nil)
+
+	if cmd := m.openProviderList(1); cmd == nil {
+		t.Fatal("Creators entry returned no artist-load command")
+	}
+	m.navBrowser.loading = false
+	m.navBrowser.artists = []provider.ArtistInfo{{ID: "creator", Name: "Creator"}}
+	if cmd := m.handleNavBrowserKey(tea.KeyPressMsg{Code: tea.KeyEnter}); cmd == nil {
+		t.Fatal("creator selection returned no collection-load command")
+	}
+	if m.navBrowser.screen != navBrowseScreenAlbums || !m.navBrowser.fromProvList {
+		t.Fatalf("creator collection state = %+v", m.navBrowser)
+	}
+
+	m.handleNavBrowserKey(tea.KeyPressMsg{Code: tea.KeyLeft})
+	if !m.navBrowser.visible || m.navBrowser.screen != navBrowseScreenList || !m.navBrowser.fromProvList {
+		t.Fatalf("nav state after first Back = %+v, want creator list", m.navBrowser)
+	}
+	m.handleNavBrowserKey(tea.KeyPressMsg{Code: tea.KeyLeft})
+	if m.navBrowser.visible || m.navBrowser.fromProvList {
+		t.Fatalf("nav state after second Back = %+v, want provider list", m.navBrowser)
+	}
+}
+
+func TestNormalBrowseRootBackReturnsToBrowseMenu(t *testing.T) {
+	browse := providerPaneBrowseProvider{interactionBrowseProvider{commandsTestProvider{name: "Mixcloud"}}}
+	for _, mode := range []provider.BrowseMode{provider.BrowseAlbums, provider.BrowseArtistAlbums, provider.BrowseGenres} {
+		m := keybindingTestModel()
+		m.openNavBrowserAt(browse, mode)
+		m.navBrowser.cursor = 40
+		m.navBrowser.scroll = 35
+		m.handleNavBrowserKey(tea.KeyPressMsg{Code: tea.KeyLeft})
+		if !m.navBrowser.visible || m.navBrowser.mode != navBrowseModeMenu || m.navBrowser.fromProvList {
+			t.Fatalf("mode %v nav state after Back = %+v, want browse menu", mode, m.navBrowser)
+		}
+		if m.navBrowser.cursor != 0 || m.navBrowser.scroll != 0 {
+			t.Fatalf("mode %v menu position = cursor:%d scroll:%d, want 0,0", mode, m.navBrowser.cursor, m.navBrowser.scroll)
+		}
+	}
+}
+
+func TestPositionedBrowseEntriesFollowPreferredSection(t *testing.T) {
+	browse := positionedBrowseProvider{providerPaneBrowseProvider{interactionBrowseProvider{commandsTestProvider{name: "Mixcloud"}}}}
+	lists := providerListsWithBrowse(browse, []playlist.PlaylistInfo{
+		{ID: "stream", Name: "Stream", Section: "Library"},
+		{ID: "favorites", Name: "Favorites", Section: "Library"},
+		{ID: "collection", Name: "Collection", Section: "Collections"},
+		{ID: "recent", Name: "Recent", Section: "Discover"},
+	})
+	want := []string{"stream", "favorites", "browse:creators", "browse:shows", "browse:genres", "collection", "recent"}
+	got := make([]string, 0, len(lists))
+	for _, item := range lists {
+		got = append(got, item.ID)
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("positioned provider lists = %v, want %v", got, want)
+	}
+
+	publicOnly := providerListsWithBrowse(browse, []playlist.PlaylistInfo{{ID: "recent", Name: "Recent", Section: "Discover"}})
+	if len(publicOnly) != 3 || publicOnly[0].ID != "browse:shows" || publicOnly[1].ID != "browse:genres" || publicOnly[2].ID != "recent" {
+		t.Fatalf("public-only provider lists = %+v, want Browse without account-only Creators", publicOnly)
+	}
+	m := keybindingTestModel()
+	m.openNavBrowserAt(browse, provider.BrowseArtistAlbums)
+	if !m.navBrowser.openInPlaylist {
+		t.Fatal("creator leaf behavior depended on the account-only pane entry being visible")
+	}
+}
+
+func TestBrowseEntryGroupingAndAnchorRules(t *testing.T) {
+	lists := []playlist.PlaylistInfo{
+		{ID: "stream", Name: "Stream", Section: "Library"},
+		{ID: "favorites", Name: "Favorites", Section: "Library"},
+		{ID: "uploads", Name: "Uploads", Section: "Library"},
+		{ID: "collection", Name: "Collection", Section: "Collections"},
+		{ID: "recent", Name: "Recent", Section: "Discover"},
+	}
+	entries := []provider.BrowseEntry{
+		{ID: "recent", Name: "Duplicate", Section: "Browse"},
+		{ID: "browse:creator", Name: "Creator", Section: "Library", AfterID: "favorites", AfterSection: "Library"},
+		{ID: "browse:fallback", Name: "Fallback", Section: "Browse", AfterID: "missing", AfterSection: "Collections"},
+		{ID: "browse:fallback-2", Name: "Fallback 2", Section: "Browse", AfterID: "missing", AfterSection: "Collections"},
+		{ID: "browse:account", Name: "Account", Section: "Account", AfterSection: "Account"},
+		{ID: "browse:public", Name: "Public", Section: "Browse", AfterSection: "Missing"},
+		{ID: "", Name: "Invalid", Section: "Browse"},
+	}
+
+	groups := groupBrowseEntries(entries, lists)
+	gotLists := spliceBrowseGroups(lists, groups)
+	got := make([]string, 0, len(gotLists))
+	for _, item := range gotLists {
+		got = append(got, item.ID)
+	}
+	want := []string{
+		"browse:public", "stream", "favorites", "browse:creator", "uploads",
+		"collection", "browse:fallback", "browse:fallback-2", "recent",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("spliced browse lists = %v, want %v", got, want)
+	}
+}
+
+func TestBrowsePlayableLeavesOpenInMainPlaylist(t *testing.T) {
+	browse := positionedBrowseProvider{providerPaneBrowseProvider{interactionBrowseProvider{commandsTestProvider{name: "Mixcloud"}}}}
+	lists := providerListsWithBrowse(browse, []playlist.PlaylistInfo{
+		{ID: "stream", Name: "Stream", Section: "Library"},
+		{ID: "favorites", Name: "Favorites", Section: "Library"},
+	})
+
+	for _, id := range []string{"browse:shows", "browse:creators", "browse:genres"} {
+		t.Run(id, func(t *testing.T) {
+			index := slices.IndexFunc(lists, func(item playlist.PlaylistInfo) bool { return item.ID == id })
+			if index < 0 {
+				t.Fatalf("browse entry %q missing from %+v", id, lists)
+			}
+			m := keybindingTestModel()
+			m.provider = browse
+			m.providerLists = lists
+			if cmd := m.openProviderList(index); cmd == nil {
+				t.Fatalf("openProviderList(%q) returned no load command", id)
+			}
+			if !m.navBrowser.openInPlaylist {
+				t.Fatalf("browse entry %q did not opt into the main playlist", id)
+			}
+
+			updated, _ := m.Update(navTracksLoadedMsg{
+				tracks: []playlist.Track{{Title: id, Path: "https://example.com/show"}},
+				gen:    m.requests.nav,
+			})
+			got := updated.(Model)
+			if got.navBrowser.visible || got.focus != focusPlaylist || got.playlist.Len() != 1 {
+				t.Fatalf("browse entry %q result = nav:%t focus:%v tracks:%d", id, got.navBrowser.visible, got.focus, got.playlist.Len())
+			}
+			if !strings.Contains(got.status.text, "Replaced queue with 1 tracks") {
+				t.Fatalf("browse entry %q status = %+v", id, got.status)
+			}
+		})
+	}
+}
+
+func TestProviderPaneUsesExactBrowseEntryLeafBehavior(t *testing.T) {
+	browse := sharedModeBrowseProvider{providerPaneBrowseProvider{interactionBrowseProvider{commandsTestProvider{name: "Shared mode"}}}}
+	lists := providerListsWithBrowse(browse, nil)
+	m := keybindingTestModel()
+	m.provider = browse
+	m.providerLists = lists
+
+	if cmd := m.openProviderList(1); cmd == nil {
+		t.Fatal("second same-mode browse entry returned no load command")
+	}
+	if !m.navBrowser.openInPlaylist {
+		t.Fatalf("second entry inherited first entry behavior: %+v", m.navBrowser)
+	}
+}
+
+func TestBackCancelsInFlightPlayableLeaf(t *testing.T) {
+	browse := positionedBrowseProvider{providerPaneBrowseProvider{interactionBrowseProvider{commandsTestProvider{name: "Mixcloud"}}}}
+	tests := []struct {
+		name  string
+		start func(*Model) tea.Cmd
+	}{
+		{
+			name: "shows",
+			start: func(m *Model) tea.Cmd {
+				m.openNavBrowserAt(browse, provider.BrowseAlbums)
+				m.navBrowser.albumLoading = false
+				m.navBrowser.albums = []provider.AlbumInfo{{ID: "show", Name: "Show"}}
+				return m.handleNavBrowserKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+			},
+		},
+		{
+			name: "creator collection",
+			start: func(m *Model) tea.Cmd {
+				m.openNavBrowserAt(browse, provider.BrowseArtistAlbums)
+				m.navBrowser.loading = false
+				m.navBrowser.screen = navBrowseScreenAlbums
+				m.navBrowser.albums = []provider.AlbumInfo{{ID: "uploads", Name: "Uploads"}}
+				return m.handleNavBrowserKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+			},
+		},
+		{
+			name: "genre sort",
+			start: func(m *Model) tea.Cmd {
+				m.openNavBrowserAt(browse, provider.BrowseGenres)
+				m.navBrowser.loading = false
+				m.navBrowser.genres = []provider.GenreInfo{{ID: "house", Name: "House"}}
+				m.handleNavBrowserKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+				m.navBrowser.cursor = 1
+				return m.handleNavBrowserKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := keybindingTestModel()
+			m.playlist.Add(playlist.Track{Title: "Keep", Path: "keep.mp3"})
+			cmd := tt.start(&m)
+			if cmd == nil {
+				t.Fatal("leaf selection returned no load command")
+			}
+			leafRequest := m.requests.nav
+			m.handleNavBrowserKey(tea.KeyPressMsg{Code: tea.KeyEscape})
+			if m.requests.nav == leafRequest {
+				t.Fatal("Back did not cancel the in-flight leaf request")
+			}
+
+			updated, _ := m.Update(cmd())
+			got := updated.(Model)
+			track, _ := got.playlist.Track(0)
+			if !got.navBrowser.visible || got.playlist.Len() != 1 || track.Title != "Keep" {
+				t.Fatalf("stale leaf changed state = nav:%t tracks:%d first:%+v", got.navBrowser.visible, got.playlist.Len(), track)
+			}
+		})
+	}
+}
+
+func TestEmptyBrowseLeafPreservesCurrentPlaylist(t *testing.T) {
+	browse := positionedBrowseProvider{providerPaneBrowseProvider{interactionBrowseProvider{commandsTestProvider{name: "Mixcloud"}}}}
+	m := keybindingTestModel()
+	m.playlist.Add(playlist.Track{Title: "Keep", Path: "keep.mp3"})
+	m.openNavBrowserAt(browse, provider.BrowseGenres)
+
+	updated, _ := m.Update(navTracksLoadedMsg{gen: m.requests.nav})
+	got := updated.(Model)
+	track, _ := got.playlist.Track(0)
+	if !got.navBrowser.visible || got.playlist.Len() != 1 || track.Title != "Keep" {
+		t.Fatalf("empty leaf result = nav:%t tracks:%d first:%+v", got.navBrowser.visible, got.playlist.Len(), track)
+	}
+	if got.status.kind != feedbackWarning || !strings.Contains(got.status.text, "No tracks found") {
+		t.Fatalf("empty leaf status = %+v", got.status)
+	}
+}
+
+func TestAlbumLeafKeepsSelectedRowHighlightedWhileLoading(t *testing.T) {
+	browse := positionedBrowseProvider{providerPaneBrowseProvider{interactionBrowseProvider{commandsTestProvider{name: "Mixcloud"}}}}
+	m := keybindingTestModel()
+	m.navBrowser = navBrowserState{
+		prov: browse, visible: true, mode: navBrowseModeByArtistAlbum,
+		screen: navBrowseScreenAlbums, openInPlaylist: true, cursor: 1,
+		albums: []provider.AlbumInfo{{ID: "uploads", Name: "Uploads"}, {ID: "favorites", Name: "Favorites"}},
+	}
+	if cmd := m.handleNavBrowserKey(tea.KeyPressMsg{Code: tea.KeyEnter}); cmd == nil {
+		t.Fatal("Favorites selection returned no load command")
+	}
+	if m.navBrowser.cursor != 1 || m.navBrowser.selAlbum.ID != "favorites" {
+		t.Fatalf("leaf selection moved while loading: %+v", m.navBrowser)
+	}
+}
+
+func TestUnknownArtistItemCountIsOmitted(t *testing.T) {
+	m := keybindingTestModel()
+	m.plVisible = 5
+	m.navBrowser = navBrowserState{
+		prov:    &labelProv{},
+		visible: true,
+		mode:    navBrowseModeByArtist,
+		screen:  navBrowseScreenList,
+		artists: []provider.ArtistInfo{
+			{ID: "unknown", Name: "Unknown count"},
+			{ID: "known", Name: "Known count", AlbumCount: 3},
+		},
+	}
+	body := m.renderNavBody()
+	if strings.Contains(body, "Unknown count (0 books)") {
+		t.Fatalf("artist body displayed unknown zero count: %q", body)
+	}
+	if !strings.Contains(body, "Known count (3 books)") {
+		t.Fatalf("artist body omitted known count: %q", body)
+	}
+}
+
+func TestProviderFavoriteRefreshKeepsBrowseEntries(t *testing.T) {
+	p := favoriteBrowseProvider{commandsTestProvider{name: "Both", lists: []playlist.PlaylistInfo{{ID: "recent", Name: "Recent Releases"}}}}
+	m := Model{
+		provider:      p,
+		providerLists: providerListsWithBrowse(p, p.lists),
+		provCursor:    1,
+	}
+
+	m.toggleProviderFavorite()
+
+	if len(m.providerLists) != 2 || m.providerLists[0].ID != "browse:shows" || m.providerLists[1].ID != "recent" {
+		t.Fatalf("provider lists after favorite refresh = %+v", m.providerLists)
+	}
+	if m.provCursor != 1 {
+		t.Fatalf("provider cursor = %d, want refreshed item at 1", m.provCursor)
 	}
 }
 

--- a/ui/model/keymap.go
+++ b/ui/model/keymap.go
@@ -34,12 +34,13 @@ func (m Model) buildKeymapEntries() []keymapEntry {
 	out := make([]keymapEntry, 0, len(commandRegistry)+6)
 	seen := make(map[string]bool)
 	add := func(command commandSpec) {
-		id := command.KeyLabel + "\x00" + command.Label
+		label := command.label(m)
+		id := command.KeyLabel + "\x00" + label
 		if seen[id] {
 			return
 		}
 		seen[id] = true
-		out = append(out, keymapEntry{key: command.KeyLabel, action: command.Label})
+		out = append(out, keymapEntry{key: command.KeyLabel, action: label})
 	}
 
 	mode, label := m.keymapContext()

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -23,9 +23,11 @@ func (m *Model) quit() tea.Cmd {
 	// Only save resume for seekable tracks:
 	// - local files (not stream)
 	// - HTTP streams with known duration (podcast MP3s, seek-by-reconnect)
-	// Exclude YTDL (position unreliable) and real-time live streams.
+	// - finite Mixcloud shows (yt-dlp tracks with a counted PCM position)
+	// Other yt-dlp sites and real-time live streams remain excluded.
 	if track, _ := m.currentPlaybackTrack(); track.Path != "" &&
-		!playlist.IsYTDL(track.Path) && !track.IsLive() &&
+		(!playlist.IsYTDL(track.Path) || playlist.IsMixcloudURL(track.Path)) &&
+		!track.IsLive() &&
 		m.player.IsPlaying() {
 		if secs := int(m.player.Position().Seconds()); secs > 0 {
 			m.exitResume.path = track.Path
@@ -356,9 +358,7 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 				}
 			}
 			if len(m.providerLists) > 0 && !m.provLoading {
-				m.provLoading = true
-				m.activeProviderPlaylistID = m.providerLists[m.provCursor].ID
-				return m.fetchProviderTracks(m.providerLists[m.provCursor].ID)
+				return m.openProviderList(m.provCursor)
 			}
 		case "tab":
 			m.focus = m.nextMainFocus(focusPlaylist)
@@ -396,8 +396,11 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 		case "o":
 			m.openFileBrowser()
 		case "N":
-			if prov := m.findBrowseProvider(); prov != nil {
-				m.openNavBrowserWith(prov)
+			// Provider-pane browsing must stay scoped to the provider being
+			// viewed. Falling back to another registered browser can otherwise
+			// send (for example) Spotify's pane into Mixcloud.
+			if providerSupportsBrowse(m.provider) {
+				m.openNavBrowserWith(m.provider)
 			}
 		case "pgup", "ctrl+u":
 			m.providerPageUp()
@@ -425,6 +428,8 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 			return m.switchToProvider("yt")
 		case "C":
 			return m.switchToProvider("soundcloud")
+		case "X":
+			return m.switchToProvider("mixcloud")
 		case "M":
 			return m.switchToProvider("netease")
 		case "Q":
@@ -779,8 +784,11 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 		m.urlErr = ""
 
 	case "N":
-		if prov := m.findBrowseProvider(); prov != nil {
-			m.openNavBrowserWith(prov)
+		if cmd, ok := m.openSelectedTrackArtistBrowser(); ok {
+			return cmd
+		}
+		if providerSupportsBrowse(m.provider) {
+			m.openNavBrowserWith(m.provider)
 		}
 
 	case "L":
@@ -793,6 +801,8 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 		return m.switchToProvider("yt")
 	case "C":
 		return m.switchToProvider("soundcloud")
+	case "X":
+		return m.switchToProvider("mixcloud")
 	case "M":
 		return m.switchToProvider("netease")
 	case "Q":
@@ -1133,10 +1143,8 @@ func (m *Model) handleProvSearchKey(msg tea.KeyPressMsg) tea.Cmd {
 			idx := m.provSearch.results[m.provSearch.cursor]
 			m.provCursor = idx
 			m.providerMaybeAdjustScroll()
-			m.provLoading = true
 			m.provSearch.active = false
-			m.activeProviderPlaylistID = m.providerLists[idx].ID
-			return m.fetchProviderTracks(m.providerLists[idx].ID)
+			return m.openProviderList(idx)
 		}
 	case tea.KeyUp:
 		if m.provSearch.cursor > 0 {
@@ -1196,7 +1204,7 @@ func (m *Model) restoreCatalog(cs provider.CatalogSearcher) {
 	}
 	cs.ClearSearch()
 	if lists, err := m.provider.Playlists(); err == nil {
-		m.providerLists = lists
+		m.providerLists = providerListsWithBrowse(m.provider, lists)
 	}
 	m.provCursor = 0
 	m.provScroll = 0

--- a/ui/model/keys_nav.go
+++ b/ui/model/keys_nav.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"strings"
+
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/bjarneo/cliamp/playlist"
@@ -61,12 +63,33 @@ func (m *Model) handleNavBrowserKey(msg tea.KeyPressMsg) tea.Cmd {
 		return m.handleNavByArtistKey(msg)
 	case navBrowseModeByArtistAlbum:
 		return m.handleNavByArtistAlbumKey(msg)
+	case navBrowseModeByGenre:
+		return m.handleNavByGenreKey(msg)
 	}
 	return nil
 }
 
+type navMenuItem struct {
+	label string
+	mode  provider.BrowseMode
+}
+
+func (m Model) navMenuItems() []navMenuItem {
+	labels := m.navLabels()
+	items := []navMenuItem{
+		{label: "By " + labels.album, mode: provider.BrowseAlbums},
+		{label: "By " + labels.artist, mode: provider.BrowseArtists},
+		{label: "By " + labels.artist + " / " + labels.album, mode: provider.BrowseArtistAlbums},
+	}
+	if _, ok := m.navBrowser.prov.(provider.GenreBrowser); ok {
+		items = append(items, navMenuItem{label: "Genres", mode: provider.BrowseGenres})
+	}
+	return items
+}
+
 func (m *Model) handleNavMenuKey(msg tea.KeyPressMsg) tea.Cmd {
-	const menuItems = 3
+	menuItems := m.navMenuItems()
+	menuLen := len(menuItems)
 	switch msg.String() {
 	case "ctrl+x":
 		m.toggleExpandedView()
@@ -77,55 +100,18 @@ func (m *Model) handleNavMenuKey(msg tea.KeyPressMsg) tea.Cmd {
 	case "up", "k":
 		if m.navBrowser.cursor > 0 {
 			m.navBrowser.cursor--
-		} else {
-			m.navBrowser.cursor = menuItems - 1
+		} else if menuLen > 0 {
+			m.navBrowser.cursor = menuLen - 1
 		}
 	case "down", "j":
-		if m.navBrowser.cursor < menuItems-1 {
+		if m.navBrowser.cursor < menuLen-1 {
 			m.navBrowser.cursor++
 		} else {
 			m.navBrowser.cursor = 0
 		}
 	case "enter", "l", "right":
-		switch m.navBrowser.cursor {
-		case 0: // By Album
-			ab, ok := m.navBrowser.prov.(provider.AlbumBrowser)
-			if !ok {
-				return nil
-			}
-			m.navBrowser.mode = navBrowseModeByAlbum
-			m.navBrowser.screen = navBrowseScreenList
-			m.navBrowser.cursor = 0
-			m.navBrowser.scroll = 0
-			m.navBrowser.albums = nil
-			m.navBrowser.albumLoading = true
-			m.navBrowser.albumDone = false
-			m.navBrowser.loading = false
-			return fetchNavAlbumListCmd(ab, m.navBrowser.sortType, 0, m.nextNavRequest())
-		case 1: // By Artist
-			ab, ok := m.navBrowser.prov.(provider.ArtistBrowser)
-			if !ok {
-				return nil
-			}
-			m.navBrowser.mode = navBrowseModeByArtist
-			m.navBrowser.screen = navBrowseScreenList
-			m.navBrowser.cursor = 0
-			m.navBrowser.scroll = 0
-			m.navBrowser.artists = nil
-			m.navBrowser.loading = true
-			return fetchNavArtistsCmd(ab, m.nextNavRequest())
-		case 2: // By Artist / Album
-			ab, ok := m.navBrowser.prov.(provider.ArtistBrowser)
-			if !ok {
-				return nil
-			}
-			m.navBrowser.mode = navBrowseModeByArtistAlbum
-			m.navBrowser.screen = navBrowseScreenList
-			m.navBrowser.cursor = 0
-			m.navBrowser.scroll = 0
-			m.navBrowser.artists = nil
-			m.navBrowser.loading = true
-			return fetchNavArtistsCmd(ab, m.nextNavRequest())
+		if m.navBrowser.cursor >= 0 && m.navBrowser.cursor < menuLen {
+			return m.openNavBrowserAt(m.navBrowser.prov, menuItems[m.navBrowser.cursor].mode)
 		}
 	case "esc", "N", "backspace", "b":
 		m.cancelNavRequests()
@@ -164,6 +150,155 @@ func (m *Model) handleNavByArtistAlbumKey(msg tea.KeyPressMsg) tea.Cmd {
 		return m.handleNavTrackListKey(msg)
 	}
 	return nil
+}
+
+func (m *Model) handleNavByGenreKey(msg tea.KeyPressMsg) tea.Cmd {
+	switch m.navBrowser.screen {
+	case navBrowseScreenList:
+		return m.handleNavGenreListKey(msg)
+	case navBrowseScreenAlbums:
+		return m.handleNavGenreSortKey(msg)
+	case navBrowseScreenTracks:
+		return m.handleNavTrackListKey(msg)
+	}
+	return nil
+}
+
+func (m *Model) handleNavGenreListKey(msg tea.KeyPressMsg) tea.Cmd {
+	listLen := len(m.navBrowser.genres)
+	if m.navBrowser.search != "" {
+		listLen = len(m.navBrowser.searchIdx)
+	}
+
+	switch msg.String() {
+	case "ctrl+c":
+		m.navBrowser.visible = false
+		return m.quit()
+	case "up", "k":
+		if m.navBrowser.cursor > 0 {
+			m.navBrowser.cursor--
+		} else if listLen > 0 {
+			m.navBrowser.cursor = listLen - 1
+		}
+		m.navMaybeAdjustScroll()
+	case "down", "j":
+		if m.navBrowser.cursor < listLen-1 {
+			m.navBrowser.cursor++
+		} else if listLen > 0 {
+			m.navBrowser.cursor = 0
+		}
+		m.navMaybeAdjustScroll()
+	case "enter", "l", "right":
+		genre, ok := m.selectedNavGenre()
+		if m.navBrowser.loading || !ok {
+			return nil
+		}
+		browser, ok := m.navBrowser.prov.(provider.GenreBrowser)
+		if !ok {
+			return nil
+		}
+		m.navBrowser.selGenre = genre
+		m.navBrowser.genreSorts = browser.GenreSortTypes()
+		m.navBrowser.screen = navBrowseScreenAlbums
+		m.navClearSearch()
+	case "f":
+		genre, ok := m.selectedNavGenre()
+		if m.navBrowser.loading || !ok {
+			return nil
+		}
+		browser, ok := m.navBrowser.prov.(provider.GenreFavoriteToggler)
+		if !ok {
+			return nil
+		}
+		favorite, err := browser.ToggleGenreFavorite(genre.ID)
+		if err != nil {
+			m.status.Errorf(statusTTLDefault, "Genre favorite save failed: %s", err)
+			return nil
+		}
+		rawIdx := m.selectedNavRawIndex(len(m.navBrowser.genres))
+		m.navBrowser.genres[rawIdx].Favorite = favorite
+		providerName := m.navBrowser.prov.Name()
+		if favorite {
+			m.status.Showf(statusTTLDefault, "★ Added %s to %s favorites", genre.Name, providerName)
+		} else {
+			m.status.Showf(statusTTLDefault, "☆ Removed %s from %s favorites", genre.Name, providerName)
+		}
+		if m.provider != nil && m.provider == m.navBrowser.prov {
+			return m.fetchProviderPlaylists()
+		}
+	case "esc", "h", "left", "backspace":
+		m.navBackFromRoot()
+	}
+	return nil
+}
+
+func (m *Model) handleNavGenreSortKey(msg tea.KeyPressMsg) tea.Cmd {
+	listLen := len(m.navBrowser.genreSorts)
+	if m.navBrowser.search != "" {
+		listLen = len(m.navBrowser.searchIdx)
+	}
+	switch msg.String() {
+	case "ctrl+c":
+		m.navBrowser.visible = false
+		return m.quit()
+	case "up", "k":
+		if m.navBrowser.cursor > 0 {
+			m.navBrowser.cursor--
+		} else if listLen > 0 {
+			m.navBrowser.cursor = listLen - 1
+		}
+		m.navMaybeAdjustScroll()
+	case "down", "j":
+		if m.navBrowser.cursor < listLen-1 {
+			m.navBrowser.cursor++
+		} else if listLen > 0 {
+			m.navBrowser.cursor = 0
+		}
+		m.navMaybeAdjustScroll()
+	case "enter", "l", "right":
+		if listLen == 0 {
+			return nil
+		}
+		rawIdx := m.selectedNavRawIndex(len(m.navBrowser.genreSorts))
+		if rawIdx < 0 {
+			return nil
+		}
+		browser, ok := m.navBrowser.prov.(provider.GenreBrowser)
+		if !ok {
+			return nil
+		}
+		m.navBrowser.selGenreSort = m.navBrowser.genreSorts[rawIdx]
+		m.navBrowser.loading = true
+		m.navClearSearchKeepingCursor(rawIdx)
+		return fetchNavGenreTracksCmd(browser, m.navBrowser.selGenre.ID, m.navBrowser.selGenreSort.ID, m.nextNavRequest())
+	case "esc", "h", "left", "backspace":
+		m.cancelNavRequests()
+		m.navClearSearch()
+		m.navBrowser.screen = navBrowseScreenList
+	}
+	return nil
+}
+
+func (m Model) selectedNavRawIndex(rawLen int) int {
+	idx := m.navBrowser.cursor
+	if m.navBrowser.search != "" {
+		if idx < 0 || idx >= len(m.navBrowser.searchIdx) {
+			return -1
+		}
+		idx = m.navBrowser.searchIdx[idx]
+	}
+	if idx < 0 || idx >= rawLen {
+		return -1
+	}
+	return idx
+}
+
+func (m Model) selectedNavGenre() (provider.GenreInfo, bool) {
+	idx := m.selectedNavRawIndex(len(m.navBrowser.genres))
+	if idx < 0 {
+		return provider.GenreInfo{}, false
+	}
+	return m.navBrowser.genres[idx], true
 }
 
 // handleNavArtistListKey handles the artist list screen.
@@ -218,13 +353,10 @@ func (m *Model) handleNavArtistListKey(msg tea.KeyPressMsg) tea.Cmd {
 			m.navClearSearch()
 			return fetchNavArtistAlbumsCmd(ab, artist.ID, m.nextNavRequest())
 		}
-		m.navClearSearch()
+		m.navClearSearchKeepingCursor(rawIdx)
 		return m.fetchNavArtistAllTracksCmd(ab, artist.ID)
 	case "esc", "h", "left", "backspace":
-		// Back to menu.
-		m.navClearSearch()
-		m.navBrowser.mode = navBrowseModeMenu
-		m.navBrowser.screen = navBrowseScreenList
+		m.navBackFromRoot()
 	}
 	return nil
 }
@@ -276,7 +408,7 @@ func (m *Model) handleNavAlbumListKey(msg tea.KeyPressMsg, artistAlbums bool) te
 		album := m.navBrowser.albums[rawIdx]
 		m.navBrowser.selAlbum = album
 		m.navBrowser.loading = true
-		m.navClearSearch()
+		m.navClearSearchKeepingCursor(rawIdx)
 		if l, ok := m.navBrowser.prov.(provider.AlbumTrackLoader); ok {
 			return fetchNavAlbumTracksCmd(l, album.ID, m.nextNavRequest())
 		}
@@ -303,14 +435,18 @@ func (m *Model) handleNavAlbumListKey(msg tea.KeyPressMsg, artistAlbums bool) te
 		}
 		return fetchNavAlbumListCmd(ab, m.navBrowser.sortType, 0, m.nextNavRequest())
 	case "esc", "h", "left", "backspace":
-		m.navClearSearch()
 		if artistAlbums {
+			m.cancelNavRequests()
+			m.navClearSearch()
+			if m.navBrowser.directTrackJump {
+				m.navBrowser.directTrackJump = false
+				m.navBrowser.visible = false
+				return nil
+			}
 			// Back to artist list.
 			m.navBrowser.screen = navBrowseScreenList
 		} else {
-			// Back to menu.
-			m.navBrowser.mode = navBrowseModeMenu
-			m.navBrowser.screen = navBrowseScreenList
+			m.navBackFromRoot()
 		}
 	}
 	return nil
@@ -464,6 +600,8 @@ func (m *Model) handleNavTrackListKey(msg tea.KeyPressMsg) tea.Cmd {
 			m.navBrowser.screen = navBrowseScreenList
 		case navBrowseModeByArtistAlbum:
 			m.navBrowser.screen = navBrowseScreenAlbums
+		case navBrowseModeByGenre:
+			m.navBrowser.screen = navBrowseScreenAlbums
 		}
 	}
 	return nil
@@ -512,6 +650,20 @@ func (m *Model) handleNavSearchKey(msg tea.KeyPressMsg) tea.Cmd {
 		return nil
 	case tea.KeyEnter:
 		m.navBrowser.searching = false
+		if m.navBrowser.mode == navBrowseModeByGenre && m.navBrowser.screen == navBrowseScreenList {
+			query := strings.TrimSpace(m.navBrowser.search)
+			searcher, ok := m.navBrowser.prov.(provider.GenreSearcher)
+			if ok && query != "" {
+				m.navBrowser.genreQuery = query
+				m.navBrowser.search = ""
+				m.navBrowser.searchIdx = nil
+				m.navBrowser.genres = nil
+				m.navBrowser.cursor = 0
+				m.navBrowser.scroll = 0
+				m.navBrowser.loading = true
+				return fetchNavGenreSearchCmd(searcher, query, m.nextNavRequest())
+			}
+		}
 		return nil
 	}
 	if msg.Code == tea.KeySpace && msg.Text == "" {
@@ -540,7 +692,7 @@ func navNextSort(s string, types []provider.SortType) string {
 
 // navMaybeAdjustScroll keeps navCursor visible within the rendered list window.
 func (m *Model) navMaybeAdjustScroll() {
-	count := 3 // browse mode menu
+	count := len(m.navMenuItems())
 	switch m.navView() {
 	case navViewArtists:
 		count = len(m.navBrowser.artists)
@@ -548,6 +700,10 @@ func (m *Model) navMaybeAdjustScroll() {
 		count = len(m.navBrowser.albums)
 	case navViewTracks:
 		count = len(m.navBrowser.tracks)
+	case navViewGenres:
+		count = len(m.navBrowser.genres)
+	case navViewGenreSorts:
+		count = len(m.navBrowser.genreSorts)
 	}
 	if m.navBrowser.search != "" {
 		count = len(m.navBrowser.searchIdx)

--- a/ui/model/keys_radio.go
+++ b/ui/model/keys_radio.go
@@ -51,7 +51,7 @@ func (m *Model) toggleProviderFavorite() tea.Cmd {
 
 	prevID := id
 	if lists, err := m.provider.Playlists(); err == nil {
-		m.providerLists = lists
+		m.providerLists = providerListsWithBrowse(m.provider, lists)
 		for i, p := range m.providerLists {
 			if p.ID == prevID {
 				m.provCursor = i

--- a/ui/model/model.go
+++ b/ui/model/model.go
@@ -196,6 +196,7 @@ const (
 	navBrowseModeByAlbum                                // paginated album list → track list
 	navBrowseModeByArtist                               // artist list → track list (album-separated)
 	navBrowseModeByArtistAlbum                          // artist list → album list → track list
+	navBrowseModeByGenre                                // genre list → latest/popular → track list
 )
 
 // navBrowseScreenType identifies which screen within the active browse mode is shown.

--- a/ui/model/phase0_test.go
+++ b/ui/model/phase0_test.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -256,5 +257,29 @@ func TestProviderRefreshFailureKeepsExistingLists(t *testing.T) {
 	}
 	if m.provLoading {
 		t.Fatal("provLoading = true after failed refresh, want false")
+	}
+}
+
+func TestProviderPartialRefreshShowsPublicListsAndWarning(t *testing.T) {
+	current := providerPaneBrowseProvider{interactionBrowseProvider{commandsTestProvider{name: "Mixcloud"}}}
+	m := Model{provider: current, provLoading: true}
+	m.requests.provider = 1
+
+	updated, _ := m.Update(playlistsLoadedMsg{
+		providerName: "Mixcloud",
+		gen:          1,
+		playlists:    []playlist.PlaylistInfo{{ID: "recent", Name: "Recent Releases", Section: "Discover"}},
+		err:          errors.New("mixcloud: account views unavailable: User does not exist"),
+	})
+	m = updated.(Model)
+
+	if got := len(m.providerLists); got != 4 {
+		t.Fatalf("provider lists = %+v, want three browse entries and public discovery", m.providerLists)
+	}
+	if m.providerLists[0].Name != "Shows" || m.providerLists[1].Name != "Creators" || m.providerLists[2].Name != "Genres" || m.providerLists[3].Name != "Recent Releases" {
+		t.Fatalf("provider lists = %+v", m.providerLists)
+	}
+	if m.err != nil || m.status.kind != feedbackWarning || !strings.Contains(m.status.text, "account views unavailable") {
+		t.Fatalf("partial refresh state = err:%v status:%+v", m.err, m.status)
 	}
 }

--- a/ui/model/playback.go
+++ b/ui/model/playback.go
@@ -400,8 +400,14 @@ func (m *Model) playTrack(track playlist.Track) tea.Cmd {
 		}
 	} else {
 		m.err = nil
+		// yt-dlp streams resume after streamPlayedMsg; local playback reaches
+		// this branch, where applyResume performs the seek synchronously.
 		m.applyResume()
 		m.backfillLoadedPlaylistDuration(track)
+		if fetchCmd != nil {
+			return tea.Batch(m.preloadNext(), fetchCmd)
+		}
+		return m.preloadNext()
 	}
 
 	if fetchCmd != nil {
@@ -559,24 +565,34 @@ func shouldReconnectOnUnpause(track playlist.Track, idx int, pausedFor time.Dura
 }
 
 // applyResume seeks to the saved resume position if the current track matches.
-// It clears the resume state after a successful seek so it only fires once.
-func (m *Model) applyResume() {
+// yt-dlp resume is asynchronous because it rebuilds the playback pipeline.
+func (m *Model) applyResume() tea.Cmd {
 	// secs == 0 is indistinguishable from "never played"; skip resume.
 	if m.resume.path == "" || m.resume.secs <= 0 {
-		return
+		return nil
 	}
 	track, _ := m.currentPlaybackTrack()
 	if track.Path != m.resume.path {
-		return
+		return nil
 	}
 	// Only seek if the player reports the stream is seekable; otherwise the
 	// seek is a no-op that returns nil, which we must not mistake for success.
 	if !m.player.Seekable() {
-		return
+		return nil
 	}
-	target := time.Duration(m.resume.secs) * time.Second
+	target := m.clampPosition(time.Duration(m.resume.secs) * time.Second)
+	if playlist.IsMixcloudURL(track.Path) && m.player.IsYTDLSeek() {
+		m.seek.active = true
+		m.seek.targetPos = target
+		m.seek.timer = 0
+		m.seek.timerFor = 0
+		m.player.CancelSeekYTDL()
+		m.status.Activityf(statusTTLLong, "Resuming at %s…", formatJumpClock(target))
+		return m.ytdlSeekCmd(target, true)
+	}
 	if err := m.player.Seek(target - m.player.Position()); err == nil {
 		m.resume.path = ""
 		m.resume.secs = 0
 	}
+	return nil
 }

--- a/ui/model/playback_test.go
+++ b/ui/model/playback_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -17,8 +18,10 @@ type playbackFakeEngine struct {
 	paused            bool
 	ytdlSeek          bool
 	live              bool
+	seekable          bool
 	position          time.Duration
 	duration          time.Duration
+	seekYTDLErr       error
 	playCalls         []string
 	seekYTDLCalls     []time.Duration
 	preloadCalls      []string
@@ -49,14 +52,14 @@ func (f *playbackFakeEngine) TogglePause()             { f.paused = !f.paused }
 func (f *playbackFakeEngine) Seek(time.Duration) error { return nil }
 func (f *playbackFakeEngine) SeekYTDL(d time.Duration) error {
 	f.seekYTDLCalls = append(f.seekYTDLCalls, d)
-	return nil
+	return f.seekYTDLErr
 }
 func (f *playbackFakeEngine) CancelSeekYTDL()    {}
 func (f *playbackFakeEngine) IsPlaying() bool    { return f.playing }
 func (f *playbackFakeEngine) IsPaused() bool     { return f.paused }
 func (f *playbackFakeEngine) Drained() bool      { return f.drained }
 func (f *playbackFakeEngine) HasPreload() bool   { return false }
-func (f *playbackFakeEngine) Seekable() bool     { return false }
+func (f *playbackFakeEngine) Seekable() bool     { return f.seekable }
 func (f *playbackFakeEngine) IsStreamSeek() bool { return false }
 func (f *playbackFakeEngine) IsYTDLSeek() bool   { return f.ytdlSeek }
 func (f *playbackFakeEngine) IsLiveStream() bool { return f.live }
@@ -70,7 +73,7 @@ func (f *playbackFakeEngine) GaplessAdvanced() bool {
 func (f *playbackFakeEngine) Position() time.Duration { return f.position }
 func (f *playbackFakeEngine) Duration() time.Duration { return f.duration }
 func (f *playbackFakeEngine) PositionAndDuration() (time.Duration, time.Duration) {
-	return 0, 0
+	return f.position, f.duration
 }
 func (f *playbackFakeEngine) SetVolumeMin(float64)                   {}
 func (f *playbackFakeEngine) VolumeMin() float64                     { return -50 }
@@ -89,6 +92,139 @@ func (f *playbackFakeEngine) SamplesInto([]float64) int              { return 0 
 func (f *playbackFakeEngine) WaveformSamplesInto([]float64) int      { return 0 }
 func (f *playbackFakeEngine) StereoSamplesInto([][2]float64) int     { return 0 }
 func (f *playbackFakeEngine) SampleRate() int                        { return 44100 }
+
+func TestApplyResumeRestartsMixcloudAtSavedPosition(t *testing.T) {
+	track := playlist.Track{
+		Title:        "Saved show",
+		Path:         "https://www.mixcloud.com/creator/saved-show/",
+		Stream:       true,
+		DurationSecs: 3600,
+	}
+	player := &playbackFakeEngine{
+		playing:  true,
+		ytdlSeek: true,
+		seekable: true,
+		position: 5 * time.Second,
+		duration: time.Hour,
+	}
+	m := Model{player: player, playlist: playlist.New(), playingTrack: track, playingTrackActive: true}
+	m.SetResume(track.Path, 90)
+
+	cmd := m.applyResume()
+	if cmd == nil {
+		t.Fatal("applyResume() = nil, want asynchronous Mixcloud seek")
+	}
+	msg, ok := cmd().(seekTickMsg)
+	if !ok {
+		t.Fatalf("resume command message = %T, want seekTickMsg", msg)
+	}
+	if msg.err != nil || !msg.resume || msg.target != 90*time.Second {
+		t.Fatalf("resume message = %+v, want successful resume at 1m30s", msg)
+	}
+	if len(player.seekYTDLCalls) != 1 || player.seekYTDLCalls[0] != 85*time.Second {
+		t.Fatalf("SeekYTDL calls = %v, want [1m25s]", player.seekYTDLCalls)
+	}
+
+	updated, _ := m.Update(msg)
+	got := updated.(Model)
+	if got.resume.path != "" || got.resume.secs != 0 {
+		t.Fatalf("resume state was not cleared after success: %+v", got.resume)
+	}
+}
+
+func TestStreamPlayedNotifiesOnceWithoutResume(t *testing.T) {
+	track := playlist.Track{Title: "Show", Path: "https://www.mixcloud.com/creator/show/", Stream: true}
+	pl := playlist.New()
+	pl.Add(track)
+	notifier := &fakeNotifier{}
+	m := Model{
+		player:    &playbackFakeEngine{playing: true},
+		playlist:  pl,
+		notifier:  notifier,
+		buffering: true,
+	}
+	m.requests.stream = 1
+
+	updated, _ := m.Update(streamPlayedMsg{path: track.Path, gen: 1})
+	m = updated.(Model)
+	if len(notifier.updates) != 1 {
+		t.Fatalf("notifier updates = %d, want exactly 1", len(notifier.updates))
+	}
+}
+
+func TestStreamPlayedResumeKeepsNextTrackPreload(t *testing.T) {
+	current := playlist.Track{
+		Title: "Saved show", Path: "https://www.mixcloud.com/creator/saved-show/", Stream: true, DurationSecs: 3600,
+	}
+	next := playlist.Track{Title: "Next", Path: "/tmp/next.mp3", DurationSecs: 180}
+	pl := playlist.New()
+	pl.Add(current, next)
+	player := &playbackFakeEngine{playing: true, ytdlSeek: true, seekable: true, duration: time.Hour}
+	notifier := &fakeNotifier{}
+	m := Model{player: player, playlist: pl, notifier: notifier, buffering: true}
+	m.SetResume(current.Path, 90)
+	m.requests.stream = 1
+
+	updated, cmd := m.Update(streamPlayedMsg{path: current.Path, gen: 1})
+	m = updated.(Model)
+	if cmd == nil {
+		t.Fatal("streamPlayedMsg command = nil, want resume and preload batch")
+	}
+	batch, ok := cmd().(tea.BatchMsg)
+	if !ok || len(batch) != 2 {
+		t.Fatalf("streamPlayedMsg command = %T len=%d, want two-command batch", batch, len(batch))
+	}
+	if !m.preloading {
+		t.Fatal("next track preload was not armed while resuming")
+	}
+	if len(notifier.updates) != 1 {
+		t.Fatalf("notifier updates = %d, want exactly 1", len(notifier.updates))
+	}
+}
+
+func TestApplyResumeFailureKeepsMixcloudPlayable(t *testing.T) {
+	track := playlist.Track{
+		Title:        "Saved show",
+		Path:         "https://www.mixcloud.com/creator/saved-show/",
+		Stream:       true,
+		DurationSecs: 3600,
+	}
+	player := &playbackFakeEngine{
+		playing:     true,
+		ytdlSeek:    true,
+		seekable:    true,
+		duration:    time.Hour,
+		seekYTDLErr: errors.New("seek not permitted"),
+	}
+	m := Model{player: player, playlist: playlist.New(), playingTrack: track, playingTrackActive: true}
+	m.SetResume(track.Path, 90)
+
+	msg := m.applyResume()().(seekTickMsg)
+	updated, _ := m.Update(msg)
+	got := updated.(Model)
+	if got.resume.path != "" || got.resume.secs != 0 {
+		t.Fatalf("failed resume remained armed: %+v", got.resume)
+	}
+	if !strings.Contains(got.status.text, "playing from the previous position") {
+		t.Fatalf("status = %q, want fallback explanation", got.status.text)
+	}
+}
+
+func TestQuitCapturesMixcloudResumePosition(t *testing.T) {
+	track := playlist.Track{
+		Title:        "Partly played show",
+		Path:         "https://www.mixcloud.com/creator/partly-played/",
+		Stream:       true,
+		DurationSecs: 3600,
+	}
+	player := &playbackFakeEngine{playing: true, position: 12*time.Minute + 34*time.Second}
+	m := Model{player: player, playingTrack: track, playingTrackActive: true}
+
+	m.quit()
+	if m.exitResume.path != track.Path || m.exitResume.secs != 754 {
+		t.Fatalf("exit resume = (%q, %d), want (%q, 754)", m.exitResume.path, m.exitResume.secs, track.Path)
+	}
+}
 
 func TestNavTrackListQueueStartsQueuedTrackWhenStopped(t *testing.T) {
 	player := &playbackFakeEngine{}

--- a/ui/model/providers.go
+++ b/ui/model/providers.go
@@ -89,6 +89,29 @@ func tracksContainPath(tracks []playlist.Track, path string) bool {
 	return false
 }
 
+// replacePlayerPlaylist installs a provider result in the main playlist while
+// preserving detached playback semantics used by provider-list selection.
+func (m *Model) replacePlayerPlaylist(tracks []playlist.Track) {
+	if m.player.IsPlaying() || m.buffering {
+		m.detachPlaybackTrack()
+		m.player.ClearPreload()
+		m.preloading = false
+	} else {
+		m.player.Stop()
+		m.player.ClearPreload()
+		m.clearPlaybackTrack()
+	}
+	m.resetYTDLBatch()
+	m.replacePlaylist(tracks)
+	m.setHeaderStateFromTracks(tracks)
+	m.loadedPlaylist = ""
+	m.plCursor = 0
+	m.plScroll = 0
+	m.focus = focusPlaylist
+	m.applyHeightMode()
+	m.adjustScroll()
+}
+
 func (m Model) isActiveProvider(name string) bool {
 	return m.provider != nil && m.provider.Name() == name
 }
@@ -126,7 +149,7 @@ func (m *Model) fetchCatalogBatch(loader provider.CatalogLoader) tea.Cmd {
 
 // quickSwitchProvider closes any browser overlays and jumps to the provider
 // matched by key. Use the same Shift+letter shortcuts that switch providers
-// from the main pane (S, N, P, J, E, Y, C, M, Q, R, L). Returns nil when the key doesn't
+// from the main pane (S, N, P, J, E, B, Y, C, X, M, Q, R, L). Returns nil when the key doesn't
 // match a known provider.
 func (m *Model) quickSwitchProvider(key string) tea.Cmd {
 	provKey := providerKeyForShortcut(key)
@@ -161,6 +184,8 @@ func providerKeyForShortcut(key string) string {
 		return "yt"
 	case "C":
 		return "soundcloud"
+	case "X":
+		return "mixcloud"
 	case "M":
 		return "netease"
 	case "Q":
@@ -186,6 +211,164 @@ func (m *Model) switchToProvider(key string) tea.Cmd {
 	return nil
 }
 
+type browseEntryGroup struct {
+	afterID      string
+	afterSection string
+	section      string
+	lists        []playlist.PlaylistInfo
+}
+
+// providerListsWithBrowse adds UI-only hierarchical browse routes to a
+// provider's playable playlist list. Keeping these routes out of Playlists()
+// means IPC and other playlist consumers never mistake them for audio lists.
+func providerListsWithBrowse(prov playlist.Provider, lists []playlist.PlaylistInfo) []playlist.PlaylistInfo {
+	entries, ok := prov.(provider.BrowseEntryProvider)
+	if !ok {
+		return lists
+	}
+	groups := groupBrowseEntries(entries.BrowseEntries(), lists)
+	if len(groups) == 0 {
+		return lists
+	}
+	return spliceBrowseGroups(lists, groups)
+}
+
+// groupBrowseEntries removes invalid and duplicate shortcuts, then combines
+// adjacent entries that share placement and section metadata.
+func groupBrowseEntries(entries []provider.BrowseEntry, lists []playlist.PlaylistInfo) []browseEntryGroup {
+	existing := make(map[string]struct{}, len(lists))
+	for _, item := range lists {
+		existing[item.ID] = struct{}{}
+	}
+	groups := make([]browseEntryGroup, 0, len(entries))
+	for _, entry := range entries {
+		if entry.ID == "" || entry.Name == "" {
+			continue
+		}
+		if _, duplicate := existing[entry.ID]; duplicate {
+			continue
+		}
+		existing[entry.ID] = struct{}{}
+		item := playlist.PlaylistInfo{ID: entry.ID, Name: entry.Name, Section: entry.Section}
+		last := len(groups) - 1
+		if last >= 0 &&
+			groups[last].afterID == entry.AfterID &&
+			groups[last].afterSection == entry.AfterSection &&
+			groups[last].section == entry.Section {
+			groups[last].lists = append(groups[last].lists, item)
+		} else {
+			groups = append(groups, browseEntryGroup{
+				afterID:      entry.AfterID,
+				afterSection: entry.AfterSection,
+				section:      entry.Section,
+				lists:        []playlist.PlaylistInfo{item},
+			})
+		}
+	}
+	return groups
+}
+
+// spliceBrowseGroups resolves exact-item and section fallback anchors, omits
+// extensions of missing sections, and prepends otherwise unanchored groups.
+func spliceBrowseGroups(lists []playlist.PlaylistInfo, groups []browseEntryGroup) []playlist.PlaylistInfo {
+	itemIndex := make(map[string]int, len(lists))
+	lastSectionIndex := make(map[string]int, len(lists))
+	for i, item := range lists {
+		itemIndex[item.ID] = i
+		lastSectionIndex[item.Section] = i
+	}
+	entryCount := 0
+	for _, group := range groups {
+		entryCount += len(group.lists)
+	}
+	prepend := make([]playlist.PlaylistInfo, 0, entryCount)
+	groupsAfter := make(map[int][]browseEntryGroup, len(groups))
+	for _, group := range groups {
+		anchor := -1
+		if group.afterID != "" {
+			if index, found := itemIndex[group.afterID]; found {
+				anchor = index
+			}
+		}
+		if anchor < 0 && group.afterSection != "" {
+			if index, found := lastSectionIndex[group.afterSection]; found {
+				anchor = index
+			}
+		}
+		if anchor >= 0 {
+			groupsAfter[anchor] = append(groupsAfter[anchor], group)
+			continue
+		}
+		if group.afterSection != "" && group.section == group.afterSection {
+			continue
+		}
+		prepend = append(prepend, group.lists...)
+	}
+	out := make([]playlist.PlaylistInfo, 0, len(lists)+entryCount)
+	out = append(out, prepend...)
+	for i, item := range lists {
+		out = append(out, item)
+		for _, group := range groupsAfter[i] {
+			out = append(out, group.lists...)
+		}
+	}
+	return out
+}
+
+func providerBrowseEntryForID(prov playlist.Provider, id string) (provider.BrowseEntry, bool) {
+	entries, ok := prov.(provider.BrowseEntryProvider)
+	if !ok {
+		return provider.BrowseEntry{}, false
+	}
+	for _, entry := range entries.BrowseEntries() {
+		if entry.ID == id {
+			return entry, true
+		}
+	}
+	return provider.BrowseEntry{}, false
+}
+
+func providerBrowseEntryForMode(prov playlist.Provider, mode provider.BrowseMode) (provider.BrowseEntry, bool) {
+	entries, ok := prov.(provider.BrowseEntryProvider)
+	if !ok {
+		return provider.BrowseEntry{}, false
+	}
+	for _, entry := range entries.BrowseEntries() {
+		if entry.Mode == mode {
+			return entry, true
+		}
+	}
+	return provider.BrowseEntry{}, false
+}
+
+func (m Model) selectedProviderListIsBrowseEntry() bool {
+	if m.provCursor < 0 || m.provCursor >= len(m.providerLists) {
+		return false
+	}
+	_, ok := providerBrowseEntryForID(m.provider, m.providerLists[m.provCursor].ID)
+	return ok
+}
+
+// openProviderList activates either a playable provider list or a UI-only
+// hierarchical browse entry contributed by the provider.
+func (m *Model) openProviderList(index int) tea.Cmd {
+	if index < 0 || index >= len(m.providerLists) || m.provider == nil {
+		return nil
+	}
+	item := m.providerLists[index]
+	if entry, ok := providerBrowseEntryForID(m.provider, item.ID); ok {
+		m.activeProviderPlaylistID = ""
+		cmd := m.openNavBrowserEntry(m.provider, entry)
+		if m.navBrowser.visible {
+			m.navBrowser.fromProvList = true
+		}
+		return cmd
+	}
+	m.provLoading = true
+	m.activeProviderPlaylistID = item.ID
+	return m.fetchProviderTracks(item.ID)
+}
+
 // SetPendingURLs stores remote URLs (feeds, M3U) for async resolution after Init.
 func (m *Model) SetPendingURLs(urls []string) {
 	m.pendingURLs = urls
@@ -198,16 +381,34 @@ func (m *Model) SetLoadedPlaylist(name string) {
 	m.loadedPlaylist = name
 }
 
-// findBrowseProvider returns the first provider that supports browsing
-// (ArtistBrowser or AlbumBrowser), preferring the active provider.
+// findBrowseProvider returns the first provider that supports artist, album,
+// or genre browsing, preferring the active provider.
 func (m *Model) findBrowseProvider() playlist.Provider {
-	return m.findProviderWith(func(p playlist.Provider) bool {
-		if _, ok := p.(provider.ArtistBrowser); ok {
-			return true
-		}
-		_, ok := p.(provider.AlbumBrowser)
-		return ok
-	})
+	return m.findProviderWith(providerSupportsBrowse)
+}
+
+func providerSupportsBrowse(prov playlist.Provider) bool {
+	if prov == nil {
+		return false
+	}
+	if _, ok := prov.(provider.ArtistBrowser); ok {
+		return true
+	}
+	if _, ok := prov.(provider.AlbumBrowser); ok {
+		return true
+	}
+	_, ok := prov.(provider.GenreBrowser)
+	return ok
+}
+
+// canOpenProviderBrowser keeps help scoped to the active provider or a
+// highlighted track with a provider-specific creator jump. Merely registering
+// another browsable provider must not advertise its browser in this context.
+func (m Model) canOpenProviderBrowser() bool {
+	if _, ok := m.selectedTrackArtistBrowserTarget(); ok {
+		return true
+	}
+	return providerSupportsBrowse(m.provider)
 }
 
 func (m *Model) openNavBrowserWith(prov playlist.Provider) {
@@ -221,6 +422,8 @@ func (m *Model) openNavBrowserWith(prov playlist.Provider) {
 	m.navBrowser.artists = nil
 	m.navBrowser.albums = nil
 	m.navBrowser.tracks = nil
+	m.navBrowser.genres = nil
+	m.navBrowser.genreSorts = nil
 	m.navBrowser.loading = false
 	m.navBrowser.albumLoading = false
 	m.navBrowser.albumDone = false
@@ -228,13 +431,150 @@ func (m *Model) openNavBrowserWith(prov playlist.Provider) {
 	m.navBrowser.search = ""
 	m.navBrowser.searchIdx = nil
 	m.navBrowser.confirmReplace = false
+	m.navBrowser.directTrackJump = false
+	m.navBrowser.fromProvList = false
+	m.navBrowser.openInPlaylist = false
 	m.navBrowser.selArtist = provider.ArtistInfo{}
 	m.navBrowser.selAlbum = provider.AlbumInfo{}
+	m.navBrowser.selGenre = provider.GenreInfo{}
+	m.navBrowser.selGenreSort = provider.SortType{}
+	m.navBrowser.genreQuery = ""
 	if ab, ok := prov.(provider.AlbumBrowser); ok {
 		m.navBrowser.sortType = ab.DefaultAlbumSort()
 	} else {
 		m.navBrowser.sortType = ""
 	}
+}
+
+func (m *Model) navBackFromRoot() {
+	m.cancelNavRequests()
+	m.navClearSearch()
+	if m.navBrowser.fromProvList {
+		m.navBrowser.fromProvList = false
+		m.navBrowser.visible = false
+		return
+	}
+	m.navBrowser.mode = navBrowseModeMenu
+	m.navBrowser.screen = navBrowseScreenList
+	m.navBrowser.cursor = 0
+	m.navBrowser.scroll = 0
+}
+
+// openNavBrowserAt opens a provider's hierarchy at a concrete route instead
+// of making the user pass through the generic browse-mode menu first.
+func (m *Model) openNavBrowserAt(prov playlist.Provider, mode provider.BrowseMode) tea.Cmd {
+	openInPlaylist := false
+	if entry, ok := providerBrowseEntryForMode(prov, mode); ok {
+		openInPlaylist = entry.OpenInPlaylist
+	}
+	return m.openNavBrowserRoute(prov, mode, openInPlaylist)
+}
+
+// openNavBrowserEntry opens the exact provider-pane route selected by ID. It
+// must not re-resolve by mode because providers may expose multiple entries
+// with the same hierarchy and different leaf behavior.
+func (m *Model) openNavBrowserEntry(prov playlist.Provider, entry provider.BrowseEntry) tea.Cmd {
+	return m.openNavBrowserRoute(prov, entry.Mode, entry.OpenInPlaylist)
+}
+
+func (m *Model) openNavBrowserRoute(prov playlist.Provider, mode provider.BrowseMode, openInPlaylist bool) tea.Cmd {
+	m.openNavBrowserWith(prov)
+	m.navBrowser.openInPlaylist = openInPlaylist
+	switch mode {
+	case provider.BrowseAlbums:
+		browser, ok := prov.(provider.AlbumBrowser)
+		if !ok {
+			m.navBrowser.visible = false
+			return nil
+		}
+		m.navBrowser.mode = navBrowseModeByAlbum
+		m.navBrowser.albumLoading = true
+		return fetchNavAlbumListCmd(browser, m.navBrowser.sortType, 0, m.nextNavRequest())
+	case provider.BrowseArtists, provider.BrowseArtistAlbums:
+		browser, ok := prov.(provider.ArtistBrowser)
+		if !ok {
+			m.navBrowser.visible = false
+			return nil
+		}
+		if mode == provider.BrowseArtistAlbums {
+			m.navBrowser.mode = navBrowseModeByArtistAlbum
+		} else {
+			m.navBrowser.mode = navBrowseModeByArtist
+		}
+		m.navBrowser.loading = true
+		return fetchNavArtistsCmd(browser, m.nextNavRequest())
+	case provider.BrowseGenres:
+		browser, ok := prov.(provider.GenreBrowser)
+		if !ok {
+			m.navBrowser.visible = false
+			return nil
+		}
+		m.navBrowser.mode = navBrowseModeByGenre
+		m.navBrowser.loading = true
+		return fetchNavGenresCmd(browser, m.nextNavRequest())
+	default:
+		m.navBrowser.visible = false
+		return nil
+	}
+}
+
+type selectedTrackArtistTarget struct {
+	prov    playlist.Provider
+	browser provider.ArtistBrowser
+	artist  provider.ArtistInfo
+}
+
+func (m Model) selectedTrackArtistBrowserTarget() (selectedTrackArtistTarget, bool) {
+	if m.focus != focusPlaylist || m.playlist == nil {
+		return selectedTrackArtistTarget{}, false
+	}
+	track, ok := m.playlist.Track(m.plCursor)
+	if !ok {
+		return selectedTrackArtistTarget{}, false
+	}
+	candidates := make([]playlist.Provider, 0, len(m.providers)+1)
+	if m.provider != nil {
+		candidates = append(candidates, m.provider)
+	}
+	for _, entry := range m.providers {
+		if entry.Provider != nil {
+			candidates = append(candidates, entry.Provider)
+		}
+	}
+	for _, candidate := range candidates {
+		resolver, ok := candidate.(provider.TrackArtistResolver)
+		if !ok {
+			continue
+		}
+		artist, ok := resolver.ArtistForTrack(track)
+		if !ok {
+			continue
+		}
+		browser, ok := candidate.(provider.ArtistBrowser)
+		if ok {
+			return selectedTrackArtistTarget{prov: candidate, browser: browser, artist: artist}, true
+		}
+	}
+	return selectedTrackArtistTarget{}, false
+}
+
+// openSelectedTrackArtistBrowser jumps from the highlighted track to its
+// artist's album/show categories when one registered provider recognizes it.
+func (m *Model) openSelectedTrackArtistBrowser() (tea.Cmd, bool) {
+	target, ok := m.selectedTrackArtistBrowserTarget()
+	if !ok {
+		return nil, false
+	}
+	m.openNavBrowserWith(target.prov)
+	m.navBrowser.mode = navBrowseModeByArtistAlbum
+	m.navBrowser.screen = navBrowseScreenAlbums
+	m.navBrowser.selArtist = target.artist
+	m.navBrowser.directTrackJump = true
+	if entry, found := providerBrowseEntryForMode(target.prov, provider.BrowseArtistAlbums); found {
+		m.navBrowser.openInPlaylist = entry.OpenInPlaylist
+	}
+	m.navBrowser.loading = true
+	return fetchNavArtistAlbumsCmd(target.browser, target.artist.ID, m.nextNavRequest()), true
 }
 
 func (m *Model) nextNavRequest() uint64 {
@@ -272,6 +612,19 @@ func (m *Model) navUpdateSearch() {
 				m.navBrowser.searchIdx = append(m.navBrowser.searchIdx, i)
 			}
 		}
+	case m.navBrowser.mode == navBrowseModeByGenre && m.navBrowser.screen == navBrowseScreenList:
+		for i, genre := range m.navBrowser.genres {
+			if strings.Contains(strings.ToLower(genre.Name), q) ||
+				strings.Contains(strings.ToLower(genre.Group), q) {
+				m.navBrowser.searchIdx = append(m.navBrowser.searchIdx, i)
+			}
+		}
+	case m.navBrowser.mode == navBrowseModeByGenre && m.navBrowser.screen == navBrowseScreenAlbums:
+		for i, sortType := range m.navBrowser.genreSorts {
+			if strings.Contains(strings.ToLower(sortType.Label), q) {
+				m.navBrowser.searchIdx = append(m.navBrowser.searchIdx, i)
+			}
+		}
 	case m.navBrowser.screen == navBrowseScreenTracks:
 		for i, t := range m.navBrowser.tracks {
 			if strings.Contains(strings.ToLower(t.Title), q) ||
@@ -290,6 +643,14 @@ func (m *Model) navClearSearch() {
 	m.navBrowser.searchIdx = nil
 	m.navBrowser.cursor = 0
 	m.navBrowser.scroll = 0
+}
+
+// navClearSearchKeepingCursor removes a filter while keeping the selected raw
+// item highlighted during an in-flight leaf request.
+func (m *Model) navClearSearchKeepingCursor(cursor int) {
+	m.navClearSearch()
+	m.navBrowser.cursor = cursor
+	m.navMaybeAdjustScroll()
 }
 
 // fetchNavArtistAllTracksCmd first fetches the artist's album list, then fetches

--- a/ui/model/seek.go
+++ b/ui/model/seek.go
@@ -13,8 +13,12 @@ import (
 // before actually executing the yt-dlp seek (restart).
 const seekDebounceTicks = 8 // ~800ms at 100ms tick interval
 
-// seekTickMsg fires when the async seek completes.
-type seekTickMsg struct{}
+// seekTickMsg fires when an async seek completes.
+type seekTickMsg struct {
+	err    error
+	resume bool
+	target time.Duration
+}
 
 type ytdlUnpauseReconnectMsg struct{ err error }
 
@@ -29,16 +33,16 @@ func (m *Model) doSeek(d time.Duration) tea.Cmd {
 func (m *Model) streamSeekRelative(delta time.Duration) tea.Cmd {
 	p := m.player
 	return func() tea.Msg {
-		p.Seek(delta)
-		return seekTickMsg{}
+		err := p.Seek(delta)
+		return seekTickMsg{err: err}
 	}
 }
 
 func (m *Model) streamSeekAbsolute(target time.Duration) tea.Cmd {
 	p := m.player
 	return func() tea.Msg {
-		p.Seek(target - p.Position())
-		return seekTickMsg{}
+		err := p.Seek(target - p.Position())
+		return seekTickMsg{err: err, target: target}
 	}
 }
 
@@ -100,14 +104,17 @@ func (m *Model) finishSeek() {
 }
 
 func (m *Model) commitPendingYTDLSeek() tea.Cmd {
-	target := m.seek.targetPos
+	return m.ytdlSeekCmd(m.seek.targetPos, false)
+}
+
+func (m *Model) ytdlSeekCmd(target time.Duration, resume bool) tea.Cmd {
 	curPos := m.player.Position()
 	d := target - curPos
 
 	p := m.player
 	return func() tea.Msg {
-		p.SeekYTDL(d)
-		return seekTickMsg{}
+		err := p.SeekYTDL(d)
+		return seekTickMsg{err: err, resume: resume, target: target}
 	}
 }
 

--- a/ui/model/state.go
+++ b/ui/model/state.go
@@ -213,25 +213,33 @@ type fileBrowserState struct {
 
 // navBrowserState holds state for the provider browser overlay.
 type navBrowserState struct {
-	prov           playlist.Provider
-	visible        bool
-	mode           navBrowseModeType
-	screen         navBrowseScreenType
-	cursor         int
-	scroll         int
-	artists        []provider.ArtistInfo
-	albums         []provider.AlbumInfo
-	tracks         []playlist.Track
-	selArtist      provider.ArtistInfo
-	selAlbum       provider.AlbumInfo
-	sortType       string
-	albumLoading   bool
-	albumDone      bool
-	loading        bool
-	searching      bool
-	search         string
-	searchIdx      []int
-	confirmReplace bool
+	prov            playlist.Provider
+	visible         bool
+	mode            navBrowseModeType
+	screen          navBrowseScreenType
+	cursor          int
+	scroll          int
+	artists         []provider.ArtistInfo
+	albums          []provider.AlbumInfo
+	tracks          []playlist.Track
+	genres          []provider.GenreInfo
+	genreSorts      []provider.SortType
+	selArtist       provider.ArtistInfo
+	selAlbum        provider.AlbumInfo
+	selGenre        provider.GenreInfo
+	selGenreSort    provider.SortType
+	genreQuery      string
+	sortType        string
+	albumLoading    bool
+	albumDone       bool
+	loading         bool
+	searching       bool
+	search          string
+	searchIdx       []int
+	confirmReplace  bool
+	directTrackJump bool
+	fromProvList    bool
+	openInPlaylist  bool
 }
 
 // requestState tracks the latest request in each independently asynchronous UI

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -87,8 +87,26 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Grace period: suppress reconnect for a few ticks after seek completes.
 		m.seek.grace = 10
 		m.seek.graceFor = 0
+		if msg.resume {
+			// A failed resume must not be retried every time the track is opened
+			// during this session. The original pipeline remains playable.
+			m.resume.path = ""
+			m.resume.secs = 0
+		}
+		if msg.err != nil {
+			if msg.resume {
+				m.status.Warningf(statusTTLLong, "Couldn't resume this show; playing from the previous position: %s", msg.err)
+			} else {
+				m.status.Warningf(statusTTLMedium, "Seek failed; playback continues from the previous position: %s", msg.err)
+			}
+			m.notifyAll()
+			return m, m.preloadNext()
+		}
+		if msg.resume {
+			m.status.Showf(statusTTLDefault, "Resumed at %s", formatJumpClock(msg.target))
+		}
 		m.finishSeek()
-		return m, nil
+		return m, m.preloadNext()
 
 	case ytdlUnpauseReconnectMsg:
 		m.seek.active = false
@@ -340,10 +358,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.err = nil
 				return m, nil
 			}
-			m.err = msg.err
-			return m, nil
+			if len(msg.playlists) == 0 {
+				m.err = msg.err
+				return m, nil
+			}
+			m.err = nil
+			m.status.Warningf(statusTTLLong, "%s", msg.err)
 		}
-		m.providerLists = msg.playlists
+		m.providerLists = providerListsWithBrowse(m.provider, msg.playlists)
 		// Start loading catalog when the provider supports lazy catalog loading.
 		if loader, ok := m.provider.(provider.CatalogLoader); ok && !m.catalogBatch.loading && !m.catalogBatch.done {
 			m.catalogBatch.loading = true
@@ -365,28 +387,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.err = msg.err
 			return m, nil
 		}
-		if m.player.IsPlaying() || m.buffering {
-			m.detachPlaybackTrack()
-			m.player.ClearPreload()
-			m.preloading = false
-		} else {
-			m.player.Stop()
-			m.player.ClearPreload()
-			m.clearPlaybackTrack()
-		}
-		m.resetYTDLBatch()
-		m.replacePlaylist(msg.tracks)
-		m.setHeaderStateFromTracks(msg.tracks)
+		m.replacePlayerPlaylist(msg.tracks)
 		if msg.playlistExact && m.localProvider != nil && msg.providerName == m.localProvider.Name() && msg.playlistID != history.PlaylistName {
 			m.loadedPlaylist = msg.playlistID
-		} else {
-			m.loadedPlaylist = ""
 		}
-		m.plCursor = 0
-		m.plScroll = 0
 		m.applyTracksResume(msg)
-		m.focus = focusPlaylist
-		m.applyHeightMode()
 		m.adjustScroll()
 		m.notifyAll()
 		return m, nil
@@ -434,6 +439,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// also clear the general loading flag.
 		return m, nil
 
+	case navGenresLoadedMsg:
+		if !m.isCurrentNavRequest(msg.gen) {
+			return m, nil
+		}
+		m.navBrowser.loading = false
+		if msg.err != nil {
+			m.status.Errorf(statusTTLDefault, "Genre load failed: %s", msg.err)
+			return m, nil
+		}
+		m.navBrowser.genres = msg.genres
+		m.navBrowser.cursor = 0
+		m.navBrowser.scroll = 0
+		return m, nil
+
 	case navTracksLoadedMsg:
 		if !m.isCurrentNavRequest(msg.gen) {
 			return m, nil
@@ -441,6 +460,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.navBrowser.loading = false
 		if msg.err != nil {
 			m.status.Errorf(statusTTLDefault, "Track load failed: %s", msg.err)
+			return m, nil
+		}
+		if m.navBrowser.openInPlaylist {
+			if len(msg.tracks) == 0 {
+				m.status.Warning("No tracks found", statusTTLDefault)
+				return m, nil
+			}
+			m.replacePlayerPlaylist(msg.tracks)
+			m.navBrowser.visible = false
+			m.status.Successf(statusTTLDefault, "Replaced queue with %d tracks", len(msg.tracks))
+			m.notifyAll()
 			return m, nil
 		}
 		m.navBrowser.tracks = msg.tracks
@@ -465,7 +495,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		if lists, err := m.provider.Playlists(); err == nil {
-			m.providerLists = lists
+			m.providerLists = providerListsWithBrowse(m.provider, lists)
 		}
 		m.catalogBatch.offset += msg.added
 		if msg.added < catalogBatchSize {
@@ -482,7 +512,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.status.Error("Search failed", statusTTLDefault)
 		} else {
 			if lists, err := m.provider.Playlists(); err == nil {
-				m.providerLists = lists
+				m.providerLists = providerListsWithBrowse(m.provider, lists)
 			}
 			m.provCursor = 0
 			m.provScroll = 0
@@ -672,6 +702,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.buffering = false
+		var resumeCmd tea.Cmd
 		if msg.err != nil {
 			m.err = msg.err
 			if track, idx := m.currentPlaybackTrack(); idx >= 0 {
@@ -681,10 +712,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.err = nil
 			m.reconnect.attempts = 0
 			m.reconnect.at = time.Time{}
-			m.applyResume()
+			resumeCmd = m.applyResume()
 		}
 		m.notifyAll()
-		return m, m.preloadNext()
+		return m, tea.Batch(resumeCmd, m.preloadNext())
 
 	case streamPreloadedMsg:
 		if msg.gen != m.requests.preload {

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -378,7 +378,7 @@ func (m Model) renderTitle() string {
 
 func (m Model) renderTrackInfo() string {
 	track, _ := m.currentPlaybackTrack()
-	name := track.DisplayName()
+	name := trackViewName(track)
 	if name == "" {
 		name = "No track loaded"
 	}
@@ -894,7 +894,7 @@ func (m Model) renderPlaylist() string {
 		}
 		markers := cursorMarker + playingMarker + queueMarker + bookmarkMarker + unavailableMarker + " "
 
-		name := t.DisplayName()
+		name := trackViewName(t)
 		queueSuffix := ""
 		if queuePosition > 0 && ui.PanelWidth >= 64 {
 			queueSuffix = fmt.Sprintf(" [Q%d]", queuePosition)

--- a/ui/model/view_helpers.go
+++ b/ui/model/view_helpers.go
@@ -10,8 +10,28 @@ import (
 	"github.com/charmbracelet/x/ansi"
 
 	"github.com/bjarneo/cliamp/playlist"
+	"github.com/bjarneo/cliamp/provider"
 	"github.com/bjarneo/cliamp/ui"
 )
+
+const restrictedViewSuffix = " [E]"
+
+// trackViewName decorates provider-specific presentation metadata without
+// mutating the title used by playlist export, IPC, or media-session metadata.
+func trackViewName(track playlist.Track) string {
+	name := track.DisplayName()
+	if track.Meta(provider.MetaMixcloudExclusive) == "true" {
+		return strings.TrimSpace(name) + restrictedViewSuffix
+	}
+	return name
+}
+
+func albumViewName(album provider.AlbumInfo) string {
+	if album.Restricted {
+		return strings.TrimSpace(album.Name) + restrictedViewSuffix
+	}
+	return album.Name
+}
 
 // formatListMatchCount returns a human-readable "matches of total" summary
 // for filtered lists.

--- a/ui/model/view_helpers_test.go
+++ b/ui/model/view_helpers_test.go
@@ -5,7 +5,46 @@ import (
 	"testing"
 
 	"github.com/bjarneo/cliamp/playlist"
+	"github.com/bjarneo/cliamp/provider"
 )
+
+func TestRestrictedMarkersAreViewOnly(t *testing.T) {
+	track := playlist.Track{
+		Title:        "Members Only",
+		Artist:       "Creator",
+		ProviderMeta: map[string]string{provider.MetaMixcloudExclusive: "true"},
+	}
+	if got := trackViewName(track); got != "Creator - Members Only [E]" {
+		t.Fatalf("trackViewName = %q", got)
+	}
+	if track.Title != "Members Only" {
+		t.Fatalf("track title mutated to %q", track.Title)
+	}
+
+	album := provider.AlbumInfo{Name: "Members Only", Restricted: true}
+	if got := albumViewName(album); got != "Members Only [E]" {
+		t.Fatalf("albumViewName = %q", got)
+	}
+	if album.Name != "Members Only" {
+		t.Fatalf("album name mutated to %q", album.Name)
+	}
+
+	plain := playlist.Track{Title: "Open Show", Artist: "Creator"}
+	if got := trackViewName(plain); got != "Creator - Open Show" {
+		t.Fatalf("unrestricted trackViewName = %q", got)
+	}
+	notExclusive := playlist.Track{
+		Title:        "Open Show",
+		Artist:       "Creator",
+		ProviderMeta: map[string]string{provider.MetaMixcloudExclusive: "false"},
+	}
+	if got := trackViewName(notExclusive); got != "Creator - Open Show" {
+		t.Fatalf("non-exclusive trackViewName = %q", got)
+	}
+	if got := albumViewName(provider.AlbumInfo{Name: "Open Show"}); got != "Open Show" {
+		t.Fatalf("unrestricted albumViewName = %q", got)
+	}
+}
 
 func TestFormatTrackTime(t *testing.T) {
 	tests := []struct {
@@ -231,6 +270,7 @@ func TestProviderKeyForShortcut(t *testing.T) {
 		"P": "plex",
 		"J": "jellyfin",
 		"Y": "yt",
+		"X": "mixcloud",
 		"L": "local",
 		"R": "radio",
 		"x": "",

--- a/ui/model/view_nav.go
+++ b/ui/model/view_nav.go
@@ -61,8 +61,26 @@ func (m Model) navBreadcrumb() string {
 			if m.navBrowser.selAlbum.Name != "" {
 				parts = append(parts, m.navBrowser.selAlbum.Name)
 			}
+		case navBrowseModeByGenre:
+			parts = append(parts, "Genres")
+			if m.navBrowser.selGenre.Name != "" {
+				parts = append(parts, m.navBrowser.selGenre.Name)
+			}
+			if m.navBrowser.selGenreSort.Label != "" {
+				parts = append(parts, m.navBrowser.selGenreSort.Label)
+			}
 		}
 		parts = append(parts, "Tracks")
+	case navViewGenres:
+		parts = append(parts, "Genres")
+		if m.navBrowser.genreQuery != "" {
+			parts = append(parts, "Search: "+m.navBrowser.genreQuery)
+		}
+	case navViewGenreSorts:
+		parts = append(parts, "Genres")
+		if m.navBrowser.selGenre.Name != "" {
+			parts = append(parts, m.navBrowser.selGenre.Name)
+		}
 	default:
 		parts = append(parts, "Browse")
 	}

--- a/ui/model/view_overlays.go
+++ b/ui/model/view_overlays.go
@@ -103,7 +103,7 @@ func (m Model) renderPlMgrFormBody() string {
 	}
 	label := "Create the playlist (nothing playing to add)."
 	if track, idx := m.currentPlaybackTrack(); idx >= 0 && track.Path != "" {
-		label = "Create & add: " + truncate(track.DisplayName(), max(1, ui.PanelWidth-16))
+		label = "Create & add: " + truncate(trackViewName(track), max(1, ui.PanelWidth-16))
 	}
 	lines := []string{dimStyle.Render("  " + label)}
 	if m.plManager.inputErr != "" {
@@ -260,7 +260,7 @@ func (m Model) plMgrTrackLabel(realIdx int) string {
 	if realIdx < len(m.plManager.missingLocal) && m.plManager.missingLocal[realIdx] {
 		missing = "! "
 	}
-	return mark + missing + formatTrackRow(realIdx+1, t.DisplayName()+trackAlbumSuffix(t, m.showAlbumHeaders), t.DurationSecs)
+	return mark + missing + formatTrackRow(realIdx+1, trackViewName(t)+trackAlbumSuffix(t, m.showAlbumHeaders), t.DurationSecs)
 }
 
 // renderSearchList renders the playlist-search results for the playlist region
@@ -298,7 +298,7 @@ func (m Model) renderSearchList() string {
 			style = playlistActiveStyle
 		}
 
-		name := track.DisplayName()
+		name := trackViewName(track)
 		queueSuffix := ""
 		if qp := m.playlist.QueuePosition(i); qp > 0 {
 			queueSuffix = fmt.Sprintf(" [Q%d]", qp)


### PR DESCRIPTION
## Summary

Adds [Mixcloud](https://www.mixcloud.com/) as a provider: DJ mixes, radio shows and podcasts browsed through Mixcloud's public REST API and played through cliamp's existing yt-dlp pipeline.

Queue entries store the stable `mixcloud.com` page URL rather than an extracted media URL, so yt-dlp resolves the current stream only when playback begins and saved playlists never go stale.

Along the way it adds three opt-in provider capabilities to the core. They are provider-agnostic — Mixcloud is just the first implementer:

| Capability | What it does | Existing providers that could adopt it |
|---|---|---|
| `TrackArtistResolver` | Jump from a highlighted track straight to its artist/creator with `N` | Navidrome, Jellyfin, Emby, Qobuz — all already implement `ArtistBrowser` and need only map a track back to its artist |
| `BrowseEntryProvider` | Advertise hierarchical browse routes in the provider pane, with per-entry placement (`AfterID` / `AfterSection`) and leaf behaviour (`OpenInPlaylist`) | any provider whose browse hierarchy is a primary entry point rather than a secondary overlay |
| `GenreBrowser` (+ optional `GenreSearcher`, `GenreFavoriteToggler`) | A category screen in the `N` browser with provider-defined sort views, and `f` to pin favourites | SoundCloud, whose curated genre rows are currently seeded as virtual playlists |

**Suggested review order** — the core surface is 84 lines and worth reading first:

1. `provider/interfaces.go` (+65) and `provider/types.go` (+19) — the interfaces, `BrowseEntry`, `GenreInfo`
2. `ui/model/providers.go`, `keys_nav.go`, `update.go`, `inline_overlays_nav.go`, `view_helpers.go` — the UI plumbing
3. `external/mixcloud/` — the provider itself (client, types, provider)
4. Wiring: `config/config.go`, `main.go`, `commands.go`, `cmd/setup.go`
5. `player/player.go` and `ui/model/seek.go` — see the section below; these are **not** Mixcloud-specific

Defaults are unchanged for every existing provider: the capabilities are discovered by type assertion, and a provider that implements none of them renders exactly as before. No new dependencies — `go.mod` and `go.sum` are untouched.

## Player changes that affect every yt-dlp source

Two changes here are not scoped to Mixcloud and are worth reviewing on their own terms:

- **`SeekYTDL` could leave playback permanently silent.** It mutes the gapless streamer (`gapless.Replace(nil)`) before rebuilding the pipeline, but returned early when the rebuild failed, so the muted state was never undone. `restoreYTDLSeekSource` now puts the original source back, guarded by the seek generation so an obsolete seek cannot overwrite a newer one. This is a pre-existing bug reachable from YouTube, SoundCloud and Bandcamp seeks, not just Mixcloud.
- **Seek errors now reach the UI.** `Player.Seek`'s error was previously discarded; failures surface as a status warning. `Seek` still returns `nil` for non-seekable streams, so seeks on radio and live sources remain no-ops as before.

## What it does

- Opt-in with `[mixcloud] enabled = true`. That alone provides Recent Releases, Popular, genre browsing, per-style Latest/Popular views, and `Ctrl+F` show search — no account, no token.
- `username` adds the following stream, profile activity, uploads, favourites, listening history, collections, and followed-creator browsing. An optional developer `access_token` resolves `/me` and adds Listen Later. `cookies_from` is handed to yt-dlp for playback that needs a signed-in session.
- Provider pane for a configured account reads: **Your Mixcloud** (Stream, Favorites, Creators, Uploads, Profile Activity, Listening History, Listen Later) → **Browse** (Shows, Genres) → **Collections** → **Discover** → **Music Styles**. Public-only setups start at Browse.
- Account-side failures degrade to a warning and keep public discovery working, so a stale username or an expired token never takes the whole provider down.
- `N` browses Shows, Creators → Uploads/Favorites, and Genres → Latest/Popular. Selecting a leaf loads those shows into the main playlist and closes the browser; empty results leave the queue and browser untouched with a warning.
- `f` in the genre browser pins a category, persisted to `[mixcloud].styles` as Latest/Popular rows. This is local to cliamp config and does not touch the Mixcloud account.
- Shows Mixcloud marks as exclusive get a padlock **at render time only**, so the marker stays out of playlist exports, IPC output and media-session metadata. They are not pre-filtered — entitlement is resolved by yt-dlp at playback.
- Resume works for Mixcloud shows. They are long-form enough to be worth resuming and report a reliable position from decoded PCM plus the restart offset; other yt-dlp sites remain excluded.
- `Shift+X` shortcut, `--provider mixcloud`, and an interactive `cliamp setup` step.

## Screenshots / video

Not included. The provider and navigation changes are terminal UI flows covered by interaction tests.

## How to test

No account is required for the public path.

1. Add to `~/.config/cliamp/config.toml` — or run `cliamp setup` and pick the Mixcloud step:

   ```toml
   [mixcloud]
   enabled = true
   # optional, adds account views and followed creators:
   # username = "yourname"
   # optional, adds /me and Listen Later:
   # access_token = "${MIXCLOUD_ACCESS_TOKEN}"
   # optional, for signed-in playback via yt-dlp:
   # cookies_from = "firefox"
   # styles = ["ambient", "deep-house", "house", "jazz", "techno"]
   ```

2. `make build && ./cliamp`, then press `Shift+X`. Expect Discover and Music Styles rows; play a show to confirm yt-dlp playback.
3. Press `N` → Genres, press `f` on a category, and check it appears under Music Styles in the provider pane and in `[mixcloud].styles` on disk.
4. With a `username` set, confirm the pane leads with Your Mixcloud. Set a deliberately wrong username to confirm the account views warn while Discover and Music Styles still load.
5. Seek inside a show, quit, relaunch, and reopen the same show to confirm it resumes.

Tests against the live API are opt-in and skipped by default:

```sh
CLIAMP_LIVE_MIXCLOUD=1 CLIAMP_LIVE_MIXCLOUD_USER=someuser go test ./external/mixcloud/
```

## Known limitations and trade-offs

- Mixcloud has no stream endpoint, so **Stream (Following Releases)** is approximated by merging the newest uploads from followed creators. That costs one request per creator, bounded by `stream_creators` (default 20, max 100) and run at a concurrency of 6. A creator that 404s between listing and loading is skipped; any other error fails the view rather than returning a silently partial stream.
- Exclusive and subscriber-only shows are listed rather than hidden. Whether they play depends on the session yt-dlp sees, which is only known at playback time.
- Genre favourites are cliamp-local config, not synced to the Mixcloud account.
- Catalog and track pages are deliberately not cached, so every open fetches fresh releases and no expiring audio URL is ever retained. `Ctrl+R` additionally clears the cached `/me/` identity.

## Checklist

- [x] `make check` passes
- [x] `docs/` and `site/index.html` updated for user-facing changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Mixcloud support for public discovery, account views, creator collections, search, playlists, and direct playback.
  * Added genre browsing, filtering, favorites, and latest/popular sorting.
  * Added OAuth, browser-session, style preference, and item-limit configuration.
  * Added quick-switch access, hierarchical browsing, resume/seeking, and restricted-show indicators.

* **Bug Fixes**
  * Improved failed stream-seek recovery while preserving playback sources.
  * Preserved available public content when account-specific data cannot be loaded.

* **Documentation**
  * Added Mixcloud setup, configuration, playback, limitations, and keybinding guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->