### PR TITLE
fix(plex): respect the returned album page size

### DIFF
--- a/external/plex/client.go
+++ b/external/plex/client.go
@@ -174,7 +174,9 @@ const pageSize = 300
 func (c *Client) Albums(sectionKey string) ([]Album, error) {
 	type albumPage struct {
 		MediaContainer struct {
-			TotalSize int `json:"totalSize"`
+			// TotalSize is a pointer so a server that omits it is
+			// distinguishable from one that reports zero.
+			TotalSize *int `json:"totalSize"`
 			Metadata  []struct {
 				RatingKey   string `json:"ratingKey"`
 				Title       string `json:"title"`
@@ -186,7 +188,7 @@ func (c *Client) Albums(sectionKey string) ([]Album, error) {
 	}
 
 	var albums []Album
-	for offset := 0; ; offset += pageSize {
+	for offset := 0; ; {
 		params := url.Values{
 			"type":                   {"9"}, // 9 = album
 			"X-Plex-Container-Start": {fmt.Sprintf("%d", offset)},
@@ -205,8 +207,14 @@ func (c *Client) Albums(sectionKey string) ([]Album, error) {
 				TrackCount: m.LeafCount,
 			})
 		}
-		// Stop when we've fetched everything.
-		if offset+pageSize >= page.MediaContainer.TotalSize {
+		// Advance by what the server actually returned, not by what was
+		// asked for: Plex may answer with fewer items than pageSize.
+		count := len(page.MediaContainer.Metadata)
+		if count == 0 {
+			break
+		}
+		offset += count
+		if page.MediaContainer.TotalSize != nil && offset >= *page.MediaContainer.TotalSize {
 			break
 		}
 	}

--- a/external/plex/client_test.go
+++ b/external/plex/client_test.go
@@ -211,19 +211,22 @@ func TestAlbums_RequestsType9(t *testing.T) {
 }
 
 func TestAlbums_Paginates(t *testing.T) {
-	callCount := 0
+	seenStarts := map[string]bool{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		callCount++
 		start := r.URL.Query().Get("X-Plex-Container-Start")
+		seenStarts[start] = true
 		w.Header().Set("Content-Type", "application/json")
 		switch start {
 		case "0", "":
-			w.Write([]byte(`{"MediaContainer":{"totalSize":2,"Metadata":[{"ratingKey":"1","title":"A","parentTitle":"Art","year":2000,"leafCount":1}]}}`))
-		case "300":
-			// Second page — but totalSize=2 means we should never reach here with pageSize=300.
-			// This tests that we stop after the first page when totalSize <= pageSize.
-			t.Errorf("unexpected second page request (offset=%s)", start)
-			w.Write([]byte(`{"MediaContainer":{"totalSize":2,"Metadata":[]}}`))
+			// Two albums for a page of 300: the server returned fewer
+			// items than were asked for, which is the case that used to
+			// make the loop skip straight past the remainder.
+			w.Write([]byte(`{"MediaContainer":{"totalSize":3,"Metadata":[{"ratingKey":"1","title":"A","parentTitle":"Art","year":2000,"leafCount":1},{"ratingKey":"2","title":"B","parentTitle":"Art","year":2001,"leafCount":2}]}}`))
+		case "2":
+			w.Write([]byte(`{"MediaContainer":{"totalSize":3,"Metadata":[{"ratingKey":"3","title":"C","parentTitle":"Art","year":2002,"leafCount":3}]}}`))
+		default:
+			t.Errorf("unexpected start %q", start)
+			w.WriteHeader(http.StatusBadRequest)
 		}
 	}))
 	defer srv.Close()
@@ -232,11 +235,68 @@ func TestAlbums_Paginates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Albums() error: %v", err)
 	}
-	if len(albums) != 1 {
-		t.Errorf("expected 1 album, got %d", len(albums))
+	if len(albums) != 3 {
+		t.Fatalf("expected 3 albums, got %d", len(albums))
 	}
-	if callCount != 1 {
-		t.Errorf("expected 1 API call, got %d", callCount)
+	if albums[2].Title != "C" || albums[2].TrackCount != 3 {
+		t.Errorf("unexpected albums[2]: %+v", albums[2])
+	}
+	if !seenStarts["0"] || !seenStarts["2"] {
+		t.Errorf("expected pagination to hit starts 0 and 2, got %v", seenStarts)
+	}
+}
+
+func TestAlbums_PaginatesWithoutTotalSize(t *testing.T) {
+	var starts []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := r.URL.Query().Get("X-Plex-Container-Start")
+		starts = append(starts, start)
+		w.Header().Set("Content-Type", "application/json")
+		switch start {
+		case "0", "":
+			w.Write([]byte(`{"MediaContainer":{"Metadata":[{"ratingKey":"1","title":"A"}]}}`))
+		case "1":
+			w.Write([]byte(`{"MediaContainer":{"Metadata":[{"ratingKey":"2","title":"B"}]}}`))
+		case "2":
+			w.Write([]byte(`{"MediaContainer":{"Metadata":[]}}`))
+		default:
+			t.Errorf("unexpected start %q", start)
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer srv.Close()
+
+	albums, err := newTestClient(srv).Albums("1")
+	if err != nil {
+		t.Fatalf("Albums() error: %v", err)
+	}
+	if len(albums) != 2 {
+		t.Fatalf("expected 2 albums, got %d", len(albums))
+	}
+	wantStarts := []string{"0", "1", "2"}
+	if !slices.Equal(starts, wantStarts) {
+		t.Fatalf("starts = %v, want %v", starts, wantStarts)
+	}
+}
+
+func TestAlbums_StopsWhenTotalSizeReached(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"MediaContainer":{"totalSize":1,"Metadata":[{"ratingKey":"1","title":"A"}]}}`))
+	}))
+	defer srv.Close()
+
+	albums, err := newTestClient(srv).Albums("1")
+	if err != nil {
+		t.Fatalf("Albums() error: %v", err)
+	}
+	if len(albums) != 1 {
+		t.Fatalf("expected 1 album, got %d", len(albums))
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 API call once totalSize was reached, got %d", calls)
 	}
 }
 


### PR DESCRIPTION
## Summary

`external/plex/client.go` holds two paging loops that terminate by different rules.

`PlaylistTracks` uses the corrected one, from `983641b` *"fix(plex): respect returned playlist page size"* — advance by `len(Metadata)`, stop on an empty page, `TotalSize *int` so an omitted `totalSize` is distinguishable from zero.

`Albums` still advances by the size it *asked* for:

```go
for offset := 0; ; offset += pageSize {
	...
	if offset+pageSize >= page.MediaContainer.TotalSize {
```

A server that answers with fewer items than `X-Plex-Container-Size` leaves a gap — the next request starts past the items it did not send, so those albums never appear in the library view. And because `TotalSize` was a plain `int`, a response omitting `totalSize` was indistinguishable from one reporting `0`, so the loop stopped after the first page.

This applies your `983641b` rule to `Albums`. The two terminators are now byte-identical.

**One consequence worth stating up front,** since it changes a property rather than just fixing one: termination now depends on the server either returning an empty page or reporting `totalSize` — the contract `PlaylistTracks` has used since `983641b`. A server that ignored `X-Plex-Container-Start` *and* omitted `totalSize` would loop, as it already would for playlists today. If you want a hard iteration bound, I think it belongs on both loops in one change rather than on `Albums` alone, and I'm happy to do that instead.

## Screenshots / video

None — no visual change; this is a data-completeness fix in the Plex client.

## How to test

1. `go test ./external/plex/`
2. Against a Plex server with a music library larger than one page, browse albums and confirm the count matches the server's.

I don't have a Plex instance, so **this is covered by unit tests only** — I have not verified it against a real server. The argument that stands without one is the internal inconsistency above: two loops in one file, one already corrected by you, the other not.

`TestAlbums_Paginates` encoded the old behaviour — it declared `totalSize:2`, returned a single album, and asserted one album back — so it is rewritten rather than extended, mirroring `TestPlaylistTracks_Paginates`. Added alongside it:

- `TestAlbums_PaginatesWithoutTotalSize`, mirroring `TestPlaylistTracks_PaginatesWithoutTotalSize`
- `TestAlbums_StopsWhenTotalSizeReached`, pinning that a reached `totalSize` still stops after one call

Three mutations were applied. Restoring the advance-by-`pageSize` rule fails on `expected 3 albums, got 2`; treating an omitted `totalSize` as zero fails `TestAlbums_PaginatesWithoutTotalSize`. Dropping the empty-page guard makes that test repeat its `start=2` request forever, so it is killed by the test timeout rather than an assertion — which is what the guard is there to prevent.

## Checklist

- [x] `make check` passes — also `make ci` (staticcheck 0, govulncheck 0 affecting) and `go test -race -count=1 ./...`
- [x] `docs/` and `site/index.html` updated for user-facing changes — no change needed; no documented behaviour changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved album loading across paginated results.
  * Results now continue correctly when pages contain fewer items than requested.
  * Album retrieval stops appropriately when no more results are available or the reported total has been reached.
  * Improved handling when total result counts are not provided.

* **Tests**
  * Added coverage for partial pages, missing totals, and completed pagination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->