### PR TITLE
fix(resolve): reject oversized PLS playlists instead of reading them whole

### DIFF
--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -452,9 +452,10 @@ func resolveFeed(feedURL string) ([]playlist.Track, error) {
 	return tracks, nil
 }
 
-// maxM3UBody caps how much of a remote playlist we read before classifying it.
-// HLS/M3U playlists are tiny (a few KB); 1 MB is a generous safety bound.
-const maxM3UBody = 1 << 20
+// maxPlaylistBody caps how much of a remote playlist we read before
+// classifying it. HLS/M3U and PLS playlists are tiny (a few KB); 1 MB is a
+// generous safety bound.
+const maxPlaylistBody = 1 << 20
 
 // resolveM3U fetches an M3U/M3U8 URL. HLS playlists (master or media) are a
 // single live/VOD stream — not a track list — so the original URL is handed to
@@ -471,7 +472,7 @@ func resolveM3U(m3uURL string) ([]playlist.Track, error) {
 		return nil, fmt.Errorf("http status %s", resp.Status)
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxM3UBody))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxPlaylistBody))
 	if err != nil {
 		return nil, err
 	}
@@ -506,7 +507,18 @@ func resolvePLS(plsURL string) ([]playlist.Track, error) {
 		return nil, fmt.Errorf("http status %s", resp.Status)
 	}
 
-	entries, err := parsePLS(resp.Body)
+	// Read one byte past the cap so an oversized playlist is reported rather
+	// than silently truncated: io.LimitReader alone would cut mid-line and
+	// hand parsePLS a partial "FileN=https:/", which becomes a bogus track.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxPlaylistBody+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > maxPlaylistBody {
+		return nil, fmt.Errorf("pls playlist exceeds %d bytes", maxPlaylistBody)
+	}
+
+	entries, err := parsePLS(bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -512,7 +512,7 @@ func resolvePLS(plsURL string) ([]playlist.Track, error) {
 	// hand parsePLS a partial "FileN=https:/", which becomes a bogus track.
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxPlaylistBody+1))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("reading pls playlist: %w", err)
 	}
 	if len(body) > maxPlaylistBody {
 		return nil, fmt.Errorf("pls playlist exceeds %d bytes", maxPlaylistBody)

--- a/resolve/resolve_test.go
+++ b/resolve/resolve_test.go
@@ -1,6 +1,7 @@
 package resolve
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -9,8 +10,11 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/bjarneo/cliamp/playlist"
 )
 
 func TestArgsTreatsXiaoyuzhouEpisodeAsPending(t *testing.T) {
@@ -329,4 +333,100 @@ func TestParseYTDLTracksCountsMalformedEntries(t *testing.T) {
 	if len(tracks) != 1 || tracks[0].Title != "One" {
 		t.Fatalf("tracks = %+v, want one valid track", tracks)
 	}
+}
+
+// TestResolvePLSCapsBody pins that an oversized remote PLS is rejected rather
+// than silently truncated. io.LimitReader alone cuts mid-line, and parsePLS
+// would turn the partial "FileN=https:/" into a track with a non-URL path,
+// which the player then treats as a local file.
+func TestResolvePLSCapsBody(t *testing.T) {
+	oversized := buildPLS(40000) // 1,577,799 bytes, over maxPlaylistBody
+	if len(oversized) <= maxPlaylistBody {
+		t.Fatalf("fixture is %d bytes, needs to exceed maxPlaylistBody (%d)", len(oversized), maxPlaylistBody)
+	}
+
+	tests := []struct {
+		name    string
+		body    string
+		wantErr bool
+		want    int
+	}{
+		{name: "under the cap", body: buildPLS(10), want: 10},
+		{name: "over the cap", body: oversized, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "audio/x-scpls")
+				io.WriteString(w, tt.body)
+			}))
+			defer srv.Close()
+
+			tracks, err := resolvePLS(srv.URL + "/stations.pls")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("resolvePLS accepted a %d-byte body and returned %d tracks, want an error",
+						len(tt.body), len(tracks))
+				}
+				if !strings.Contains(err.Error(), "exceeds") {
+					t.Fatalf("error = %v, want it to name the cap", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolvePLS returned error: %v", err)
+			}
+			if len(tracks) != tt.want {
+				t.Fatalf("got %d tracks, want %d", len(tracks), tt.want)
+			}
+			for i, tr := range tracks {
+				if !playlist.IsURL(tr.Path) {
+					t.Fatalf("tracks[%d].Path = %q, want a URL: a truncated entry must never reach the playlist", i, tr.Path)
+				}
+			}
+		})
+	}
+}
+
+// TestResolvePLSStopsReadingAtTheCap pins that the cap bounds the read itself,
+// not just the size check afterwards. Without the LimitReader the whole body is
+// pulled into memory before its length is ever examined, which is the condition
+// the cap exists to prevent.
+func TestResolvePLSStopsReadingAtTheCap(t *testing.T) {
+	const served = 32 << 20 // far more than maxPlaylistBody
+
+	var written atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "audio/x-scpls")
+		io.WriteString(w, "[playlist]\n")
+		chunk := []byte(strings.Repeat("File1=https://example.com/1.mp3\n", 2048))
+		for written.Load() < served {
+			n, err := w.Write(chunk)
+			written.Add(int64(n))
+			if err != nil {
+				return // client stopped reading, which is the point
+			}
+		}
+	}))
+	defer srv.Close()
+
+	if _, err := resolvePLS(srv.URL + "/endless.pls"); err == nil {
+		t.Fatal("resolvePLS accepted an oversized body, want an error")
+	}
+
+	// Allow generous slack for socket and proxy buffering; without the cap the
+	// server drains all 32 MB.
+	if got := written.Load(); got >= served/2 {
+		t.Fatalf("server wrote %d bytes before the client stopped, want well under %d", got, served)
+	}
+}
+
+func buildPLS(entries int) string {
+	var sb strings.Builder
+	sb.WriteString("[playlist]\n")
+	for i := 1; i <= entries; i++ {
+		fmt.Fprintf(&sb, "File%d=https://example.com/%d.mp3\n", i, i)
+	}
+	return sb.String()
 }


### PR DESCRIPTION
## Summary

`resolvePLS` hands `resp.Body` straight to `parsePLS` with no bound, while both siblings in the same file cap first — `resolveFeed` reads through `io.LimitReader` with `maxFeedBody`, `resolveM3U` with `maxM3UBody`.

`parsePLS` stores one map entry per line whose key is `FileN`/`TitleN`/`LengthN` with a parseable integer suffix. `bufio.Scanner`'s 64 KB limit bounds a *single line*, not the number of lines, so a crafted body of `FileN=` lines grows those maps until the 30 s `httpClient` timeout fires.

The `.pls` URL is not always typed by hand: `resolveWrapperURLs` in `ui/model` auto-expands any provider track whose `Path` is a `.pls` URL, and the radio provider takes station URLs from the public radio-browser directory.

**A bare `io.LimitReader` is not sufficient, and it's worth saying why because it was my first attempt.** `LimitReader` cuts mid-line and the partial line still parses. On a generated 1,577,799-byte body, a 1 MiB cut leaves the final token `File26770=https:/` — which yields a track whose `Path` is not a URL, so `playlist.TrackFromPath` classifies it as a **local file** and the user gets a phantom entry. Silently corrupting the playlist is a worse failure than the unbounded read.

So this reads one byte past the cap and reports the overflow — the shape this tree already uses in three places:

- `luaplugin/api_fs.go`, whose comment says *"reject it explicitly rather than returning a silently truncated value"*
- `pluginmgr/pluginmgr.go` — `plugin too large (max %d bytes)`
- `upgrade/upgrade.go` — `checksum file is too large`

`maxM3UBody` is renamed `maxPlaylistBody` and reused rather than duplicated; its own comment already described it as capping *"a remote playlist"*. The local-file path in `pls.go` is unchanged.

## Screenshots / video

None — no visual change; this is an input-validation fix in the resolver.

## How to test

1. `go test ./resolve/`
2. Point cliamp at a `.pls` URL under 1 MB — unchanged, still resolves.

Tests added:

- `TestResolvePLSCapsBody` — an under-cap body still resolves; an over-cap body errors naming the cap; and **no returned track ever has a non-URL path**, which is the assertion that catches the truncation failure above.
- `TestResolvePLSStopsReadingAtTheCap` — the server cannot drain 32 MB into the client. This pins the `LimitReader` itself rather than only the length check.

That second test exists because without it the first one passes with the `LimitReader` removed entirely: the length check fires either way, so only a test that observes the read stopping distinguishes them.

Four mutations were applied: removing the `LimitReader` fails the drain test; deleting the overflow check and an off-by-one on it each fail both tests; parsing the unread body fails the truncation assertion.

## Checklist

- [x] `make check` passes — also `make ci` (staticcheck 0, govulncheck 0 affecting) and `go test -race -count=1 ./...`
- [x] `docs/` and `site/index.html` updated for user-facing changes — no change needed; no documented behaviour changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added size limits for remotely loaded PLS playlists, matching M3U behavior.
  * Oversized playlists are now rejected instead of producing incomplete track lists.
  * Reading stops near the configured limit, helping prevent excessive response processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->