### PR TITLE
fix(ui): search all provider albums

### DIFF
--- a/ui/model/commands.go
+++ b/ui/model/commands.go
@@ -380,6 +380,23 @@ func fetchNavAlbumListCmd(b provider.AlbumBrowser, sortType string, offset int, 
 	}
 }
 
+func fetchNavRemainingAlbumsCmd(b provider.AlbumBrowser, sortType string, offset int, gen uint64) tea.Cmd {
+	return func() tea.Msg {
+		start := offset
+		var albums []provider.AlbumInfo
+		for {
+			page, err := b.AlbumList(sortType, offset+len(albums), navAlbumPageSize)
+			if err != nil {
+				return navAlbumsLoadedMsg{offset: start, gen: gen, err: err}
+			}
+			albums = append(albums, page...)
+			if len(page) < navAlbumPageSize {
+				return navAlbumsLoadedMsg{albums: albums, offset: start, isLast: true, gen: gen}
+			}
+		}
+	}
+}
+
 func fetchNavAlbumTracksCmd(l provider.AlbumTrackLoader, albumID string, gen uint64) tea.Cmd {
 	return func() tea.Msg {
 		tracks, err := l.AlbumTracks(albumID)

--- a/ui/model/keys_nav.go
+++ b/ui/model/keys_nav.go
@@ -47,6 +47,13 @@ func (m *Model) handleNavBrowserKey(msg tea.KeyPressMsg) tea.Cmd {
 				m.navClearSearch()
 			} else {
 				m.navBrowser.searching = true
+				if m.navBrowser.mode == navBrowseModeByAlbum &&
+					m.navBrowser.screen == navBrowseScreenList && !m.navBrowser.albumDone {
+					if ab, ok := m.navBrowser.prov.(provider.AlbumBrowser); ok {
+						m.navBrowser.albumLoading = true
+						return fetchNavRemainingAlbumsCmd(ab, m.navBrowser.sortType, len(m.navBrowser.albums), m.nextNavRequest())
+					}
+				}
 			}
 			return nil
 		}

--- a/ui/model/nav_search_pagination_test.go
+++ b/ui/model/nav_search_pagination_test.go
@@ -1,0 +1,75 @@
+package model
+
+import (
+	"fmt"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/bjarneo/cliamp/playlist"
+	"github.com/bjarneo/cliamp/provider"
+)
+
+type pagedAlbumBrowseProvider struct {
+	commandsTestProvider
+	albums []provider.AlbumInfo
+	calls  []int
+}
+
+func (p *pagedAlbumBrowseProvider) AlbumList(_ string, offset, size int) ([]provider.AlbumInfo, error) {
+	p.calls = append(p.calls, offset)
+	if offset >= len(p.albums) {
+		return nil, nil
+	}
+	end := min(len(p.albums), offset+size)
+	return append([]provider.AlbumInfo(nil), p.albums[offset:end]...), nil
+}
+
+func (*pagedAlbumBrowseProvider) AlbumSortTypes() []provider.SortType { return nil }
+func (*pagedAlbumBrowseProvider) DefaultAlbumSort() string            { return "" }
+
+func TestNavAlbumSearchLoadsRemainingPages(t *testing.T) {
+	albums := make([]provider.AlbumInfo, navAlbumPageSize*2+1)
+	for i := range navAlbumPageSize * 2 {
+		albums[i] = provider.AlbumInfo{ID: fmt.Sprintf("album-%03d", i), Name: fmt.Sprintf("Album %03d", i)}
+	}
+	albums[navAlbumPageSize*2] = provider.AlbumInfo{ID: "target", Name: "Needle Album"}
+
+	prov := &pagedAlbumBrowseProvider{
+		commandsTestProvider: commandsTestProvider{name: "Navidrome"},
+		albums:               albums,
+	}
+	m := Model{navBrowser: navBrowserState{
+		prov:      prov,
+		visible:   true,
+		mode:      navBrowseModeByAlbum,
+		screen:    navBrowseScreenList,
+		albums:    append([]provider.AlbumInfo(nil), albums[:navAlbumPageSize]...),
+		albumDone: false,
+	}}
+
+	cmd := m.handleNavBrowserKey(tea.KeyPressMsg{Text: "/"})
+	if cmd == nil {
+		t.Fatal("starting album search did not request the remaining pages")
+	}
+	m.handlePaste("needle")
+	if len(m.navBrowser.searchIdx) != 0 {
+		t.Fatalf("search matched %d albums before the remaining page loaded, want 0", len(m.navBrowser.searchIdx))
+	}
+
+	next, _ := m.Update(cmd())
+	m = next.(Model)
+	if len(m.navBrowser.albums) != len(albums) {
+		t.Fatalf("loaded albums = %d, want %d", len(m.navBrowser.albums), len(albums))
+	}
+	if len(m.navBrowser.searchIdx) != 1 || m.navBrowser.albums[m.navBrowser.searchIdx[0]].ID != "target" {
+		t.Fatalf("search results = %v, want target album", m.navBrowser.searchIdx)
+	}
+	wantCalls := []int{navAlbumPageSize, navAlbumPageSize * 2}
+	if len(prov.calls) != len(wantCalls) || prov.calls[0] != wantCalls[0] || prov.calls[1] != wantCalls[1] {
+		t.Fatalf("album page offsets = %v, want %v", prov.calls, wantCalls)
+	}
+}
+
+var _ playlist.Provider = (*pagedAlbumBrowseProvider)(nil)
+var _ provider.AlbumBrowser = (*pagedAlbumBrowseProvider)(nil)

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -430,6 +430,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.navBrowser.cursor = 0
 			m.navBrowser.scroll = 0
 		}
+		if m.navBrowser.search != "" {
+			m.navUpdateSearch()
+		}
 		// If we just loaded the first page and it was a full menu → list transition,
 		// also clear the general loading flag.
 		return m, nil


### PR DESCRIPTION
## Summary

Load the remaining paginated albums when `/` search starts in the global album browser, then refresh the filter against the complete list.

Fixes #355

## Screenshots / video

N/A

## How to test

1. Browse `By Album` on a provider with more than 100 albums.
2. Search for an album beyond the first loaded page.

## Checklist

- [x] `make check` passes
- [x] No docs/site update needed; this restores the existing album search behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Album search now loads additional album pages automatically, helping results include albums beyond the initially displayed list.
  - Search results refresh as new album data becomes available.

- **Bug Fixes**
  - Improved album search navigation by correctly handling loading states and pagination.

- **Tests**
  - Added coverage verifying album searches discover results across multiple pages and request subsequent pages correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->