### PR TITLE
feat(player): add optional MPV backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Download from [GitHub Releases](https://github.com/bjarneo/cliamp/releases/lates
 
 - [ffmpeg](https://ffmpeg.org/) — for AAC, ALAC, Opus, and WMA playback
 - [yt-dlp](https://github.com/yt-dlp/yt-dlp) — for YouTube, YouTube Music, SoundCloud, Bandcamp, Bilibili, and NetEase Cloud Music
+- [mpv](https://mpv.io/) — optional playback backend for direct ALSA output and bit-perfect-capable Linux setups
 
 On macOS: `brew install ffmpeg yt-dlp`. On Linux, use your distribution's package manager.
 
@@ -102,6 +103,15 @@ git clone https://github.com/bjarneo/cliamp.git && cd cliamp && go build -o clia
 cliamp ~/Music                     # play a directory
 cliamp *.mp3 *.flac               # play files
 cliamp https://example.com/stream  # play a URL
+```
+
+The native audio backend remains the default. Linux users can select the optional
+[MPV backend](docs/mpv.md) for direct ALSA playback:
+
+```sh
+cliamp --audio-backend mpv \
+  --audio-device 'alsa/hw:CARD=Generic,DEV=0' \
+  --bit-perfect ~/Music
 ```
 
 Press `Ctrl+K` to see all keybindings.

--- a/commands.go
+++ b/commands.go
@@ -43,7 +43,11 @@ func buildApp() *cli.Command {
 		&cli.IntFlag{Name: "buffer-ms", Usage: "speaker buffer in milliseconds (50-5000)", HideDefault: true},
 		&cli.IntFlag{Name: "resample-quality", Usage: "resample quality factor (1-4)", HideDefault: true},
 		&cli.IntFlag{Name: "bit-depth", Usage: "PCM bit depth: 16 or 32", HideDefault: true},
+		&cli.StringFlag{Name: "audio-backend", Usage: "audio backend: native or mpv"},
 		&cli.StringFlag{Name: "audio-device", Usage: "audio output device (use 'list' to show)"},
+		&cli.StringFlag{Name: "audio-reservation", Usage: "Linux ReserveDevice1 name for MPV (for example Audio2)"},
+		&cli.BoolFlag{Name: "bit-perfect", Usage: "lock MPV to unity volume, 1.0x speed, and no DSP"},
+		&cli.BoolFlag{Name: "no-bit-perfect", Usage: "disable configured MPV bit-perfect mode"},
 		&cli.StringFlag{Name: "playlist", Usage: "load a local TOML playlist by name and start playing"},
 		&cli.StringFlag{Name: "log-level", Usage: "log level: debug, info, warn, error"},
 		&cli.BoolFlag{Name: "expand-playlist", Usage: "expand YouTube Music playlists from list= URLs"},
@@ -59,12 +63,12 @@ func buildApp() *cli.Command {
 		EnableShellCompletion: true,
 		Flags:                 rootFlags,
 		Action: func(ctx context.Context, c *cli.Command) error {
-			if strings.EqualFold(c.String("audio-device"), "list") {
-				return listAudioDevices()
-			}
 			ov, err := overridesFromFlags(c)
 			if err != nil {
 				return err
+			}
+			if strings.EqualFold(c.String("audio-device"), "list") {
+				return listAudioDevices(ov)
 			}
 			return run(ov, c.Args().Slice(), c.Bool("daemon"), c.Bool("visualizer-60fps"))
 		},
@@ -102,8 +106,26 @@ func buildApp() *cli.Command {
 	}
 }
 
-func listAudioDevices() error {
-	devices, err := player.ListAudioDevices()
+func listAudioDevices(overrides config.Overrides) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	overrides.Apply(&cfg)
+	var devices []player.AudioDevice
+	switch cfg.AudioBackend {
+	case "native":
+		devices, err = player.ListAudioDevices()
+	case "mpv":
+		backend, startErr := player.NewMPVBackend(player.MPVOptions{})
+		if startErr != nil {
+			return startErr
+		}
+		defer backend.Close()
+		devices, err = backend.ListAudioDevices()
+	default:
+		return fmt.Errorf("audio_backend must be native or mpv (got %q)", cfg.AudioBackend)
+	}
 	if err != nil {
 		return err
 	}
@@ -199,6 +221,27 @@ func overridesFromFlags(c *cli.Command) (config.Overrides, error) {
 	if c.IsSet("audio-device") {
 		v := c.String("audio-device")
 		ov.AudioDevice = &v
+	}
+	if c.IsSet("audio-backend") {
+		v := strings.ToLower(strings.TrimSpace(c.String("audio-backend")))
+		switch v {
+		case "native", "mpv":
+			ov.AudioBackend = &v
+		default:
+			return ov, fmt.Errorf("--audio-backend must be native or mpv (got %q)", v)
+		}
+	}
+	if c.IsSet("audio-reservation") {
+		v := strings.TrimSpace(c.String("audio-reservation"))
+		ov.AudioReservation = &v
+	}
+	if c.IsSet("bit-perfect") {
+		v := true
+		ov.BitPerfect = &v
+	}
+	if c.IsSet("no-bit-perfect") {
+		v := false
+		ov.BitPerfect = &v
 	}
 	if c.IsSet("playlist") {
 		v := c.String("playlist")
@@ -698,6 +741,27 @@ func statusCommand() *cli.Command {
 				fmt.Printf("Position: %.0f / %.0f sec\n", resp.Position, resp.Duration)
 			}
 			fmt.Printf("Volume: %.0f dB\n", resp.Volume)
+			if resp.Backend != "" {
+				fmt.Printf("Backend: %s\n", strings.ToUpper(resp.Backend))
+			}
+			if resp.Device != "" {
+				fmt.Printf("Device: %s\n", resp.Device)
+			}
+			if resp.BitPerfect {
+				fmt.Println("Bit-perfect mode: enabled (not independently verified)")
+				if resp.DSPDisabled {
+					fmt.Println("DSP: disabled")
+				}
+				if resp.DirectALSA {
+					fmt.Println("Output path: direct ALSA")
+				}
+			}
+			if resp.SourceAudio != nil {
+				fmt.Printf("Source audio: %s\n", formatAudioInfo(*resp.SourceAudio))
+			}
+			if resp.OutputAudio != nil {
+				fmt.Printf("Output audio: %s\n", formatAudioInfo(*resp.OutputAudio))
+			}
 			if resp.Shuffle != nil {
 				if *resp.Shuffle {
 					fmt.Println("Shuffle: on")
@@ -724,6 +788,20 @@ func statusCommand() *cli.Command {
 			return nil
 		},
 	}
+}
+
+func formatAudioInfo(info ipc.AudioInfo) string {
+	parts := make([]string, 0, 3)
+	if info.Format != "" {
+		parts = append(parts, info.Format)
+	}
+	if info.SampleRate > 0 {
+		parts = append(parts, fmt.Sprintf("%.1f kHz", float64(info.SampleRate)/1000))
+	}
+	if info.Channels != "" {
+		parts = append(parts, info.Channels)
+	}
+	return strings.Join(parts, " / ")
 }
 
 func volumeCommand() *cli.Command {

--- a/config.toml.example
+++ b/config.toml.example
@@ -5,7 +5,7 @@
 # audio_backend = "native"
 # Exact MPV direct ALSA device example:
 # audio_device = "alsa/hw:CARD=Generic,DEV=0"
-# Optional Linux ReserveDevice1 name; requires pw-reserve:
+# Optional Linux ReserveDevice1 name; requires audio_backend = "mpv" and pw-reserve:
 # audio_reservation = "Audio2"
 # MPV-only unity-gain, 1.0x-speed, no-DSP mode. Requires an alsa/hw: device.
 # bit_perfect = false

--- a/config.toml.example
+++ b/config.toml.example
@@ -1,6 +1,15 @@
 # CLIAMP configuration
 # Copy to ~/.config/cliamp/config.toml
 
+# Playback backend: "native" (default) or "mpv"
+# audio_backend = "native"
+# Exact MPV direct ALSA device example:
+# audio_device = "alsa/hw:CARD=Generic,DEV=0"
+# Optional Linux ReserveDevice1 name; requires pw-reserve:
+# audio_reservation = "Audio2"
+# MPV-only unity-gain, 1.0x-speed, no-DSP mode. Requires an alsa/hw: device.
+# bit_perfect = false
+
 # Default volume in dB (range: volume_min to +6)
 volume = 0
 

--- a/config/audio_backend_test.go
+++ b/config/audio_backend_test.go
@@ -1,0 +1,107 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAudioBackendConfigParsing(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CLIAMP_CONFIG_DIR", dir)
+	data := []byte(`audio_backend = "mpv"
+audio_device = "alsa/hw:CARD=Generic,DEV=0"
+audio_reservation = "Audio2"
+bit_perfect = true
+volume = 0
+speed = 1.0
+eq_preset = "Flat"
+`)
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AudioBackend != "mpv" || cfg.AudioDevice != "alsa/hw:CARD=Generic,DEV=0" || cfg.AudioReservation != "Audio2" || !cfg.BitPerfect {
+		t.Fatalf("audio config = %+v", cfg)
+	}
+}
+
+func TestValidateAudio(t *testing.T) {
+	validMPV := defaultConfig()
+	validMPV.AudioBackend = "mpv"
+	validMPV.AudioDevice = "alsa/hw:CARD=Generic,DEV=0"
+	validMPV.BitPerfect = true
+
+	tests := []struct {
+		name    string
+		mutate  func(*Config)
+		wantErr string
+	}{
+		{name: "valid native"},
+		{name: "valid MPV bit-perfect", mutate: func(c *Config) { *c = validMPV }},
+		{name: "invalid backend", mutate: func(c *Config) { c.AudioBackend = "vlc" }, wantErr: "native or mpv"},
+		{name: "native bit-perfect", mutate: func(c *Config) { c.BitPerfect = true }, wantErr: "requires audio_backend"},
+		{name: "MPV mono", mutate: func(c *Config) { c.AudioBackend, c.Mono = "mpv", true }, wantErr: "mono is unsupported"},
+		{name: "MPV EQ", mutate: func(c *Config) { c.AudioBackend, c.EQPreset = "mpv", "Rock" }, wantErr: "EQ is unsupported"},
+		{name: "non-direct device", mutate: func(c *Config) { *c = validMPV; c.AudioDevice = "alsa/default" }, wantErr: "direct MPV ALSA device"},
+		{name: "volume conflict", mutate: func(c *Config) { *c = validMPV; c.Volume = -3 }, wantErr: "requires volume = 0"},
+		{name: "speed conflict", mutate: func(c *Config) { *c = validMPV; c.Speed = 1.25 }, wantErr: "requires speed = 1.0"},
+		{name: "native reservation", mutate: func(c *Config) { c.AudioReservation = "Audio2" }, wantErr: "audio_reservation requires"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := defaultConfig()
+			if test.mutate != nil {
+				test.mutate(&cfg)
+			}
+			err := cfg.ValidateAudio()
+			if test.wantErr == "" && err != nil {
+				t.Fatalf("ValidateAudio() = %v", err)
+			}
+			if test.wantErr != "" && (err == nil || !strings.Contains(err.Error(), test.wantErr)) {
+				t.Fatalf("ValidateAudio() = %v, want %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestAudioBackendOverrides(t *testing.T) {
+	cfg := defaultConfig()
+	backend := "mpv"
+	device := "alsa/hw:CARD=Generic,DEV=0"
+	reservation := "Audio2"
+	bitPerfect := true
+	Overrides{
+		AudioBackend:     &backend,
+		AudioDevice:      &device,
+		AudioReservation: &reservation,
+		BitPerfect:       &bitPerfect,
+	}.Apply(&cfg)
+	if err := cfg.ValidateAudio(); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AudioBackend != backend || cfg.AudioDevice != device || cfg.AudioReservation != reservation || !cfg.BitPerfect {
+		t.Fatalf("overridden config = %+v", cfg)
+	}
+}
+
+func TestAudioValidationRunsAfterOverrides(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CLIAMP_CONFIG_DIR", dir)
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte("audio_backend = \"mpv\"\nmono = true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend, mono := "native", false
+	Overrides{AudioBackend: &backend, Mono: &mono}.Apply(&cfg)
+	if err := cfg.ValidateAudio(); err != nil {
+		t.Fatalf("overridden config: %v", err)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -294,7 +294,10 @@ type Config struct {
 	Simplified       bool                         // simplified playback view: track summary and time strip
 	PaddingH         int                          // horizontal padding for the UI frame (default 3)
 	PaddingV         int                          // vertical padding for the UI frame (default 1)
+	AudioBackend     string                       // "native" (default) or "mpv"
 	AudioDevice      string                       // preferred audio output device name (empty = system default)
+	AudioReservation string                       // explicit ReserveDevice1 name (for example Audio2)
+	BitPerfect       bool                         // MPV direct-ALSA mode with DSP controls locked
 	Playlist         string                       // local TOML playlist name to load on startup
 	InitialDirectory string                       // initial directory for the file browser
 	Navidrome        NavidromeConfig              // optional Navidrome/Subsonic server credentials
@@ -331,6 +334,7 @@ func defaultConfig() Config {
 		BitDepth:        16,
 		PaddingH:        3,
 		PaddingV:        1,
+		AudioBackend:    "native",
 		Spotify:         SpotifyConfig{Bitrate: 320},
 		Qobuz:           QobuzConfig{Quality: 6},
 		LogLevel:        "info",
@@ -604,8 +608,14 @@ func Load() (Config, error) {
 				}
 			case "simplified":
 				cfg.Simplified = val == "true"
+			case "audio_backend":
+				cfg.AudioBackend = strings.ToLower(parseString(val))
 			case "audio_device":
 				cfg.AudioDevice = parseString(val)
+			case "audio_reservation":
+				cfg.AudioReservation = parseString(val)
+			case "bit_perfect":
+				cfg.BitPerfect = strings.ToLower(val) == "true"
 			case "initial_directory":
 				cfg.InitialDirectory = parseString(val)
 			case "padding_horizontal":
@@ -821,6 +831,10 @@ func (c Config) SeekStepLargeDuration() time.Duration {
 
 // clamp constrains all Config fields to their valid ranges.
 func (c *Config) clamp() {
+	c.AudioBackend = strings.ToLower(strings.TrimSpace(c.AudioBackend))
+	if c.AudioBackend == "" {
+		c.AudioBackend = "native"
+	}
 	c.VolumeMin = max(min(c.VolumeMin, 0), -90)
 	c.Volume = max(min(c.Volume, 6), c.VolumeMin)
 	if c.Speed < 0.25 || c.Speed > 2.0 {
@@ -836,6 +850,59 @@ func (c *Config) clamp() {
 	c.PaddingV = max(min(c.PaddingV, 5), 0)
 	if c.LowPower {
 		c.Visualizer = "none"
+	}
+}
+
+// ValidateAudio rejects backend/DSP combinations that cannot be honored.
+func (c Config) ValidateAudio() error {
+	switch c.AudioBackend {
+	case "native", "mpv":
+	default:
+		return fmt.Errorf("audio_backend must be native or mpv (got %q)", c.AudioBackend)
+	}
+	if c.AudioBackend != "mpv" {
+		if c.BitPerfect {
+			return errors.New("bit_perfect requires audio_backend = \"mpv\"")
+		}
+		if c.AudioReservation != "" {
+			return errors.New("audio_reservation requires audio_backend = \"mpv\"")
+		}
+		return nil
+	}
+	if c.Mono {
+		return errors.New("mono is unsupported with MPV backend")
+	}
+	if configUsesEQ(c) {
+		return errors.New("EQ is unsupported with MPV backend; use eq_preset = \"Flat\"")
+	}
+	if !c.BitPerfect {
+		return nil
+	}
+	if !strings.HasPrefix(c.AudioDevice, "alsa/hw:") {
+		return errors.New("bit_perfect requires a direct MPV ALSA device such as alsa/hw:CARD=Generic,DEV=0")
+	}
+	if c.Volume != 0 {
+		return fmt.Errorf("bit_perfect requires volume = 0 dB (got %.2f)", c.Volume)
+	}
+	if c.Speed != 1 {
+		return fmt.Errorf("bit_perfect requires speed = 1.0 (got %.2f)", c.Speed)
+	}
+	return nil
+}
+
+func configUsesEQ(c Config) bool {
+	switch strings.ToLower(strings.TrimSpace(c.EQPreset)) {
+	case "flat":
+		return false
+	case "", "custom":
+		for _, gain := range c.EQ {
+			if gain != 0 {
+				return true
+			}
+		}
+		return false
+	default:
+		return true
 	}
 }
 

--- a/config/flags.go
+++ b/config/flags.go
@@ -2,25 +2,28 @@ package config
 
 // Overrides holds CLI flag values. Nil pointers mean "not set".
 type Overrides struct {
-	Volume          *float64
-	Shuffle         *bool
-	Repeat          *string
-	Mono            *bool
-	Provider        *string
-	Theme           *string
-	Visualizer      *string
-	EQPreset        *string
-	SampleRate      *int
-	BufferMs        *int
-	ResampleQuality *int
-	BitDepth        *int
-	Play            *bool
-	Simplified      *bool
-	AudioDevice     *string
-	Playlist        *string
-	LogLevel        *string
-	LowPower        *bool
-	ExpandPlaylist  *bool
+	Volume           *float64
+	Shuffle          *bool
+	Repeat           *string
+	Mono             *bool
+	Provider         *string
+	Theme            *string
+	Visualizer       *string
+	EQPreset         *string
+	SampleRate       *int
+	BufferMs         *int
+	ResampleQuality  *int
+	BitDepth         *int
+	Play             *bool
+	Simplified       *bool
+	AudioBackend     *string
+	AudioDevice      *string
+	AudioReservation *string
+	BitPerfect       *bool
+	Playlist         *string
+	LogLevel         *string
+	LowPower         *bool
+	ExpandPlaylist   *bool
 }
 
 // Apply merges non-nil overrides into cfg and clamps the result.
@@ -72,6 +75,15 @@ func (o Overrides) Apply(cfg *Config) {
 	}
 	if o.Playlist != nil {
 		cfg.Playlist = *o.Playlist
+	}
+	if o.AudioBackend != nil {
+		cfg.AudioBackend = *o.AudioBackend
+	}
+	if o.AudioReservation != nil {
+		cfg.AudioReservation = *o.AudioReservation
+	}
+	if o.BitPerfect != nil {
+		cfg.BitPerfect = *o.BitPerfect
 	}
 	if o.LogLevel != nil {
 		cfg.LogLevel = *o.LogLevel

--- a/daemon.go
+++ b/daemon.go
@@ -34,16 +34,20 @@ const daemonControlQueueCapacity = 64
 
 // runDaemon runs cliamp without a TUI: serves IPC against the shared
 // player+playlist, auto-advances tracks, exits on SIGINT/SIGTERM.
-func runDaemon(p *player.Player, pl *playlist.Playlist, localProv *local.Provider, providers []model.ProviderEntry, autoPlay bool, eqPreset string) error {
+func runDaemon(p player.Engine, pl *playlist.Playlist, localProv *local.Provider, providers []model.ProviderEntry, autoPlay bool, eqPreset string) error {
 	fmt.Fprintf(os.Stderr, "cliamp: running headless (socket: %s)\n", ipc.DefaultSocketPath())
 	applog.Info("daemon: starting headless mode")
 
+	var vis *ui.Visualizer
+	if player.FeatureError(p, player.FeatureVisualizer) == nil {
+		vis = ui.NewVisualizer(float64(p.SampleRate()))
+	}
 	d := &daemon{
 		player:       p,
 		playlist:     pl,
 		localProv:    localProv,
 		providers:    providers,
-		vis:          ui.NewVisualizer(float64(p.SampleRate())),
+		vis:          vis,
 		historyStore: history.New(),
 		eqPreset:     eqPreset,
 		quit:         make(chan struct{}, 1),
@@ -214,7 +218,11 @@ func (d *daemon) handleMessage(msg any) {
 		}
 
 	case playback.SetVolumeMsg:
-		d.player.SetVolume(m.VolumeDB)
+		if err := player.FeatureError(d.player, player.FeatureVolume); err != nil {
+			applog.Warn("daemon: %v", err)
+		} else {
+			d.player.SetVolume(m.VolumeDB)
+		}
 
 	case playback.SeekMsg:
 		_ = d.player.Seek(m.Offset)
@@ -245,6 +253,10 @@ func (d *daemon) handleMessage(msg any) {
 		d.handleMono(m)
 
 	case ipc.SpeedMsg:
+		if err := player.FeatureError(d.player, player.FeatureSpeed); err != nil {
+			reply(m.Reply, ipc.Response{OK: false, Error: err.Error()})
+			break
+		}
 		d.player.SetSpeed(m.Speed)
 		reply(m.Reply, ipc.Response{OK: true, Speed: d.player.Speed()})
 
@@ -492,6 +504,10 @@ func (d *daemon) handleRepeat(m ipc.RepeatMsg) {
 }
 
 func (d *daemon) handleMono(m ipc.MonoMsg) {
+	if err := player.FeatureError(d.player, player.FeatureMono); err != nil {
+		reply(m.Reply, ipc.Response{OK: false, Error: err.Error()})
+		return
+	}
 	switch strings.ToLower(m.Name) {
 	case "on":
 		if !d.player.Mono() {
@@ -509,6 +525,10 @@ func (d *daemon) handleMono(m ipc.MonoMsg) {
 }
 
 func (d *daemon) handleEQ(m ipc.EQMsg) {
+	if err := player.FeatureError(d.player, player.FeatureEQ); err != nil {
+		reply(m.Reply, ipc.Response{OK: false, Error: err.Error()})
+		return
+	}
 	if m.Band > 0 || (m.Band == 0 && m.Name == "") {
 		d.player.SetEQBand(m.Band, m.Value)
 		d.eqPreset = "Custom"
@@ -533,7 +553,7 @@ func (d *daemon) handleEQ(m ipc.EQMsg) {
 
 func (d *daemon) handleDevice(m ipc.DeviceMsg) {
 	if strings.EqualFold(m.Name, "list") {
-		devices, err := player.ListAudioDevices()
+		devices, err := player.EngineAudioDevices(d.player)
 		if err != nil {
 			reply(m.Reply, ipc.Response{OK: false, Error: fmt.Sprintf("list devices: %v", err)})
 			return
@@ -552,7 +572,7 @@ func (d *daemon) handleDevice(m ipc.DeviceMsg) {
 		reply(m.Reply, ipc.Response{OK: true, Device: strings.Join(lines, "\n"), Devices: items})
 		return
 	}
-	if err := player.SwitchAudioDevice(m.Name); err != nil {
+	if err := player.SwitchEngineAudioDevice(d.player, m.Name); err != nil {
 		reply(m.Reply, ipc.Response{OK: false, Error: fmt.Sprintf("switch device: %v", err)})
 		return
 	}
@@ -1076,6 +1096,9 @@ func trackFromInfo(info ipc.TrackInfo) playlist.Track {
 // bandsResponse performs the same FFT analysis used by the interactive TUI so
 // V2 clients can render a real spectrum while cliamp runs headless.
 func (d *daemon) bandsResponse() ipc.Response {
+	if err := player.FeatureError(d.player, player.FeatureVisualizer); err != nil {
+		return ipc.Response{OK: false, Error: err.Error()}
+	}
 	if d.vis == nil {
 		return ipc.Response{OK: false, Error: "visualizer not available in headless mode"}
 	}

--- a/daemon_v2.go
+++ b/daemon_v2.go
@@ -54,6 +54,7 @@ type daemonRuntimeFingerprint struct {
 	eq               [10]float64
 	eqPreset         string
 	device           string
+	backend          player.BackendStatus
 	visualizer       string
 	streamTitle      string
 	streamError      string
@@ -676,6 +677,7 @@ func (d *daemon) runtimeFingerprintLocked() daemonRuntimeFingerprint {
 	fingerprint.mono = d.player.Mono()
 	fingerprint.speed = d.player.Speed()
 	fingerprint.eq = d.player.EQBands()
+	fingerprint.backend = player.EngineBackendStatus(d.player)
 	if d.vis != nil {
 		fingerprint.visualizer = d.vis.ModeName()
 	}

--- a/daemon_v2.go
+++ b/daemon_v2.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bjarneo/cliamp/internal/playback"
 	"github.com/bjarneo/cliamp/ipc"
+	"github.com/bjarneo/cliamp/player"
 	"github.com/bjarneo/cliamp/playlist"
 )
 
@@ -215,9 +216,15 @@ func (d *daemon) executeV2Operation(ctx context.Context, request ipc.V2Request) 
 	case "prev":
 		d.handleMessage(playback.PrevMsg{})
 	case "volume":
+		if err := player.FeatureError(d.player, player.FeatureVolume); err != nil {
+			return ipc.Response{OK: false, Error: err.Error()}, nil
+		}
 		d.handleMessage(playback.SetVolumeMsg{VolumeDB: params.Value})
 		return ipc.Response{OK: true, Volume: d.player.Volume()}, nil
 	case "volume.adjust":
+		if err := player.FeatureError(d.player, player.FeatureVolume); err != nil {
+			return ipc.Response{OK: false, Error: err.Error()}, nil
+		}
 		d.handleMessage(playback.SetVolumeMsg{VolumeDB: d.player.Volume() + params.Value})
 		return ipc.Response{OK: true, Volume: d.player.Volume()}, nil
 	case "seek":
@@ -564,10 +571,26 @@ func (d *daemon) runtimeSnapshotLocked() ipc.RuntimeSnapshot {
 	mono := d.player.Mono()
 	snapshot.Mono = &mono
 	snapshot.Speed = d.player.Speed()
-	snapshot.EQPreset = d.eqPreset
-	bands := d.player.EQBands()
-	snapshot.EQBands = append([]float64(nil), bands[:]...)
-	if d.vis != nil {
+	backend := player.EngineBackendStatus(d.player)
+	snapshot.Backend = backend.Name
+	if backend.Device != "" {
+		snapshot.Device = backend.Device
+	}
+	snapshot.BitPerfect = backend.BitPerfectMode
+	snapshot.DSPDisabled = backend.DSPDisabled
+	snapshot.DirectALSA = backend.DirectALSA
+	if backend.Source != (player.AudioParameters{}) {
+		snapshot.SourceAudio = &ipc.AudioInfo{Format: backend.Source.Format, SampleRate: backend.Source.SampleRate, Channels: backend.Source.Channels}
+	}
+	if backend.Output != (player.AudioParameters{}) {
+		snapshot.OutputAudio = &ipc.AudioInfo{Format: backend.Output.Format, SampleRate: backend.Output.SampleRate, Channels: backend.Output.Channels}
+	}
+	if player.FeatureError(d.player, player.FeatureEQ) == nil {
+		snapshot.EQPreset = d.eqPreset
+		bands := d.player.EQBands()
+		snapshot.EQBands = append([]float64(nil), bands[:]...)
+	}
+	if d.vis != nil && player.FeatureError(d.player, player.FeatureVisualizer) == nil {
 		snapshot.Visualizer = d.vis.ModeName()
 	}
 	if err := d.player.StreamErr(); err != nil {

--- a/daemon_v2_test.go
+++ b/daemon_v2_test.go
@@ -24,6 +24,7 @@ type daemonV2Engine struct {
 	speed    float64
 	mono     bool
 	eq       [10]float64
+	backend  player.BackendStatus
 }
 
 func (e *daemonV2Engine) Play(string, time.Duration) error {
@@ -48,8 +49,11 @@ func (e *daemonV2Engine) Volume() float64         { return e.volume }
 func (e *daemonV2Engine) Speed() float64          { return e.speed }
 func (e *daemonV2Engine) Mono() bool              { return e.mono }
 func (e *daemonV2Engine) EQBands() [10]float64    { return e.eq }
-func (*daemonV2Engine) StreamTitle() string       { return "" }
-func (*daemonV2Engine) StreamErr() error          { return nil }
+func (e *daemonV2Engine) BackendStatus() player.BackendStatus {
+	return e.backend
+}
+func (*daemonV2Engine) StreamTitle() string { return "" }
+func (*daemonV2Engine) StreamErr() error    { return nil }
 func (e *daemonV2Engine) PositionAndDuration() (time.Duration, time.Duration) {
 	return e.position, e.duration
 }
@@ -82,6 +86,21 @@ func newDaemonV2TestDaemon() (*daemon, *daemonV2Engine) {
 	)
 	pl.Queue(1)
 	return &daemon{player: engine, playlist: pl, eqPreset: "Custom", runtimeRevision: 9}, engine
+}
+
+func TestDaemonRuntimeFingerprintIncludesBackendStatus(t *testing.T) {
+	d, engine := newDaemonV2TestDaemon()
+	engine.backend = player.BackendStatus{
+		Name:   "mpv",
+		Device: "alsa/hw:CARD=Generic,DEV=0",
+		Output: player.AudioParameters{Format: "s32", SampleRate: 48000, Channels: "stereo"},
+	}
+	before := d.runtimeFingerprintLocked()
+	engine.backend.Output.SampleRate = 96000
+	after := d.runtimeFingerprintLocked()
+	if before == after {
+		t.Fatal("backend status change did not change runtime fingerprint")
+	}
 }
 
 func TestDaemonV2StateSnapshot(t *testing.T) {

--- a/docs/audio-quality.md
+++ b/docs/audio-quality.md
@@ -2,6 +2,10 @@
 
 cliamp lets you tune the output sample rate, speaker buffer size, resample quality, and bit depth via `~/.config/cliamp/config.toml`. The active settings are shown in the `OUT` status line below the EQ.
 
+These controls apply to the default native backend. The optional
+[MPV backend](mpv.md) leaves format and sample-rate negotiation to MPV and the
+output device.
+
 ## Configuration
 
 Add any of these to your config file:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,11 +17,24 @@ cliamp --playlist "Blade Runner"      # load a local TOML playlist (add --auto-p
 ## Audio engine
 
 ```sh
+cliamp --audio-backend native ~/Music         # default native backend
+cliamp --audio-backend mpv track.flac         # persistent MPV JSON-IPC backend
+cliamp --audio-backend mpv --audio-device list # list MPV output devices
+cliamp --audio-backend mpv \
+  --audio-device 'alsa/hw:CARD=Generic,DEV=0' \
+  --bit-perfect track.flac                    # direct ALSA, unity gain, no DSP
+cliamp --audio-backend mpv \
+  --audio-reservation Audio2 track.flac       # optional Linux PipeWire reservation
 cliamp --sample-rate 48000 track.mp3      # output sample rate (22050, 44100, 48000, 96000, 192000)
 cliamp --buffer-ms 2000 track.mp3         # speaker buffer in ms (50-5000; useful for unstable radio)
 cliamp --resample-quality 1 track.mp3     # resample quality factor (1–4)
 cliamp --bit-depth 32 track.m4a           # PCM bit depth: 16 (default) or 32 (lossless)
 ```
+
+`--sample-rate`, `--buffer-ms`, `--resample-quality`, and `--bit-depth` are
+native-backend controls. MPV mode leaves format and sample-rate negotiation to
+MPV and the selected output device. See [MPV backend](mpv.md) for requirements,
+limitations, PipeWire reservation, and the Linux verification procedure.
 
 ## Appearance
 
@@ -129,6 +142,10 @@ cliamp track.mp3 --repeat all --mono ~/Music
 | `--visualizer-60fps` | bool | false | render a visible visualizer at roughly 60 FPS |
 | `--start-theme` | string | | theme name |
 | `--eq-preset` | string | | preset name |
+| `--audio-backend` | string | native | native, mpv |
+| `--audio-device` | string | | native device name or exact MPV device string |
+| `--audio-reservation` | string | | Linux ReserveDevice1 name, for example Audio2 |
+| `--bit-perfect` / `--no-bit-perfect` | bool | false | MPV only; unity gain, 1.0x speed, no DSP |
 | `--sample-rate` | int | 44100 | 22050, 44100, 48000, 96000, 192000 |
 | `--buffer-ms` | int | 250 | 50-5000 |
 | `--resample-quality` | int | 4 | 1–4 |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,6 +24,7 @@ cliamp --audio-backend mpv \
   --audio-device 'alsa/hw:CARD=Generic,DEV=0' \
   --bit-perfect track.flac                    # direct ALSA, unity gain, no DSP
 cliamp --audio-backend mpv \
+  --audio-device 'alsa/hw:CARD=Generic,DEV=0' \
   --audio-reservation Audio2 track.flac       # optional Linux PipeWire reservation
 cliamp --sample-rate 48000 track.mp3      # output sample rate (22050, 44100, 48000, 96000, 192000)
 cliamp --buffer-ms 2000 track.mp3         # speaker buffer in ms (50-5000; useful for unstable radio)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,6 +29,20 @@ cp config.toml.example ~/.config/cliamp/config.toml
 ## Options
 
 ```toml
+# Playback backend: "native" (default) or "mpv"
+audio_backend = "native"
+
+# Exact output-device name. MPV direct ALSA example:
+# audio_device = "alsa/hw:CARD=Generic,DEV=0"
+
+# Optional Linux ReserveDevice1 name. Requires MPV and pw-reserve.
+# audio_reservation = "Audio2"
+
+# MPV only. Requires a direct alsa/hw: device, volume=0, speed=1.0,
+# flat EQ, and stereo output. This enables a bit-perfect-capable path;
+# hardware and driver behavior must still be verified.
+bit_perfect = false
+
 # Default volume in dB (range: volume_min to 6)
 volume = 0
 
@@ -91,6 +105,9 @@ theme = "Tokyo Night"
 log_level = "info"
 
 ```
+
+MPV mode disables cliamp's EQ, mono conversion, visualizer, gapless preloading,
+and native resampler/bit-depth controls. See [MPV backend](mpv.md).
 
 `Stereo` shows true left/right horizontal LED meters with held peak markers.
 

--- a/docs/mpv.md
+++ b/docs/mpv.md
@@ -1,0 +1,179 @@
+# MPV playback backend
+
+cliamp can use one persistent [MPV](https://mpv.io/) process as an optional
+playback backend. The native backend remains the default and is unchanged.
+cliamp still owns the playlist, queue, repeat, shuffle, next/previous, metadata,
+TUI, daemon, and remote-control state. MPV receives one track at a time over its
+newline-delimited JSON IPC socket.
+
+## Install and run
+
+Install `mpv` with your operating system's package manager and keep it on
+`PATH`. cliamp does not silently fall back to native playback if MPV is missing
+or fails to start.
+
+```sh
+cliamp --audio-backend native ~/Music
+
+cliamp \
+  --audio-backend mpv \
+  --audio-device 'alsa/hw:CARD=Generic,DEV=0' \
+  --bit-perfect \
+  ~/Music
+```
+
+Equivalent persistent configuration:
+
+```toml
+audio_backend = "mpv"
+audio_device = "alsa/hw:CARD=Generic,DEV=0"
+bit_perfect = true
+```
+
+MPV receives the `audio_device` value exactly. cliamp does not convert `hw:` to
+`default`, PipeWire, PulseAudio, or `plughw:`.
+
+## What bit-perfect mode means
+
+`bit_perfect = true` configures a bit-perfect-capable path. It:
+
+- requires an explicit direct MPV ALSA device beginning with `alsa/hw:`;
+- locks software volume to 0 dB / MPV volume 100;
+- locks speed to 1.0x;
+- disables MPV configuration files, audio filters, ReplayGain, pitch
+  correction, and normalization;
+- rejects mono and non-flat EQ configuration;
+- does not force an output rate or PCM format, so MPV and ALSA can negotiate
+  each source natively.
+
+cliamp intentionally does not force `S16_LE`, `S24_LE`, or a fixed sample rate.
+24-bit audio carried as `S32_LE` is normal for hardware such as HDA codecs.
+
+"Bit-perfect mode enabled" is configuration status, not proof of the complete
+hardware path. Mixer controls, ALSA plugins, drivers, firmware, and the DAC are
+outside cliamp. Confirm that source and output rates match and inspect MPV/ALSA
+logs before claiming end-to-end bit-perfect output.
+
+Conflicting startup configuration is rejected with a clear error. While this
+mode is active, volume, speed, EQ, and mono changes from the TUI, daemon, IPC,
+MPRIS, or Lua plugins are rejected or ignored with a warning.
+
+## PipeWire reservation on Linux
+
+PipeWire may own the ALSA PCM node and prevent MPV from opening `hw:`. cliamp
+never kills PipeWire or stops its services. You can release the card manually:
+
+```sh
+pw-reserve -n Audio2 -r
+```
+
+Or ask cliamp to own that helper for its process lifetime:
+
+```sh
+cliamp --audio-backend mpv \
+  --audio-device 'alsa/hw:CARD=Generic,DEV=0' \
+  --audio-reservation Audio2 \
+  ~/Music
+```
+
+Persistent configuration:
+
+```toml
+audio_reservation = "Audio2"
+```
+
+This optional feature is Linux-only and requires `pw-reserve` on `PATH`.
+Reservation names follow the `AudioN` convention, but the mapping from an ALSA
+card name such as `Generic` to `Audio2` is not reliably derivable. cliamp
+therefore requires the explicit reservation name and makes no guess. The helper
+is terminated and the reservation released when cliamp exits.
+
+## Unsupported MPV-mode features
+
+The first implementation deliberately reports these as unavailable rather than
+faking them:
+
+- cliamp EQ and mono conversion;
+- PCM visualizers and plugin visualizers;
+- native sample-rate, resampler-quality, bit-depth, and speaker-buffer controls;
+- gapless preloading;
+- Spotify playback through cliamp's native Spotify engine;
+- provider sources that require cliamp's segmented native decoder.
+
+Normal MPV mode supports MPV software volume and playback speed. Bit-perfect
+mode locks both. Local files, direct URLs, and MPV-supported yt-dlp URLs use MPV.
+Provider browsing, playlists, queueing, shuffle, repeat, metadata, TUI controls,
+daemon control, and JSON IPC remain owned by cliamp.
+
+## Status and logs
+
+The track-information overlay and `cliamp status` expose the backend, configured
+device, source/output format and rate when MPV reports them, DSP-disabled state,
+and whether the observed output is direct ALSA. This status avoids an
+unqualified `BIT PERFECT` claim.
+
+Set `--log-level debug` to record the MPV command line, IPC connection and
+requests, MPV errors, file and end events, audio parameters, shutdown, and
+reservation lifetime in `~/.config/cliamp/cliamp.log`.
+
+## Manual Linux verification
+
+1. Find the card and device:
+
+   ```sh
+   aplay -l
+   ```
+
+2. If PipeWire owns the target, reserve it in a second terminal. For the
+   example machine:
+
+   ```sh
+   pw-reserve -n Audio2 -r
+   ```
+
+3. Confirm no process owns the PCM node:
+
+   ```sh
+   fuser -v /dev/snd/pcmC2D0p
+   ```
+
+   Expected: no process.
+
+4. Test MPV directly:
+
+   ```sh
+   mpv -v \
+     --audio-device='alsa/hw:CARD=Generic,DEV=0' \
+     --no-video \
+     song.flac
+   ```
+
+   A 48 kHz, 24-bit file may correctly report:
+
+   ```text
+   requested format: 48000 Hz, stereo channels, s32
+   opening device 'hw:CARD=Generic,DEV=0'
+   AO: [alsa] 48000Hz stereo 2ch s32
+   ```
+
+5. Test cliamp:
+
+   ```sh
+   cliamp \
+     --audio-backend mpv \
+     --audio-device 'alsa/hw:CARD=Generic,DEV=0' \
+     --bit-perfect \
+     song.flac
+   ```
+
+6. Verify TUI playback, pause/resume, seeking, next/previous, queue changes,
+   duration/position, repeat, shuffle, and end-of-track advancement. Test
+   `16/44.1`, `16/48`, `24/44.1`, `24/48`, `24/96`, and `24/192` files. Confirm
+   the output rate follows each source instead of being forced to 192 kHz.
+
+7. Exit cliamp. Confirm MPV, the runtime socket, and any `pw-reserve` helper are
+   gone, then confirm PipeWire can reclaim the card.
+
+The MPV IPC and audio-device syntax used here follow the
+[official MPV manual](https://mpv.io/manual/stable/). The reservation helper is
+documented by [PipeWire](https://docs.pipewire.org/page_man_pw-reserve_1.html).

--- a/docs/remote-control.md
+++ b/docs/remote-control.md
@@ -68,7 +68,7 @@ playlist writes, remains asynchronous.
 
 `state.get` returns a snapshot containing the active audio track, logical
 playlist track, current playback state, position, duration, seekability, modes,
-EQ, visualizer, theme, stream error, and two revisions.
+backend/output diagnostics, EQ, visualizer, theme, stream error, and two revisions.
 
 ```json
 {

--- a/ipc/protocol.go
+++ b/ipc/protocol.go
@@ -37,37 +37,50 @@ type Request struct {
 // Response is the operation-specific data embedded in a successful V2 job.
 // V2Response and Job carry protocol success and failure state.
 type Response struct {
-	OK         bool           `json:"ok"`
-	Error      string         `json:"error,omitempty"`
-	State      string         `json:"state,omitempty"`
-	Track      *TrackInfo     `json:"track,omitempty"`
-	Position   float64        `json:"position,omitempty"`
-	Duration   float64        `json:"duration,omitempty"`
-	Volume     float64        `json:"volume,omitempty"`
-	Playlist   string         `json:"playlist,omitempty"`
-	Index      int            `json:"index,omitempty"`
-	Total      int            `json:"total,omitempty"`
-	Visualizer string         `json:"visualizer,omitempty"`
-	Shuffle    *bool          `json:"shuffle,omitempty"`
-	Repeat     string         `json:"repeat,omitempty"`
-	Mono       *bool          `json:"mono,omitempty"`
-	Speed      float64        `json:"speed,omitempty"`
-	EQPreset   string         `json:"eq_preset,omitempty"`
-	Device     string         `json:"device,omitempty"`
-	Output     string         `json:"output,omitempty"`
-	Items      []string       `json:"items,omitempty"`
-	Theme      *ThemeInfo     `json:"theme,omitempty"`
-	Bands      []float64      `json:"bands,omitempty"`
-	EQBands    []float64      `json:"eq_bands,omitempty"`
-	Tracks     []TrackInfo    `json:"tracks,omitempty"`
-	Playlists  []PlaylistInfo `json:"playlists,omitempty"`
-	Providers  []ProviderInfo `json:"providers,omitempty"`
-	Artists    []ArtistInfo   `json:"artists,omitempty"`
-	Albums     []AlbumInfo    `json:"albums,omitempty"`
-	Sorts      []SortInfo     `json:"sorts,omitempty"`
-	Lyrics     []LyricLine    `json:"lyrics,omitempty"`
-	History    []HistoryInfo  `json:"history,omitempty"`
-	Devices    []DeviceInfo   `json:"devices,omitempty"`
+	OK          bool           `json:"ok"`
+	Error       string         `json:"error,omitempty"`
+	State       string         `json:"state,omitempty"`
+	Track       *TrackInfo     `json:"track,omitempty"`
+	Position    float64        `json:"position,omitempty"`
+	Duration    float64        `json:"duration,omitempty"`
+	Volume      float64        `json:"volume,omitempty"`
+	Playlist    string         `json:"playlist,omitempty"`
+	Index       int            `json:"index,omitempty"`
+	Total       int            `json:"total,omitempty"`
+	Visualizer  string         `json:"visualizer,omitempty"`
+	Shuffle     *bool          `json:"shuffle,omitempty"`
+	Repeat      string         `json:"repeat,omitempty"`
+	Mono        *bool          `json:"mono,omitempty"`
+	Speed       float64        `json:"speed,omitempty"`
+	EQPreset    string         `json:"eq_preset,omitempty"`
+	Device      string         `json:"device,omitempty"`
+	Backend     string         `json:"backend,omitempty"`
+	BitPerfect  bool           `json:"bit_perfect_mode,omitempty"`
+	DSPDisabled bool           `json:"dsp_disabled,omitempty"`
+	DirectALSA  bool           `json:"direct_alsa,omitempty"`
+	SourceAudio *AudioInfo     `json:"source_audio,omitempty"`
+	OutputAudio *AudioInfo     `json:"output_audio,omitempty"`
+	Output      string         `json:"output,omitempty"`
+	Items       []string       `json:"items,omitempty"`
+	Theme       *ThemeInfo     `json:"theme,omitempty"`
+	Bands       []float64      `json:"bands,omitempty"`
+	EQBands     []float64      `json:"eq_bands,omitempty"`
+	Tracks      []TrackInfo    `json:"tracks,omitempty"`
+	Playlists   []PlaylistInfo `json:"playlists,omitempty"`
+	Providers   []ProviderInfo `json:"providers,omitempty"`
+	Artists     []ArtistInfo   `json:"artists,omitempty"`
+	Albums      []AlbumInfo    `json:"albums,omitempty"`
+	Sorts       []SortInfo     `json:"sorts,omitempty"`
+	Lyrics      []LyricLine    `json:"lyrics,omitempty"`
+	History     []HistoryInfo  `json:"history,omitempty"`
+	Devices     []DeviceInfo   `json:"devices,omitempty"`
+}
+
+// AudioInfo describes source or audio-output parameters reported by a backend.
+type AudioInfo struct {
+	Format     string `json:"format,omitempty"`
+	SampleRate int    `json:"sample_rate,omitempty"`
+	Channels   string `json:"channels,omitempty"`
 }
 
 // ThemeInfo carries the active theme name and its resolved hex colors.

--- a/ipc/v2.go
+++ b/ipc/v2.go
@@ -125,6 +125,12 @@ type RuntimeSnapshot struct {
 	EQPreset         string     `json:"eq_preset,omitempty"`
 	EQBands          []float64  `json:"eq_bands,omitempty"`
 	Device           string     `json:"device,omitempty"`
+	Backend          string     `json:"backend,omitempty"`
+	BitPerfect       bool       `json:"bit_perfect_mode,omitempty"`
+	DSPDisabled      bool       `json:"dsp_disabled,omitempty"`
+	DirectALSA       bool       `json:"direct_alsa,omitempty"`
+	SourceAudio      *AudioInfo `json:"source_audio,omitempty"`
+	OutputAudio      *AudioInfo `json:"output_audio,omitempty"`
 	Visualizer       string     `json:"visualizer,omitempty"`
 	Theme            *ThemeInfo `json:"theme,omitempty"`
 	StreamError      string     `json:"stream_error,omitempty"`
@@ -192,6 +198,14 @@ func cloneSnapshot(snapshot *RuntimeSnapshot) *RuntimeSnapshot {
 	if snapshot.Theme != nil {
 		theme := *snapshot.Theme
 		snapshotCopy.Theme = &theme
+	}
+	if snapshot.SourceAudio != nil {
+		source := *snapshot.SourceAudio
+		snapshotCopy.SourceAudio = &source
+	}
+	if snapshot.OutputAudio != nil {
+		output := *snapshot.OutputAudio
+		snapshotCopy.OutputAudio = &output
 	}
 	return &snapshotCopy
 }

--- a/main.go
+++ b/main.go
@@ -296,8 +296,6 @@ func run(overrides config.Overrides, positional []string, daemon, visualizer60FP
 			AudioReservation: cfg.AudioReservation,
 			BitPerfect:       cfg.BitPerfect,
 		})
-		cfg.Visualizer = "none"
-		applog.UserWarn("MPV backend: EQ, mono, visualizer, gapless preload, and native audio-quality controls are unavailable")
 	default:
 		if cfg.AudioDevice != "" {
 			cleanup := player.PrepareAudioDevice(cfg.AudioDevice)
@@ -320,6 +318,10 @@ func run(overrides config.Overrides, positional []string, daemon, visualizer60FP
 	}
 	if err != nil {
 		return fmt.Errorf("player: %w", err)
+	}
+	if cfg.AudioBackend == "mpv" {
+		cfg.Visualizer = "none"
+		applog.UserWarn("MPV backend: EQ, mono, visualizer, gapless preload, and native audio-quality controls are unavailable")
 	}
 	defer p.Close()
 
@@ -474,7 +476,7 @@ func run(overrides config.Overrides, positional []string, daemon, visualizer60FP
 		}
 	}
 
-	progOpts := []tea.ProgramOption{tea.WithFPS(defaultUIFPS)}
+	progOpts := []tea.ProgramOption{tea.WithFPS(defaultUIFPS), tea.WithoutSignalHandler()}
 	if cfg.LowPower {
 		progOpts[0] = tea.WithFPS(lowPowerUIFPS)
 	}

--- a/main.go
+++ b/main.go
@@ -6,8 +6,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -57,6 +59,9 @@ func run(overrides config.Overrides, positional []string, daemon, visualizer60FP
 		return fmt.Errorf("config: %w", err)
 	}
 	overrides.Apply(&cfg)
+	if err := cfg.ValidateAudio(); err != nil {
+		return fmt.Errorf("audio configuration: %w", err)
+	}
 
 	closeLog, appliedLevel, logErr := initLogging(cfg.LogLevel)
 	defer closeLog()
@@ -283,57 +288,75 @@ func run(overrides config.Overrides, positional []string, daemon, visualizer60FP
 		pl.Add(remote...)
 	}
 
-	if cfg.AudioDevice != "" {
-		cleanup := player.PrepareAudioDevice(cfg.AudioDevice)
-		defer cleanup()
-	}
-
-	sampleRate := cfg.SampleRate
-	if sampleRate == 0 {
-		if detected := player.DeviceSampleRate(); detected > 0 {
-			sampleRate = detected
-		} else {
-			sampleRate = 44100
+	var p player.Engine
+	switch cfg.AudioBackend {
+	case "mpv":
+		p, err = player.NewMPVBackend(player.MPVOptions{
+			AudioDevice:      cfg.AudioDevice,
+			AudioReservation: cfg.AudioReservation,
+			BitPerfect:       cfg.BitPerfect,
+		})
+		cfg.Visualizer = "none"
+		applog.UserWarn("MPV backend: EQ, mono, visualizer, gapless preload, and native audio-quality controls are unavailable")
+	default:
+		if cfg.AudioDevice != "" {
+			cleanup := player.PrepareAudioDevice(cfg.AudioDevice)
+			defer cleanup()
 		}
+		sampleRate := cfg.SampleRate
+		if sampleRate == 0 {
+			if detected := player.DeviceSampleRate(); detected > 0 {
+				sampleRate = detected
+			} else {
+				sampleRate = 44100
+			}
+		}
+		p, err = player.New(player.Quality{
+			SampleRate:      sampleRate,
+			BufferMs:        cfg.BufferMs,
+			ResampleQuality: cfg.ResampleQuality,
+			BitDepth:        cfg.BitDepth,
+		})
 	}
-
-	p, err := player.New(player.Quality{
-		SampleRate:      sampleRate,
-		BufferMs:        cfg.BufferMs,
-		ResampleQuality: cfg.ResampleQuality,
-		BitDepth:        cfg.BitDepth,
-	})
 	if err != nil {
 		return fmt.Errorf("player: %w", err)
 	}
 	defer p.Close()
 
 	if spotifyProv != nil {
-		p.RegisterStreamerFactory("spotify:", spotifyProv.NewStreamer)
+		if native, ok := p.(*player.Player); ok {
+			native.RegisterStreamerFactory("spotify:", spotifyProv.NewStreamer)
+		}
 	}
 
 	if tidalProv != nil {
 		// Tidal tracks carry tidal:// URIs; the provider resolves them to a
 		// fresh signed URL or DASH segment list when playback starts.
-		p.RegisterSourceResolver(tidal.TrackURIPrefix, func(uri string) (player.ResolvedSource, error) {
-			u, segments, err := tidalProv.ResolveSource(uri)
-			return player.ResolvedSource{URL: u, Segments: segments}, err
-		})
+		if registrar, ok := p.(interface {
+			RegisterSourceResolver(string, player.SourceResolver)
+		}); ok {
+			registrar.RegisterSourceResolver(tidal.TrackURIPrefix, func(uri string) (player.ResolvedSource, error) {
+				u, segments, err := tidalProv.ResolveSource(uri)
+				return player.ResolvedSource{URL: u, Segments: segments}, err
+			})
+		}
 	}
 
-	p.RegisterBufferedURLMatcher(func(u string) bool {
-		return navidrome.IsSubsonicStreamURL(u) || jellyfin.IsStreamURL(u) || emby.IsStreamURL(u) || plex.IsStreamURL(u) || qobuz.IsStreamURL(u) || tidal.IsStreamURL(u) || audiobookshelf.IsStreamURL(u)
-	})
+	if native, ok := p.(*player.Player); ok {
+		native.RegisterBufferedURLMatcher(func(u string) bool {
+			return navidrome.IsSubsonicStreamURL(u) || jellyfin.IsStreamURL(u) || emby.IsStreamURL(u) || plex.IsStreamURL(u) || qobuz.IsStreamURL(u) || tidal.IsStreamURL(u) || audiobookshelf.IsStreamURL(u)
+		})
 
-	// Pull now-playing for stations that carry no inline ICY metadata (NTS, FIP).
-	p.RegisterStreamMetadataResolver(radiometa.Resolver)
+		// Pull now-playing for stations that carry no inline ICY metadata (NTS, FIP).
+		native.RegisterStreamMetadataResolver(radiometa.Resolver)
+	}
 
 	cfg.ApplyPlayer(p)
 	cfg.ApplyPlaylist(pl)
 	ui.SetPadding(cfg.PaddingH, cfg.PaddingV)
 
 	if daemon {
-		if cfg.EQPreset != "" && cfg.EQPreset != "Custom" {
+		if player.FeatureError(p, player.FeatureEQ) == nil && cfg.EQPreset != "" && cfg.EQPreset != "Custom" {
 			if preset, ok := model.EQPresetByName(cfg.EQPreset); ok {
 				for i, gain := range preset.Bands {
 					p.SetEQBand(i, gain)
@@ -426,7 +449,7 @@ func run(overrides config.Overrides, positional []string, daemon, visualizer60FP
 	if len(resolved.Tracks) == 0 && len(resolved.Pending) == 0 && pl.Len() == 0 {
 		m.StartInProvider()
 	}
-	if cfg.EQPreset != "" && cfg.EQPreset != "Custom" {
+	if player.FeatureError(p, player.FeatureEQ) == nil && cfg.EQPreset != "" && cfg.EQPreset != "Custom" {
 		m.SetEQPreset(cfg.EQPreset, nil)
 	}
 	if cfg.Theme != "" {
@@ -456,6 +479,18 @@ func run(overrides config.Overrides, positional []string, daemon, visualizer60FP
 		progOpts[0] = tea.WithFPS(lowPowerUIFPS)
 	}
 	prog := tea.NewProgram(m, progOpts...)
+	signalCh := make(chan os.Signal, 1)
+	signalDone := make(chan struct{})
+	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(signalCh)
+	defer close(signalDone)
+	go func() {
+		select {
+		case <-signalCh:
+			prog.Send(playback.QuitMsg{})
+		case <-signalDone:
+		}
+	}()
 
 	if spotifyProv != nil {
 		spotify.SetAuthURLObserver(func(u string) {
@@ -485,10 +520,28 @@ func run(overrides config.Overrides, positional []string, daemon, visualizer60FP
 
 	if luaMgr != nil {
 		luaMgr.SetControlProvider(luaplugin.ControlProvider{
-			SetVolume:   func(db float64) { p.SetVolume(db) },
-			SetSpeed:    func(ratio float64) { p.SetSpeed(ratio) },
-			SetEQBand:   func(band int, db float64) { prog.Send(model.SetEQBandMsg{Band: band, Gain: db}) },
-			ToggleMono:  func() { p.ToggleMono() },
+			SetVolume: func(db float64) {
+				if err := player.FeatureError(p, player.FeatureVolume); err != nil {
+					applog.UserWarn("%v", err)
+					return
+				}
+				p.SetVolume(db)
+			},
+			SetSpeed: func(ratio float64) {
+				if err := player.FeatureError(p, player.FeatureSpeed); err != nil {
+					applog.UserWarn("%v", err)
+					return
+				}
+				p.SetSpeed(ratio)
+			},
+			SetEQBand: func(band int, db float64) { prog.Send(model.SetEQBandMsg{Band: band, Gain: db}) },
+			ToggleMono: func() {
+				if err := player.FeatureError(p, player.FeatureMono); err != nil {
+					applog.UserWarn("%v", err)
+					return
+				}
+				p.ToggleMono()
+			},
 			TogglePause: func() { p.TogglePause() },
 			Stop:        func() { p.Stop() },
 			Seek: func(secs float64) {
@@ -743,23 +796,30 @@ func ipcState() (ipc.RuntimeSnapshot, error) {
 
 func stateResult(snapshot ipc.RuntimeSnapshot) ipc.Response {
 	return ipc.Response{
-		OK:         true,
-		State:      snapshot.State,
-		Track:      snapshot.Track,
-		Position:   snapshot.Position,
-		Duration:   snapshot.Duration,
-		Volume:     snapshot.Volume,
-		Playlist:   snapshot.Playlist,
-		Index:      snapshot.Index,
-		Total:      snapshot.Total,
-		Visualizer: snapshot.Visualizer,
-		Shuffle:    snapshot.Shuffle,
-		Repeat:     snapshot.Repeat,
-		Mono:       snapshot.Mono,
-		Speed:      snapshot.Speed,
-		EQPreset:   snapshot.EQPreset,
-		Theme:      snapshot.Theme,
-		EQBands:    snapshot.EQBands,
+		OK:          true,
+		State:       snapshot.State,
+		Track:       snapshot.Track,
+		Position:    snapshot.Position,
+		Duration:    snapshot.Duration,
+		Volume:      snapshot.Volume,
+		Playlist:    snapshot.Playlist,
+		Index:       snapshot.Index,
+		Total:       snapshot.Total,
+		Visualizer:  snapshot.Visualizer,
+		Shuffle:     snapshot.Shuffle,
+		Repeat:      snapshot.Repeat,
+		Mono:        snapshot.Mono,
+		Speed:       snapshot.Speed,
+		EQPreset:    snapshot.EQPreset,
+		Theme:       snapshot.Theme,
+		EQBands:     snapshot.EQBands,
+		Device:      snapshot.Device,
+		Backend:     snapshot.Backend,
+		BitPerfect:  snapshot.BitPerfect,
+		DSPDisabled: snapshot.DSPDisabled,
+		DirectALSA:  snapshot.DirectALSA,
+		SourceAudio: snapshot.SourceAudio,
+		OutputAudio: snapshot.OutputAudio,
 	}
 }
 

--- a/player/engine.go
+++ b/player/engine.go
@@ -2,6 +2,84 @@ package player
 
 import "time"
 
+// Feature identifies optional controls that are not supported by every
+// playback engine.
+type Feature string
+
+const (
+	FeatureEQ         Feature = "EQ"
+	FeatureMono       Feature = "mono"
+	FeatureVisualizer Feature = "visualizer"
+	FeatureVolume     Feature = "volume"
+	FeatureSpeed      Feature = "speed"
+)
+
+// FeatureReporter is optional. Engines that omit it support all features.
+type FeatureReporter interface {
+	FeatureError(Feature) error
+}
+
+// FeatureError reports whether engine supports feature.
+func FeatureError(engine Engine, feature Feature) error {
+	if reporter, ok := engine.(FeatureReporter); ok {
+		return reporter.FeatureError(feature)
+	}
+	return nil
+}
+
+// DeviceController lets an engine own device discovery and switching.
+type DeviceController interface {
+	ListAudioDevices() ([]AudioDevice, error)
+	SwitchAudioDevice(string) error
+}
+
+// EngineAudioDevices uses backend-specific discovery when available.
+func EngineAudioDevices(engine Engine) ([]AudioDevice, error) {
+	if controller, ok := engine.(DeviceController); ok {
+		return controller.ListAudioDevices()
+	}
+	return ListAudioDevices()
+}
+
+// SwitchEngineAudioDevice uses backend-specific switching when available.
+func SwitchEngineAudioDevice(engine Engine, device string) error {
+	if controller, ok := engine.(DeviceController); ok {
+		return controller.SwitchAudioDevice(device)
+	}
+	return SwitchAudioDevice(device)
+}
+
+// AudioParameters describes MPV's decoder or audio-output format.
+type AudioParameters struct {
+	Format     string
+	SampleRate int
+	Channels   string
+}
+
+// BackendStatus is optional diagnostic data exposed by a playback engine.
+type BackendStatus struct {
+	Name           string
+	Device         string
+	BitPerfectMode bool
+	DSPDisabled    bool
+	DirectALSA     bool
+	Source         AudioParameters
+	Output         AudioParameters
+}
+
+// BackendReporter exposes diagnostic backend state.
+type BackendReporter interface {
+	BackendStatus() BackendStatus
+}
+
+// EngineBackendStatus returns backend diagnostics when available.
+func EngineBackendStatus(engine Engine) BackendStatus {
+	if reporter, ok := engine.(BackendReporter); ok {
+		return reporter.BackendStatus()
+	}
+	return BackendStatus{}
+}
+
 // Engine is the interface used by the TUI model to control audio playback.
 // It is satisfied by *Player and can be replaced with a mock for testing.
 type Engine interface {
@@ -67,3 +145,11 @@ type Engine interface {
 
 // Compile-time check that *Player satisfies Engine.
 var _ Engine = (*Player)(nil)
+
+// BackendStatus reports the native engine and its configured output rate.
+func (p *Player) BackendStatus() BackendStatus {
+	return BackendStatus{
+		Name:   "native",
+		Output: AudioParameters{SampleRate: int(p.sr)},
+	}
+}

--- a/player/mpv.go
+++ b/player/mpv.go
@@ -1,0 +1,1016 @@
+package player
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bjarneo/cliamp/applog"
+)
+
+const (
+	defaultMPVRequestTimeout = 3 * time.Second
+	mpvConnectTimeout        = 5 * time.Second
+)
+
+var errMPVClosed = errors.New("MPV backend is closed")
+
+// MPVOptions configures the persistent MPV process.
+type MPVOptions struct {
+	Executable       string
+	AudioDevice      string
+	AudioReservation string
+	BitPerfect       bool
+	RequestTimeout   time.Duration
+}
+
+type reservationHandle interface {
+	Close() error
+}
+
+// MPVBackend implements Engine with one persistent MPV process controlled over
+// JSON IPC. cliamp remains responsible for playlist sequencing.
+type MPVBackend struct {
+	stateMu sync.RWMutex
+
+	playing        bool
+	paused         bool
+	drained        bool
+	seekable       bool
+	hasPreload     bool
+	position       time.Duration
+	duration       time.Duration
+	volumeDB       float64
+	volumeMinDB    float64
+	speed          float64
+	path           string
+	mediaTitle     string
+	device         string
+	currentAO      string
+	sourceParams   AudioParameters
+	outputParams   AudioParameters
+	streamErr      error
+	closing        bool
+	bitPerfect     bool
+	requestTimeout time.Duration
+
+	resolverMu      sync.RWMutex
+	sourceResolvers map[string]SourceResolver
+
+	ipcMu sync.RWMutex
+	ipc   *mpvIPC
+
+	cmd         *exec.Cmd
+	processDone chan struct{}
+	stderr      *lockedBuffer
+	runtimeDir  string
+	socketPath  string
+	reservation reservationHandle
+	closeOnce   sync.Once
+}
+
+// NewMPVBackend starts MPV, connects its JSON IPC socket, and registers
+// property observations used by cliamp's UI and daemon.
+func NewMPVBackend(options MPVOptions) (*MPVBackend, error) {
+	executable := strings.TrimSpace(options.Executable)
+	if executable == "" {
+		executable = "mpv"
+	}
+	path, err := exec.LookPath(executable)
+	if err != nil {
+		return nil, fmt.Errorf("MPV backend requested, but %q was not found in PATH; install mpv or use --audio-backend native", executable)
+	}
+
+	runtimeDir, socketPath, err := newMPVRuntimeSocket()
+	if err != nil {
+		return nil, err
+	}
+	cleanupRuntime := func() { _ = os.RemoveAll(runtimeDir) }
+
+	reservation, err := acquireAudioReservation(options.AudioReservation)
+	if err != nil {
+		cleanupRuntime()
+		return nil, err
+	}
+
+	timeout := options.RequestTimeout
+	if timeout <= 0 {
+		timeout = defaultMPVRequestTimeout
+	}
+	stderr := &lockedBuffer{}
+	args := mpvCommandArgs(options, socketPath)
+	cmd := exec.Command(path, args...)
+	cmd.Stdout = stderr
+	cmd.Stderr = stderr
+	applog.Debug("MPV command: %q", append([]string{path}, args...))
+	if err := cmd.Start(); err != nil {
+		if reservation != nil {
+			_ = reservation.Close()
+		}
+		cleanupRuntime()
+		return nil, fmt.Errorf("start MPV: %w", err)
+	}
+
+	b := &MPVBackend{
+		volumeMinDB:     -50,
+		speed:           1,
+		device:          options.AudioDevice,
+		bitPerfect:      options.BitPerfect,
+		requestTimeout:  timeout,
+		sourceResolvers: make(map[string]SourceResolver),
+		cmd:             cmd,
+		processDone:     make(chan struct{}),
+		stderr:          stderr,
+		runtimeDir:      runtimeDir,
+		socketPath:      socketPath,
+		reservation:     reservation,
+	}
+	go b.waitProcess()
+
+	conn, err := b.connectIPC(mpvConnectTimeout)
+	if err != nil {
+		b.Close()
+		if detail := strings.TrimSpace(stderr.String()); detail != "" {
+			return nil, fmt.Errorf("connect MPV IPC socket %s: %w: %s", socketPath, err, detail)
+		}
+		return nil, fmt.Errorf("connect MPV IPC socket %s: %w", socketPath, err)
+	}
+	ipc := newMPVIPC(conn, timeout, b.handleIPCMessage)
+	b.ipcMu.Lock()
+	b.ipc = ipc
+	b.ipcMu.Unlock()
+	applog.Info("MPV IPC connected: %s", socketPath)
+
+	if err := b.observeProperties(); err != nil {
+		b.Close()
+		return nil, fmt.Errorf("initialize MPV IPC: %w", err)
+	}
+	return b, nil
+}
+
+func mpvCommandArgs(options MPVOptions, socketPath string) []string {
+	args := []string{
+		"--idle=yes",
+		"--no-video",
+		"--audio-display=no",
+		"--no-terminal",
+		"--no-config",
+		"--audio-fallback-to-null=no",
+		"--gapless-audio=no",
+		"--input-ipc-server=" + socketPath,
+		"--volume-max=200",
+	}
+	if options.AudioDevice != "" {
+		args = append(args, "--audio-device="+options.AudioDevice)
+	}
+	if options.BitPerfect {
+		args = append(args,
+			"--volume=100",
+			"--volume-max=100",
+			"--speed=1.0",
+			"--af=",
+			"--replaygain=no",
+			"--audio-pitch-correction=no",
+			"--audio-normalize-downmix=no",
+		)
+	}
+	return args
+}
+
+func newMPVRuntimeSocket() (runtimeDir, socketPath string, err error) {
+	base := strings.TrimSpace(os.Getenv("XDG_RUNTIME_DIR"))
+	if base != "" {
+		base = filepath.Join(base, "cliamp")
+		if err := os.MkdirAll(base, 0o700); err != nil {
+			return "", "", fmt.Errorf("create MPV runtime directory: %w", err)
+		}
+		runtimeDir, err = os.MkdirTemp(base, "mpv-")
+	} else {
+		runtimeDir, err = os.MkdirTemp("", "cliamp-mpv-")
+	}
+	if err != nil {
+		return "", "", fmt.Errorf("create MPV runtime directory: %w", err)
+	}
+	if err := os.Chmod(runtimeDir, 0o700); err != nil {
+		_ = os.RemoveAll(runtimeDir)
+		return "", "", fmt.Errorf("secure MPV runtime directory: %w", err)
+	}
+	return runtimeDir, filepath.Join(runtimeDir, "ipc.sock"), nil
+}
+
+func (b *MPVBackend) connectIPC(timeout time.Duration) (net.Conn, error) {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("unix", b.socketPath, 100*time.Millisecond)
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+		select {
+		case <-b.processDone:
+			if detail := strings.TrimSpace(b.stderr.String()); detail != "" {
+				return nil, fmt.Errorf("MPV exited before creating IPC socket: %s", detail)
+			}
+			return nil, errors.New("MPV exited before creating IPC socket")
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+	if lastErr == nil {
+		lastErr = errors.New("timeout")
+	}
+	return nil, lastErr
+}
+
+func (b *MPVBackend) waitProcess() {
+	err := b.cmd.Wait()
+	b.stateMu.Lock()
+	closing := b.closing
+	b.stateMu.Unlock()
+	if !closing {
+		b.recordUnexpectedExit(err, strings.TrimSpace(b.stderr.String()))
+	}
+	close(b.processDone)
+
+	b.ipcMu.RLock()
+	ipc := b.ipc
+	b.ipcMu.RUnlock()
+	if ipc != nil {
+		if err == nil {
+			err = errors.New("MPV process exited")
+		}
+		ipc.fail(err)
+	}
+	if !closing {
+		applog.Error("MPV process exited unexpectedly: %v", err)
+	}
+}
+
+func (b *MPVBackend) recordUnexpectedExit(err error, detail string) {
+	b.stateMu.Lock()
+	defer b.stateMu.Unlock()
+	switch {
+	case err != nil && detail != "":
+		b.streamErr = fmt.Errorf("MPV exited unexpectedly: %w: %s", err, detail)
+	case err != nil:
+		b.streamErr = fmt.Errorf("MPV exited unexpectedly: %w", err)
+	default:
+		b.streamErr = errors.New("MPV exited unexpectedly")
+	}
+	b.playing = false
+	b.paused = false
+}
+
+func (b *MPVBackend) observeProperties() error {
+	properties := []string{
+		"time-pos", "duration", "pause", "volume", "speed", "audio-params",
+		"audio-out-params", "path", "media-title", "seekable", "audio-device", "current-ao",
+	}
+	for id, name := range properties {
+		if _, err := b.command([]any{"observe_property", id + 1, name}); err != nil {
+			return fmt.Errorf("observe %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func (b *MPVBackend) command(command []any) (json.RawMessage, error) {
+	b.ipcMu.RLock()
+	ipc := b.ipc
+	b.ipcMu.RUnlock()
+	if ipc == nil {
+		return nil, errMPVClosed
+	}
+	return ipc.command(command)
+}
+
+func (b *MPVBackend) handleIPCMessage(message mpvMessage) {
+	switch message.Event {
+	case "property-change":
+		b.handleProperty(message.Name, message.Data)
+	case "file-loaded":
+		b.stateMu.Lock()
+		b.playing = true
+		b.drained = false
+		b.streamErr = nil
+		b.stateMu.Unlock()
+		applog.Info("MPV event: file-loaded")
+	case "end-file":
+		b.stateMu.Lock()
+		if message.Reason == "eof" {
+			b.drained = true
+			if b.duration > 0 {
+				b.position = b.duration
+			}
+		} else if message.Reason == "error" {
+			if message.Error != "" {
+				b.streamErr = fmt.Errorf("MPV playback error: %s", message.Error)
+			} else {
+				b.streamErr = errors.New("MPV playback error")
+			}
+		}
+		b.stateMu.Unlock()
+		applog.Info("MPV event: end-file reason=%s error=%s", message.Reason, message.Error)
+	case "playback-restart":
+		applog.Debug("MPV event: playback-restart")
+	case "shutdown":
+		applog.Info("MPV event: shutdown")
+	}
+}
+
+func (b *MPVBackend) handleProperty(name string, raw json.RawMessage) {
+	b.stateMu.Lock()
+	defer b.stateMu.Unlock()
+
+	switch name {
+	case "time-pos":
+		if value, ok := jsonFloat(raw); ok {
+			b.position = secondsDuration(value)
+		}
+	case "duration":
+		if value, ok := jsonFloat(raw); ok {
+			b.duration = secondsDuration(value)
+		}
+	case "pause":
+		_ = json.Unmarshal(raw, &b.paused)
+	case "volume":
+		if value, ok := jsonFloat(raw); ok {
+			b.volumeDB = mpvPercentToDB(value, b.volumeMinDB)
+		}
+	case "speed":
+		if value, ok := jsonFloat(raw); ok {
+			b.speed = value
+		}
+	case "path":
+		b.path = jsonString(raw)
+	case "media-title":
+		b.mediaTitle = jsonString(raw)
+	case "seekable":
+		_ = json.Unmarshal(raw, &b.seekable)
+	case "audio-device":
+		b.device = jsonString(raw)
+	case "current-ao":
+		b.currentAO = jsonString(raw)
+	case "audio-params":
+		b.sourceParams = decodeAudioParameters(raw)
+		applog.Debug("MPV audio-params: format=%s rate=%d channels=%s", b.sourceParams.Format, b.sourceParams.SampleRate, b.sourceParams.Channels)
+	case "audio-out-params":
+		b.outputParams = decodeAudioParameters(raw)
+		applog.Debug("MPV audio-out-params: format=%s rate=%d channels=%s", b.outputParams.Format, b.outputParams.SampleRate, b.outputParams.Channels)
+	}
+}
+
+func jsonString(raw json.RawMessage) string {
+	var value string
+	_ = json.Unmarshal(raw, &value)
+	return value
+}
+
+func jsonFloat(raw json.RawMessage) (float64, bool) {
+	var value float64
+	if len(raw) == 0 || string(raw) == "null" || json.Unmarshal(raw, &value) != nil {
+		return 0, false
+	}
+	return value, true
+}
+
+func secondsDuration(seconds float64) time.Duration {
+	return time.Duration(seconds * float64(time.Second))
+}
+
+func decodeAudioParameters(raw json.RawMessage) AudioParameters {
+	var value struct {
+		Format     string `json:"format"`
+		SampleRate int    `json:"samplerate"`
+		Channels   string `json:"hr-channels"`
+		Fallback   string `json:"channels"`
+	}
+	if json.Unmarshal(raw, &value) != nil {
+		return AudioParameters{}
+	}
+	if value.Channels == "" {
+		value.Channels = value.Fallback
+	}
+	return AudioParameters{Format: value.Format, SampleRate: value.SampleRate, Channels: value.Channels}
+}
+
+func (b *MPVBackend) resolvePath(path string) (string, error) {
+	b.resolverMu.RLock()
+	var resolver SourceResolver
+	for prefix, candidate := range b.sourceResolvers {
+		if strings.HasPrefix(path, prefix) {
+			resolver = candidate
+			break
+		}
+	}
+	b.resolverMu.RUnlock()
+	if resolver == nil {
+		return path, nil
+	}
+	source, err := resolver(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve source: %w", err)
+	}
+	if len(source.Segments) > 0 {
+		return "", errors.New("segmented provider streams are unsupported with MPV backend; use --audio-backend native")
+	}
+	if source.URL == "" {
+		return "", fmt.Errorf("resolve source: empty result for %s", path)
+	}
+	return source.URL, nil
+}
+
+// Play loads path into the persistent MPV process.
+func (b *MPVBackend) Play(path string, knownDuration time.Duration) error {
+	if strings.HasPrefix(path, "spotify:") {
+		return errors.New("Spotify playback is unsupported with MPV backend; use --audio-backend native")
+	}
+	resolved, err := b.resolvePath(path)
+	if err != nil {
+		return err
+	}
+	b.stateMu.Lock()
+	b.path = path
+	b.mediaTitle = ""
+	b.position = 0
+	b.duration = knownDuration
+	b.playing = true
+	b.paused = false
+	b.drained = false
+	b.seekable = false
+	b.hasPreload = false
+	b.streamErr = nil
+	b.sourceParams = AudioParameters{}
+	b.outputParams = AudioParameters{}
+	b.stateMu.Unlock()
+	if _, err := b.command([]any{"loadfile", resolved, "replace"}); err != nil {
+		b.recordPlaybackError(err)
+		return fmt.Errorf("MPV loadfile: %w", err)
+	}
+	if _, err := b.command([]any{"set_property", "pause", false}); err != nil {
+		b.recordPlaybackError(err)
+		return fmt.Errorf("MPV resume after load: %w", err)
+	}
+	return nil
+}
+
+func (b *MPVBackend) recordPlaybackError(err error) {
+	b.stateMu.Lock()
+	b.streamErr = err
+	b.playing = false
+	b.paused = false
+	b.stateMu.Unlock()
+}
+
+// PlayYTDL lets MPV's built-in yt-dlp hook resolve the page URL.
+func (b *MPVBackend) PlayYTDL(pageURL string, knownDuration time.Duration) error {
+	return b.Play(pageURL, knownDuration)
+}
+
+// ponytail: preload is marker-only until MPV can prebuffer without taking
+// playlist ownership; EOF still returns to cliamp for sequencing.
+func (b *MPVBackend) Preload(_ string, _ time.Duration) error {
+	b.stateMu.Lock()
+	b.hasPreload = true
+	b.stateMu.Unlock()
+	return nil
+}
+
+func (b *MPVBackend) PreloadYTDL(path string, knownDuration time.Duration) error {
+	return b.Preload(path, knownDuration)
+}
+
+func (b *MPVBackend) ClearPreload() {
+	b.stateMu.Lock()
+	b.hasPreload = false
+	b.stateMu.Unlock()
+}
+
+func (b *MPVBackend) Stop() {
+	if _, err := b.command([]any{"stop"}); err != nil && !errors.Is(err, errMPVClosed) {
+		applog.UserError("MPV stop failed: %v", err)
+	}
+	b.stateMu.Lock()
+	b.playing = false
+	b.paused = false
+	b.drained = false
+	b.seekable = false
+	b.hasPreload = false
+	b.position = 0
+	b.duration = 0
+	b.path = ""
+	b.mediaTitle = ""
+	b.sourceParams = AudioParameters{}
+	b.outputParams = AudioParameters{}
+	b.stateMu.Unlock()
+}
+
+func (b *MPVBackend) TogglePause() {
+	b.stateMu.RLock()
+	paused := b.paused
+	b.stateMu.RUnlock()
+	if _, err := b.command([]any{"set_property", "pause", !paused}); err != nil {
+		applog.UserError("MPV pause failed: %v", err)
+		return
+	}
+	b.stateMu.Lock()
+	b.paused = !paused
+	b.stateMu.Unlock()
+}
+
+func (b *MPVBackend) Seek(offset time.Duration) error {
+	_, err := b.command([]any{"seek", offset.Seconds(), "relative"})
+	if err != nil {
+		return fmt.Errorf("MPV seek: %w", err)
+	}
+	b.stateMu.Lock()
+	b.position = max(0, b.position+offset)
+	b.drained = false
+	b.stateMu.Unlock()
+	return nil
+}
+
+func (b *MPVBackend) SeekYTDL(offset time.Duration) error { return b.Seek(offset) }
+func (b *MPVBackend) CancelSeekYTDL()                     {}
+func (b *MPVBackend) IsStreamSeek() bool                  { return false }
+func (b *MPVBackend) IsYTDLSeek() bool                    { return false }
+func (b *MPVBackend) GaplessAdvanced() bool               { return false }
+
+func (b *MPVBackend) Position() time.Duration {
+	b.stateMu.RLock()
+	defer b.stateMu.RUnlock()
+	return b.position
+}
+
+func (b *MPVBackend) Duration() time.Duration {
+	b.stateMu.RLock()
+	defer b.stateMu.RUnlock()
+	return b.duration
+}
+
+func (b *MPVBackend) PositionAndDuration() (time.Duration, time.Duration) {
+	b.stateMu.RLock()
+	defer b.stateMu.RUnlock()
+	return b.position, b.duration
+}
+
+func (b *MPVBackend) SetVolumeMin(db float64) {
+	b.stateMu.Lock()
+	b.volumeMinDB = max(min(db, 0), -90)
+	if b.volumeDB < b.volumeMinDB {
+		b.volumeDB = b.volumeMinDB
+	}
+	b.stateMu.Unlock()
+}
+
+func (b *MPVBackend) VolumeMin() float64 {
+	b.stateMu.RLock()
+	defer b.stateMu.RUnlock()
+	return b.volumeMinDB
+}
+
+func (b *MPVBackend) SetVolume(db float64) {
+	b.stateMu.RLock()
+	bitPerfect := b.bitPerfect
+	minDB := b.volumeMinDB
+	b.stateMu.RUnlock()
+	if bitPerfect {
+		if db != 0 {
+			applog.UserWarn("MPV bit-perfect mode: volume is locked at 0 dB")
+		}
+		return
+	}
+	db = max(min(db, 6), minDB)
+	if _, err := b.command([]any{"set_property", "volume", dbToMPVPercent(db)}); err != nil {
+		applog.UserError("MPV volume failed: %v", err)
+		return
+	}
+	b.stateMu.Lock()
+	b.volumeDB = db
+	b.stateMu.Unlock()
+}
+
+func dbToMPVPercent(db float64) float64 { return 100 * math.Pow(10, db/20) }
+
+func mpvPercentToDB(percent, floor float64) float64 {
+	if percent <= 0 {
+		return floor
+	}
+	return max(20*math.Log10(percent/100), floor)
+}
+
+func (b *MPVBackend) Volume() float64 {
+	b.stateMu.RLock()
+	defer b.stateMu.RUnlock()
+	return b.volumeDB
+}
+
+func (b *MPVBackend) SetSpeed(ratio float64) {
+	b.stateMu.RLock()
+	bitPerfect := b.bitPerfect
+	b.stateMu.RUnlock()
+	if bitPerfect {
+		if ratio != 1 {
+			applog.UserWarn("MPV bit-perfect mode: speed is locked at 1.0x")
+		}
+		return
+	}
+	ratio = max(min(ratio, 2), 0.25)
+	if _, err := b.command([]any{"set_property", "speed", ratio}); err != nil {
+		applog.UserError("MPV speed failed: %v", err)
+		return
+	}
+	b.stateMu.Lock()
+	b.speed = ratio
+	b.stateMu.Unlock()
+}
+
+func (b *MPVBackend) Speed() float64 {
+	b.stateMu.RLock()
+	defer b.stateMu.RUnlock()
+	return b.speed
+}
+
+func (b *MPVBackend) ToggleMono() {
+	applog.UserWarn("Mono is unsupported with MPV backend")
+}
+
+func (b *MPVBackend) Mono() bool { return false }
+
+func (b *MPVBackend) SetEQBand(_ int, db float64) {
+	if db != 0 {
+		applog.UserWarn("EQ is unsupported with MPV backend")
+	}
+}
+
+func (b *MPVBackend) EQBands() [10]float64 { return [10]float64{} }
+
+func (b *MPVBackend) IsPlaying() bool {
+	b.stateMu.RLock()
+	defer b.stateMu.RUnlock()
+	return b.playing
+}
+
+func (b *MPVBackend) IsPaused() bool {
+	b.stateMu.RLock()
+	defer b.stateMu.RUnlock()
+	return b.paused
+}
+
+func (b *MPVBackend) Drained() bool {
+	b.stateMu.RLock()
+	defer b.stateMu.RUnlock()
+	return b.drained
+}
+
+func (b *MPVBackend) HasPreload() bool {
+	b.stateMu.RLock()
+	defer b.stateMu.RUnlock()
+	return b.hasPreload
+}
+
+func (b *MPVBackend) Seekable() bool {
+	b.stateMu.RLock()
+	defer b.stateMu.RUnlock()
+	return b.seekable
+}
+
+func (b *MPVBackend) IsLiveStream() bool {
+	b.stateMu.RLock()
+	defer b.stateMu.RUnlock()
+	return b.playing && b.duration <= 0 && (strings.HasPrefix(b.path, "http://") || strings.HasPrefix(b.path, "https://"))
+}
+
+func (b *MPVBackend) StreamErr() error {
+	b.stateMu.RLock()
+	defer b.stateMu.RUnlock()
+	return b.streamErr
+}
+
+func (b *MPVBackend) StreamTitle() string {
+	b.stateMu.RLock()
+	defer b.stateMu.RUnlock()
+	return b.mediaTitle
+}
+
+func (b *MPVBackend) StreamBytes() (downloaded, total int64) { return 0, 0 }
+func (b *MPVBackend) SamplesInto(_ []float64) int            { return 0 }
+func (b *MPVBackend) WaveformSamplesInto(_ []float64) int    { return 0 }
+func (b *MPVBackend) StereoSamplesInto(_ [][2]float64) int   { return 0 }
+
+func (b *MPVBackend) SampleRate() int {
+	b.stateMu.RLock()
+	defer b.stateMu.RUnlock()
+	if b.outputParams.SampleRate > 0 {
+		return b.outputParams.SampleRate
+	}
+	if b.sourceParams.SampleRate > 0 {
+		return b.sourceParams.SampleRate
+	}
+	return 44100
+}
+
+// RegisterSourceResolver resolves provider URIs immediately before playback.
+func (b *MPVBackend) RegisterSourceResolver(scheme string, resolver SourceResolver) {
+	b.resolverMu.Lock()
+	b.sourceResolvers[scheme] = resolver
+	b.resolverMu.Unlock()
+}
+
+func (b *MPVBackend) FeatureError(feature Feature) error {
+	switch feature {
+	case FeatureEQ, FeatureMono, FeatureVisualizer:
+		return fmt.Errorf("%s is unsupported with MPV backend", feature)
+	case FeatureVolume, FeatureSpeed:
+		b.stateMu.RLock()
+		bitPerfect := b.bitPerfect
+		b.stateMu.RUnlock()
+		if bitPerfect {
+			return fmt.Errorf("%s is locked in MPV bit-perfect mode", feature)
+		}
+	}
+	return nil
+}
+
+func (b *MPVBackend) BackendStatus() BackendStatus {
+	b.stateMu.RLock()
+	defer b.stateMu.RUnlock()
+	return BackendStatus{
+		Name:           "mpv",
+		Device:         b.device,
+		BitPerfectMode: b.bitPerfect,
+		DSPDisabled:    b.bitPerfect,
+		DirectALSA:     strings.HasPrefix(b.device, "alsa/hw:") && b.currentAO == "alsa",
+		Source:         b.sourceParams,
+		Output:         b.outputParams,
+	}
+}
+
+func (b *MPVBackend) ListAudioDevices() ([]AudioDevice, error) {
+	data, err := b.command([]any{"get_property", "audio-device-list"})
+	if err != nil {
+		return nil, fmt.Errorf("MPV audio-device-list: %w", err)
+	}
+	var entries []struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	}
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return nil, fmt.Errorf("decode MPV audio-device-list: %w", err)
+	}
+	b.stateMu.RLock()
+	active := b.device
+	b.stateMu.RUnlock()
+	devices := make([]AudioDevice, len(entries))
+	for i, entry := range entries {
+		devices[i] = AudioDevice{Index: i, Name: entry.Name, Description: entry.Description, Active: entry.Name == active}
+	}
+	return devices, nil
+}
+
+func (b *MPVBackend) SwitchAudioDevice(device string) error {
+	if device == "" {
+		return errors.New("MPV audio device cannot be empty")
+	}
+	b.stateMu.RLock()
+	bitPerfect := b.bitPerfect
+	b.stateMu.RUnlock()
+	if bitPerfect && !strings.HasPrefix(device, "alsa/hw:") {
+		return errors.New("MPV bit-perfect mode requires a direct ALSA device such as alsa/hw:CARD=Generic,DEV=0")
+	}
+	if _, err := b.command([]any{"set_property", "audio-device", device}); err != nil {
+		return fmt.Errorf("MPV audio device: %w", err)
+	}
+	b.stateMu.Lock()
+	b.device = device
+	b.stateMu.Unlock()
+	return nil
+}
+
+// Close terminates MPV, releases device reservation, and removes runtime files.
+func (b *MPVBackend) Close() {
+	b.closeOnce.Do(func() {
+		b.stateMu.Lock()
+		b.closing = true
+		b.playing = false
+		b.paused = false
+		b.stateMu.Unlock()
+
+		b.ipcMu.RLock()
+		ipc := b.ipc
+		b.ipcMu.RUnlock()
+		if ipc != nil {
+			_ = ipc.writeNoReply([]any{"quit"})
+		}
+		if b.cmd != nil && b.cmd.Process != nil {
+			select {
+			case <-b.processDone:
+			case <-time.After(2 * time.Second):
+				_ = b.cmd.Process.Kill()
+				<-b.processDone
+			}
+		}
+		if ipc != nil {
+			ipc.fail(errMPVClosed)
+		}
+		if b.reservation != nil {
+			if err := b.reservation.Close(); err != nil {
+				applog.Warn("audio reservation release: %v", err)
+			}
+		}
+		if b.runtimeDir != "" {
+			if err := os.RemoveAll(b.runtimeDir); err != nil {
+				applog.Warn("remove MPV runtime directory: %v", err)
+			}
+		}
+		applog.Info("MPV backend shutdown complete")
+	})
+}
+
+var _ Engine = (*MPVBackend)(nil)
+var _ DeviceController = (*MPVBackend)(nil)
+var _ FeatureReporter = (*MPVBackend)(nil)
+var _ BackendReporter = (*MPVBackend)(nil)
+
+type mpvMessage struct {
+	Command   []any           `json:"command,omitempty"`
+	RequestID *int64          `json:"request_id,omitempty"`
+	Error     string          `json:"error,omitempty"`
+	Data      json.RawMessage `json:"data,omitempty"`
+	Event     string          `json:"event,omitempty"`
+	Name      string          `json:"name,omitempty"`
+	Reason    string          `json:"reason,omitempty"`
+}
+
+type mpvResult struct {
+	message mpvMessage
+	err     error
+}
+
+type mpvIPC struct {
+	conn    net.Conn
+	timeout time.Duration
+	onEvent func(mpvMessage)
+
+	writeMu  sync.Mutex
+	nextID   int64
+	mu       sync.Mutex
+	pending  map[int64]chan mpvResult
+	done     chan struct{}
+	failOnce sync.Once
+}
+
+func newMPVIPC(conn net.Conn, timeout time.Duration, onEvent func(mpvMessage)) *mpvIPC {
+	ipc := &mpvIPC{
+		conn:    conn,
+		timeout: timeout,
+		onEvent: onEvent,
+		pending: make(map[int64]chan mpvResult),
+		done:    make(chan struct{}),
+	}
+	go ipc.readLoop()
+	return ipc
+}
+
+func (c *mpvIPC) command(command []any) (json.RawMessage, error) {
+	c.mu.Lock()
+	select {
+	case <-c.done:
+		c.mu.Unlock()
+		return nil, errMPVClosed
+	default:
+	}
+	c.nextID++
+	id := c.nextID
+	result := make(chan mpvResult, 1)
+	c.pending[id] = result
+	c.mu.Unlock()
+
+	requestID := id
+	if err := c.write(mpvMessage{Command: command, RequestID: &requestID}); err != nil {
+		c.removePending(id)
+		c.fail(err)
+		return nil, err
+	}
+	name := "unknown"
+	if len(command) > 0 {
+		name = fmt.Sprint(command[0])
+	}
+	applog.Debug("MPV IPC request: id=%d command=%s", id, name)
+
+	timer := time.NewTimer(c.timeout)
+	defer timer.Stop()
+	select {
+	case response := <-result:
+		if response.err != nil {
+			return nil, response.err
+		}
+		if response.message.Error != "" && response.message.Error != "success" {
+			applog.Warn("MPV IPC error: id=%d command=%s error=%s", id, name, response.message.Error)
+			return nil, errors.New(response.message.Error)
+		}
+		return response.message.Data, nil
+	case <-timer.C:
+		c.removePending(id)
+		return nil, fmt.Errorf("MPV request %d (%s) timed out after %s", id, name, c.timeout)
+	case <-c.done:
+		return nil, errMPVClosed
+	}
+}
+
+func (c *mpvIPC) writeNoReply(command []any) error {
+	return c.write(mpvMessage{Command: command})
+}
+
+func (c *mpvIPC) write(message mpvMessage) error {
+	data, err := json.Marshal(message)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	_ = c.conn.SetWriteDeadline(time.Now().Add(c.timeout))
+	_, err = c.conn.Write(data)
+	_ = c.conn.SetWriteDeadline(time.Time{})
+	return err
+}
+
+func (c *mpvIPC) readLoop() {
+	scanner := bufio.NewScanner(c.conn)
+	scanner.Buffer(make([]byte, 4096), 1024*1024)
+	for scanner.Scan() {
+		var message mpvMessage
+		if err := json.Unmarshal(scanner.Bytes(), &message); err != nil {
+			applog.Warn("decode MPV IPC message: %v", err)
+			continue
+		}
+		if message.RequestID != nil && *message.RequestID != 0 {
+			c.mu.Lock()
+			result := c.pending[*message.RequestID]
+			delete(c.pending, *message.RequestID)
+			c.mu.Unlock()
+			if result != nil {
+				result <- mpvResult{message: message}
+			}
+			continue
+		}
+		if c.onEvent != nil {
+			c.onEvent(message)
+		}
+	}
+	err := scanner.Err()
+	if err == nil {
+		err = errors.New("MPV IPC connection closed")
+	}
+	c.fail(err)
+}
+
+func (c *mpvIPC) removePending(id int64) {
+	c.mu.Lock()
+	delete(c.pending, id)
+	c.mu.Unlock()
+}
+
+func (c *mpvIPC) fail(err error) {
+	c.failOnce.Do(func() {
+		_ = c.conn.Close()
+		c.mu.Lock()
+		pending := c.pending
+		c.pending = make(map[int64]chan mpvResult)
+		close(c.done)
+		c.mu.Unlock()
+		for _, result := range pending {
+			select {
+			case result <- mpvResult{err: err}:
+			default:
+			}
+		}
+	})
+}
+
+type lockedBuffer struct {
+	mu sync.Mutex
+	b  strings.Builder
+}
+
+func (b *lockedBuffer) Write(data []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.Write(data)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.String()
+}

--- a/player/mpv.go
+++ b/player/mpv.go
@@ -158,6 +158,10 @@ func NewMPVBackend(options MPVOptions) (*MPVBackend, error) {
 }
 
 func mpvCommandArgs(options MPVOptions, socketPath string) []string {
+	volumeMax := "200"
+	if options.BitPerfect {
+		volumeMax = "100"
+	}
 	args := []string{
 		"--idle=yes",
 		"--no-video",
@@ -167,7 +171,7 @@ func mpvCommandArgs(options MPVOptions, socketPath string) []string {
 		"--audio-fallback-to-null=no",
 		"--gapless-audio=no",
 		"--input-ipc-server=" + socketPath,
-		"--volume-max=200",
+		"--volume-max=" + volumeMax,
 	}
 	if options.AudioDevice != "" {
 		args = append(args, "--audio-device="+options.AudioDevice)
@@ -175,7 +179,6 @@ func mpvCommandArgs(options MPVOptions, socketPath string) []string {
 	if options.BitPerfect {
 		args = append(args,
 			"--volume=100",
-			"--volume-max=100",
 			"--speed=1.0",
 			"--af=",
 			"--replaygain=no",

--- a/player/mpv_test.go
+++ b/player/mpv_test.go
@@ -1,0 +1,286 @@
+package player
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMPVCommandArgsBitPerfect(t *testing.T) {
+	args := mpvCommandArgs(MPVOptions{
+		AudioDevice: "alsa/hw:CARD=Generic,DEV=0",
+		BitPerfect:  true,
+	}, "/run/user/1000/cliamp/mpv/ipc.sock")
+	joined := strings.Join(args, "\n")
+	for _, want := range []string{
+		"--idle=yes",
+		"--no-config",
+		"--input-ipc-server=/run/user/1000/cliamp/mpv/ipc.sock",
+		"--audio-device=alsa/hw:CARD=Generic,DEV=0",
+		"--volume=100",
+		"--volume-max=100",
+		"--speed=1.0",
+		"--af=",
+		"--replaygain=no",
+		"--audio-pitch-correction=no",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("args missing %q: %v", want, args)
+		}
+	}
+	for _, forbidden := range []string{"--audio-samplerate", "--audio-format", "S16_LE", "S24_LE"} {
+		if strings.Contains(joined, forbidden) {
+			t.Errorf("args force %q: %v", forbidden, args)
+		}
+	}
+}
+
+func TestMPVIPCMatchesResponsesByRequestID(t *testing.T) {
+	client, server := net.Pipe()
+	events := make(chan mpvMessage, 1)
+	ipc := newMPVIPC(client, time.Second, func(message mpvMessage) { events <- message })
+	defer ipc.fail(errMPVClosed)
+	defer server.Close()
+
+	type commandResult struct {
+		name string
+		data string
+		err  error
+	}
+	results := make(chan commandResult, 2)
+	go func() {
+		data, err := ipc.command([]any{"first"})
+		results <- commandResult{name: "first", data: string(data), err: err}
+	}()
+
+	scanner := bufio.NewScanner(server)
+	if !scanner.Scan() {
+		t.Fatal("first request not received")
+	}
+	var first mpvMessage
+	if err := json.Unmarshal(scanner.Bytes(), &first); err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		data, err := ipc.command([]any{"second"})
+		results <- commandResult{name: "second", data: string(data), err: err}
+	}()
+	if !scanner.Scan() {
+		t.Fatal("second request not received")
+	}
+	var second mpvMessage
+	if err := json.Unmarshal(scanner.Bytes(), &second); err != nil {
+		t.Fatal(err)
+	}
+	if first.RequestID == nil || second.RequestID == nil || *first.RequestID == *second.RequestID {
+		t.Fatalf("request IDs = %v, %v; want distinct integers", first.RequestID, second.RequestID)
+	}
+	if first.Command[0] != "first" || second.Command[0] != "second" {
+		t.Fatalf("commands = %v, %v", first.Command, second.Command)
+	}
+
+	encoder := json.NewEncoder(server)
+	if err := encoder.Encode(mpvMessage{Event: "property-change", Name: "pause", Data: json.RawMessage(`true`)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := encoder.Encode(mpvMessage{RequestID: second.RequestID, Error: "success", Data: json.RawMessage(`"two"`)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := encoder.Encode(mpvMessage{RequestID: first.RequestID, Error: "success", Data: json.RawMessage(`"one"`)}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := map[string]string{}
+	for range 2 {
+		result := <-results
+		if result.err != nil {
+			t.Fatalf("%s command: %v", result.name, result.err)
+		}
+		got[result.name] = result.data
+	}
+	if got["first"] != `"one"` || got["second"] != `"two"` {
+		t.Fatalf("responses = %#v", got)
+	}
+	select {
+	case event := <-events:
+		if event.Name != "pause" || string(event.Data) != "true" {
+			t.Fatalf("event = %+v", event)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("asynchronous event not dispatched")
+	}
+}
+
+func TestMPVIPCRequestTimeoutRemovesPending(t *testing.T) {
+	client, server := net.Pipe()
+	ipc := newMPVIPC(client, 20*time.Millisecond, nil)
+	defer ipc.fail(errMPVClosed)
+	defer server.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := ipc.command([]any{"unanswered"})
+		done <- err
+	}()
+	if !bufio.NewScanner(server).Scan() {
+		t.Fatal("request not received")
+	}
+	if err := <-done; err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("command error = %v", err)
+	}
+	ipc.mu.Lock()
+	pending := len(ipc.pending)
+	ipc.mu.Unlock()
+	if pending != 0 {
+		t.Fatalf("pending requests after timeout = %d", pending)
+	}
+}
+
+func TestMPVEventStateTransitions(t *testing.T) {
+	b := &MPVBackend{speed: 1, volumeMinDB: -50}
+	b.handleIPCMessage(mpvMessage{Event: "file-loaded"})
+	if !b.IsPlaying() || b.IsPaused() || b.Drained() {
+		t.Fatalf("file-loaded state: playing=%v paused=%v drained=%v", b.IsPlaying(), b.IsPaused(), b.Drained())
+	}
+	b.handleProperty("duration", json.RawMessage(`120.5`))
+	b.handleProperty("time-pos", json.RawMessage(`30.25`))
+	b.handleProperty("audio-params", json.RawMessage(`{"format":"s32p","samplerate":48000,"hr-channels":"stereo"}`))
+	b.handleProperty("audio-out-params", json.RawMessage(`{"format":"s32","samplerate":48000,"hr-channels":"stereo"}`))
+	b.handleIPCMessage(mpvMessage{Event: "end-file", Reason: "eof"})
+	if !b.Drained() || b.Position() != b.Duration() {
+		t.Fatalf("EOF state: drained=%v position=%v duration=%v", b.Drained(), b.Position(), b.Duration())
+	}
+	status := b.BackendStatus()
+	if status.Source.Format != "s32p" || status.Output.Format != "s32" || status.Output.SampleRate != 48000 {
+		t.Fatalf("backend status = %+v", status)
+	}
+}
+
+func TestMPVUnexpectedExitState(t *testing.T) {
+	b := &MPVBackend{playing: true, paused: true}
+	b.recordUnexpectedExit(errors.New("exit status 1"), "fatal audio error")
+	if b.IsPlaying() || b.IsPaused() {
+		t.Fatalf("unexpected exit left playback active: playing=%v paused=%v", b.IsPlaying(), b.IsPaused())
+	}
+	if err := b.StreamErr(); err == nil || !strings.Contains(err.Error(), "fatal audio error") {
+		t.Fatalf("StreamErr() = %v", err)
+	}
+}
+
+func TestMPVRuntimeSocketCleanup(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", xdg)
+	dir, socket, err := newMPVRuntimeSocket()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Dir(filepath.Dir(dir)) != xdg {
+		t.Fatalf("runtime dir = %q, want under %q/cliamp", dir, xdg)
+	}
+	if err := os.WriteFile(socket, []byte("stale"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	b := &MPVBackend{runtimeDir: dir}
+	b.Close()
+	if _, err := os.Stat(dir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("runtime dir after Close: %v", err)
+	}
+}
+
+func TestMPVFeatureErrors(t *testing.T) {
+	b := &MPVBackend{bitPerfect: true}
+	for _, feature := range []Feature{FeatureEQ, FeatureMono, FeatureVisualizer, FeatureVolume, FeatureSpeed} {
+		if err := b.FeatureError(feature); err == nil {
+			t.Errorf("FeatureError(%s) = nil", feature)
+		}
+	}
+	b.bitPerfect = false
+	if err := b.FeatureError(FeatureVolume); err != nil {
+		t.Errorf("normal MPV volume support: %v", err)
+	}
+}
+
+func TestMPVVolumeConversions(t *testing.T) {
+	for _, db := range []float64{-50, -12, -3, 0, 6} {
+		got := mpvPercentToDB(dbToMPVPercent(db), -90)
+		if math.Abs(got-db) > 1e-9 {
+			t.Errorf("round trip %.2f dB = %.12f", db, got)
+		}
+	}
+}
+
+func TestMPVMissingExecutable(t *testing.T) {
+	_, err := NewMPVBackend(MPVOptions{Executable: "cliamp-mpv-does-not-exist"})
+	if err == nil || !strings.Contains(err.Error(), "was not found in PATH") {
+		t.Fatalf("NewMPVBackend missing executable error = %v", err)
+	}
+}
+
+func TestMPVIntegration(t *testing.T) {
+	if os.Getenv("CLIAMP_TEST_MPV") == "" {
+		t.Skip("set CLIAMP_TEST_MPV=1 to run against an installed mpv")
+	}
+	mpvPath, err := exec.LookPath("mpv")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	wrapper := filepath.Join(t.TempDir(), "mpv-null-audio")
+	script := fmt.Sprintf("#!/bin/sh\nexec %q --ao=null \"$@\"\n", mpvPath)
+	if err := os.WriteFile(wrapper, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	b, err := NewMPVBackend(MPVOptions{Executable: wrapper})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer b.Close()
+	if err := b.Play("../cliamp_whips_terminal_ass.mp3", 0); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for b.Duration() == 0 && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if b.Duration() == 0 {
+		t.Fatalf("MPV did not report file duration: %v", b.StreamErr())
+	}
+	b.TogglePause()
+	if !b.IsPaused() {
+		t.Fatal("pause state not updated")
+	}
+	b.TogglePause()
+	if b.IsPaused() {
+		t.Fatal("resume state not updated")
+	}
+	if err := b.Seek(time.Second); err != nil {
+		t.Fatal(err)
+	}
+	b.Stop()
+	if b.IsPlaying() {
+		t.Fatal("stop left playback active")
+	}
+
+	bitPerfect, err := NewMPVBackend(MPVOptions{
+		Executable:  wrapper,
+		AudioDevice: "alsa/hw:CARD=Generic,DEV=0",
+		BitPerfect:  true,
+	})
+	if err != nil {
+		t.Fatalf("bit-perfect MPV startup: %v", err)
+	}
+	if status := bitPerfect.BackendStatus(); status.Device != "alsa/hw:CARD=Generic,DEV=0" || !status.BitPerfectMode || !status.DSPDisabled {
+		t.Fatalf("bit-perfect status = %+v", status)
+	}
+	bitPerfect.Close()
+}

--- a/player/mpv_test.go
+++ b/player/mpv_test.go
@@ -42,6 +42,9 @@ func TestMPVCommandArgsBitPerfect(t *testing.T) {
 			t.Errorf("args force %q: %v", forbidden, args)
 		}
 	}
+	if count := strings.Count(joined, "--volume-max="); count != 1 {
+		t.Errorf("volume-max argument count = %d, want 1: %v", count, args)
+	}
 }
 
 func TestMPVIPCMatchesResponsesByRequestID(t *testing.T) {

--- a/player/reservation_linux.go
+++ b/player/reservation_linux.go
@@ -1,0 +1,85 @@
+//go:build linux
+
+package player
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/bjarneo/cliamp/applog"
+)
+
+type pwReservation struct {
+	cmd       *exec.Cmd
+	done      chan error
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func acquireAudioReservation(name string) (reservationHandle, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, nil
+	}
+	path, err := exec.LookPath("pw-reserve")
+	if err != nil {
+		return nil, errors.New("audio reservation requested, but 'pw-reserve' was not found in PATH")
+	}
+	stderr := &lockedBuffer{}
+	cmd := exec.Command(path, "-n", name, "-a", "cliamp", "-r")
+	cmd.Stdout = stderr
+	cmd.Stderr = stderr
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start pw-reserve for %s: %w", name, err)
+	}
+	r := &pwReservation{cmd: cmd, done: make(chan error, 1)}
+	go func() { r.done <- cmd.Wait() }()
+
+	// ponytail: pw-reserve has no machine-readable ready signal; keep the 300 ms
+	// liveness check until direct ReserveDevice1 D-Bus support is justified.
+	select {
+	case err := <-r.done:
+		detail := strings.TrimSpace(stderr.String())
+		if detail != "" {
+			return nil, fmt.Errorf("reserve audio device %s: %w: %s", name, err, detail)
+		}
+		return nil, fmt.Errorf("reserve audio device %s: %w", name, err)
+	case <-time.After(300 * time.Millisecond):
+	}
+	applog.Info("audio reservation acquired: %s", name)
+	return r, nil
+}
+
+func (r *pwReservation) Close() error {
+	r.closeOnce.Do(func() {
+		if r.cmd == nil || r.cmd.Process == nil {
+			return
+		}
+		if err := r.cmd.Process.Signal(syscall.SIGTERM); err != nil {
+			select {
+			case <-r.done:
+				return
+			default:
+				r.closeErr = err
+				return
+			}
+		}
+		select {
+		case err := <-r.done:
+			if err != nil {
+				r.closeErr = fmt.Errorf("pw-reserve exit: %w", err)
+			}
+		case <-time.After(2 * time.Second):
+			_ = r.cmd.Process.Kill()
+			<-r.done
+			r.closeErr = errors.New("pw-reserve did not exit after SIGTERM")
+		}
+		applog.Info("audio reservation released")
+	})
+	return r.closeErr
+}

--- a/player/reservation_linux.go
+++ b/player/reservation_linux.go
@@ -45,6 +45,9 @@ func acquireAudioReservation(name string) (reservationHandle, error) {
 	select {
 	case err := <-r.done:
 		detail := strings.TrimSpace(stderr.String())
+		if err == nil {
+			err = errors.New("pw-reserve exited immediately")
+		}
 		if detail != "" {
 			return nil, fmt.Errorf("reserve audio device %s: %w: %s", name, err, detail)
 		}

--- a/player/reservation_linux_test.go
+++ b/player/reservation_linux_test.go
@@ -3,7 +3,9 @@
 package player
 
 import (
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -12,6 +14,19 @@ import (
 func TestAudioReservationMissingHelper(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 	if _, err := acquireAudioReservation("Audio2"); err == nil || !strings.Contains(err.Error(), "pw-reserve") {
+		t.Fatalf("acquireAudioReservation() = %v", err)
+	}
+}
+
+func TestAudioReservationSuccessfulEarlyExit(t *testing.T) {
+	dir := t.TempDir()
+	helper := filepath.Join(dir, "pw-reserve")
+	if err := os.WriteFile(helper, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+	_, err := acquireAudioReservation("Audio2")
+	if err == nil || !strings.Contains(err.Error(), "pw-reserve exited immediately") {
 		t.Fatalf("acquireAudioReservation() = %v", err)
 	}
 }

--- a/player/reservation_linux_test.go
+++ b/player/reservation_linux_test.go
@@ -1,0 +1,36 @@
+//go:build linux
+
+package player
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAudioReservationMissingHelper(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	if _, err := acquireAudioReservation("Audio2"); err == nil || !strings.Contains(err.Error(), "pw-reserve") {
+		t.Fatalf("acquireAudioReservation() = %v", err)
+	}
+}
+
+func TestPWReservationCloseStopsHelper(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", "trap 'exit 0' TERM; while :; do /bin/sleep 0.05; done")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	r := &pwReservation{cmd: cmd, done: make(chan error, 1)}
+	go func() { r.done <- cmd.Wait() }()
+	time.Sleep(50 * time.Millisecond)
+	if err := r.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if cmd.ProcessState == nil || !cmd.ProcessState.Exited() {
+		t.Fatal("reservation helper still running after Close")
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("second Close() = %v", err)
+	}
+}

--- a/player/reservation_other.go
+++ b/player/reservation_other.go
@@ -1,0 +1,15 @@
+//go:build !linux
+
+package player
+
+import (
+	"errors"
+	"strings"
+)
+
+func acquireAudioReservation(name string) (reservationHandle, error) {
+	if strings.TrimSpace(name) == "" {
+		return nil, nil
+	}
+	return nil, errors.New("audio reservation is supported only on Linux")
+}

--- a/site/index.html
+++ b/site/index.html
@@ -717,7 +717,7 @@ footer{border-top:1px solid var(--line);background:var(--ink-2);padding:46px 0 5
       <span class="strip-meter"><i></i><i></i><i></i><i></i><i></i></span>
     </div>
     <p class="sources-intro reveal">
-      Stream from everywhere. Every provider runs through the same <em>playlist, EQ, visualizer, and lyrics pipeline</em> — your config follows you across services. Run <code>cliamp setup</code> for an interactive wizard that walks you through Navidrome, Plex, Jellyfin, Emby, Audiobookshelf, Spotify, Qobuz, Tidal, NetEase, and YouTube Music.
+      Stream from everywhere. The default native backend runs supported providers through the same <em>playlist, EQ, visualizer, and lyrics pipeline</em> — your config follows you across services. Run <code>cliamp setup</code> for an interactive wizard that walks you through Navidrome, Plex, Jellyfin, Emby, Audiobookshelf, Spotify, Qobuz, Tidal, NetEase, and YouTube Music.
     </p>
     <div class="sources-grid reveal">
       <div class="source" style="--src-color:#1db954"><div class="source-badge">OAuth · cached</div><div class="source-name">Spotify</div><div class="source-desc">Stream your Premium library. Bring your own developer <code>client_id</code> for a private Web API quota; playback is authorized separately. Search with <kbd>Ctrl+F</kbd>; Development Mode paging is automatic. Pre-built Windows releases include Spotify support.</div></div>
@@ -769,6 +769,7 @@ user_id = "your-account-user-id"</code></pre>
       <div class="feature"><div class="feature-icon">♬</div><div class="feature-name">MPRIS / Media Keys</div><p>Desktop integration. Hardware media keys, <code>playerctl</code>, and embedded local cover art.</p></div>
       <div class="feature"><div class="feature-icon">▮</div><div class="feature-name">Quickshell Widget (Omarchy)</div><p>Drop-in <a href="https://quickshell.org">Quickshell</a> now-playing card with a Winamp 2-style spectrum, tracking your active Omarchy theme. <a href="https://github.com/bjarneo/cliamp/blob/main/docs/quickshell.md">Setup</a>.</p></div>
       <div class="feature"><div class="feature-icon">⚙</div><div class="feature-name">Audio Quality</div><p>Configurable sample rate (22kHz-192kHz), up to 5 seconds of buffering, and resampling.</p></div>
+      <div class="feature"><div class="feature-icon">◉</div><div class="feature-name">MPV Direct ALSA</div><p>Optional persistent MPV JSON-IPC backend for exact Linux ALSA device selection and bit-perfect-capable no-DSP playback. The native backend remains the default. <a href="https://github.com/bjarneo/cliamp/blob/main/docs/mpv.md">Setup</a>.</p></div>
       <div class="feature"><div class="feature-icon">⌀</div><div class="feature-name">Live Radio Metadata</div><p>ICY/Shoutcast metadata for the current song on internet radio, plus API-based now-playing for FIP and NTS.</p></div>
       <div class="feature"><div class="feature-icon">✎</div><div class="feature-name">Embedded Tag Reading</div><p>ID3v2, Vorbis comments, MP4 atoms - artist, album, genre, year, lyrics, cover art.</p></div>
       <div class="feature"><div class="feature-icon">▶</div><div class="feature-name">CLI Flags</div><p>Override volume, shuffle, repeat, theme, EQ, sample rate per-session.</p></div>

--- a/ui/model/audio.go
+++ b/ui/model/audio.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/bjarneo/cliamp/player"
 )
 
 const (
@@ -15,6 +17,9 @@ const (
 // SetEQPreset sets a built-in preset by name. Supplying bands selects the
 // persistent Custom slot and uses name as its optional label.
 func (m *Model) SetEQPreset(name string, bands *[10]float64) {
+	if !m.requirePlayerFeature(player.FeatureEQ) {
+		return
+	}
 	m.eqCustomLabel = ""
 	if bands != nil {
 		m.eqPresetIdx = -1
@@ -72,6 +77,9 @@ func (m *Model) applyEQBands(bands [eqBandCount]float64) {
 }
 
 func (m *Model) setCustomEQBand(band int, gain float64) {
+	if !m.requirePlayerFeature(player.FeatureEQ) {
+		return
+	}
 	m.player.SetEQBand(band, gain)
 	m.eqPresetIdx = -1
 	m.eqCustomLabel = ""
@@ -80,6 +88,9 @@ func (m *Model) setCustomEQBand(band int, gain float64) {
 }
 
 func (m *Model) cycleEQPreset() {
+	if !m.requirePlayerFeature(player.FeatureEQ) {
+		return
+	}
 	if m.eqPresetIdx >= len(eqPresets)-1 {
 		m.eqPresetIdx = -1
 		m.applyEQBands(m.eqCustomBands)
@@ -115,6 +126,9 @@ func (m *Model) saveSpeed() {
 }
 
 func (m *Model) changeSpeed(delta float64) {
+	if !m.requirePlayerFeature(player.FeatureSpeed) {
+		return
+	}
 	m.player.SetSpeed(m.player.Speed() + delta)
 	m.speedSaveAfter = speedSaveDebounce
 }

--- a/ui/model/backend.go
+++ b/ui/model/backend.go
@@ -1,0 +1,11 @@
+package model
+
+import "github.com/bjarneo/cliamp/player"
+
+func (m *Model) requirePlayerFeature(feature player.Feature) bool {
+	if err := player.FeatureError(m.player, feature); err != nil {
+		m.status.Warning(err.Error(), statusTTLDefault)
+		return false
+	}
+	return true
+}

--- a/ui/model/commands.go
+++ b/ui/model/commands.go
@@ -181,16 +181,16 @@ func AttachNotifier(notifier playback.Notifier) tea.Msg {
 	return attachNotifierMsg{notifier: notifier}
 }
 
-func listDevicesCmd() tea.Cmd {
+func listDevicesCmd(engine player.Engine) tea.Cmd {
 	return func() tea.Msg {
-		devices, err := player.ListAudioDevices()
+		devices, err := player.EngineAudioDevices(engine)
 		return devicesListedMsg{devices: devices, err: err}
 	}
 }
 
-func switchDeviceCmd(name string) tea.Cmd {
+func switchDeviceCmd(engine player.Engine, name string) tea.Cmd {
 	return func() tea.Msg {
-		err := player.SwitchAudioDevice(name)
+		err := player.SwitchEngineAudioDevice(engine, name)
 		return deviceSwitchedMsg{name: name, err: err}
 	}
 }

--- a/ui/model/inline_overlays.go
+++ b/ui/model/inline_overlays.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/bjarneo/cliamp/lyrics"
+	"github.com/bjarneo/cliamp/player"
 	"github.com/bjarneo/cliamp/playlist"
 	"github.com/bjarneo/cliamp/theme"
 	"github.com/bjarneo/cliamp/ui"
@@ -327,10 +328,42 @@ func (m Model) infoLines() []string {
 		field("Track", fmt.Sprintf("%d", track.TrackNumber))
 	}
 	field("Path", track.Path)
+	backend := player.EngineBackendStatus(m.player)
+	field("Backend", strings.ToUpper(backend.Name))
+	field("Device", backend.Device)
+	if backend.BitPerfectMode {
+		field("Bit-perfect mode", "Enabled (not independently verified)")
+		if backend.DSPDisabled {
+			field("DSP", "Disabled")
+		}
+		if backend.DirectALSA {
+			field("Output path", "Direct ALSA")
+		}
+	}
+	if value := audioParametersText(backend.Source); value != "" {
+		field("Source audio", value)
+	}
+	if value := audioParametersText(backend.Output); value != "" {
+		field("Output audio", value)
+	}
 	if len(lines) == 0 {
 		lines = append(lines, dimStyle.Render("  No track metadata available."))
 	}
 	return lines
+}
+
+func audioParametersText(params player.AudioParameters) string {
+	parts := make([]string, 0, 3)
+	if params.Format != "" {
+		parts = append(parts, params.Format)
+	}
+	if params.SampleRate > 0 {
+		parts = append(parts, fmt.Sprintf("%.1f kHz", float64(params.SampleRate)/1000))
+	}
+	if params.Channels != "" {
+		parts = append(parts, params.Channels)
+	}
+	return strings.Join(parts, " / ")
 }
 
 func (m *Model) infoMaybeAdjustScroll() {

--- a/ui/model/ipc_runtime.go
+++ b/ui/model/ipc_runtime.go
@@ -51,6 +51,7 @@ type ipcRuntimeFingerprint struct {
 	speed            float64
 	eq               [10]float64
 	eqPreset         string
+	backend          player.BackendStatus
 	visualizer       string
 	theme            string
 	streamTitle      string
@@ -678,6 +679,7 @@ func (m *Model) runtimeFingerprint() ipcRuntimeFingerprint {
 	fingerprint.speed = m.player.Speed()
 	fingerprint.eq = m.player.EQBands()
 	fingerprint.eqPreset = m.EQPresetName()
+	fingerprint.backend = player.EngineBackendStatus(m.player)
 	fingerprint.detached = m.playbackDetached
 	fingerprint.streamTitle = m.streamTitle
 	if m.player.IsPlaying() && !m.player.IsPaused() {

--- a/ui/model/ipc_runtime.go
+++ b/ui/model/ipc_runtime.go
@@ -163,11 +163,19 @@ func (m *Model) handleV2Request(msg V2RequestMsg) tea.Cmd {
 		m.completeV2Job(msg.Jobs, msg.JobID, ipc.Response{OK: true})
 		return cmd
 	case "volume":
+		if err := player.FeatureError(m.player, player.FeatureVolume); err != nil {
+			m.completeV2Job(msg.Jobs, msg.JobID, ipc.Response{OK: false, Error: err.Error()})
+			return nil
+		}
 		m.player.SetVolume(request.Value)
 		m.notifyAll()
 		m.completeV2Job(msg.Jobs, msg.JobID, ipc.Response{OK: true, Volume: m.player.Volume()})
 		return nil
 	case "volume.adjust":
+		if err := player.FeatureError(m.player, player.FeatureVolume); err != nil {
+			m.completeV2Job(msg.Jobs, msg.JobID, ipc.Response{OK: false, Error: err.Error()})
+			return nil
+		}
 		m.player.SetVolume(m.player.Volume() + request.Value)
 		m.notifyAll()
 		m.completeV2Job(msg.Jobs, msg.JobID, ipc.Response{OK: true, Volume: m.player.Volume()})
@@ -188,11 +196,19 @@ func (m *Model) handleV2Request(msg V2RequestMsg) tea.Cmd {
 			m.failV2Job(msg.Jobs, msg.JobID, v2InvalidParamsError())
 			return nil
 		}
+		if err := player.FeatureError(m.player, player.FeatureSpeed); err != nil {
+			m.completeV2Job(msg.Jobs, msg.JobID, ipc.Response{OK: false, Error: err.Error()})
+			return nil
+		}
 		m.player.SetSpeed(request.Value)
 		m.saveSpeed()
 		m.completeV2Job(msg.Jobs, msg.JobID, ipc.Response{OK: true, Speed: m.player.Speed()})
 		return nil
 	case "speed.adjust":
+		if err := player.FeatureError(m.player, player.FeatureSpeed); err != nil {
+			m.completeV2Job(msg.Jobs, msg.JobID, ipc.Response{OK: false, Error: err.Error()})
+			return nil
+		}
 		m.player.SetSpeed(m.player.Speed() + request.Value)
 		m.saveSpeed()
 		m.completeV2Job(msg.Jobs, msg.JobID, ipc.Response{OK: true, Speed: m.player.Speed()})
@@ -363,6 +379,10 @@ func (m *Model) handleV2Theme(jobs *ipc.JobStore, jobID string, request ipc.Requ
 }
 
 func (m *Model) handleV2Visualizer(jobs *ipc.JobStore, jobID string, request ipc.Request) tea.Cmd {
+	if err := player.FeatureError(m.player, player.FeatureVisualizer); err != nil {
+		m.completeV2Job(jobs, jobID, ipc.Response{OK: false, Error: err.Error()})
+		return nil
+	}
 	if strings.EqualFold(request.Name, "list") {
 		m.completeV2Job(jobs, jobID, ipc.Response{OK: true, Items: ui.VisModeNames()})
 		return nil
@@ -389,7 +409,7 @@ func (m *Model) handleV2Visualizer(jobs *ipc.JobStore, jobID string, request ipc
 func (m *Model) handleV2Device(jobs *ipc.JobStore, jobID string, request ipc.Request) tea.Cmd {
 	if strings.EqualFold(request.Name, "list") {
 		return func() tea.Msg {
-			devices, err := player.ListAudioDevices()
+			devices, err := player.EngineAudioDevices(m.player)
 			if err != nil {
 				return ipcV2ResponseMsg{Jobs: jobs, JobID: jobID, Operation: "device", Response: ipc.Response{OK: false, Error: err.Error()}}
 			}
@@ -401,7 +421,7 @@ func (m *Model) handleV2Device(jobs *ipc.JobStore, jobID string, request ipc.Req
 		}
 	}
 	return func() tea.Msg {
-		err := player.SwitchAudioDevice(request.Name)
+		err := player.SwitchEngineAudioDevice(m.player, request.Name)
 		response := ipc.Response{OK: true, Device: request.Name}
 		if err != nil {
 			response = ipc.Response{OK: false, Error: err.Error()}
@@ -411,6 +431,10 @@ func (m *Model) handleV2Device(jobs *ipc.JobStore, jobID string, request ipc.Req
 }
 
 func (m *Model) handleV2EQ(jobs *ipc.JobStore, jobID string, request ipc.Request) tea.Cmd {
+	if err := player.FeatureError(m.player, player.FeatureEQ); err != nil {
+		m.completeV2Job(jobs, jobID, ipc.Response{OK: false, Error: err.Error()})
+		return nil
+	}
 	if request.Band > 0 || (request.Band == 0 && request.Name == "") {
 		if request.Band >= eqBandCount {
 			m.failV2Job(jobs, jobID, v2InvalidParamsError())
@@ -454,6 +478,10 @@ func (m *Model) handleV2Mode(jobs *ipc.JobStore, jobID string, request ipc.Reque
 		m.player.ClearPreload()
 		m.completeV2Job(jobs, jobID, ipc.Response{OK: true, Repeat: m.playlist.Repeat().String()})
 	case "mono":
+		if err := player.FeatureError(m.player, player.FeatureMono); err != nil {
+			m.completeV2Job(jobs, jobID, ipc.Response{OK: false, Error: err.Error()})
+			return nil
+		}
 		if (name == "on" && !m.player.Mono()) || (name == "off" && m.player.Mono()) || (name != "on" && name != "off") {
 			m.player.ToggleMono()
 		}
@@ -582,10 +610,26 @@ func (m *Model) runtimeSnapshot() ipc.RuntimeSnapshot {
 	mono := m.player.Mono()
 	snapshot.Mono = &mono
 	snapshot.Speed = m.player.Speed()
-	snapshot.EQPreset = m.EQPresetName()
-	bands := m.player.EQBands()
-	snapshot.EQBands = append([]float64(nil), bands[:]...)
-	if m.vis != nil {
+	backend := player.EngineBackendStatus(m.player)
+	snapshot.Backend = backend.Name
+	if backend.Device != "" {
+		snapshot.Device = backend.Device
+	}
+	snapshot.BitPerfect = backend.BitPerfectMode
+	snapshot.DSPDisabled = backend.DSPDisabled
+	snapshot.DirectALSA = backend.DirectALSA
+	if backend.Source != (player.AudioParameters{}) {
+		snapshot.SourceAudio = &ipc.AudioInfo{Format: backend.Source.Format, SampleRate: backend.Source.SampleRate, Channels: backend.Source.Channels}
+	}
+	if backend.Output != (player.AudioParameters{}) {
+		snapshot.OutputAudio = &ipc.AudioInfo{Format: backend.Output.Format, SampleRate: backend.Output.SampleRate, Channels: backend.Output.Channels}
+	}
+	if player.FeatureError(m.player, player.FeatureEQ) == nil {
+		snapshot.EQPreset = m.EQPresetName()
+		bands := m.player.EQBands()
+		snapshot.EQBands = append([]float64(nil), bands[:]...)
+	}
+	if m.vis != nil && player.FeatureError(m.player, player.FeatureVisualizer) == nil {
 		snapshot.Visualizer = m.vis.ModeName()
 	}
 	if m.themeIdx >= 0 && m.themeIdx < len(m.themes) {
@@ -660,6 +704,9 @@ func (m *Model) runtimeFingerprint() ipcRuntimeFingerprint {
 }
 
 func (m *Model) v2BandsResponse() ipc.Response {
+	if err := player.FeatureError(m.player, player.FeatureVisualizer); err != nil {
+		return ipc.Response{OK: false, Error: err.Error()}
+	}
 	response := ipc.Response{OK: true}
 	if m.vis != nil {
 		response.Visualizer = m.vis.ModeName()

--- a/ui/model/ipc_runtime_test.go
+++ b/ui/model/ipc_runtime_test.go
@@ -5,9 +5,35 @@ import (
 	"testing"
 
 	"github.com/bjarneo/cliamp/ipc"
+	"github.com/bjarneo/cliamp/player"
 	"github.com/bjarneo/cliamp/playlist"
 	"github.com/bjarneo/cliamp/ui"
 )
+
+type backendStatusEngine struct {
+	*playbackFakeEngine
+	status player.BackendStatus
+}
+
+func (e *backendStatusEngine) BackendStatus() player.BackendStatus { return e.status }
+
+func TestRuntimeFingerprintIncludesBackendStatus(t *testing.T) {
+	engine := &backendStatusEngine{
+		playbackFakeEngine: &playbackFakeEngine{},
+		status: player.BackendStatus{
+			Name:   "mpv",
+			Device: "alsa/hw:CARD=Generic,DEV=0",
+			Output: player.AudioParameters{Format: "s32", SampleRate: 48000, Channels: "stereo"},
+		},
+	}
+	m := Model{player: engine, playlist: playlist.New()}
+	before := m.runtimeFingerprint()
+	engine.status.Output.SampleRate = 96000
+	after := m.runtimeFingerprint()
+	if before == after {
+		t.Fatal("backend status change did not change runtime fingerprint")
+	}
+}
 
 func TestV2StateRequestReturnsRetainedGUIState(t *testing.T) {
 	engine := &playbackFakeEngine{playing: true}

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/bjarneo/cliamp/history"
 	"github.com/bjarneo/cliamp/internal/fileutil"
+	"github.com/bjarneo/cliamp/player"
 	"github.com/bjarneo/cliamp/playlist"
 	"github.com/bjarneo/cliamp/provider"
 )
@@ -655,12 +656,16 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 		}
 
 	case "+", "=":
-		m.player.SetVolume(m.player.Volume() + 1)
-		m.notifyPlayback()
+		if m.requirePlayerFeature(player.FeatureVolume) {
+			m.player.SetVolume(m.player.Volume() + 1)
+			m.notifyPlayback()
+		}
 
 	case "-":
-		m.player.SetVolume(m.player.Volume() - 1)
-		m.notifyPlayback()
+		if m.requirePlayerFeature(player.FeatureVolume) {
+			m.player.SetVolume(m.player.Volume() - 1)
+			m.notifyPlayback()
+		}
 
 	case "r":
 		m.playlist.CycleRepeat()
@@ -695,8 +700,10 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 		if m.simplified || m.layout.tier == layoutMinimal {
 			break
 		}
-		m.cycleEQPreset()
-		m.scheduleEQSave()
+		if m.requirePlayerFeature(player.FeatureEQ) {
+			m.cycleEQPreset()
+			m.scheduleEQSave()
+		}
 
 	case "a":
 		if m.focus == focusPlaylist {
@@ -726,7 +733,9 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 		return m.switchToProvider("spotify")
 
 	case "m":
-		m.player.ToggleMono()
+		if m.requirePlayerFeature(player.FeatureMono) {
+			m.player.ToggleMono()
+		}
 
 	case "/":
 		m.search.active = true
@@ -808,6 +817,9 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 		if m.simplified {
 			break
 		}
+		if !m.requirePlayerFeature(player.FeatureVisualizer) {
+			break
+		}
 		m.vis.CycleMode()
 		m.vis.RequestRefresh()
 		m.refreshChrome()
@@ -821,10 +833,15 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 		if m.simplified {
 			break
 		}
-		m.openVisPicker()
+		if m.requirePlayerFeature(player.FeatureVisualizer) {
+			m.openVisPicker()
+		}
 
 	case "V":
 		if m.simplified {
+			break
+		}
+		if !m.requirePlayerFeature(player.FeatureVisualizer) {
 			break
 		}
 		m.fullVis = !m.fullVis
@@ -846,7 +863,7 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 		m.devicePicker.scroll = 0
 		if len(m.devicePicker.devices) == 0 {
 			m.devicePicker.loading = true
-			return listDevicesCmd()
+			return listDevicesCmd(m.player)
 		}
 
 	case "]":
@@ -901,15 +918,21 @@ func (m *Model) handleFullVisualizerKey(msg tea.KeyPressMsg) tea.Cmd {
 	case "shift+right":
 		return m.doSeek(m.seekStepLarge)
 	case "+", "=":
-		m.player.SetVolume(m.player.Volume() + 1)
-		m.notifyPlayback()
+		if m.requirePlayerFeature(player.FeatureVolume) {
+			m.player.SetVolume(m.player.Volume() + 1)
+			m.notifyPlayback()
+		}
 	case "-":
-		m.player.SetVolume(m.player.Volume() - 1)
-		m.notifyPlayback()
+		if m.requirePlayerFeature(player.FeatureVolume) {
+			m.player.SetVolume(m.player.Volume() - 1)
+			m.notifyPlayback()
+		}
 	case "v":
-		m.vis.CycleMode()
-		m.vis.RequestRefresh()
-		m.refreshChrome()
+		if m.requirePlayerFeature(player.FeatureVisualizer) {
+			m.vis.CycleMode()
+			m.vis.RequestRefresh()
+			m.refreshChrome()
+		}
 	case "ctrl+k", "?":
 		m.exitFullVisualizer()
 		m.openKeymap()
@@ -2752,7 +2775,7 @@ func (m *Model) handleDeviceKey(msg tea.KeyPressMsg) tea.Cmd {
 		if len(m.devicePicker.devices) > 0 && m.devicePicker.cursor < len(m.devicePicker.devices) {
 			dev := m.devicePicker.devices[m.devicePicker.cursor]
 			m.devicePicker.visible = false
-			return switchDeviceCmd(dev.Name)
+			return switchDeviceCmd(m.player, dev.Name)
 		}
 	case "esc", "d":
 		m.devicePicker.visible = false

--- a/ui/model/model.go
+++ b/ui/model/model.go
@@ -60,11 +60,16 @@ func (m Model) mainFocusAreas() []focusArea {
 	if m.simplified || m.layout.tier == layoutMinimal || m.layout.tier == layoutTooSmall {
 		return areas
 	}
-	areas = append(areas, focusEQ)
+	if player.FeatureError(m.player, player.FeatureEQ) == nil {
+		areas = append(areas, focusEQ)
+	}
 	if len(m.providers) > 1 {
 		areas = append(areas, focusProvPill)
 	}
-	return append(areas, focusSpeed)
+	if player.FeatureError(m.player, player.FeatureSpeed) == nil {
+		areas = append(areas, focusSpeed)
+	}
+	return areas
 }
 
 func (m Model) mainFocusAllowed(focus focusArea) bool {

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -907,8 +907,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.seekAbsolute(msg.Position)
 
 	case playback.SetVolumeMsg:
-		m.player.SetVolume(msg.VolumeDB)
-		m.notifyAll()
+		if m.requirePlayerFeature(player.FeatureVolume) {
+			m.player.SetVolume(msg.VolumeDB)
+			m.notifyAll()
+		}
 		return m, nil
 
 	case playback.StopMsg:
@@ -926,8 +928,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 
 	case SetEQPresetMsg:
-		m.SetEQPreset(msg.Name, msg.Bands)
-		m.scheduleEQSave()
+		if m.requirePlayerFeature(player.FeatureEQ) {
+			m.SetEQPreset(msg.Name, msg.Bands)
+			m.scheduleEQSave()
+		}
 		return m, nil
 
 	case SetEQBandMsg:
@@ -1002,6 +1006,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case ipc.VisMsg:
+		if err := player.FeatureError(m.player, player.FeatureVisualizer); err != nil {
+			if msg.Reply != nil {
+				msg.Reply <- ipc.Response{OK: false, Error: err.Error()}
+			}
+			m.status.Warning(err.Error(), statusTTLDefault)
+			return m, nil
+		}
 		if m.vis == nil {
 			if msg.Reply != nil {
 				msg.Reply <- ipc.Response{OK: false, Error: "visualizer not available"}
@@ -1070,6 +1081,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 
 	case ipc.MonoMsg:
+		if err := player.FeatureError(m.player, player.FeatureMono); err != nil {
+			if msg.Reply != nil {
+				msg.Reply <- ipc.Response{OK: false, Error: err.Error()}
+			}
+			m.status.Warning(err.Error(), statusTTLDefault)
+			return m, nil
+		}
 		switch strings.ToLower(msg.Name) {
 		case "on":
 			if !m.player.Mono() {
@@ -1089,6 +1107,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case ipc.SpeedMsg:
+		if err := player.FeatureError(m.player, player.FeatureSpeed); err != nil {
+			if msg.Reply != nil {
+				msg.Reply <- ipc.Response{OK: false, Error: err.Error()}
+			}
+			m.status.Warning(err.Error(), statusTTLDefault)
+			return m, nil
+		}
 		m.player.SetSpeed(msg.Speed)
 		m.saveSpeed()
 		if msg.Reply != nil {
@@ -1097,6 +1122,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case ipc.EQMsg:
+		if err := player.FeatureError(m.player, player.FeatureEQ); err != nil {
+			if msg.Reply != nil {
+				msg.Reply <- ipc.Response{OK: false, Error: err.Error()}
+			}
+			m.status.Warning(err.Error(), statusTTLDefault)
+			return m, nil
+		}
 		if msg.Band > 0 || (msg.Band == 0 && msg.Name == "") {
 			// Set a specific band (0-9).
 			m.setCustomEQBand(msg.Band, msg.Value)
@@ -1119,7 +1151,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case ipc.DeviceMsg:
 		if strings.EqualFold(msg.Name, "list") {
-			devices, err := player.ListAudioDevices()
+			devices, err := player.EngineAudioDevices(m.player)
 			if err != nil {
 				if msg.Reply != nil {
 					msg.Reply <- ipc.Response{OK: false, Error: fmt.Sprintf("list devices: %v", err)}
@@ -1142,7 +1174,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 		}
-		err := player.SwitchAudioDevice(msg.Name)
+		err := player.SwitchEngineAudioDevice(m.player, msg.Name)
 		if err != nil {
 			if msg.Reply != nil {
 				msg.Reply <- ipc.Response{OK: false, Error: fmt.Sprintf("switch device: %v", err)}

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -9,6 +9,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
+	"github.com/bjarneo/cliamp/player"
 	"github.com/bjarneo/cliamp/playlist"
 	"github.com/bjarneo/cliamp/provider"
 	"github.com/bjarneo/cliamp/theme"
@@ -321,15 +322,21 @@ func (m Model) renderCompactControls() string {
 		mono = " [M]"
 	}
 	eqLabel := labelStyle.Render("EQ ")
-	eqValue := activeToggle.Render("[" + m.EQPresetName() + "]")
-	if m.focus == focusEQ {
+	eqValue := dimStyle.Render("[unavailable]")
+	if player.FeatureError(m.player, player.FeatureEQ) == nil {
+		eqValue = activeToggle.Render("[" + m.EQPresetName() + "]")
+	}
+	if m.focus == focusEQ && player.FeatureError(m.player, player.FeatureEQ) == nil {
 		eqLabel = activeToggle.Render("EQ ▸ ")
 		bands := m.player.EQBands()
 		labels := [10]string{"70", "180", "320", "600", "1k", "3k", "6k", "12k", "14k", "16k"}
 		eqValue += " " + eqActiveStyle.Render(fmt.Sprintf("%s %+.0fdB", labels[m.eqCursor], bands[m.eqCursor]))
 	}
-	return eqLabel + eqValue +
-		" " + labelStyle.Render("VOL ") + fmt.Sprintf("%+.0fdB", m.player.Volume()) + mono
+	volume := fmt.Sprintf("%+.0fdB", m.player.Volume())
+	if player.FeatureError(m.player, player.FeatureVolume) != nil {
+		volume = "[locked " + volume + "]"
+	}
+	return eqLabel + eqValue + " " + labelStyle.Render("VOL ") + volume + mono
 }
 
 func (m Model) renderCompactSource() string {
@@ -565,6 +572,9 @@ func (m Model) renderControls() string {
 		eqLabel = activeToggle.Render("EQ ▸ ")
 	}
 	left := eqLabel + dimStyle.Render("[") + activeToggle.Render(presetName) + dimStyle.Render("] ") + strings.Join(eqParts, " ")
+	if player.FeatureError(m.player, player.FeatureEQ) != nil {
+		left = labelStyle.Render("EQ ") + dimStyle.Render("[unavailable]")
+	}
 
 	vol := m.player.Volume()
 	volMin := m.player.VolumeMin()
@@ -587,6 +597,9 @@ func (m Model) renderControls() string {
 		dimStyle.Render(strings.Repeat("░", barW-filled))
 
 	right := volLabel + bar + volSuffix
+	if player.FeatureError(m.player, player.FeatureVolume) != nil {
+		right = volLabel + dimStyle.Render("[locked"+dbStr+"]") + monoStr
+	}
 	rightW := lipgloss.Width(right)
 	gap := max(1, ui.PanelWidth-leftW-rightW)
 
@@ -978,7 +991,9 @@ func (m Model) renderBottomStatus() string {
 
 	var left string
 	speedLabel := labelStyle.Render("SPD ")
-	if m.focus == focusSpeed {
+	if player.FeatureError(m.player, player.FeatureSpeed) != nil {
+		left = speedLabel + dimStyle.Render("[locked "+speedVal+"]")
+	} else if m.focus == focusSpeed {
 		speedLabel = activeToggle.Render("SPD ▸ ")
 		left = speedLabel + activeToggle.Render("["+speedVal+"]")
 	} else if speed != 1.0 {


### PR DESCRIPTION
## Architecture summary

- Preserves `player.Engine` as the application playback boundary; the existing native `*player.Player` remains the default.
- Adds `MPVBackend` behind the same engine contract and optional capability/status interfaces.
- cliamp remains authoritative for playlists, queueing, shuffle, repeat, next/previous, metadata, TUI, daemon, and remote-control behavior.
- MPV receives one track at a time; no MPV-owned playlist sequencing is introduced.

## Persistent MPV JSON IPC design

- Starts one persistent `mpv --idle=yes --no-video --no-terminal` process.
- Uses a unique Unix socket below `$XDG_RUNTIME_DIR/cliamp` when available, with a private temporary-directory fallback.
- Correlates commands and responses with MPV `request_id` values while dispatching asynchronous events independently.
- Observes playback position, duration, pause, volume, speed, source/output audio parameters, file load, end-file, and shutdown state.
- Includes request timeouts, synchronized state, unexpected-process-exit handling, and deterministic process/socket cleanup.
- Missing MPV or startup/IPC errors are returned; the backend never silently falls back to native playback.

## New CLI and configuration options

- `--audio-backend native|mpv` / `audio_backend` (default: `native`)
- `--audio-device` / `audio_device`; MPV receives the exact configured value
- `--bit-perfect`, `--no-bit-perfect` / `bit_perfect`
- `--audio-reservation` / `audio_reservation` for an explicit Linux ReserveDevice1 name
- `--audio-device list` uses backend-specific device discovery

## Bit-perfect safeguards

Bit-perfect mode requires an explicit `alsa/hw:` MPV device, locks MPV volume to 100 and speed to 1.0, disables MPV config files, audio filters, ReplayGain, normalization, pitch correction, cliamp EQ, and mono, and rejects conflicting startup/runtime controls. It does not force sample rate or PCM format, so ALSA may negotiate native rates and carry 24-bit samples as `S32_LE`.

The UI and status describe this as a bit-perfect-capable configuration, not proof of the complete hardware path.

## PipeWire reservation behavior

Linux users may set an explicit reservation such as `Audio2`. cliamp then owns `pw-reserve -n Audio2 -a cliamp -r` for its lifetime and releases it during shutdown. The feature is optional, requires `pw-reserve`, never kills PipeWire, and never guesses ALSA-card-to-reservation mapping.

## Unsupported MPV-mode features

- cliamp EQ and mono conversion
- PCM and plugin visualizers
- native sample-rate, resampler-quality, bit-depth, and speaker-buffer controls
- gapless preloading
- Spotify playback through the native Spotify engine
- provider sources requiring the segmented native decoder

These capabilities report unavailable instead of being faked. Normal MPV mode still supports software volume and speed; bit-perfect mode locks them.

## Tests and exact results

Executed with Go 1.26.6:

- `make check` — PASS (`gofmt -l -w .`, `go vet ./...`, `go test ./...`)
- `go test -race ./...` — PASS
- `go build ./...` — PASS
- `git diff --check` — PASS

Unit coverage includes backend/config selection, bit-perfect validation, MPV arguments, JSON request-ID response routing, asynchronous events and state transitions, end-file behavior, socket cleanup, process termination, reservation handling, and a separately gated fake/real MPV integration path. The default suite needs no MPV, ALSA, PipeWire, or audio hardware.

## Manual direct-ALSA test plan

```sh
aplay -l
pw-reserve -n Audio2 -r
fuser -v /dev/snd/pcmC2D0p

mpv -v \
  --audio-device=alsa/hw:CARD=Generic,DEV=0 \
  --no-video \
  song.flac

cliamp \
  --audio-backend mpv \
  --audio-device alsa/hw:CARD=Generic,DEV=0 \
  --bit-perfect \
  song.flac
```

Verify TUI play/pause, seek, next/previous, queue, repeat, shuffle, duration/position, end-of-track advancement, direct ALSA ownership, source-rate switching, and cleanup/reclaim after exit. Exercise 16/44.1, 16/48, 24/44.1, 24/48, 24/96, and 24/192 files; do not force all tracks to one sample rate.

## Known limitations

- Direct ALSA and physical DAC behavior require manual Linux hardware verification.
- Bit-perfect mode cannot prove mixer, driver, firmware, or DAC behavior outside cliamp.
- MPV mode intentionally has no PCM visualizer data or native DSP pipeline.
- PipeWire reservation is Linux-only, depends on `pw-reserve`, and requires an explicit reservation name.
- Unix-socket MPV IPC limits this initial backend to Unix-like systems.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional MPV playback with direct ALSA device selection, bit-perfect mode, and Linux audio reservation.
  * Added audio backend, device, reservation, and bit-perfect CLI and configuration options.
  * Added backend, device, DSP, and source/output audio details to status and remote runtime snapshots.
  * Added feature-aware controls that hide or report unavailable volume, EQ, speed, mono, and visualizer functions.

* **Documentation**
  * Added MPV setup, configuration, usage, and audio-quality guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->