### PR TITLE
docs(lyrion): add Lyrion to the shared provider lists

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -43,7 +43,7 @@ eq_preset = "Flat"
 # Saved Custom curve; applied when eq_preset is "Custom" or empty
 eq = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 
-# Default provider on startup: "radio", "navidrome", "spotify", "qobuz", "tidal", "plex", "jellyfin", "emby", "soundcloud", "mixcloud", "netease", "audiobookshelf", or a YouTube provider
+# Default provider on startup: "radio", "navidrome", "lyrion", "spotify", "qobuz", "tidal", "plex", "jellyfin", "emby", "soundcloud", "mixcloud", "netease", "audiobookshelf", or a YouTube provider
 # provider = "radio"
 
 # Simplified mode: artist/title and time strip without a visualizer or playlist.
@@ -147,6 +147,24 @@ eq = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 #               frequent, starred, byYear, byGenre
 # This is updated automatically when you press [s] inside the browser.
 # browse_sort = alphabeticalByName
+
+# ---
+# Lyrion Music Server / LMS (optional)
+# Only `url` is required; add credentials if the server has password
+# protection enabled. Port 9000 is the LMS default — the same port as its web
+# interface, not the 9090 CLI port.
+# These values take precedence over the LYRION_URL / LYRION_USER /
+# LYRION_PASS environment variables when both are present.
+# [lyrion]
+# url      = "http://nas.local:9000"
+# user     = "alice"
+# password = "secret"
+#
+# Tracks and playlists contributed by LMS plugins (Spotty and similar) are not
+# file-backed, so cliamp cannot stream them and hides them by default. Set this
+# to show them anyway, flagged as unplayable and skipped during playback.
+# See docs/lyrion.md.
+# show_unplayable = true
 
 # ---
 # SoundCloud (optional, opt-in)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -142,7 +142,7 @@ CLI flags override config file values for the current session only. They are not
 
 ## Setup wizard
 
-Configure remote providers (Navidrome, Plex, Jellyfin, Emby, Spotify, Qobuz, Tidal, Mixcloud, NetEase, Audiobookshelf, YouTube Music) through a small TUI. Each provider page links to where to find the required credentials and writes the resulting `[provider]` block to `~/.config/cliamp/config.toml` without disturbing the rest of the file. Supported server connections are validated during setup. OAuth providers (Spotify, Qobuz, Tidal) authenticate later in the player; Mixcloud's optional browser-session or OAuth credentials are checked when used.
+Configure remote providers (Navidrome, Lyrion, Plex, Jellyfin, Emby, Spotify, Qobuz, Tidal, Mixcloud, NetEase, Audiobookshelf, YouTube Music) through a small TUI. Each provider page links to where to find the required credentials and writes the resulting `[provider]` block to `~/.config/cliamp/config.toml` without disturbing the rest of the file. Supported server connections are validated during setup. OAuth providers (Spotify, Qobuz, Tidal) authenticate later in the player; Mixcloud's optional browser-session or OAuth credentials are checked when used.
 
 ```sh
 cliamp setup

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -75,7 +75,7 @@ active when the picker opened. While typing a filter, `Enter` finishes it and
 | Key | Action |
 |---|---|
 | `f` | Toggle bookmark ★ on selected track (or favorite radio station in radio browser) |
-| `Ctrl+F` | Search — active provider's native search (Spotify, Qobuz, Tidal, Navidrome, Jellyfin, Emby, Plex, Audiobookshelf, Mixcloud, NetEase, Local) or YouTube fallback. Available from playlist and provider-browser views. |
+| `Ctrl+F` | Search — active provider's native search (Spotify, Qobuz, Tidal, Navidrome, Lyrion, Jellyfin, Emby, Plex, Audiobookshelf, Mixcloud, NetEase, Local) or YouTube fallback. Available from playlist and provider-browser views. |
 | `u` | Load URL (stream/playlist) |
 | `y` | Show or close lyrics |
 | `r` | Retry lyrics lookup while lyrics are open |
@@ -146,7 +146,7 @@ Shift-letter keys are reserved for provider switching, so playlist-manager track
 
 ## Provider browser (`N` key)
 
-When you press `N` to drill into a provider (Navidrome, Plex, Jellyfin, Emby, Audiobookshelf, Spotify, Qobuz, Tidal, Mixcloud, YouTube Music), the album/artist/track screens use:
+When you press `N` to drill into a provider (Navidrome, Lyrion, Plex, Jellyfin, Emby, Audiobookshelf, Spotify, Qobuz, Tidal, Mixcloud, YouTube Music), the album/artist/track screens use:
 
 | Key | Action |
 |---|---|

--- a/docs/lyrion.md
+++ b/docs/lyrion.md
@@ -49,9 +49,13 @@ A configured `[lyrion]` block always takes precedence over these.
 
 Cliamp queries your library over the LMS JSON-RPC endpoint (`POST /jsonrpc.js`) and plays tracks from its HTTP file endpoint (`/music/<track_id>/download`). Playback runs in Cliamp's own audio engine, exactly as it does for every other provider.
 
+Lyrion has no dedicated shortcut key. Press `Esc` for the provider list and pick it there, or make it the startup provider with `cliamp --provider lyrion` or `provider = "lyrion"` in `config.toml`.
+
 Browse playlists with the arrow keys and press Enter to load one.
 
 **Press `N` to open the artist/album browser.** The provider pane lists only your server's *saved playlists*; your music files are organised by artist and album, and the browser is how you reach them.
+
+`Ctrl+F` searches your library through the server's own search, from either the playlist view or the browser.
 
 ## Limitations
 


### PR DESCRIPTION
Follow-up to #349. The Lyrion provider landed with its own `docs/lyrion.md` and a site card, but it never got added to the shared lists where every other provider is enumerated.

**`config.toml.example`** — had no `[lyrion]` block at all, unlike Navidrome, SoundCloud, and Mixcloud. Added one covering `url` / `user` / `password`, the env-var precedence, and `show_unplayable`. Lyrion was also the only provider missing from the `provider =` value list.

**`docs/keybindings.md`** — Lyrion was absent from both the `Ctrl+F` native-search list and the `N` provider-browser list. Both already work: the client implements `provider.Searcher`, and search dispatch is interface-based (`ui/model/commands.go`), so it was purely a documentation gap.

**`docs/cli.md`** — the setup-wizard provider list omitted Lyrion, though the wizard does have a Lyrion page (`cmd/setup.go`).

**`docs/lyrion.md`** — the page said "press `N` to open the browser" without saying how you reach the Lyrion provider in the first place. It has no shift-letter shortcut (same as Navidrome), so noted the three ways: `Esc` provider list, `cliamp --provider lyrion`, or `provider = "lyrion"`. Also mentioned that `Ctrl+F` searches the library.

No behaviour change — docs and config example only. `make check` is green.

`site/index.html` needs nothing here; the Lyrion card and the wizard paragraph already name it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Lyrion as a supported remote music provider.
  * Added optional configuration for Lyrion Music Server credentials and unavailable-track handling.
  * Added support for accessing and searching Lyrion through provider selection, startup settings, and library search.

* **Documentation**
  * Updated setup, keybinding, and Lyrion integration guidance to describe the new provider and access methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->