### PR TITLE
fix(pluginmgr): trust single-file plugins

### DIFF
--- a/pluginmgr/pluginmgr.go
+++ b/pluginmgr/pluginmgr.go
@@ -48,6 +48,13 @@ type pluginInfo struct {
 	err         error
 }
 
+func (p pluginInfo) trustName() string {
+	if strings.HasSuffix(p.file, "/") {
+		return strings.TrimSuffix(p.file, "/")
+	}
+	return strings.TrimSuffix(p.file, ".lua")
+}
+
 // List prints all installed plugins with their metadata.
 func List() error {
 	dir, err := appdir.PluginDir()
@@ -70,7 +77,7 @@ func List() error {
 		return trustErr
 	}
 	for i := range plugins {
-		switch err := plugintrust.Verify(manifest, plugins[i].name, plugins[i].path); {
+		switch err := plugintrust.Verify(manifest, plugins[i].trustName(), plugins[i].path); {
 		case err == nil:
 			plugins[i].trust = "trusted"
 		case err == plugintrust.ErrHashMismatch:

--- a/pluginmgr/pluginmgr.go
+++ b/pluginmgr/pluginmgr.go
@@ -70,7 +70,7 @@ func List() error {
 		return trustErr
 	}
 	for i := range plugins {
-		switch err := plugintrust.Verify(manifest, strings.TrimSuffix(plugins[i].file, "/"), plugins[i].path); {
+		switch err := plugintrust.Verify(manifest, plugins[i].name, plugins[i].path); {
 		case err == nil:
 			plugins[i].trust = "trusted"
 		case err == plugintrust.ErrHashMismatch:

--- a/pluginmgr/pluginmgr_test.go
+++ b/pluginmgr/pluginmgr_test.go
@@ -1,6 +1,7 @@
 package pluginmgr
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -170,6 +171,33 @@ func TestListPluginsShowsInstalled(t *testing.T) {
 	// List writes to stdout — we just verify it doesn't error.
 	if err := List(); err != nil {
 		t.Errorf("List: %v", err)
+	}
+}
+
+func TestTrustSingleFilePlugin(t *testing.T) {
+	home := withTempHome(t)
+	pluginDir := filepath.Join(home, ".config", "cliamp", "plugins")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "hello.lua"), []byte(`plugin.register({ name = "hello", version = "1.0", type = "hook" })`), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	var out bytes.Buffer
+	oldOutput := output
+	output = &out
+	t.Cleanup(func() { output = oldOutput })
+
+	if err := Trust("hello", true); err != nil {
+		t.Fatalf("Trust: %v", err)
+	}
+	out.Reset()
+	if err := List(); err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if strings.Contains(out.String(), "untrusted") || !strings.Contains(out.String(), "trusted") {
+		t.Errorf("List output = %q, want trusted", out.String())
 	}
 }
 

--- a/pluginmgr/pluginmgr_test.go
+++ b/pluginmgr/pluginmgr_test.go
@@ -174,30 +174,41 @@ func TestListPluginsShowsInstalled(t *testing.T) {
 	}
 }
 
-func TestTrustSingleFilePlugin(t *testing.T) {
-	home := withTempHome(t)
-	pluginDir := filepath.Join(home, ".config", "cliamp", "plugins")
-	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(pluginDir, "hello.lua"), []byte(`plugin.register({ name = "hello", version = "1.0", type = "hook" })`), 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
+func TestTrustUsesPluginEntryName(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		path string
+	}{
+		{name: "single file", path: "hello.lua"},
+		{name: "directory", path: "hello/init.lua"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			home := withTempHome(t)
+			pluginDir := filepath.Join(home, ".config", "cliamp", "plugins")
+			path := filepath.Join(pluginDir, tt.path)
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatalf("MkdirAll: %v", err)
+			}
+			if err := os.WriteFile(path, []byte(`plugin.register({ name = "registered", version = "1.0", type = "hook" })`), 0o644); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
 
-	var out bytes.Buffer
-	oldOutput := output
-	output = &out
-	t.Cleanup(func() { output = oldOutput })
+			var out bytes.Buffer
+			oldOutput := output
+			output = &out
+			t.Cleanup(func() { output = oldOutput })
 
-	if err := Trust("hello", true); err != nil {
-		t.Fatalf("Trust: %v", err)
-	}
-	out.Reset()
-	if err := List(); err != nil {
-		t.Fatalf("List: %v", err)
-	}
-	if strings.Contains(out.String(), "untrusted") || !strings.Contains(out.String(), "trusted") {
-		t.Errorf("List output = %q, want trusted", out.String())
+			if err := Trust("hello", true); err != nil {
+				t.Fatalf("Trust: %v", err)
+			}
+			out.Reset()
+			if err := List(); err != nil {
+				t.Fatalf("List: %v", err)
+			}
+			if strings.Contains(out.String(), "untrusted") || !strings.Contains(out.String(), "trusted") {
+				t.Errorf("List output = %q, want trusted", out.String())
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #354.\n\nUse the logical plugin name when checking trust status so `plugins trust <name>` correctly marks single-file plugins as trusted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed plugin trust verification for both single-file and directory plugins.
  * Plugin listings now correctly display trusted status when trust has been granted.

* **Tests**
  * Added coverage for trusted single-file and directory plugins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->