### PR TITLE
fix: Retry transient yt-dlp 403 failures on restart

### DIFF
--- a/player/ytdl.go
+++ b/player/ytdl.go
@@ -30,6 +30,8 @@ const ytdlPipeTimeout = 30 * time.Second
 // when the process is slow to flush and exit.
 const ytdlCauseGrace = 3 * time.Second
 
+const ytdlPipelineMaxAttempts = 3
+
 // YTDLPAvailable reports whether yt-dlp is installed and on PATH.
 func YTDLPAvailable() bool {
 	_, err := exec.LookPath("yt-dlp")
@@ -398,11 +400,32 @@ func decodeYTDLPipe(pageURL string, sr beep.SampleRate, bitDepth, startSec int) 
 func (p *Player) buildYTDLPipeline(pageURL string, startSec int) (*trackPipeline, error) {
 	p.streamTitle.Store("")
 
-	decoder, format, err := decodeYTDLPipe(pageURL, p.sr, p.bitDepth, startSec)
-	if err != nil {
-		return nil, err
-	}
+	for attempt := 1; ; attempt++ {
+		decoder, format, err := decodeYTDLPipe(pageURL, p.sr, p.bitDepth, startSec)
+		if err != nil {
+			return nil, err
+		}
 
+		if err := prefillYTDLPipe(decoder); err != nil {
+			if attempt == ytdlPipelineMaxAttempts || !isTransientYTDL403(err) {
+				return nil, err
+			}
+			continue
+		}
+
+		return &trackPipeline{
+			decoder:      decoder,
+			stream:       decoder,
+			format:       format,
+			seekable:     false,
+			path:         pageURL,
+			ytdlSeek:     true,
+			streamOffset: time.Duration(startSec) * time.Second,
+		}, nil
+	}
+}
+
+func prefillYTDLPipe(decoder *ytdlPipeStreamer) error {
 	// Pre-fill: block until yt-dlp + ffmpeg produce initial audio data.
 	// This runs in a tea.Cmd goroutine (not the UI thread), ensuring the
 	// speaker goroutine won't block on an empty pipe and hold its lock
@@ -423,23 +446,19 @@ func (p *Player) buildYTDLPipeline(pageURL string, startSec int) (*trackPipeline
 			cause := decoder.waitCause(ytdlCauseGrace)
 			decoder.Close()
 			if cause != nil {
-				return nil, cause
+				return cause
 			}
-			return nil, fmt.Errorf("waiting for audio data: %w", err)
+			return fmt.Errorf("waiting for audio data: %w", err)
 		}
 	case <-time.After(ytdlPipeTimeout):
 		decoder.Close()
 		<-peekErr // drain goroutine after Close() unblocks the pipe
-		return nil, fmt.Errorf("timed out waiting for audio data (%v)", ytdlPipeTimeout)
+		return fmt.Errorf("timed out waiting for audio data (%v)", ytdlPipeTimeout)
 	}
+	return nil
+}
 
-	return &trackPipeline{
-		decoder:      decoder,
-		stream:       decoder,
-		format:       format,
-		seekable:     false,
-		path:         pageURL,
-		ytdlSeek:     true,
-		streamOffset: time.Duration(startSec) * time.Second,
-	}, nil
+func isTransientYTDL403(err error) bool {
+	message := err.Error()
+	return strings.Contains(message, "yt-dlp:") && strings.Contains(message, "HTTP Error 403: Forbidden")
 }

--- a/player/ytdl_test.go
+++ b/player/ytdl_test.go
@@ -5,11 +5,121 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/gopxl/beep/v2"
 )
+
+func installYTDLRetryFixtures(t *testing.T, mode string) (string, string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX process fixtures")
+	}
+
+	dir := t.TempDir()
+	attemptsPath := filepath.Join(dir, "attempts")
+	ffmpegDonePath := filepath.Join(dir, "ffmpeg-done")
+	ytdlScript := `#!/bin/sh
+count=0
+if [ -f "$YTDL_ATTEMPTS" ]; then
+	count=$(wc -l < "$YTDL_ATTEMPTS")
+fi
+printf 'attempt\n' >> "$YTDL_ATTEMPTS"
+case "$YTDL_MODE" in
+	403-once)
+		if [ "$count" -eq 0 ]; then
+			printf 'ERROR: unable to download video data: HTTP Error 403: Forbidden\n' >&2
+			exit 1
+		fi
+		;;
+	403-always)
+		printf 'ERROR: unable to download video data: HTTP Error 403: Forbidden\n' >&2
+		exit 1
+		;;
+	unavailable)
+		printf 'ERROR: Video unavailable\n' >&2
+		exit 1
+		;;
+esac
+printf '\001\002\003\004'
+`
+	ffmpegScript := `#!/bin/sh
+trap 'printf "done\n" >> "$FFMPEG_DONE"' EXIT
+cat
+`
+	for name, contents := range map[string]string{
+		"yt-dlp": ytdlScript,
+		"ffmpeg": ffmpegScript,
+	} {
+		writeExecutable(t, filepath.Join(dir, name), contents)
+	}
+	t.Setenv("YTDL_ATTEMPTS", attemptsPath)
+	t.Setenv("YTDL_MODE", mode)
+	t.Setenv("FFMPEG_DONE", ffmpegDonePath)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return attemptsPath, ffmpegDonePath
+}
+
+func fixtureLineCount(t *testing.T, path string) int {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0
+	}
+	if err != nil {
+		t.Fatalf("read fixture output: %v", err)
+	}
+	return len(strings.Fields(string(b)))
+}
+
+func TestBuildYTDLPipelineRetriesTransient403(t *testing.T) {
+	attemptsPath, ffmpegDonePath := installYTDLRetryFixtures(t, "403-once")
+	p := &Player{sr: beep.SampleRate(44100), bitDepth: 16}
+
+	pipeline, err := p.buildYTDLPipeline("https://www.youtube.com/watch?v=retry", 0)
+	if err != nil {
+		t.Fatalf("buildYTDLPipeline() error = %v", err)
+	}
+	defer pipeline.decoder.Close()
+	if got := fixtureLineCount(t, attemptsPath); got != 2 {
+		t.Fatalf("yt-dlp attempts = %d, want 2", got)
+	}
+	if got := fixtureLineCount(t, ffmpegDonePath); got < 1 {
+		t.Fatal("abandoned ffmpeg process was not reaped before retry")
+	}
+}
+
+func TestBuildYTDLPipelineStopsAfterTransient403RetryBudget(t *testing.T) {
+	attemptsPath, _ := installYTDLRetryFixtures(t, "403-always")
+	p := &Player{sr: beep.SampleRate(44100), bitDepth: 16}
+
+	_, err := p.buildYTDLPipeline("https://www.youtube.com/watch?v=retry", 0)
+	if err == nil || !strings.Contains(err.Error(), "HTTP Error 403: Forbidden") {
+		t.Fatalf("buildYTDLPipeline() error = %v, want yt-dlp 403 cause", err)
+	}
+	if got := fixtureLineCount(t, attemptsPath); got != 3 {
+		t.Fatalf("yt-dlp attempts = %d, want 3", got)
+	}
+}
+
+func TestBuildYTDLPipelineDoesNotRetryPermanentYTDLError(t *testing.T) {
+	attemptsPath, _ := installYTDLRetryFixtures(t, "unavailable")
+	p := &Player{sr: beep.SampleRate(44100), bitDepth: 16}
+
+	_, err := p.buildYTDLPipeline("https://www.youtube.com/watch?v=unavailable", 0)
+	if err == nil || !strings.Contains(err.Error(), "Video unavailable") {
+		t.Fatalf("buildYTDLPipeline() error = %v, want unavailable-video cause", err)
+	}
+	if got := fixtureLineCount(t, attemptsPath); got != 1 {
+		t.Fatalf("yt-dlp attempts = %d, want 1", got)
+	}
+}
 
 func TestWaitCause(t *testing.T) {
 	ytdlErr := errors.New("yt-dlp: Sign in to confirm you're not a bot")

--- a/ui/model/playback_test.go
+++ b/ui/model/playback_test.go
@@ -79,10 +79,11 @@ func (f *playbackFakeEngine) PreloadForGeneration(path string, dur time.Duration
 	}
 	return f.Preload(path, dur)
 }
-func (f *playbackFakeEngine) PreloadYTDLForGeneration(_ string, _ time.Duration, generation uint64) error {
+func (f *playbackFakeEngine) PreloadYTDLForGeneration(path string, _ time.Duration, generation uint64) error {
 	if f.preloadGeneration != generation {
 		return nil
 	}
+	f.preloadCalls = append(f.preloadCalls, path)
 	return nil
 }
 func (f *playbackFakeEngine) ClearPreload() {
@@ -580,6 +581,46 @@ func TestPreloadAfterProviderPlaylistLoadUsesFirstNewTrack(t *testing.T) {
 
 	if len(player.preloadCalls) != 1 || player.preloadCalls[0] != "new1.mp3" {
 		t.Fatalf("preloadCalls = %v, want first new track", player.preloadCalls)
+	}
+}
+
+func TestPreloadNextSkipsCurrentYTDLTrackInRepeatOne(t *testing.T) {
+	const path = "https://www.youtube.com/watch?v=current"
+	player := &playbackFakeEngine{playing: true, duration: time.Minute, position: 50 * time.Second}
+	p := playlist.New()
+	p.Replace([]playlist.Track{{Title: "Current", Path: path, DurationSecs: 60}})
+	p.SetIndex(0)
+	p.SetRepeat(playlist.RepeatOne)
+
+	m := Model{player: player, playlist: p}
+	if cmd := m.preloadNext(); cmd != nil {
+		t.Fatal("preloadNext() returned a command for the current repeat-one yt-dlp track")
+	}
+	if m.preloading {
+		t.Fatal("preloading = true for the current repeat-one yt-dlp track")
+	}
+	if len(player.preloadCalls) != 0 {
+		t.Fatalf("preloadCalls = %v, want none", player.preloadCalls)
+	}
+}
+
+func TestPreloadNextKeepsDistinctYTDLTrack(t *testing.T) {
+	player := &playbackFakeEngine{playing: true, duration: time.Minute, position: 50 * time.Second}
+	p := playlist.New()
+	p.Replace([]playlist.Track{
+		{Title: "Current", Path: "https://www.youtube.com/watch?v=current", DurationSecs: 60},
+		{Title: "Next", Path: "https://www.youtube.com/watch?v=next", DurationSecs: 60},
+	})
+	p.SetIndex(0)
+
+	m := Model{player: player, playlist: p}
+	cmd := m.preloadNext()
+	if cmd == nil {
+		t.Fatal("preloadNext() = nil, want distinct yt-dlp preload command")
+	}
+	_ = cmd()
+	if len(player.preloadCalls) != 1 || player.preloadCalls[0] != "https://www.youtube.com/watch?v=next" {
+		t.Fatalf("preloadCalls = %v, want distinct next URL", player.preloadCalls)
 	}
 }
 

--- a/ui/model/preload.go
+++ b/ui/model/preload.go
@@ -47,7 +47,8 @@ func (m *Model) preloadNext() tea.Cmd {
 	// Live streams do not have a track boundary. Preloading another station
 	// would turn a transient EOF into a gapless switch instead of reconnecting
 	// the station the user selected.
-	if current, idx := m.currentPlaybackTrack(); idx >= 0 && m.currentPlaybackIsLive(current) {
+	current, currentIdx := m.currentPlaybackTrack()
+	if currentIdx >= 0 && m.currentPlaybackIsLive(current) {
 		return nil
 	}
 
@@ -63,8 +64,12 @@ func (m *Model) preloadNext() tea.Cmd {
 	if !ok {
 		return nil
 	}
+	isYTDL := playlist.IsYTDL(next.Path)
+	if isYTDL && currentIdx >= 0 && next.Path == current.Path {
+		return nil
+	}
 	// Preload yt-dlp tracks with the same lead-time deferral as HTTP streams.
-	if playlist.IsYTDL(next.Path) {
+	if isYTDL {
 		dur := m.player.Duration()
 		if dur > 0 {
 			remaining := dur - m.player.Position()


### PR DESCRIPTION
## Summary

Wrap yt-dlp pipeline construction and initial-audio prefill in a bounded attempt loop in `player/ytdl.go`, retrying only when the captured yt-dlp cause identifies `HTTP Error 403: Forbidden`; close every failed pipeline before retrying, retain the existing timeout behavior, and return the final cause when the retry budget is exhausted. Use two immediate retries so permanent errors, ffmpeg failures, process-start failures, and initial-audio timeouts remain single-attempt failures while the reported transient receives up to three independent fetches. In `ui/model/preload.go`, compare a yt-dlp candidate from `PeekNext` with `currentPlaybackTrack` and decline to arm a preload when their paths match, without changing playlist navigation or suppressing distinct queued/next URLs.

Restarting a YouTube-backed track creates a fresh `yt-dlp | ffmpeg` pipeline, and an intermittent yt-dlp `HTTP Error 403: Forbidden` currently makes that playback attempt fail permanently. The failure is surfaced during `buildYTDLPipeline`'s initial-audio prefill, after `decodeYTDLPipe` has successfully started both processes. Repeat-one aggravates the problem because `preloadNext` sees the current item as next and opens a second yt-dlp pipeline shortly before every loop. The issue includes a concrete external reproduction and distinguishes the transient 403 from permanent unavailable-video errors.

Fixes #304

## Screenshots / video

No user-visible surface changes in this PR, so there is nothing to show.

## How to test

1.

## Checklist

- [x] `make check` passes
- [x] `docs/` and `site/index.html` updated for user-facing changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved playback startup reliability by retrying transient video service access failures.
  - Prevented repeated preloading of the track currently playing when repeat-one mode is enabled.
  - Preserved immediate handling for permanent playback errors.

- **Tests**
  - Added coverage for transient failures, retry limits, permanent errors, process cleanup, and playback preloading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->