### PR TITLE
fix: arturl UTF8 encoding panic

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,5 +39,30 @@
           meta.description = "Run cliamp";
         };
       });
+
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            name = "cliamp-dev";
+            buildInputs = with pkgs; [
+              go
+              pkg-config
+              alsa-lib
+              flac
+              libogg
+              libvorbis
+              mpg123
+              ffmpeg-headless
+              yt-dlp
+            ];
+            shellHook = ''
+              echo "🎵 cliamp dev shell loaded"
+            '';
+          };
+        }
+      );
     };
 }

--- a/mediactl/metadata.go
+++ b/mediactl/metadata.go
@@ -22,6 +22,7 @@ func makeMetadata(t playback.Track, trackID dbus.ObjectPath) map[string]dbus.Var
 	t.Album = dbusString(t.Album)
 	t.Genre = dbusString(t.Genre)
 	t.URL = dbusString(t.URL)
+	t.ArtURL = dbusString(t.ArtURL)
 
 	m := map[string]dbus.Variant{
 		"mpris:trackid": dbus.MakeVariant(trackID),

--- a/mediactl/metadata_test.go
+++ b/mediactl/metadata_test.go
@@ -101,3 +101,39 @@ func TestMakeMetadataCoercesInvalidDBusStrings(t *testing.T) {
 		}
 	}
 }
+
+func TestMakeMetadataCoercesInvalidArtURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		artURL string
+		want   string
+	}{
+		{
+			name:   "invalid UTF-8 in artURL",
+			artURL: "file:///tmp/cover\xff.jpg",
+			want:   "file:///tmp/cover\uFFFD.jpg",
+		},
+		{
+			name:   "null byte in artURL",
+			artURL: "file:///tmp/cover\x00.jpg",
+			want:   "file:///tmp/cover.jpg",
+		},
+		{
+			name:   "valid artURL unchanged",
+			artURL: "file:///tmp/cover.jpg",
+			want:   "file:///tmp/cover.jpg",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			track := playback.Track{ArtURL: tt.artURL}
+			got := makeMetadata(track, trackPath(1))
+
+			gotArtURL := got["mpris:artUrl"].Value().(string)
+			if gotArtURL != tt.want {
+				t.Fatalf("artURL = %q, want %q", gotArtURL, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Don't know why my initial message didn't save, anyway - writing again.

This was an intermittent issue I had while streaming a japanese radio station.
Loading the stream while certain songs were playing would cause a panic.
I noticed the artUrl wasn't being sanitized, and changing that seemed to fix the issue.

I've added some test cases, and minor tweaks to add a nix dev shell, since that's what I use.

## How to test

1. Tests added. Removing the fix shows the tests fail.

## Checklist

- [ x ] `make check` passes
- [ x ] `docs/` and `site/index.html` updated for user-facing changes
