### PR TITLE
fix(ui): Correct expanded height calculations when visualizer is disabled

### DIFF
--- a/ui/model/layout.go
+++ b/ui/model/layout.go
@@ -74,6 +74,13 @@ func (m *Model) recomputeLayout() {
 	} else if simplified {
 		layout.visualizerRows = 0
 		layout.fixedRows = 3
+	} else if m.vis == nil || m.vis.Mode == ui.VisNone {
+		layout.visualizerRows = 0
+		if layout.tier == layoutFull {
+			layout.fixedRows = 10
+		} else if layout.tier == layoutCompact {
+			layout.fixedRows = 9
+		}
 	}
 
 	layout.fullVisualizerRows = max(1, height-6-2*paddingV)
@@ -103,7 +110,7 @@ func (m *Model) recomputeLayout() {
 			m.vis.Rows = layout.fullVisualizerRows
 		} else {
 			rows := layout.visualizerRows
-			if contentFirst {
+			if contentFirst || m.vis.Mode == ui.VisNone {
 				// Keep the normal canvas size cached while visualizer work is paused
 				// so modes resume with valid dimensions when the layout returns.
 				switch layout.tier {

--- a/ui/model/layout.go
+++ b/ui/model/layout.go
@@ -74,7 +74,7 @@ func (m *Model) recomputeLayout() {
 	} else if simplified {
 		layout.visualizerRows = 0
 		layout.fixedRows = 3
-	} else if m.vis == nil || m.vis.Mode == ui.VisNone {
+	} else if m.visualizerDisabled() {
 		layout.visualizerRows = 0
 		if layout.tier == layoutFull {
 			layout.fixedRows = 10
@@ -110,7 +110,7 @@ func (m *Model) recomputeLayout() {
 			m.vis.Rows = layout.fullVisualizerRows
 		} else {
 			rows := layout.visualizerRows
-			if contentFirst || m.vis.Mode == ui.VisNone {
+			if contentFirst || m.visualizerDisabled() {
 				// Keep the normal canvas size cached while visualizer work is paused
 				// so modes resume with valid dimensions when the layout returns.
 				switch layout.tier {

--- a/ui/model/layout_test.go
+++ b/ui/model/layout_test.go
@@ -116,6 +116,58 @@ func TestExpandedPlaylistUsesAvailableRows(t *testing.T) {
 	}
 }
 
+func TestExpandedPlaylistWithoutVisualizerFillsTerminal(t *testing.T) {
+	for _, size := range []struct {
+		width, height int
+		wantFixed     int
+		extraBodyRows int
+	}{
+		{width: 80, height: 50, wantFixed: 10, extraBodyRows: 6},
+		{width: 80, height: 24, wantFixed: 10, extraBodyRows: 6},
+		{width: 56, height: 20, wantFixed: 9, extraBodyRows: 3},
+	} {
+		t.Run(fmt.Sprintf("%dx%d", size.width, size.height), func(t *testing.T) {
+			mWithVis := newLayoutTestModel(size.width, size.height)
+			mWithVis.heightExpanded = true
+			mWithVis.recomputeLayout()
+			bodyRowsWithVis := mWithVis.layout.bodyRows
+
+			m := newLayoutTestModel(size.width, size.height)
+			for i := 16; i < 100; i++ {
+				m.playlist.Add(playlist.Track{Path: fmt.Sprintf("/tmp/track-%d.mp3", i), Title: "Track"})
+			}
+			m.providers = []ProviderEntry{{Name: "Local"}, {Name: "Radio"}}
+			m.vis.Mode = ui.VisNone
+			m.heightExpanded = true
+			m.recomputeLayout()
+
+			if m.layout.fixedRows != size.wantFixed {
+				t.Fatalf("fixed rows = %d, want %d", m.layout.fixedRows, size.wantFixed)
+			}
+			if m.layout.bodyRows != bodyRowsWithVis+size.extraBodyRows {
+				t.Fatalf("body rows = %d, want %d (%d more than with visualizer)", m.layout.bodyRows, bodyRowsWithVis+size.extraBodyRows, size.extraBodyRows)
+			}
+			if m.plVisible != m.layout.bodyRows {
+				t.Fatalf("expanded playlist rows = %d, want available body rows %d", m.plVisible, m.layout.bodyRows)
+			}
+
+			// View without transient status message should not have empty top padding lines
+			out := m.View().Content
+			lines := strings.Split(out, "\n")
+			if lines[0] == "" {
+				t.Fatalf("first line is empty, view has extra top padding when expanded without visualizer")
+			}
+
+			// When a transient status message is present, view height should match terminal height exactly
+			m.status.Show("status", statusTTLDefault)
+			outWithStatus := m.View().Content
+			if got := lipgloss.Height(outWithStatus); got != size.height {
+				t.Fatalf("view height with status = %d, want %d", got, size.height)
+			}
+		})
+	}
+}
+
 func TestCollapsedPlaylistCentersFrameVertically(t *testing.T) {
 	m := newLayoutTestModel(80, 50)
 	body := ui.FitRect(m.renderMainBody(), m.layout.panelWidth, m.layout.bodyRows)

--- a/ui/model/model.go
+++ b/ui/model/model.go
@@ -502,6 +502,10 @@ func (m Model) usesSimplifiedLayout() bool {
 	return m.simplified && m.activeScreen() == screenMain && m.focus != focusProvider
 }
 
+func (m Model) visualizerDisabled() bool {
+	return m.vis == nil || m.vis.Mode == ui.VisNone
+}
+
 func (m Model) isPlaying() bool {
 	return m.player != nil && m.player.IsPlaying()
 }

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -233,7 +233,7 @@ func (m Model) mainSections(playlist string, includeTransient, contentFirst bool
 				m.renderTrackInfo(),
 				m.renderTimeStatus(),
 			}
-			if m.vis != nil && m.vis.Mode != ui.VisNone {
+			if !m.visualizerDisabled() {
 				sections = append(sections, m.renderSpectrum())
 			}
 			sections = append(sections,
@@ -256,7 +256,7 @@ func (m Model) mainSections(playlist string, includeTransient, contentFirst bool
 				m.renderTimeStatus(),
 				"",
 			}
-			if m.vis != nil && m.vis.Mode != ui.VisNone {
+			if !m.visualizerDisabled() {
 				sections = append(sections, m.renderSpectrum())
 			}
 			sections = append(sections,
@@ -511,7 +511,7 @@ func (m Model) renderTimeStatus() string {
 }
 
 func (m Model) renderSpectrum() string {
-	if m.vis.Mode == ui.VisNone {
+	if m.visualizerDisabled() {
 		return ""
 	}
 	return m.vis.Render()

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -232,12 +232,16 @@ func (m Model) mainSections(playlist string, includeTransient, contentFirst bool
 				m.renderTitle(),
 				m.renderTrackInfo(),
 				m.renderTimeStatus(),
-				m.renderSpectrum(),
+			}
+			if m.vis != nil && m.vis.Mode != ui.VisNone {
+				sections = append(sections, m.renderSpectrum())
+			}
+			sections = append(sections,
 				m.renderSeekBar(),
 				m.renderCompactControls(),
 				m.renderCompactSource(),
 				m.renderPlaylistHeader(),
-			}
+			)
 		case layoutMinimal:
 			sections = []string{
 				m.renderTrackInfo(),
@@ -250,11 +254,14 @@ func (m Model) mainSections(playlist string, includeTransient, contentFirst bool
 				m.renderTitle(),
 				m.renderTrackInfo(),
 				m.renderTimeStatus(),
-				"",
-				m.renderSpectrum(),
+			}
+			if m.vis != nil && m.vis.Mode != ui.VisNone {
+				sections = append(sections, "", m.renderSpectrum())
+			}
+			sections = append(sections,
 				m.renderSeekBar(),
 				m.renderControls(),
-			}
+			)
 			if source := m.renderProviderPill(); source != "" {
 				sections = append(sections, source)
 			}

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -254,9 +254,10 @@ func (m Model) mainSections(playlist string, includeTransient, contentFirst bool
 				m.renderTitle(),
 				m.renderTrackInfo(),
 				m.renderTimeStatus(),
+				"",
 			}
 			if m.vis != nil && m.vis.Mode != ui.VisNone {
-				sections = append(sections, "", m.renderSpectrum())
+				sections = append(sections, m.renderSpectrum())
 			}
 			sections = append(sections,
 				m.renderSeekBar(),


### PR DESCRIPTION
## Summary

Fixes height calculation in expanded view mode `ctrl+x` when the empty visualizer `VisNone` is active. Previously `recomputeLayout()` and `mainSections()` expected a fixed height for the visualizer region, causing the rendered content to be shorter than expected, leaving empty padding at the top and bottom of the terminal.

## How to test

1. Start `cliamp` with tracks loaded.
2. Toggle expanded view with `ctrl+x`.
3. Choose the empty visualizer (press `v` or `ctrl+v` until `None` is chosen).
4. Verify the content expands to fill the entire terminal height without extra empty space at the top and bottom.
5. Cycle through other visualizer modes and verify they still layout and render correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout behavior when the visualizer is disabled or unavailable.
  * The playlist now correctly uses the freed visualizer space.
  * Prevented empty visualizer areas in compact and full layouts.
  * Improved terminal height handling when transient status messages are shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->