### PR TITLE
Expose live radio track title (broadcast_title) over IPC status

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -956,6 +956,9 @@ func (d *daemon) statusResponse() ipc.Response {
 	}
 	if cur, _ := d.playlist.Current(); cur.Path != "" {
 		info := trackInfo(cur, d.playlist.Index(), d.playlist.QueuePosition(d.playlist.Index()))
+		if info.Stream {
+			info.BroadcastTitle = d.player.StreamTitle()
+		}
 		resp.Track = &info
 	}
 	pos, dur := d.player.PositionAndDuration()

--- a/docs/remote-control.md
+++ b/docs/remote-control.md
@@ -53,6 +53,12 @@ JSON output:
 
 The `theme` block carries the active cliamp theme's resolved hex colors. Empty hex fields mean the default ANSI fallback theme is active.
 
+For a stream (`"stream": true` — radio or any HTTP/HTTPS source), `track` may also
+carry `broadcast_title`: the live now-playing title (e.g. `"Stevie Wonder -
+Superstition"`), sourced from ICY inline metadata or a station-API fallback
+when the stream doesn't send ICY metadata. Omitted when unavailable or the
+current stream has no now-playing info yet.
+
 ## Volume and Seek
 
 ```sh

--- a/ipc/protocol.go
+++ b/ipc/protocol.go
@@ -102,6 +102,11 @@ type TrackInfo struct {
 	Realtime      bool   `json:"realtime,omitempty"`
 	Bookmark      bool   `json:"bookmark,omitempty"`
 	Unplayable    bool   `json:"unplayable,omitempty"`
+	// BroadcastTitle is the live now-playing title for a stream (Player.StreamTitle:
+	// ICY inline metadata, or the registered StreamMetadataResolver fallback for
+	// stations without ICY support). Empty for non-stream tracks or when the
+	// current stream has no now-playing info available.
+	BroadcastTitle string `json:"broadcast_title,omitempty"`
 }
 
 type PlaylistInfo struct {

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -1136,6 +1136,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if cur, _ := m.currentPlaybackTrack(); cur.Path != "" {
 			info := ipcTrackInfo(cur, m.playlist.Index(), m.playlist.QueuePosition(m.playlist.Index()))
+			if info.Stream {
+				info.BroadcastTitle = m.player.StreamTitle()
+			}
 			resp.Track = &info
 		}
 		resp.Position = m.player.Position().Seconds()


### PR DESCRIPTION
Player.StreamTitle() already unifies ICY inline metadata and the radiometa station-API fallback, and cliamp's own TUI displays it live, but neither status-response builder (daemon.go's headless path, or ui/model/update.go's interactive-TUI path) put it on the wire. Add it to ipc.TrackInfo as broadcast_title, set from Player.StreamTitle() in both builders when the track is a stream.

Verified against live playback (Radio Motown, real ICY metadata confirmed via a standalone probe of the stream) using a locally built binary as both client and server.

## Summary

<!-- What does this PR do and why? -->

## Screenshots / video

<!-- Drag-and-drop screenshots or a short screen recording for UI changes. -->

## How to test

1.

## Checklist

- [ ] `make check` passes
- [ ] `docs/` and `site/index.html` updated for user-facing changes
