### PR TITLE
feat(spotify): list saved albums in the provider

### DIFF
--- a/docs/spotify.md
+++ b/docs/spotify.md
@@ -57,7 +57,7 @@ cliamp uses a built-in `client_id`. [librespot](https://github.com/librespot-org
 
 After authentication, Spotify appears in the provider list. Press `Esc`/`b` to open the provider browser and select Spotify.
 
-The provider panel lists Spotify playlists. Use the arrow keys to select one and press `Enter` to load it. Tracks stream through the cliamp audio pipeline. EQ, the visualizer, mono, and other effects work as they do for local files.
+The provider panel lists your Spotify playlists and saved albums. Use the arrow keys to select one and press `Enter` to load it. Tracks stream through the cliamp audio pipeline. EQ, the visualizer, mono, and other effects work as they do for local files.
 
 ## Controls
 
@@ -72,9 +72,11 @@ When focused on the provider panel:
 
 After you load a playlist, Cliamp returns to the standard playlist view. Use the usual controls for seek, volume, EQ, shuffle, repeat, queue, search, and lyrics.
 
-## Playlists
+## Playlists and albums
 
-The provider shows only playlists in the Spotify library. This includes playlists you created and saved, or followed. If a public playlist is missing, open Spotify and click **Save** first. You do not need to copy tracks to a new playlist.
+The provider lists both playlists and saved albums in the Spotify library. Playlists include those you created and saved, or followed. If a public playlist is missing, open Spotify and click **Save** first. You do not need to copy tracks to a new playlist.
+
+Saved albums appear under a **Saved albums** section, labelled `Artist - Album` and sorted alphabetically by artist. These are the albums in **Your Library**. To add one, open the album in Spotify and click **Save**. Selecting a saved album loads all of its tracks in disc and track order.
 
 ## Podcasts
 

--- a/external/spotify/album_test.go
+++ b/external/spotify/album_test.go
@@ -128,6 +128,26 @@ func TestSearchTracksLeadsWithAlbums(t *testing.T) {
 	}
 }
 
+// TestTracksExpandsSavedAlbum verifies a saved-album playlist entry is routed
+// through AlbumTracks rather than the playlist items endpoint.
+func TestTracksExpandsSavedAlbum(t *testing.T) {
+	p, _ := albumSpotify(t, 0, 0, 3)
+
+	got, err := p.Tracks(savedAlbumIDPrefix + "al0")
+	if err != nil {
+		t.Fatalf("Tracks() error = %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d tracks, want 3", len(got))
+	}
+	if got[0].Path != "spotify:track:at0" {
+		t.Errorf("first track path = %q, want %q", got[0].Path, "spotify:track:at0")
+	}
+	if got[0].Album != "Punk In Drublic" {
+		t.Errorf("first track album = %q, want %q", got[0].Album, "Punk In Drublic")
+	}
+}
+
 func TestAlbumTracksPagesAndFillsAlbumMetadata(t *testing.T) {
 	const total = spotifyTrackPageSize + 3
 	p, _ := albumSpotify(t, 0, 0, total)

--- a/external/spotify/provider.go
+++ b/external/spotify/provider.go
@@ -292,12 +292,20 @@ func (p *SpotifyProvider) Playlists() ([]playlist.PlaylistInfo, error) {
 		offset += limit
 	}
 
+	albums, err := p.savedAlbums(ctx)
+	if err != nil {
+		return nil, err
+	}
+	all = append(all, albums...)
+
 	// Group playlists by section so the UI can emit one header per group.
-	// Library first, then owned, then followed; preserve API order within.
+	// Library first, then owned, then followed, then saved albums; preserve
+	// API order within each section.
 	sectionOrder := map[string]int{
 		"Library":            0,
 		"Your playlists":     1,
 		"Followed playlists": 2,
+		savedAlbumSection:    3,
 	}
 	sort.SliceStable(all, func(i, j int) bool {
 		return sectionOrder[all[i].Section] < sectionOrder[all[j].Section]
@@ -311,12 +319,77 @@ func (p *SpotifyProvider) Playlists() ([]playlist.PlaylistInfo, error) {
 	return slices.Clone(all), nil
 }
 
+// savedAlbums returns the authenticated user's saved albums from
+// /v1/me/albums, paginated. Each is surfaced as a playlist entry whose ID
+// carries the savedAlbumIDPrefix, so Tracks() expands it via AlbumTracks.
+func (p *SpotifyProvider) savedAlbums(ctx context.Context) ([]playlist.PlaylistInfo, error) {
+	var all []playlist.PlaylistInfo
+	offset := 0
+
+	for {
+		query := url.Values{
+			"limit":  {strconv.Itoa(spotifyAlbumPageSize)},
+			"offset": {strconv.Itoa(offset)},
+		}
+
+		resp, err := p.webAPI(ctx, "GET", "/v1/me/albums", query)
+		if err != nil {
+			return nil, fmt.Errorf("spotify: list saved albums: %w", err)
+		}
+
+		var result struct {
+			Items []struct {
+				Album spotifyAlbumItem `json:"album"`
+			} `json:"items"`
+			Total int `json:"total"`
+		}
+		if err := decodeBody(resp, &result); err != nil {
+			return nil, fmt.Errorf("spotify: parse saved albums: %w", err)
+		}
+
+		for _, item := range result.Items {
+			a := item.Album
+			if a.ID == "" {
+				continue // skip unavailable albums
+			}
+			name := a.Name
+			if artist := artistNames(a.Artists); artist != "" {
+				name = artist + " - " + a.Name
+			}
+			all = append(all, playlist.PlaylistInfo{
+				ID:         savedAlbumIDPrefix + a.ID,
+				Name:       name,
+				TrackCount: a.TotalTracks,
+				Section:    savedAlbumSection,
+			})
+		}
+
+		if offset+spotifyAlbumPageSize >= result.Total {
+			break
+		}
+		offset += spotifyAlbumPageSize
+	}
+
+	// Spotify returns saved albums most-recently-added first; sort by the
+	// "Artist - Album" display name so the list reads alphabetically by artist.
+	sort.SliceStable(all, func(i, j int) bool {
+		return strings.ToLower(all[i].Name) < strings.ToLower(all[j].Name)
+	})
+
+	return all, nil
+}
+
 // Tracks returns all tracks for the given Spotify playlist ID.
 // Track.Path is set to the canonical spotify: URI for the player to resolve.
 // Results are cached by snapshot_id; unchanged playlists skip the API call.
+// Saved-album entries (savedAlbumIDPrefix) are expanded via AlbumTracks.
 func (p *SpotifyProvider) Tracks(playlistID string) ([]playlist.Track, error) {
 	if err := p.ensureSession(); err != nil {
 		return nil, err
+	}
+
+	if albumID, ok := isSavedAlbumID(playlistID); ok {
+		return p.AlbumTracks(albumID)
 	}
 	// Check cache — if we have tracks and the snapshot_id hasn't changed, return cached.
 	p.mu.Lock()

--- a/external/spotify/provider_playlists_test.go
+++ b/external/spotify/provider_playlists_test.go
@@ -30,6 +30,12 @@ func TestPlaylistsIncludesFollowedPlaylists(t *testing.T) {
 				`{"id":"owned","name":"Owned","snapshot_id":"one","owner":{"id":"me"},"items":{"total":2}},` +
 				`{"id":"followed","name":"Followed","snapshot_id":"two","owner":{"id":"other"},"items":{"total":3}}` +
 				`],"total":2}`
+		case "/v1/me/albums":
+			// Returned most-recently-added first; the provider re-sorts by artist.
+			body = `{"items":[` +
+				`{"album":{"id":"al0","name":"Punk In Drublic","total_tracks":17,"artists":[{"name":"NOFX"}]}},` +
+				`{"album":{"id":"al1","name":"Suffer","total_tracks":15,"artists":[{"name":"Bad Religion"}]}}` +
+				`],"total":2}`
 		default:
 			return nil, fmt.Errorf("unexpected Spotify API path %q", req.URL.Path)
 		}
@@ -56,6 +62,9 @@ func TestPlaylistsIncludesFollowedPlaylists(t *testing.T) {
 		{id: "YOUR MUSIC", section: "Library"},
 		{id: "owned", section: "Your playlists"},
 		{id: "followed", section: "Followed playlists"},
+		// Saved albums sort alphabetically by artist: Bad Religion before NOFX.
+		{id: "spotify:album:al1", section: "Saved albums"},
+		{id: "spotify:album:al0", section: "Saved albums"},
 	}
 	if len(got) != len(want) {
 		t.Fatalf("Playlists() returned %d playlists, want %d: %#v", len(got), len(want), got)
@@ -64,5 +73,14 @@ func TestPlaylistsIncludesFollowedPlaylists(t *testing.T) {
 		if got[i].ID != want[i].id || got[i].Section != want[i].section {
 			t.Errorf("playlist %d = (%q, %q), want (%q, %q)", i, got[i].ID, got[i].Section, want[i].id, want[i].section)
 		}
+	}
+
+	// The saved album row carries its artist and track count for display.
+	album := got[len(got)-1]
+	if album.Name != "NOFX - Punk In Drublic" {
+		t.Errorf("saved album name = %q, want %q", album.Name, "NOFX - Punk In Drublic")
+	}
+	if album.TrackCount != 17 {
+		t.Errorf("saved album track count = %d, want 17", album.TrackCount)
 	}
 }

--- a/external/spotify/provider_shared.go
+++ b/external/spotify/provider_shared.go
@@ -18,7 +18,24 @@ const (
 	// silently truncates larger limits; requesting more would cause the loop
 	// to skip items when offset advances by the requested limit.
 	spotifyTrackPageSize = 50
+	// spotifyAlbumPageSize is the maximum /v1/me/albums accepts per request.
+	spotifyAlbumPageSize = 50
 )
+
+// savedAlbumIDPrefix marks a PlaylistInfo.ID as a saved album rather than a
+// playlist, so Tracks() routes it to AlbumTracks. Real playlist and album IDs
+// are bare base62, so the "spotify:album:" prefix never collides with one.
+const savedAlbumIDPrefix = "spotify:album:"
+
+// savedAlbumSection is the UI section header for the user's saved albums.
+const savedAlbumSection = "Saved albums"
+
+// isSavedAlbumID reports whether id is a saved-album playlist entry and returns
+// the bare album ID.
+func isSavedAlbumID(id string) (albumID string, ok bool) {
+	rest, ok := strings.CutPrefix(id, savedAlbumIDPrefix)
+	return rest, ok
+}
 
 // spotifyPlaylistItem is the raw playlist object returned by /v1/me/playlists.
 type spotifyPlaylistItem struct {
@@ -34,6 +51,15 @@ type spotifyPlaylistItem struct {
 }
 type spotifyArtist struct {
 	Name string `json:"name"`
+}
+
+// artistNames joins the artist display names with ", ".
+func artistNames(artists []spotifyArtist) string {
+	names := make([]string, len(artists))
+	for i, a := range artists {
+		names[i] = a.Name
+	}
+	return strings.Join(names, ", ")
 }
 
 // spotifyItem is a track or podcast episode object from the Spotify Web API.
@@ -79,11 +105,6 @@ type spotifyAlbumItem struct {
 // Callers must expand it through SearchTracks' companion AlbumTracks before
 // queueing it, which playlist.Track.IsAlbum signals to the UI.
 func albumFromItem(a *spotifyAlbumItem) playlist.Track {
-	artists := make([]string, len(a.Artists))
-	for i, ar := range a.Artists {
-		artists[i] = ar.Name
-	}
-
 	var year int
 	if len(a.ReleaseDate) >= 4 {
 		if y, err := strconv.Atoi(a.ReleaseDate[:4]); err == nil {
@@ -99,7 +120,7 @@ func albumFromItem(a *spotifyAlbumItem) playlist.Track {
 	return playlist.Track{
 		Path:   uri,
 		Title:  a.Name,
-		Artist: strings.Join(artists, ", "),
+		Artist: artistNames(a.Artists),
 		Album:  a.Name,
 		Year:   year,
 		ProviderMeta: map[string]string{


### PR DESCRIPTION
## Summary

Fetch the user's saved albums from /v1/me/albums and show them in a Saved albums section, sorted by artist.

## Screenshots / video

<img width="874" height="518" alt="Screenshot 2026-08-27 at 09 18 10" src="https://github.com/user-attachments/assets/20302d05-b1c0-4c4a-9cec-d8409a2c722d" />

## How to test

1.

## Checklist

- [x] `make check` passes
- [x] `docs/` and `site/index.html` updated for user-facing changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Spotify now displays saved albums alongside playlists.
  - Saved albums appear in a dedicated “Saved albums” section, labeled by artist and album title and sorted alphabetically by artist.
  - Selecting a saved album loads all tracks in disc and track order.

- **Documentation**
  - Updated Spotify provider documentation to explain saved album browsing and playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->