### PR TITLE
fix(player): follow the audible position so waveform visualizers reach the tick rate

### DIFF
--- a/player/player.go
+++ b/player/player.go
@@ -53,6 +53,9 @@ type Player struct {
 	resampleQuality int
 	bitDepth        int // 16 or 32
 	tapBufferFrames int
+	// speakerBufferFrames is the audio backend's buffer, in frames: the latency
+	// between a frame reaching the tap and the same frame being heard.
+	speakerBufferFrames int
 
 	gaplessAdvance atomic.Bool   // set when gapless transition fires
 	seekGen        atomic.Int64  // generation counter for yt-dlp seeks; incremented to cancel stale seeks
@@ -91,10 +94,11 @@ func New(q Quality) (*Player, error) {
 		bitDepth = 16
 	}
 	p := &Player{
-		sr:              sr,
-		resampleQuality: q.ResampleQuality,
-		bitDepth:        bitDepth,
-		tapBufferFrames: max(4096, sr.N(time.Duration(q.BufferMs)*time.Millisecond)),
+		sr:                  sr,
+		resampleQuality:     q.ResampleQuality,
+		bitDepth:            bitDepth,
+		tapBufferFrames:     max(4096, sr.N(time.Duration(q.BufferMs)*time.Millisecond)),
+		speakerBufferFrames: sr.N(time.Duration(q.BufferMs) * time.Millisecond),
 	}
 	p.volMin.Store(math.Float64bits(-50))
 	p.speed.Store(math.Float64bits(1.0))
@@ -302,7 +306,7 @@ func (p *Player) playPipelineForGeneration(tp *trackPipeline, generation uint64)
 			s = newBiquad(s, eqFreqs[i], 1.4, &p.eqBands[i], float64(p.sr))
 		}
 
-		p.tap = newTap(s, p.tapBufferFrames, int(p.sr))
+		p.tap = newTap(s, p.tapBufferFrames, int(p.sr), p.speakerBufferFrames)
 		s = &volumeStreamer{s: p.tap, vol: &p.volume, mono: &p.mono, cachedDB: math.NaN()}
 		p.ctrl = &beep.Ctrl{Streamer: s}
 		p.started = true

--- a/player/player.go
+++ b/player/player.go
@@ -79,6 +79,20 @@ type Player struct {
 // function, the poll interval, and ok=false when the URL is not recognized.
 type StreamMetadataResolver func(streamURL string) (fetch func(ctx context.Context) (string, error), interval time.Duration, ok bool)
 
+// maxAnalysisWindow is the largest window the visualizer asks for in one read
+// (the classic peak meter's 4096-sample FFT). The package cannot import ui, so
+// the value is duplicated here; it only needs to be an upper bound.
+const maxAnalysisWindow = 4096
+
+// tapRingFrames sizes the tap's ring buffer. The waveform read position sits
+// speakerFrames behind the newest frame — that is where audio is actually
+// audible — so the ring has to hold that lag *plus* a full analysis window on
+// top of it. Sized to the backend buffer alone, the oldest end of the window
+// would read frames that have already been overwritten.
+func tapRingFrames(speakerFrames int) int {
+	return max(4096, speakerFrames+maxAnalysisWindow)
+}
+
 // New creates a Player and initializes the speaker with the given quality settings.
 func New(q Quality) (*Player, error) {
 	if q.SampleRate <= 0 || q.BufferMs <= 0 || q.ResampleQuality <= 0 {
@@ -97,7 +111,7 @@ func New(q Quality) (*Player, error) {
 		sr:                  sr,
 		resampleQuality:     q.ResampleQuality,
 		bitDepth:            bitDepth,
-		tapBufferFrames:     max(4096, sr.N(time.Duration(q.BufferMs)*time.Millisecond)),
+		tapBufferFrames:     tapRingFrames(sr.N(time.Duration(q.BufferMs) * time.Millisecond)),
 		speakerBufferFrames: sr.N(time.Duration(q.BufferMs) * time.Millisecond),
 	}
 	p.volMin.Store(math.Float64bits(-50))

--- a/player/tap.go
+++ b/player/tap.go
@@ -25,17 +25,25 @@ type tap struct {
 	writeFrames atomic.Int64 // frame count of the latest write
 	size        int
 	sampleRate  int
-	now         func() time.Time
+	// speakerFrames is the size of the audio backend's own buffer, in frames.
+	// Frames handed to Stream are not audible yet: they sit in that buffer for
+	// up to speakerFrames/sampleRate seconds. The waveform read position has to
+	// subtract it to follow what is actually being heard.
+	speakerFrames int
+	now           func() time.Time
 }
 
-// newTap wraps a streamer with a ring buffer of the given size.
-func newTap(s beep.Streamer, bufSize, sampleRate int) *tap {
+// newTap wraps a streamer with a ring buffer of the given size. speakerFrames
+// is the audio backend's buffer size in frames, used by WaveformSamplesInto to
+// place the read position at what is currently audible.
+func newTap(s beep.Streamer, bufSize, sampleRate, speakerFrames int) *tap {
 	return &tap{
-		s:          s,
-		buf:        make([][2]float64, bufSize),
-		size:       bufSize,
-		sampleRate: sampleRate,
-		now:        time.Now,
+		s:             s,
+		buf:           make([][2]float64, bufSize),
+		size:          bufSize,
+		sampleRate:    sampleRate,
+		speakerFrames: max(0, speakerFrames),
+		now:           time.Now,
 	}
 }
 
@@ -65,17 +73,34 @@ func (t *tap) SamplesInto(dst []float64) int {
 	return t.samplesIntoAt(dst, t.written.Load())
 }
 
-// WaveformSamplesInto copies samples from the most recent output buffer at its
-// real-time playback position. This keeps raw visualizers moving between the
-// audio backend's larger buffer refills.
+// WaveformSamplesInto copies samples at the position that is currently
+// audible, interpolated from the wall clock. Raw visualizers therefore advance
+// on every frame they are rendered at, instead of once per backend refill.
+//
+// The backend does not ask for samples at a steady rate: it refills its buffer
+// in bursts, then goes quiet for as long as that buffer takes to play. Anchoring
+// the read position to the last Stream call meant the waveform advanced only
+// through that call's frames and then froze until the next burst, so its
+// effective refresh rate followed the buffer size rather than the tick rate
+// (~7 FPS at the default 250 ms buffer, ~19 FPS at 50 ms).
+//
+// Anchoring it to the whole backend buffer instead makes the position advance
+// continuously: at the moment of a write, what is audible is speakerFrames
+// behind what has been written, and it moves forward with elapsed time.
 func (t *tap) WaveformSamplesInto(dst []float64) int {
-	frames := t.writeFrames.Load()
-	if frames <= 0 || t.sampleRate <= 0 {
+	written := t.written.Load()
+	if written <= 0 || t.sampleRate <= 0 {
 		return 0
 	}
+	if t.speakerFrames <= 0 {
+		return t.samplesIntoAt(dst, written)
+	}
 	elapsed := int64(t.now().Sub(time.Unix(0, t.writeAt.Load())) * time.Duration(t.sampleRate) / time.Second)
-	elapsed = max(0, min(elapsed, frames))
-	end := t.written.Load() - frames + elapsed
+	elapsed = max(0, elapsed)
+	end := written - int64(t.speakerFrames) + elapsed
+	// Never read past what has been written (a stall would otherwise walk the
+	// window into stale ring-buffer data) nor before the start of the stream.
+	end = max(0, min(end, written))
 	return t.samplesIntoAt(dst, end)
 }
 

--- a/player/tap_test.go
+++ b/player/tap_test.go
@@ -156,3 +156,60 @@ func TestTapWaveformDoesNotReadPastWritten(t *testing.T) {
 		t.Fatalf("WaveformSamplesInto() after stall = %v, want %v", buf, want)
 	}
 }
+
+// TestTapRingFramesLeavesRoomForTheAnalysisWindow pins the ring sizing. The
+// waveform position trails the newest frame by the whole backend buffer, so a
+// ring sized to that buffer alone would have already overwritten the oldest end
+// of the window being read.
+func TestTapRingFramesLeavesRoomForTheAnalysisWindow(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		speakerFrames int
+		want          int
+	}{
+		{name: "250ms at 44.1kHz", speakerFrames: 11025, want: 11025 + maxAnalysisWindow},
+		{name: "50ms at 44.1kHz", speakerFrames: 2205, want: 2205 + maxAnalysisWindow},
+		{name: "none", speakerFrames: 0, want: 4096},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tapRingFrames(tc.speakerFrames); got != tc.want {
+				t.Errorf("tapRingFrames(%d) = %d, want %d", tc.speakerFrames, got, tc.want)
+			}
+			if got := tapRingFrames(tc.speakerFrames); got < tc.speakerFrames+maxAnalysisWindow && tc.speakerFrames > 0 {
+				t.Errorf("tapRingFrames(%d) = %d, leaves no room for a %d-frame window",
+					tc.speakerFrames, got, maxAnalysisWindow)
+			}
+		})
+	}
+}
+
+// TestTapWaveformReadsAudiblePositionAfterRefill checks the read against a ring
+// sized the way the player sizes it: right after a refill the window must show
+// the frames that are audible now, which are speakerFrames back, not the ones
+// just handed to the backend.
+func TestTapWaveformReadsAudiblePositionAfterRefill(t *testing.T) {
+	const (
+		speakerFrames = 8
+		window        = 2
+	)
+	samples := make([][2]float64, speakerFrames+window)
+	for i := range samples {
+		samples[i] = [2]float64{float64(i), float64(i)}
+	}
+
+	now := time.Unix(1, 0)
+	tap := newTap(&sequenceStreamer{samples: samples}, speakerFrames+window, 10, speakerFrames)
+	tap.now = func() time.Time { return now }
+	if n, _ := tap.Stream(make([][2]float64, len(samples))); n != len(samples) {
+		t.Fatalf("Stream() wrote %d frames, want %d", n, len(samples))
+	}
+
+	buf := make([]float64, window)
+	if n := tap.WaveformSamplesInto(buf); n != len(buf) {
+		t.Fatalf("WaveformSamplesInto() = %d, want %d", n, len(buf))
+	}
+	// written = 10, speakerFrames = 8, elapsed = 0 -> window ends at frame 2.
+	if want := []float64{0, 1}; !reflect.DeepEqual(buf, want) {
+		t.Fatalf("WaveformSamplesInto() = %v, want %v", buf, want)
+	}
+}

--- a/player/tap_test.go
+++ b/player/tap_test.go
@@ -28,7 +28,7 @@ func TestTapPreservesStereoAndMonoMixAcrossWraparound(t *testing.T) {
 		{0.5, 0.7},
 		{0.6, 0.8},
 	}
-	tap := newTap(&sequenceStreamer{samples: samples}, 4, 44100)
+	tap := newTap(&sequenceStreamer{samples: samples}, 4, 44100, 0)
 
 	for range 2 {
 		out := make([][2]float64, 3)
@@ -63,7 +63,7 @@ func TestTapWaveformSamplesAdvanceBetweenWrites(t *testing.T) {
 	}
 
 	now := time.Unix(1, 0)
-	tap := newTap(&sequenceStreamer{samples: samples}, 16, 10)
+	tap := newTap(&sequenceStreamer{samples: samples}, 16, 10, 8)
 	tap.now = func() time.Time { return now }
 	if n, _ := tap.Stream(make([][2]float64, len(samples))); n != len(samples) {
 		t.Fatalf("Stream() wrote %d frames, want %d", n, len(samples))
@@ -84,5 +84,75 @@ func TestTapWaveformSamplesAdvanceBetweenWrites(t *testing.T) {
 	}
 	if want := []float64{5, 6}; !reflect.DeepEqual(buf, want) {
 		t.Fatalf("WaveformSamplesInto() = %v, want %v", buf, want)
+	}
+}
+
+// TestTapWaveformAdvancesPastLastWriteSize covers the case that made raw
+// visualizers stutter: the backend refills its buffer in bursts, so the last
+// Stream call can be much shorter than the buffer it filled. Anchoring the read
+// position to that call froze the waveform until the next burst — here, both
+// reads would return the same frames.
+func TestTapWaveformAdvancesPastLastWriteSize(t *testing.T) {
+	samples := make([][2]float64, 8)
+	for i := range samples {
+		samples[i] = [2]float64{float64(i), float64(i)}
+	}
+
+	now := time.Unix(1, 0)
+	// 10 Hz, an 8-frame backend buffer: 800 ms of audio in flight.
+	tap := newTap(&sequenceStreamer{samples: samples}, 16, 10, 8)
+	tap.now = func() time.Time { return now }
+
+	// A long refill followed by a short tail, as a bursty backend does.
+	if n, _ := tap.Stream(make([][2]float64, 6)); n != 6 {
+		t.Fatalf("Stream() wrote %d frames, want 6", n)
+	}
+	if n, _ := tap.Stream(make([][2]float64, 2)); n != 2 {
+		t.Fatalf("Stream() wrote %d frames, want 2", n)
+	}
+
+	buf := make([]float64, 2)
+	now = now.Add(300 * time.Millisecond)
+	if n := tap.WaveformSamplesInto(buf); n != len(buf) {
+		t.Fatalf("WaveformSamplesInto() = %d, want %d", n, len(buf))
+	}
+	if want := []float64{1, 2}; !reflect.DeepEqual(buf, want) {
+		t.Fatalf("WaveformSamplesInto() at +300ms = %v, want %v", buf, want)
+	}
+
+	// 400 ms later the window must have moved on, even though the last write
+	// was only 2 frames long.
+	now = now.Add(400 * time.Millisecond)
+	if n := tap.WaveformSamplesInto(buf); n != len(buf) {
+		t.Fatalf("WaveformSamplesInto() = %d, want %d", n, len(buf))
+	}
+	if want := []float64{5, 6}; !reflect.DeepEqual(buf, want) {
+		t.Fatalf("WaveformSamplesInto() at +700ms = %v, want %v", buf, want)
+	}
+}
+
+// TestTapWaveformDoesNotReadPastWritten guards the clamp: if the backend stalls,
+// the window must stop at the newest written frame instead of walking into
+// stale ring-buffer data.
+func TestTapWaveformDoesNotReadPastWritten(t *testing.T) {
+	samples := make([][2]float64, 8)
+	for i := range samples {
+		samples[i] = [2]float64{float64(i), float64(i)}
+	}
+
+	now := time.Unix(1, 0)
+	tap := newTap(&sequenceStreamer{samples: samples}, 16, 10, 8)
+	tap.now = func() time.Time { return now }
+	if n, _ := tap.Stream(make([][2]float64, 8)); n != 8 {
+		t.Fatalf("Stream() wrote %d frames, want 8", n)
+	}
+
+	buf := make([]float64, 2)
+	now = now.Add(30 * time.Second)
+	if n := tap.WaveformSamplesInto(buf); n != len(buf) {
+		t.Fatalf("WaveformSamplesInto() = %d, want %d", n, len(buf))
+	}
+	if want := []float64{6, 7}; !reflect.DeepEqual(buf, want) {
+		t.Fatalf("WaveformSamplesInto() after stall = %v, want %v", buf, want)
 	}
 }


### PR DESCRIPTION
Fixes #392.

### The problem

`Wave`, `Scope` and `Heartbeat` are registered with `TickWave` (16 ms, ~60 FPS), but on screen they repaint about 7-8 times per second, while `Bars` — which asks for the *slower* `TickFast` — hits its 20 FPS exactly.

The cause is in `player/tap.go`. `WaveformSamplesInto` anchored the read position to the **last `Stream` call** and clamped the elapsed time to that call's frame count:

```go
frames := t.writeFrames.Load()
elapsed = max(0, min(elapsed, frames))
end := t.written.Load() - frames + elapsed
```

The backend doesn't pull samples at a steady rate: it refills its buffer in bursts and then goes quiet for as long as that buffer takes to play, so the final `Stream` call of a refill can be a short tail. The window walked through those few frames and then froze until the next burst — tying the effective refresh rate to the **buffer size** rather than to the tick rate.

That is measurable: with `--buffer-ms 50` the same build reaches 19 FPS, with the default 250 ms it drops to 7-8.

### The change

Anchor the position to the backend buffer instead. At the moment of a write, what is audible is `speakerFrames` behind what has been written, and it advances with elapsed wall-clock time:

```go
end := written - int64(t.speakerFrames) + elapsed
end = max(0, min(end, written))
```

`speakerFrames` is the speaker buffer in frames, which `Player.New` already computes for `speaker.Init`; it is passed to `newTap` alongside the ring size. The clamp to `written` means a stalled backend stops the window instead of walking it into stale ring-buffer data, and `speakerFrames <= 0` falls back to the newest frame, so the zero value stays safe.

### Measurements

Arch Linux, foot on Hyprland/Wayland, 320 kbps MP3, `Wave` mode, counting `write()` calls to the pty with `strace -f -e trace=write` over 5 s:

| Buffer | before | after |
|---|---|---|
| 250 ms (default) | 8.2 FPS | **19.4 FPS** |
| 50 ms | 19.0 FPS | 19.0 FPS |

19-20 FPS is the ceiling set by `tea.WithFPS(defaultUIFPS)` in `main.go`, so the waveform modes now reach the renderer's cap instead of the backend's refill rate. Raising that cap to let `TickWave` actually deliver ~60 FPS is a separate decision and is not part of this PR.

### Tests

`go test ./...` passes. Two tests added to `player/tap_test.go`:

- `TestTapWaveformAdvancesPastLastWriteSize` — a long refill followed by a short tail, exactly the shape that caused the freeze; the two reads returned identical frames before this change.
- `TestTapWaveformDoesNotReadPastWritten` — a 30 s stall must leave the window at the newest written frame.

The existing `TestTapWaveformSamplesAdvanceBetweenWrites` keeps its expectations unchanged, with the backend buffer passed explicitly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved waveform visualization timing so it advances smoothly between audio buffer refills.
  * Prevented waveform displays from stalling when audio writes are shorter than the playback buffer.
  * Ensured visualizations remain synchronized with the audible playback position.
  * Prevented waveform displays from reading beyond the audio data currently available.
  * Improved waveform stability when playback pauses or reaches the latest available audio.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->