### PR TITLE
feat(ui): start with the playlist expanded via `expanded` config key and `--expanded`

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -34,6 +34,7 @@ func buildApp() *cli.Command {
 		&cli.BoolWithInverseFlag{Name: "auto-play", Usage: "start playback immediately"},
 		&cli.BoolWithInverseFlag{Name: "simplified", Usage: "simplified playback view (no visualizer or playlist)"},
 		&cli.BoolWithInverseFlag{Name: "help-bar", Usage: "show the key-binding hint bar (? still opens the full keymap)", Value: true},
+		&cli.BoolWithInverseFlag{Name: "expanded", Usage: "start with the playlist expanded (the Ctrl+X state)"},
 		&cli.StringFlag{Name: "provider", Usage: "default provider: radio, podcast, navidrome, lyrion, plex, jellyfin, emby, spotify, qobuz, tidal, soundcloud, mixcloud, netease, yandex, audiobookshelf, abs, yt, youtube, ytmusic"},
 		&cli.StringFlag{Name: "start-theme", Usage: "UI theme name"},
 		&cli.StringFlag{Name: "visualizer", Usage: "visualizer mode"},
@@ -156,6 +157,10 @@ func overridesFromFlags(c *cli.Command) (config.Overrides, error) {
 	if c.IsSet("help-bar") {
 		v := !c.Bool("help-bar")
 		ov.HideHelpBar = &v
+	}
+	if c.IsSet("expanded") {
+		v := c.Bool("expanded")
+		ov.Expanded = &v
 	}
 	if c.IsSet("provider") {
 		v := strings.ToLower(c.String("provider"))

--- a/commands_test.go
+++ b/commands_test.go
@@ -25,6 +25,8 @@ func TestInverseBoolFlags(t *testing.T) {
 		{"--no-simplified", func(ov config.Overrides) *bool { return ov.Simplified }, false},
 		{"--help-bar", func(ov config.Overrides) *bool { return ov.HideHelpBar }, false},
 		{"--no-help-bar", func(ov config.Overrides) *bool { return ov.HideHelpBar }, true},
+		{"--expanded", func(ov config.Overrides) *bool { return ov.Expanded }, true},
+		{"--no-expanded", func(ov config.Overrides) *bool { return ov.Expanded }, false},
 		{"--expand-playlist", func(ov config.Overrides) *bool { return ov.ExpandPlaylist }, true},
 		{"--no-expand-playlist", func(ov config.Overrides) *bool { return ov.ExpandPlaylist }, false},
 		{"--low-power", func(ov config.Overrides) *bool { return ov.LowPower }, true},

--- a/config.toml.example
+++ b/config.toml.example
@@ -71,6 +71,11 @@ eq = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 # section opens full info instead. Closing Settings preserves this preference.
 # show_metadata = false
 
+# Start with the playlist at the expanded height, the state Ctrl+X toggles: the
+# list gets every body row the terminal has left instead of the shorter default.
+# The key keeps working and collapses the view as before.
+# expanded = true
+
 # UI theme name (check ~/.config/cliamp/themes/ for available themes)
 # theme = "Tokyo Night"
 

--- a/config/config.go
+++ b/config/config.go
@@ -364,6 +364,7 @@ type Config struct {
 	HideHelpBar      bool                         // hide the key-binding hint bar above the status line
 	HideSettingsPane bool                         // close the settings pane beside the playlist
 	ShowMetadata     bool                         // expand highlighted-track metadata below settings (default false)
+	Expanded         bool                         // start with the playlist expanded (the Ctrl+X state)
 	PaddingH         int                          // horizontal padding for the UI frame (default 3)
 	PaddingV         int                          // vertical padding for the UI frame (default 1)
 	AudioDevice      string                       // preferred audio output device name (empty = system default)
@@ -742,6 +743,8 @@ func Load() (Config, error) {
 				cfg.HideSettingsPane = val == "true"
 			case "show_metadata":
 				cfg.ShowMetadata = val == "true"
+			case "expanded":
+				cfg.Expanded = strings.ToLower(val) == "true"
 			case "audio_device":
 				cfg.AudioDevice = parseString(val)
 			case "initial_directory":

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -871,3 +871,45 @@ func TestApplyPlaylist(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadExpanded(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		want bool
+	}{
+		{name: "true", body: "expanded = true\n", want: true},
+		{name: "mixed case", body: "expanded = True\n", want: true},
+		{name: "false", body: "expanded = false\n", want: false},
+		{name: "absent", body: "visualizer = \"Wave\"\n", want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+
+			path := filepath.Join(os.Getenv("HOME"), ".config", "cliamp", "config.toml")
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatalf("MkdirAll: %v", err)
+			}
+			if err := os.WriteFile(path, []byte(tc.body), 0o644); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.Expanded != tc.want {
+				t.Errorf("Expanded = %v, want %v", cfg.Expanded, tc.want)
+			}
+		})
+	}
+}
+
+func TestOverridesApplyExpanded(t *testing.T) {
+	cfg := defaultConfig()
+	expanded := true
+	Overrides{Expanded: &expanded}.Apply(&cfg)
+	if !cfg.Expanded {
+		t.Error("Expanded should be true after applying the override")
+	}
+}

--- a/config/flags.go
+++ b/config/flags.go
@@ -17,6 +17,7 @@ type Overrides struct {
 	Play            *bool
 	Simplified      *bool
 	HideHelpBar     *bool
+	Expanded        *bool
 	AudioDevice     *string
 	Playlist        *string
 	LogLevel        *string
@@ -67,6 +68,9 @@ func (o Overrides) Apply(cfg *Config) {
 	}
 	if o.HideHelpBar != nil {
 		cfg.HideHelpBar = *o.HideHelpBar
+	}
+	if o.Expanded != nil {
+		cfg.Expanded = *o.Expanded
 	}
 	if o.Play != nil {
 		cfg.AutoPlay = *o.Play

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -27,6 +27,7 @@ cliamp --bit-depth 32 track.m4a           # PCM bit depth: 16 (default) or 32 (l
 
 ```sh
 cliamp --simplified ~/Music                  # no visualizer or playlist
+cliamp --expanded ~/Music                    # start with the playlist expanded (Ctrl+X state)
 cliamp --eq-preset "Bass Boost" ~/Music
 cliamp --visualizer-60fps ~/Music            # smoother visualizer animation (higher CPU use)
 ```
@@ -127,6 +128,7 @@ cliamp track.mp3 --repeat all --mono ~/Music
 | `--auto-play` / `--no-auto-play` | bool | false | |
 | `--simplified` / `--no-simplified` | bool | false | artist/title and time strip; no visualizer or playlist |
 | `--help-bar` / `--no-help-bar` | bool | true | show or hide the key-binding hint bar; `?` still opens the full keymap |
+| `--expanded` / `--no-expanded` | bool | false | start with the playlist expanded (the `Ctrl+X` state) |
 | `--visualizer-60fps` | bool | false | render a visible visualizer at about 60 FPS |
 | `--start-theme` | string | | theme name |
 | `--eq-preset` | string | | preset name |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,6 +91,10 @@ simplified = false
 
 # Hide the key-binding hint bar above the status line.
 hide_help_bar = false
+# Start with the playlist expanded, the state Ctrl+X toggles (default: false).
+# The simplified playback screen has no playlist, but its provider and overlay
+# lists do, and they start expanded too.
+expanded = false
 
 # Close the Settings pane beside the playlist (Ctrl+B toggles and saves).
 hide_settings_pane = false
@@ -168,6 +172,12 @@ bar comes back the way you left it. Use `cliamp --no-help-bar` to hide it for
 one session, or `cliamp --help-bar` to show it despite this setting. Simplified
 mode draws neither the hint bar nor a playlist, so it is unaffected by this
 setting.
+
+`expanded = true` starts with the playlist at the expanded height, so the list
+gets every body row the terminal has left instead of the shorter default, and
+`Ctrl+X` is not needed on every launch. The key keeps working and collapses the
+view as before. Start one session with `cliamp --expanded`, or `--no-expanded`
+to start collapsed despite this setting.
 
 List views such as provider browsing, file selection, queues, playlists, search
 results, themes, and keybindings use a content-first layout. This layout replaces

--- a/main.go
+++ b/main.go
@@ -583,6 +583,9 @@ func run(overrides config.Overrides, positional []string, daemon, visualizer60FP
 	if cfg.ShowMetadata {
 		m.SetShowMetadata(true)
 	}
+	if cfg.Expanded {
+		m.SetExpanded(true)
+	}
 
 	if resumeState.Path != "" && resumeState.PositionSec > 0 {
 		// Jellyfin resumes the restored context above. Mixcloud is also commonly

--- a/ui/model/init.go
+++ b/ui/model/init.go
@@ -146,6 +146,18 @@ func (m *Model) SetShowMetadata(v bool) {
 	m.refreshChrome()
 }
 
+// SetExpanded starts the UI in the expanded playlist height, the state the
+// Ctrl+X binding toggles. It sets the same field toggleExpandedView does and
+// takes no view into account: usesSimplifiedLayout() is transient (it drops as
+// soon as the provider or an overlay takes focus), and recomputeLayout already
+// ignores the height while it holds, so a guard here would only make the flag
+// differ from the key.
+func (m *Model) SetExpanded(v bool) {
+	m.heightExpanded = v
+	m.applyHeightMode()
+	m.adjustScroll()
+}
+
 // SetInitialDirectory sets the initial directory for the file browser.
 func (m *Model) SetInitialDirectory(dir string) { m.initialDir = dir }
 

--- a/ui/model/layout_test.go
+++ b/ui/model/layout_test.go
@@ -604,3 +604,51 @@ func TestConfiguredVisualizerRows(t *testing.T) {
 		})
 	}
 }
+
+// Simplified mode drops its own layout as soon as the provider or an overlay
+// takes focus, and those screens do draw a list. SetExpanded must therefore
+// reach heightExpanded there exactly as Ctrl+X does, or --simplified --expanded
+// would do nothing on the only screens where it shows.
+func TestSetExpandedAppliesToSimplifiedProviderLists(t *testing.T) {
+	m := newLayoutTestModel(100, 50)
+	m.SetSimplified(true)
+	m.focus = focusProvider
+	m.recomputeLayout()
+
+	collapsed := m.plVisible
+	if collapsed == 0 {
+		t.Fatal("provider list rows = 0 in simplified mode, want the content-first list")
+	}
+
+	m.SetExpanded(true)
+	if !m.heightExpanded {
+		t.Fatal("SetExpanded did not set the expanded height in simplified mode")
+	}
+	if m.plVisible != m.layout.bodyRows {
+		t.Fatalf("expanded provider list rows = %d, want available body rows %d", m.plVisible, m.layout.bodyRows)
+	}
+	if m.plVisible <= collapsed {
+		t.Fatalf("expanded provider list rows = %d, want more than collapsed %d", m.plVisible, collapsed)
+	}
+
+	// And it matches what the key produces from the same state.
+	byKey := newLayoutTestModel(100, 50)
+	byKey.SetSimplified(true)
+	byKey.focus = focusProvider
+	byKey.recomputeLayout()
+	byKey.toggleExpandedView()
+	if byKey.plVisible != m.plVisible {
+		t.Fatalf("Ctrl+X rows = %d, SetExpanded rows = %d, want the same", byKey.plVisible, m.plVisible)
+	}
+}
+
+// The playback screen has no playlist in simplified mode, so the height is
+// carried but ignored rather than blocked.
+func TestSetExpandedIsInertOnTheSimplifiedPlaybackScreen(t *testing.T) {
+	m := newLayoutTestModel(100, 50)
+	m.SetSimplified(true)
+	m.SetExpanded(true)
+	if m.plVisible != 0 {
+		t.Fatalf("simplified playback playlist rows = %d, want 0", m.plVisible)
+	}
+}


### PR DESCRIPTION
Fixes #391.

### The problem

The expanded playlist height that `Ctrl+X` toggles is runtime-only state (`heightExpanded` in `ui/model/model.go`). On a tall terminal the collapsed view shows a handful of rows and leaves the rest empty, so the key has to be pressed on every launch. There was no config key and no flag for it — the only `expand`-ish option, `expand_playlist`, is about YouTube Music playlists.

### The change

Follows the same path `simplified` already takes:

- `Config.Expanded` plus an `expanded` case in the config parser
- `Overrides.Expanded` and `--expanded` / `--no-expanded` on the command line, as a `cli.BoolWithInverseFlag` like every other boolean after #403
- `Model.SetExpanded`, applied at startup next to `SetSimplified`

`SetExpanded` sets the same field `toggleExpandedView` does, and takes no view into account. That matters in simplified mode: `usesSimplifiedLayout()` is transient — it drops as soon as the provider or an overlay takes focus, and those screens do draw a list that `Ctrl+X` expands. `recomputeLayout` already forces `plVisible = 0` while the simplified layout holds, so the height is carried and ignored there rather than blocked, and the flag behaves exactly like the key. `Ctrl+X` is untouched and still collapses the view.

```toml
# config.toml
expanded = true
```

```sh
cliamp --expanded ~/Music
cliamp --no-expanded ~/Music   # collapsed for one session, despite the config key
```

### Tests

`go test ./...` passes. Added:

- `TestLoadExpanded` — the config key in four shapes: `true`, `True`, `false`, absent.
- `TestOverridesApplyExpanded` — the flag override reaches the config.
- `--expanded` and `--no-expanded` rows in `TestInverseBoolFlags`.
- `TestSetExpandedAppliesToSimplifiedProviderLists` — at 100x50 with the provider focused, `--simplified --expanded` takes the list to `layout.bodyRows`, and matches what `toggleExpandedView` produces from the same state.
- `TestSetExpandedIsInertOnTheSimplifiedPlaybackScreen` — the simplified playback screen still reports 0 playlist rows.

### Verified by hand

Arch Linux, foot on Hyprland, 56-track playlist in a 1261x1380 px window: with `--expanded`, and with `expanded = true` in an isolated `CLIAMP_CONFIG_DIR`, the playlist fills the window from the top on startup, exactly as after pressing `Ctrl+X`. Without either, the previous behaviour is unchanged.

### Docs

`config.toml.example` and `docs/configuration.md` get the key, `docs/cli.md` the flag pair.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to start the player with the playlist expanded.
  * Configure the initial playlist state in the configuration file or with the `--expanded` command-line flag.
  * The `--no-expanded` option explicitly starts with the playlist collapsed.
  * The existing toggle key remains available during playback.
  * The setting is ignored where no playlist is displayed in simplified mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

**Changes since @gjermundgaraba's review** (rebased onto current `main`):

1. `--expanded` / `--no-expanded` as a `BoolWithInverseFlag`. The override itself was the bug: `overridesFromFlags` did `v := true` instead of `v := c.Bool("expanded")`.
2. Dropped the simplified-mode guard in `SetExpanded`, as described above — it checked the permanent `m.simplified` while the layout checks the transient `usesSimplifiedLayout()`, which is why `Ctrl+X` reached the provider and overlay lists and the flag did not.
3. `expanded` added to `config.toml.example`.
4. The missing blank line in `docs/configuration.md`.
5. "the full list" reworded, and the line that repeated the wrong simplified-mode claim fixed.