### PR TITLE
refactor(cli): use inverse boolean flags

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -30,8 +30,7 @@ func buildApp() *cli.Command {
 		&cli.Float64Flag{Name: "vol", Usage: "startup volume in dB [-30, +6]"},
 		&cli.BoolFlag{Name: "shuffle", Usage: "shuffle playback"},
 		&cli.StringFlag{Name: "repeat", Usage: "repeat mode: off, all, one"},
-		&cli.BoolFlag{Name: "mono", Usage: "mono output"},
-		&cli.BoolFlag{Name: "no-mono", Usage: "disable mono output"},
+		&cli.BoolWithInverseFlag{Name: "mono", Usage: "mono output"},
 		&cli.BoolFlag{Name: "auto-play", Usage: "start playback immediately"},
 		&cli.BoolFlag{Name: "simplified", Usage: "simplified playback view (no visualizer or playlist)"},
 		&cli.StringFlag{Name: "provider", Usage: "default provider: radio, navidrome, lyrion, plex, jellyfin, emby, spotify, qobuz, tidal, soundcloud, mixcloud, netease, audiobookshelf, abs, yt, youtube, ytmusic"},
@@ -46,8 +45,7 @@ func buildApp() *cli.Command {
 		&cli.StringFlag{Name: "audio-device", Usage: "audio output device (use 'list' to show)"},
 		&cli.StringFlag{Name: "playlist", Usage: "load a local TOML playlist by name and start playing"},
 		&cli.StringFlag{Name: "log-level", Usage: "log level: debug, info, warn, error"},
-		&cli.BoolFlag{Name: "expand-playlist", Usage: "expand YouTube Music playlists from list= URLs"},
-		&cli.BoolFlag{Name: "no-expand-playlist", Usage: "disable playlist expansion for YouTube Music URLs"},
+		&cli.BoolWithInverseFlag{Name: "expand-playlist", Usage: "expand YouTube Music playlists from list= URLs"},
 		&cli.BoolFlag{Name: "low-power", Usage: "low-power mode: reduce CPU by lowering UI cadence and disabling visualization"},
 		&cli.BoolFlag{Name: "daemon", Aliases: []string{"d"}, Usage: "run headless (no TUI), serving IPC for scripts/Waybar"},
 	}
@@ -143,11 +141,7 @@ func overridesFromFlags(c *cli.Command) (config.Overrides, error) {
 		}
 	}
 	if c.IsSet("mono") {
-		v := true
-		ov.Mono = &v
-	}
-	if c.IsSet("no-mono") {
-		v := false
+		v := c.Bool("mono")
 		ov.Mono = &v
 	}
 	if c.IsSet("auto-play") {
@@ -218,11 +212,7 @@ func overridesFromFlags(c *cli.Command) (config.Overrides, error) {
 		ov.LowPower = &v
 	}
 	if c.IsSet("expand-playlist") {
-		v := true
-		ov.ExpandPlaylist = &v
-	}
-	if c.IsSet("no-expand-playlist") {
-		v := false
+		v := c.Bool("expand-playlist")
 		ov.ExpandPlaylist = &v
 	}
 	return ov, nil

--- a/commands_test.go
+++ b/commands_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	cli "github.com/urfave/cli/v3"
+
+	"github.com/bjarneo/cliamp/config"
+)
+
+func TestInverseBoolFlags(t *testing.T) {
+	tests := []struct {
+		flag string
+		get  func(config.Overrides) *bool
+		want bool
+	}{
+		{"--mono", func(ov config.Overrides) *bool { return ov.Mono }, true},
+		{"--no-mono", func(ov config.Overrides) *bool { return ov.Mono }, false},
+		{"--expand-playlist", func(ov config.Overrides) *bool { return ov.ExpandPlaylist }, true},
+		{"--no-expand-playlist", func(ov config.Overrides) *bool { return ov.ExpandPlaylist }, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.flag, func(t *testing.T) {
+			app := buildApp()
+			var got config.Overrides
+			app.Action = func(_ context.Context, c *cli.Command) error {
+				var err error
+				got, err = overridesFromFlags(c)
+				return err
+			}
+
+			if err := app.Run(context.Background(), []string{"cliamp", tt.flag}); err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+			value := tt.get(got)
+			if value == nil || *value != tt.want {
+				t.Errorf("value = %v, want %t", value, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This follows #400's upgrade to `urfave/cli` v3.11, which improves inverse-flag help, aliases, defaults, and error handling. We can now use the built-in inverse flag type instead of maintaining paired flags ourselves.

- replace the paired `--mono` / `--no-mono` flags with `cli.BoolWithInverseFlag`
- replace the paired `--expand-playlist` / `--no-expand-playlist` flags the same way
- parse both positive and negative forms through the canonical flag value
- add regression coverage for each form

Stacked on #400.

## Screenshots / video

Not applicable.

## How to test

1. Run `make check`.

## Checklist

- [x] `make check` passes
- [x] Existing CLI forms are unchanged; no documentation update required


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the `--mono` and `--expand-playlist` options.
  * Added support for explicitly enabling or disabling each option with inverse flags.
  * Ensured command-line settings correctly reflect the selected true or false value.

* **Tests**
  * Added coverage for enabled and disabled forms of both options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->