### PR TITLE
feat(radio): browse and pin stations by country

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,11 @@ playback, resume, seeking, and limitations.
 
 ## Radio
 
-Press `R` in the player to browse and search more than 30,000 online radio stations in the [Radio Browser](https://www.radio-browser.info/) directory.
+Press `R` in the player to browse about 58,000 online radio stations in the [Radio Browser](https://www.radio-browser.info/) directory.
 
-Add stations to `~/.config/cliamp/radios.toml` (or `%APPDATA%\cliamp\radios.toml` on Windows when `HOME` is unset). See [docs/configuration.md](docs/configuration.md#custom-radio-stations).
+Cut that down by location: `N` browses by country, `f` pins the countries you listen to, and `Enter` on a country loads its stations as a playlist. cliamp does not work out where you are unless you pick "Use my location" and accept; it then reads your country from the system timezone, never from a geo-IP service. See [docs/radio.md](docs/radio.md).
+
+Add your own stations to `~/.config/cliamp/radios.toml` (or `%APPDATA%\cliamp\radios.toml` on Windows when `HOME` is unset). See [docs/configuration.md](docs/configuration.md#custom-radio-stations).
 
 To host a radio station, use [cliamp-server](https://github.com/bjarneo/cliamp-server).
 

--- a/config/config.go
+++ b/config/config.go
@@ -203,6 +203,17 @@ func (y YouTubeMusicConfig) ResolveCredentials(fallbackFn func() (string, string
 	return "", ""
 }
 
+// RadioConfig holds settings for the built-in Radio provider. Radio is always
+// enabled, so this block only tunes it.
+type RadioConfig struct {
+	// Country is the listener's home country as an ISO 3166-1 alpha-2 code.
+	// It puts a "near you" row at the top of the radio pane, offers that
+	// country's regions in the country browser, and is the first stop of the
+	// catalog country filter. Unset means "detect from the system timezone,
+	// then the locale"; set it to "none" to turn detection off.
+	Country string
+}
+
 // SoundCloudConfig holds settings for the SoundCloud provider.
 // SoundCloud is opt-in: requires enabled = true in [soundcloud] before the
 // provider registers. Setting User exposes that profile's Tracks/Likes/Reposts
@@ -343,6 +354,7 @@ type Config struct {
 	Jellyfin         JellyfinConfig               // optional Jellyfin server credentials
 	Emby             EmbyConfig                   // optional Emby server credentials
 	Audiobookshelf   AudiobookshelfConfig         // optional Audiobookshelf server credentials
+	Radio            RadioConfig                  // built-in Radio provider settings
 	SoundCloud       SoundCloudConfig             // SoundCloud provider (opt-in via enabled = true)
 	Mixcloud         MixcloudConfig               // Mixcloud provider (opt-in via enabled = true)
 	NetEase          NetEaseConfig                // NetEase Cloud Music provider (opt-in via enabled = true)
@@ -520,6 +532,11 @@ func Load() (Config, error) {
 				cfg.Plex.Token = parseString(val)
 			case "libraries":
 				cfg.Plex.Libraries = parseStringSlice(val)
+			}
+		case "radio":
+			switch key {
+			case "country":
+				cfg.Radio.Country = strings.TrimSpace(parseString(val))
 			}
 		case "soundcloud":
 			switch key {
@@ -772,6 +789,16 @@ func Save(key, value string) error {
 // If no [navidrome] section exists, one is appended along with the key.
 func SaveNavidromeSort(sortType string) error {
 	return saveSectionValue("navidrome", "browse_sort", strconv.Quote(sortType))
+}
+
+// SaveRadioCountry persists the listener's home country in the [radio] section
+// so the choice survives a restart. Pass "" to record that detection should be
+// turned off.
+func SaveRadioCountry(code string) error {
+	if code == "" {
+		code = "none"
+	}
+	return saveSectionValue("radio", "country", strconv.Quote(code))
 }
 
 // SaveMixcloudStyles persists the selected discovery styles in the [mixcloud]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -272,6 +272,21 @@ user_id = "your-account-user-id"
 
 After you enable NetEase, the provider shows liked songs, created playlists, saved playlists, and public charts. Use `Ctrl+F` to search. Playback uses `yt-dlp` with the same browser cookie source.
 
+## Radio
+
+The Radio provider is always on. The `[radio]` block only tunes it:
+
+```toml
+[radio]
+country = "NO"
+```
+
+`country` is your home country as an ISO 3166-1 alpha-2 code. It puts a "near you" row at the top of the radio pane and offers that country's regions in the country browser.
+
+Leave it unset and cliamp does not work out where you are. It offers instead: the radio pane shows a "Use my location" row, and only if you accept does it read your country from the system timezone, then the locale, with no network call. Your answer is written here either way, so you are asked once. Set it to `"none"` to decline up front. See [radio.md](radio.md#using-your-location).
+
+Pinned countries live in `~/.config/cliamp/radio_countries.toml` and are written by pressing `f` in the country browser, so you do not normally edit that file by hand.
+
 ## Custom Radio Stations
 
 Add stations to `~/.config/cliamp/radios.toml`:

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -74,7 +74,7 @@ and `Esc` clears it.
 
 | Key | Action |
 |---|---|
-| `f` | Toggle bookmark ★ on the selected track. In the radio browser, favorite the selected station. |
+| `f` | Toggle bookmark ★ on the selected track. In the radio browser, favorite the selected station. In the country browser, pin the selected country or region. |
 | `n` | Toggle favorite ♥ on the selected track. Favorited tracks appear in the cross-playlist "Favorites" virtual playlist. |
 | `Ctrl+F` | Search with the active provider (Spotify, Qobuz, Tidal, Navidrome, Lyrion, Jellyfin, Emby, Plex, Audiobookshelf, Mixcloud, NetEase, Local), or search YouTube. Available in playlist and provider-browser views. |
 | `u` | Load URL (stream/playlist) |
@@ -83,7 +83,7 @@ and `Esc` clears it.
 | `i` | Show track metadata (`↑`/`↓` scrolls) |
 | `Ctrl+S` | Save track to `~/Music/cliamp` |
 | `w` | Write the highlighted track to a local playlist |
-| `N` | Open the active provider browser. On a selected Mixcloud show, open that creator's Uploads/Favorites. |
+| `N` | Open the active provider browser. On a selected Mixcloud show, open that creator's Uploads/Favorites. In the radio pane, open the country browser. |
 | `L` | Browse local playlists (with cliamp radio) |
 | `R` | Open radio provider |
 | `S` | Open Spotify provider |

--- a/docs/radio.md
+++ b/docs/radio.md
@@ -1,0 +1,175 @@
+# Radio
+
+cliamp ships with the [Radio Browser](https://www.radio-browser.info/) directory: about 58,000 internet radio stations across 241 countries. Press `R` in the player to open it.
+
+A list that long is only useful if you can cut it down. The main way to do that is by location.
+
+## Quick start
+
+| Do this | To get |
+| --- | --- |
+| `R`, then `Enter` on "Browse all countries" | The country list, your own regions first |
+| `/` in the country list | Filter it: type `japan`, `europe`, `oslo` |
+| `f` on a country | Pin it, so it gets its own row in the radio pane |
+| `Enter` on a country row | That country's stations as a playlist |
+| `Enter` on "Use my location" | Offers to work out your country, once, and only if you say yes |
+
+## The radio pane
+
+```
+── Countries ──────────────────────
+  Browse all countries
+  Norway (near you)
+  ★ Germany
+  ★ Japan
+── Stations ───────────────────────
+  cliamp radio
+── Favorites ──────────────────────
+  ★ Radio Paradise [320k] · United States
+── Catalog ────────────────────────
+  MANGORADIO [128k] · Germany
+  Dance Wave! [128k] · Hungary
+```
+
+"Norway (near you)" appears only once you have said yes to [using your location](#using-your-location). Starred rows are places you pinned. Selecting any of them loads that country's or region's stations as a playlist, so `>` and `<` scan between stations of one place.
+
+## Browsing by country
+
+"Browse all countries" opens the country list. Each row shows the country, its station count, and its region:
+
+```
+☆ Innlandet (16) — Norway
+☆ Oslo (11) — Norway
+☆ United States Of America (7975) — Americas
+★ Germany (6235) — Europe
+☆ Japan (215) — Asia
+```
+
+Regions of your own country come first, grouped under its name. Only about 44% of stations record a region at all, so cliamp fetches them for your home country only, where they are worth the request.
+
+`/` filters the list on both the name and the region, so `asia` narrows to Asian countries and `oslo` finds one Norwegian region.
+
+Pick a country and choose how to order its stations:
+
+| Order | Sorts by |
+| --- | --- |
+| Most Voted | Directory votes, all-time |
+| Most Listened | Total clicks |
+| Trending | Recent click growth |
+| By Name | Station name, A to Z |
+| Random | Nothing; a different set each time |
+
+The result replaces your playlist with up to 200 stations from that place.
+
+### Pinning
+
+`f` on a country or region pins it. Pinned places get their own row in the radio pane under "Countries", so the places you listen to are one keypress from anywhere. They are stored in `~/.config/cliamp/radio_countries.toml`:
+
+```toml
+[[country]]
+code = "DE"
+name = "Germany"
+
+[[country]]
+code = "NO"
+name = "Oslo, Norway"
+state = "Oslo"
+```
+
+## Using your location
+
+Until you ask for it, cliamp does not work out where you are. A fresh install
+shows one row instead:
+
+```
+── Countries ──────────────────────
+  Browse all countries
+  Use my location
+```
+
+Selecting it asks:
+
+> Use your country to suggest nearby radio? cliamp would read it from your
+> system timezone. Nothing is sent to a location service.
+
+Answer with `y` or `n`. Either answer is remembered, so you are asked once and
+the row goes away. Saying yes writes your country to `[radio] country` and adds
+a "near you" row for it; saying no writes `country = "none"` and changes
+nothing else.
+
+Nothing else in cliamp reads your location, and no other feature is gated on
+this. The country browser, pinning, and the catalog all work the same whether
+you say yes or no; a yes only saves you finding your own country in a list of
+250.
+
+### How it is worked out
+
+Only after you say yes, and never over the network:
+
+1. The system timezone: `TZ`, then the `/etc/localtime` symlink, then `/etc/timezone`.
+2. The locale: `LC_ALL`, then `LC_MESSAGES`, then `LANG`.
+
+The timezone is checked before the locale on purpose. A desktop left on
+`en_US.UTF-8` while sitting in `Europe/Oslo` is the common case, not the
+exception, and the timezone is the setting people keep accurate.
+
+There is no geo-IP lookup. That would be more precise and would also mean
+telling a third party where you live every launch, which is not a trade this
+feature is worth.
+
+### Setting it yourself
+
+Skip the question entirely with an ISO 3166-1 alpha-2 code:
+
+```toml
+[radio]
+country = "NO"
+```
+
+Or turn it off for good:
+
+```toml
+[radio]
+country = "none"
+```
+
+To be asked again, delete the `country` line.
+
+## Why not "stations near me"
+
+The directory records coordinates for stations, and it would be reasonable to expect a radius search. cliamp does not offer one, because the data does not support it:
+
+| Field | Coverage (1000 top stations) |
+| --- | --- |
+| `countrycode` | 98.7% |
+| `state` | 44.4% |
+| `geo_lat` / `geo_long` | 11.9% |
+
+A 200 km radius search would silently hide about 88% of the catalog. The API also ignores distance ordering, so what came back would not even be sorted by how close it is. Country is the axis the data actually supports, so that is the one cliamp uses.
+
+## Custom stations
+
+Stations you add yourself live in `~/.config/cliamp/radios.toml` and appear under "Stations" alongside the built-in cliamp radio. See [configuration.md](configuration.md#custom-radio-stations).
+
+Unlike directory entries, these are not filtered to `http` and `https`. That file is yours, and it carries the same trust as anything else you type.
+
+## Keys
+
+| Key | Action |
+| --- | --- |
+| `R` | Open the radio provider |
+| `/` | Search station names through the directory (Enter runs it, Esc clears) |
+| `f` | Favorite the selected station, or pin the selected country |
+| `N` | Open the country browser |
+| `i` | Show cliamp radio listener statistics |
+| `Ctrl+R` | Refresh: re-fetch the country list and the catalog |
+
+See [keybindings.md](keybindings.md) for the rest.
+
+## Track info
+
+For live radio, cliamp shows the current track from inline ICY metadata (`StreamTitle`). See [streaming.md](streaming.md#track-info) for the stations that publish now-playing data through an API instead.
+
+## Run your own station
+
+Run an internet radio station with [cliamp-server](https://github.com/bjarneo/cliamp-server). Point it at a directory of audio files to start broadcasting. It supports multiple stations, live metadata, and on-the-fly transcoding.

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -54,7 +54,9 @@ cliamp https://www.xiaoyuzhoufm.com/episode/xxxx
 
 ## Radio Catalog
 
-Press `R` in the player to browse and search more than 30,000 online radio stations in the [Radio Browser](https://www.radio-browser.info/) directory. Use `/` to search by name, `Enter` to play, and `a` to add a station to the playlist.
+Press `R` in the player to browse about 58,000 online radio stations in the [Radio Browser](https://www.radio-browser.info/) directory. Use `/` to search by name, `Enter` to play, and `a` to add a station to the playlist.
+
+To cut the list down by location, browse by country (`N`), pin the countries you listen to (`f`), and narrow the catalog to one of them (`c`). See [radio.md](radio.md).
 
 ## Track Info
 
@@ -76,5 +78,7 @@ Press `u` during playback to load a stream or playlist URL without restarting. I
 ## Run Your Own Radio Station
 
 Run an internet radio station with [cliamp-server](https://github.com/bjarneo/cliamp-server). Point it to a directory of audio files to start broadcasting. It supports multiple stations, live metadata, and on-the-fly transcoding.
+
+See [radio.md](radio.md) for the radio provider in full.
 
 See [playlists.md](playlists.md) for M3U playlist details.

--- a/external/radio/catalog.go
+++ b/external/radio/catalog.go
@@ -7,6 +7,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/bjarneo/cliamp/provider"
@@ -17,14 +20,31 @@ const cliampRadioStatsURL = "https://radio.cliamp.stream/statistics"
 
 // CatalogStation represents a station from the Radio Browser API.
 type CatalogStation struct {
-	Name     string `json:"name"`
-	URL      string `json:"url_resolved"`
-	Country  string `json:"country"`
-	Tags     string `json:"tags"`
-	Codec    string `json:"codec"`
-	Bitrate  int    `json:"bitrate"`
-	Votes    int    `json:"votes"`
-	Homepage string `json:"homepage"`
+	Name        string `json:"name"`
+	URL         string `json:"url_resolved"`
+	Country     string `json:"country"`
+	CountryCode string `json:"countrycode"`
+	State       string `json:"state"`
+	Tags        string `json:"tags"`
+	Codec       string `json:"codec"`
+	Bitrate     int    `json:"bitrate"`
+	Votes       int    `json:"votes"`
+	Homepage    string `json:"homepage"`
+}
+
+// Country is one entry of the directory's country index.
+type Country struct {
+	Name         string `json:"name"`
+	Code         string `json:"iso_3166_1"`
+	StationCount int    `json:"stationcount"`
+}
+
+// State is a region within a country. Only about 44% of stations carry one, so
+// a country's state list covers a fraction of its stations.
+type State struct {
+	Name         string `json:"name"`
+	Country      string `json:"country"`
+	StationCount int    `json:"stationcount"`
 }
 
 var catalogClient = &http.Client{Timeout: 10 * time.Second}
@@ -37,71 +57,190 @@ func (*Provider) RadioStats() (provider.RadioStats, error) {
 
 // FetchStats fetches listener statistics for cliamp radio's built-in stations.
 func FetchStats() (provider.RadioStats, error) {
-	req, err := http.NewRequest(http.MethodGet, cliampRadioStatsURL, nil)
-	if err != nil {
-		return provider.RadioStats{}, err
-	}
-	req.Header.Set("User-Agent", "cliamp/1.0")
-
-	resp, err := statsClient.Do(req)
-	if err != nil {
-		return provider.RadioStats{}, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return provider.RadioStats{}, fmt.Errorf("cliamp radio stats: HTTP %d", resp.StatusCode)
-	}
-
 	var stats provider.RadioStats
-	if err := json.NewDecoder(resp.Body).Decode(&stats); err != nil {
-		return provider.RadioStats{}, err
+	if err := getJSON(statsClient, cliampRadioStatsURL, &stats); err != nil {
+		return provider.RadioStats{}, fmt.Errorf("cliamp radio stats: %w", err)
 	}
 	return stats, nil
 }
 
-// SearchStations searches the Radio Browser API by station name.
-func SearchStations(query string, limit int) ([]CatalogStation, error) {
+// StationQuery narrows a station listing. The zero value lists everything.
+//
+// Location is expressed as a country code and optional state rather than a
+// radius: only about 12% of directory entries carry coordinates at all, and
+// the API ignores every distance ordering, so a "stations near me" search
+// would silently hide most of the catalog and return it unsorted. The country
+// code, by contrast, is present on ~99% of entries.
+type StationQuery struct {
+	Name        string // free-text station name
+	CountryCode string // ISO 3166-1 alpha-2
+	State       string // region within CountryCode
+	Order       string // one of SortVotes, SortClicks, … ; defaults to SortVotes
+	Offset      int
+	Limit       int
+}
+
+// Station listing orders accepted by the directory's search endpoint.
+const (
+	SortVotes  = "votes"
+	SortClicks = "clickcount"
+	SortTrend  = "clicktrend"
+	SortName   = "name"
+	SortRandom = "random"
+)
+
+// values renders the query as request parameters. Name, countrycode, and state
+// are matched exactly where the API allows it, so that filtering on "Georgia"
+// cannot also pull in "South Georgia".
+func (q StationQuery) values() url.Values {
+	limit := q.Limit
 	if limit <= 0 {
 		limit = 50
 	}
-	u := fmt.Sprintf("%s/stations/byname/%s?limit=%d&order=votes&reverse=true&hidebroken=true",
-		radioBrowserBase, url.PathEscape(query), limit)
-	return fetchStations(u)
+	order := q.Order
+	if order == "" {
+		order = SortVotes
+	}
+	v := url.Values{}
+	v.Set("limit", strconv.Itoa(limit))
+	v.Set("offset", strconv.Itoa(max(0, q.Offset)))
+	v.Set("order", order)
+	v.Set("hidebroken", "true")
+	// Ascending reads naturally for names and means nothing for random;
+	// every other order wants the biggest numbers first.
+	if order != SortName && order != SortRandom {
+		v.Set("reverse", "true")
+	}
+	if name := strings.TrimSpace(q.Name); name != "" {
+		v.Set("name", name)
+	}
+	if code := normalizeCountryCode(q.CountryCode); code != "" {
+		v.Set("countrycode", code)
+	}
+	if state := strings.TrimSpace(q.State); state != "" {
+		v.Set("state", state)
+		v.Set("stateExact", "true")
+	}
+	return v
 }
 
-// TopStationsOffset returns a page of the most-voted stations starting at offset.
-func TopStationsOffset(offset, limit int) ([]CatalogStation, error) {
-	if limit <= 0 {
-		limit = 50
-	}
-	if offset < 0 {
-		offset = 0
-	}
-	u := fmt.Sprintf("%s/stations/topvote/%d?offset=%d&hidebroken=true",
-		radioBrowserBase, limit, offset)
-	return fetchStations(u)
-}
-
-func fetchStations(u string) ([]CatalogStation, error) {
-	req, err := http.NewRequest("GET", u, nil)
-	if err != nil {
+// Stations runs a station query against the directory. The /stations/search
+// endpoint subsumes the directory's /topvote and /byname shortcuts: with no
+// name and no country it returns the same top-voted feed, in the same order.
+func Stations(q StationQuery) ([]CatalogStation, error) {
+	var stations []CatalogStation
+	if err := fetchJSON(radioBrowserBase+"/stations/search?"+q.values().Encode(), &stations); err != nil {
 		return nil, err
+	}
+	return stations, nil
+}
+
+// FetchCountries returns the directory's country index, most stations first.
+// Entries without a usable ISO code are dropped, and the directory's handful
+// of lowercase duplicates ("de" beside "DE") are folded into one another.
+func FetchCountries() ([]Country, error) {
+	var raw []Country
+	if err := fetchJSON(radioBrowserBase+"/countries", &raw); err != nil {
+		return nil, err
+	}
+
+	byCode := make(map[string]*Country, len(raw))
+	merged := make([]Country, 0, len(raw))
+	for _, c := range raw {
+		code := normalizeCountryCode(c.Code)
+		if code == "" {
+			continue
+		}
+		if existing, ok := byCode[code]; ok {
+			existing.StationCount += c.StationCount
+			continue
+		}
+		merged = append(merged, Country{
+			Name:         displayCountryName(c.Name),
+			Code:         code,
+			StationCount: c.StationCount,
+		})
+		byCode[code] = &merged[len(merged)-1]
+	}
+	slices.SortFunc(merged, func(a, b Country) int {
+		if a.StationCount != b.StationCount {
+			return b.StationCount - a.StationCount
+		}
+		return strings.Compare(a.Name, b.Name)
+	})
+	return merged, nil
+}
+
+// FetchStates returns the regions the directory knows for a country, named by
+// its full country name (not its code), most stations first. The directory's
+// "- None -" bucket and its inconsistent casing are cleaned up here.
+func FetchStates(country string) ([]State, error) {
+	country = strings.TrimSpace(country)
+	if country == "" {
+		return nil, nil
+	}
+	var raw []State
+	if err := fetchJSON(radioBrowserBase+"/states/"+url.PathEscape(country)+"/", &raw); err != nil {
+		return nil, err
+	}
+
+	// State names are submitter-entered, so the same region turns up as both
+	// "oslo" and "Oslo". The API matches them case-insensitively, so folding
+	// the two into one row loses nothing and spares the listener a duplicate.
+	states := make([]State, 0, len(raw))
+	byName := make(map[string]int, len(raw))
+	for _, s := range raw {
+		name := strings.TrimSpace(s.Name)
+		if name == "" || name == "- None -" || s.StationCount <= 0 {
+			continue
+		}
+		key := strings.ToLower(name)
+		if i, seen := byName[key]; seen {
+			states[i].StationCount += s.StationCount
+			continue
+		}
+		byName[key] = len(states)
+		states = append(states, State{
+			Name:         displayStateName(name),
+			Country:      country,
+			StationCount: s.StationCount,
+		})
+	}
+	slices.SortFunc(states, func(a, b State) int {
+		if a.StationCount != b.StationCount {
+			return b.StationCount - a.StationCount
+		}
+		return strings.Compare(a.Name, b.Name)
+	})
+	return states, nil
+}
+
+// fetchJSON reads a JSON document from the Radio Browser API.
+func fetchJSON(u string, out any) error {
+	if err := getJSON(catalogClient, u, out); err != nil {
+		return fmt.Errorf("radio-browser: %w", err)
+	}
+	return nil
+}
+
+// getJSON performs one GET and decodes the response body. Callers wrap the
+// error with the name of the service they were talking to.
+func getJSON(client *http.Client, u string, out any) error {
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return err
 	}
 	req.Header.Set("User-Agent", "cliamp/1.0")
 
-	resp, err := catalogClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("radio-browser: HTTP %d", resp.StatusCode)
+		return fmt.Errorf("HTTP %d", resp.StatusCode)
 	}
 
-	var stations []CatalogStation
-	if err := json.NewDecoder(resp.Body).Decode(&stations); err != nil {
-		return nil, err
-	}
-	return stations, nil
+	return json.NewDecoder(resp.Body).Decode(out)
 }

--- a/external/radio/catalog_test.go
+++ b/external/radio/catalog_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strings"
 	"testing"
 	"time"
 )
@@ -48,35 +47,33 @@ func testHTTPClient(t *testing.T, serverURL string) *http.Client {
 	}
 }
 
-func TestSearchStationsSuccess(t *testing.T) {
+func TestStationsSuccess(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !strings.Contains(r.URL.Path, "/stations/byname/") {
+		if r.URL.Path != "/json/stations/search" {
 			t.Errorf("unexpected path %q", r.URL.Path)
 		}
-		if !strings.Contains(r.URL.Path, "jazz") {
-			t.Errorf("path should contain query 'jazz': %q", r.URL.Path)
+		if got := r.URL.Query().Get("name"); got != "jazz" {
+			t.Errorf("name = %q, want jazz", got)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`[{"name":"Jazz FM","url_resolved":"https://jazz.example/stream","country":"UK","bitrate":128}]`))
+		_, _ = w.Write([]byte(`[{"name":"Jazz FM","url_resolved":"https://jazz.example/stream","country":"UK","countrycode":"GB","bitrate":128}]`))
 	}))
 	defer srv.Close()
 	installCatalogClient(t, srv.URL)
 
-	stations, err := SearchStations("jazz", 10)
+	stations, err := Stations(StationQuery{Name: "jazz", Limit: 10})
 	if err != nil {
-		t.Fatalf("SearchStations: %v", err)
+		t.Fatalf("Stations: %v", err)
 	}
 	if len(stations) != 1 {
 		t.Fatalf("got %d stations, want 1", len(stations))
 	}
-	if stations[0].Name != "Jazz FM" {
-		t.Errorf("Name = %q, want Jazz FM", stations[0].Name)
+	got := stations[0]
+	if got.Name != "Jazz FM" || got.URL != "https://jazz.example/stream" {
+		t.Errorf("station = %+v", got)
 	}
-	if stations[0].URL != "https://jazz.example/stream" {
-		t.Errorf("URL = %q", stations[0].URL)
-	}
-	if stations[0].Bitrate != 128 {
-		t.Errorf("Bitrate = %d, want 128", stations[0].Bitrate)
+	if got.Bitrate != 128 || got.CountryCode != "GB" {
+		t.Errorf("station = %+v, want bitrate 128 and country code GB", got)
 	}
 }
 
@@ -108,93 +105,27 @@ func TestFetchStats(t *testing.T) {
 	}
 }
 
-func TestSearchStationsDefaultLimit(t *testing.T) {
-	var gotURL string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotURL = r.URL.String()
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`[]`))
-	}))
-	defer srv.Close()
-	installCatalogClient(t, srv.URL)
-
-	if _, err := SearchStations("x", 0); err != nil {
-		t.Fatalf("SearchStations: %v", err)
-	}
-	if !strings.Contains(gotURL, "limit=50") {
-		t.Errorf("default limit should be 50, got URL %q", gotURL)
-	}
-}
-
-func TestSearchStationsHTTPError(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func TestStationsHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "down", http.StatusInternalServerError)
 	}))
 	defer srv.Close()
 	installCatalogClient(t, srv.URL)
 
-	_, err := SearchStations("jazz", 10)
-	if err == nil {
-		t.Error("SearchStations should return error on 500")
+	if _, err := Stations(StationQuery{Name: "jazz"}); err == nil {
+		t.Error("Stations should return an error on 500")
 	}
 }
 
-func TestTopStationsOffset(t *testing.T) {
-	var gotURL string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotURL = r.URL.String()
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`[{"name":"Top1","url_resolved":"http://t1/","bitrate":64}]`))
-	}))
-	defer srv.Close()
-	installCatalogClient(t, srv.URL)
-
-	stations, err := TopStationsOffset(50, 25)
-	if err != nil {
-		t.Fatalf("TopStationsOffset: %v", err)
-	}
-	if len(stations) != 1 || stations[0].Name != "Top1" {
-		t.Fatalf("stations = %+v", stations)
-	}
-	if !strings.Contains(gotURL, "topvote/25") {
-		t.Errorf("URL %q should use limit 25", gotURL)
-	}
-	if !strings.Contains(gotURL, "offset=50") {
-		t.Errorf("URL %q should contain offset=50", gotURL)
-	}
-}
-
-func TestTopStationsOffsetClampsNegatives(t *testing.T) {
-	var gotURL string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotURL = r.URL.String()
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`[]`))
-	}))
-	defer srv.Close()
-	installCatalogClient(t, srv.URL)
-
-	if _, err := TopStationsOffset(-10, 0); err != nil {
-		t.Fatalf("TopStationsOffset: %v", err)
-	}
-	if !strings.Contains(gotURL, "offset=0") {
-		t.Errorf("URL %q should clamp negative offset to 0", gotURL)
-	}
-	if !strings.Contains(gotURL, "topvote/50") {
-		t.Errorf("URL %q should use default limit 50", gotURL)
-	}
-}
-
-func TestFetchStationsInvalidJSON(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func TestStationsInvalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{not valid`))
 	}))
 	defer srv.Close()
 	installCatalogClient(t, srv.URL)
 
-	_, err := SearchStations("x", 10)
-	if err == nil {
-		t.Error("SearchStations should error on invalid JSON")
+	if _, err := Stations(StationQuery{Name: "x"}); err == nil {
+		t.Error("Stations should error on invalid JSON")
 	}
 }

--- a/external/radio/catalog_url_test.go
+++ b/external/radio/catalog_url_test.go
@@ -34,7 +34,7 @@ func TestCatalogStationURLsAreConstrainedToHTTP(t *testing.T) {
 		{"search results", "s", (*Provider).SetSearchResults},
 	} {
 		t.Run(setup.name, func(t *testing.T) {
-			p := New()
+			p := New(Options{})
 			setup.apply(p, hostile)
 
 			var kept []string

--- a/external/radio/consent_test.go
+++ b/external/radio/consent_test.go
@@ -1,0 +1,157 @@
+package radio
+
+import (
+	"errors"
+	"testing"
+)
+
+// The provider must not work out anybody's location until it is told to. A
+// fresh install has no answer recorded, so New must leave home unset no matter
+// what the host's timezone says.
+func TestNewDetectsNoLocationUntilAsked(t *testing.T) {
+	t.Setenv("TZ", "Europe/Oslo")
+
+	for _, tc := range []struct {
+		name       string
+		country    string
+		wantHome   string
+		wantAsking bool
+	}{
+		{name: "not asked yet", country: "", wantHome: "", wantAsking: true},
+		{name: "declined", country: CountryDeclined, wantHome: "", wantAsking: false},
+		{name: "declined, any case", country: "None", wantHome: "", wantAsking: false},
+		{name: "answered with a country", country: "NO", wantHome: "NO", wantAsking: false},
+		{name: "answered lowercase", country: "no", wantHome: "NO", wantAsking: false},
+		{name: "unusable code is not an answer", country: "XX", wantHome: "", wantAsking: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			p := New(Options{Country: tc.country})
+
+			if got := p.HomeCountry().Code; got != tc.wantHome {
+				t.Errorf("HomeCountry() = %q, want %q", got, tc.wantHome)
+			}
+			if got := p.NeedsLocationConsent(); got != tc.wantAsking {
+				t.Errorf("NeedsLocationConsent() = %v, want %v", got, tc.wantAsking)
+			}
+		})
+	}
+}
+
+func TestSetLocationConsentAllowed(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("TZ", "Europe/Oslo")
+
+	var saved string
+	p := New(Options{SaveCountry: func(code string) error { saved = code; return nil }})
+
+	place, err := p.SetLocationConsent(true)
+	if err != nil {
+		t.Fatalf("SetLocationConsent: %v", err)
+	}
+	if place != "Norway" {
+		t.Errorf("place = %q, want Norway", place)
+	}
+	if p.HomeCountry().Code != "NO" {
+		t.Errorf("HomeCountry() = %+v, want NO", p.HomeCountry())
+	}
+	if saved != "NO" {
+		t.Errorf("persisted %q, want NO", saved)
+	}
+	if p.NeedsLocationConsent() {
+		t.Error("still asking after an answer")
+	}
+}
+
+func TestSetLocationConsentRefused(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("TZ", "Europe/Oslo")
+
+	var saved string
+	p := New(Options{SaveCountry: func(code string) error { saved = code; return nil }})
+
+	place, err := p.SetLocationConsent(false)
+	if err != nil {
+		t.Fatalf("SetLocationConsent: %v", err)
+	}
+	if place != "" {
+		t.Errorf("place = %q, want nothing found", place)
+	}
+	// A refusal must leave no trace of where the listener is, even though the
+	// timezone would have answered it.
+	if p.HomeCountry().Code != "" {
+		t.Errorf("HomeCountry() = %+v, want empty after a refusal", p.HomeCountry())
+	}
+	if saved != CountryDeclined {
+		t.Errorf("persisted %q, want %q", saved, CountryDeclined)
+	}
+	if p.NeedsLocationConsent() {
+		t.Error("still asking after a refusal")
+	}
+}
+
+// Agreeing but being undetectable is recorded as a refusal: both mean "no
+// location", and neither should re-ask on the next launch.
+func TestSetLocationConsentAllowedButUndetectable(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("TZ", "Mars/Olympus")
+	t.Setenv("LC_ALL", "C")
+	t.Setenv("LC_MESSAGES", "")
+	t.Setenv("LANG", "")
+
+	var saved string
+	p := New(Options{SaveCountry: func(code string) error { saved = code; return nil }})
+
+	place, err := p.SetLocationConsent(true)
+	if err != nil {
+		t.Fatalf("SetLocationConsent: %v", err)
+	}
+	if place != "" || p.HomeCountry().Code != "" {
+		t.Errorf("place = %q, home = %+v, want both empty", place, p.HomeCountry())
+	}
+	if saved != CountryDeclined {
+		t.Errorf("persisted %q, want %q", saved, CountryDeclined)
+	}
+	if p.NeedsLocationConsent() {
+		t.Error("still asking after an answer that found nothing")
+	}
+}
+
+// A failed write must not cost the listener their answer for this run.
+func TestSetLocationConsentSurvivesAFailedSave(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("TZ", "Europe/Oslo")
+
+	p := New(Options{SaveCountry: func(string) error { return errors.New("disk full") }})
+
+	if _, err := p.SetLocationConsent(true); err == nil {
+		t.Fatal("SetLocationConsent should report the save failure")
+	}
+	if p.HomeCountry().Code != "NO" {
+		t.Errorf("HomeCountry() = %+v, want the answer honored anyway", p.HomeCountry())
+	}
+	if p.NeedsLocationConsent() {
+		t.Error("should not re-ask within the same run")
+	}
+}
+
+func TestSetLocationConsentWithoutASaverIsSessionOnly(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("TZ", "Europe/Oslo")
+
+	p := New(Options{})
+	if _, err := p.SetLocationConsent(true); err != nil {
+		t.Fatalf("SetLocationConsent: %v", err)
+	}
+	if p.HomeCountry().Code != "NO" || p.NeedsLocationConsent() {
+		t.Errorf("home = %+v, asking = %v", p.HomeCountry(), p.NeedsLocationConsent())
+	}
+}
+
+func TestLocationPromptSaysWhereTheLocationComesFrom(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	p := New(Options{})
+	if p.LocationPrompt() == "" {
+		t.Fatal("LocationPrompt is empty")
+	}
+}

--- a/external/radio/countries.go
+++ b/external/radio/countries.go
@@ -1,0 +1,356 @@
+package radio
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/bjarneo/cliamp/playlist"
+	"github.com/bjarneo/cliamp/provider"
+)
+
+// browseCountriesID is the provider-pane shortcut into the country browser.
+const browseCountriesID = "browse:countries"
+
+// locationConsentID is the provider-pane row that offers to work out the
+// listener's country. Selecting it raises the question; it is not a playlist.
+const locationConsentID = "loc:ask"
+
+// countryTrackLimit caps how many stations one country or region contributes
+// to a playlist. The largest country in the directory has ~8000 entries, which
+// is not a playlist anyone navigates; the top few hundred by the chosen order
+// is.
+const countryTrackLimit = 200
+
+// GenreLabel names the category level. The browse overlay calls these
+// "genres"; for a radio directory they are places.
+func (*Provider) GenreLabel() string { return "Countries" }
+
+// BrowseEntries advertises the country browser in the radio pane. It is
+// unanchored, which puts it at the top of the pane alongside the pinned
+// places: with 58,000 stations behind it, picking a place is the entry point
+// to the catalog, not a footnote to it.
+func (*Provider) BrowseEntries() []provider.BrowseEntry {
+	return []provider.BrowseEntry{{
+		ID:             browseCountriesID,
+		Name:           "Browse all countries",
+		Section:        sectionCountries,
+		Mode:           provider.BrowseGenres,
+		OpenInPlaylist: true,
+	}}
+}
+
+// Genres lists the places stations can be browsed by: every country in the
+// directory, grouped by region, preceded by the regions of the listener's own
+// country when one is known.
+//
+// Regions are only offered for the home country. About 44% of stations carry a
+// state at all, so a full country-by-region tree would be mostly empty; one
+// country's worth is the part that earns its API call.
+func (p *Provider) Genres() ([]provider.GenreInfo, error) {
+	countries, err := p.countryIndex()
+	if err != nil {
+		return nil, err
+	}
+
+	// HomeCountry resolves its name against the index fetched just above, so a
+	// non-empty name also means "this code is one the directory knows".
+	home := p.HomeCountry()
+	// Snapshot the pins once: checking each of ~250 countries against the live
+	// set would take and release the provider lock once per row.
+	pinned := p.pinnedIDs()
+
+	out := make([]provider.GenreInfo, 0, len(countries))
+	if home.Code != "" && countryName(countries, home.Code) != "" {
+		out = append(out, p.homeRegionGenres(home, pinned)...)
+	}
+	for _, c := range countries {
+		if c.StationCount <= 0 {
+			continue
+		}
+		id := Place{Code: c.Code}.ID()
+		out = append(out, provider.GenreInfo{
+			ID:       id,
+			Name:     fmt.Sprintf("%s (%d)", c.Name, c.StationCount),
+			Group:    Region(c.Code),
+			Favorite: pinned[id],
+		})
+	}
+	return out, nil
+}
+
+// pinnedIDs snapshots the pinned place IDs for one pass over the country list.
+func (p *Provider) pinnedIDs() map[string]bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	ids := make(map[string]bool, len(p.pins.Places()))
+	for _, place := range p.pins.Places() {
+		ids[place.ID()] = true
+	}
+	return ids
+}
+
+// homeRegionGenres returns the home country's regions, grouped under its name
+// so they sort and read as one block at the top of the list. A directory that
+// knows no regions for the country contributes nothing.
+func (p *Provider) homeRegionGenres(home Place, pinned map[string]bool) []provider.GenreInfo {
+	states, err := p.stateIndex(home.Name)
+	if err != nil || len(states) == 0 {
+		// Regions are a convenience; losing them must not cost the country list.
+		return nil
+	}
+
+	out := make([]provider.GenreInfo, 0, len(states))
+	for _, s := range states {
+		id := Place{Code: home.Code, State: s.Name}.ID()
+		out = append(out, provider.GenreInfo{
+			ID:       id,
+			Name:     fmt.Sprintf("%s (%d)", s.Name, s.StationCount),
+			Group:    home.Name,
+			Favorite: pinned[id],
+		})
+	}
+	return out
+}
+
+// GenreSortTypes returns the orders a place's stations can be listed in.
+func (*Provider) GenreSortTypes() []provider.SortType {
+	return []provider.SortType{
+		{ID: SortVotes, Label: "Most Voted"},
+		{ID: SortClicks, Label: "Most Listened"},
+		{ID: SortTrend, Label: "Trending"},
+		{ID: SortName, Label: "By Name"},
+		{ID: SortRandom, Label: "Random"},
+	}
+}
+
+// GenreTracks returns a place's stations as a playlist, so that next and
+// previous scan through the stations of one country or region.
+func (p *Provider) GenreTracks(genreID, sortType string) ([]playlist.Track, error) {
+	code, state, ok := parsePlaceID(genreID)
+	if !ok {
+		return nil, fmt.Errorf("radio: unknown place %q", genreID)
+	}
+
+	stations, err := Stations(StationQuery{
+		CountryCode: code,
+		State:       state,
+		Order:       sortType,
+		Limit:       countryTrackLimit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("radio: list stations for %s: %w", genreID, err)
+	}
+	return stationTracks(streamableStations(stations)), nil
+}
+
+// ToggleGenreFavorite pins or unpins a place. Pinned places show in the radio
+// pane and join the rotation the catalog country filter cycles through.
+func (p *Provider) ToggleGenreFavorite(genreID string) (bool, error) {
+	code, state, ok := parsePlaceID(genreID)
+	if !ok {
+		return false, fmt.Errorf("radio: unknown place %q", genreID)
+	}
+
+	p.mu.Lock()
+	place := Place{Code: code, State: state, Name: p.placeNameLocked(code, state)}
+	p.mu.Unlock()
+
+	// Toggle writes and fsyncs; it takes the pin store's own lock, not ours.
+	return p.pins.Toggle(place)
+}
+
+// placeNameLocked builds the display name for a place, preferring the
+// directory's country index and falling back to the built-in name table when
+// it has not loaded. p.mu must be held.
+func (p *Provider) placeNameLocked(code, state string) string {
+	name := countryName(p.countries, code)
+	if name == "" {
+		name = CountryName(code)
+	}
+	if name == "" {
+		name = code
+	}
+	if state == "" {
+		return name
+	}
+	return state + ", " + name
+}
+
+// NeedsLocationConsent reports whether the listener still has to answer the
+// location question. Configuration that already names a country, or records a
+// refusal, counts as answered.
+// Implements provider.LocationConsenter.
+func (p *Provider) NeedsLocationConsent() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return !p.locationSettled
+}
+
+// LocationConsentID is the provider-list row that opens the location question.
+// It is empty once the listener has answered, so the row disappears rather
+// than sitting there re-asking.
+// Implements provider.LocationConsenter.
+func (p *Provider) LocationConsentID() string {
+	if !p.NeedsLocationConsent() {
+		return ""
+	}
+	return locationConsentID
+}
+
+// LocationPrompt returns the question to put to the listener.
+// Implements provider.LocationConsenter.
+func (*Provider) LocationPrompt() string {
+	return "Use your country to suggest nearby radio? cliamp would read it from your system timezone. Nothing is sent to a location service."
+}
+
+// SetLocationConsent records the listener's answer and persists it, so the
+// question is asked once rather than every launch. Detection happens here and
+// nowhere else: until this is called with true, the provider has not worked
+// out where anybody is.
+// Implements provider.LocationConsenter.
+func (p *Provider) SetLocationConsent(allowed bool) (string, error) {
+	code := ""
+	if allowed {
+		code = DetectHomeCountry()
+	}
+
+	p.mu.Lock()
+	p.locationSettled = true
+	if code != "" {
+		p.home = namedPlace(code)
+	} else {
+		p.home = Place{}
+	}
+	home, save := p.home, p.saveCountry
+	p.mu.Unlock()
+
+	if save == nil {
+		return home.Name, nil
+	}
+	// Record a refusal, and an allowed-but-undetectable answer, as a refusal:
+	// both mean "do not use a location", and neither should re-ask next launch.
+	stored := code
+	if stored == "" {
+		stored = CountryDeclined
+	}
+	if err := save(stored); err != nil {
+		return home.Name, fmt.Errorf("radio: save location choice: %w", err)
+	}
+	return home.Name, nil
+}
+
+// HomeCountry returns the listener's own country, or the zero Place when it
+// could not be determined.
+func (p *Provider) HomeCountry() Place {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.homeLocked()
+}
+
+// homeLocked upgrades the home country's display name to the directory's own
+// once its index has loaded; until then the built-in table's name stands.
+// p.mu must be held.
+func (p *Provider) homeLocked() Place {
+	if p.home.Code == "" {
+		return Place{}
+	}
+	if name := countryName(p.countries, p.home.Code); name != "" {
+		p.home.Name = name
+	}
+	return p.home
+}
+
+// countryIndex returns the directory's country list, fetching it once per
+// process. Refresh drops the cache.
+func (p *Provider) countryIndex() ([]Country, error) {
+	p.mu.Lock()
+	cached := p.countries
+	p.mu.Unlock()
+	if cached != nil {
+		return cached, nil
+	}
+
+	countries, err := FetchCountries()
+	if err != nil {
+		return nil, fmt.Errorf("radio: list countries: %w", err)
+	}
+
+	p.mu.Lock()
+	p.countries = countries
+	p.mu.Unlock()
+	return countries, nil
+}
+
+// stateIndex returns the home country's regions, fetching them once per
+// process. Refresh drops the cache.
+func (p *Provider) stateIndex(country string) ([]State, error) {
+	p.mu.Lock()
+	cached := p.states
+	p.mu.Unlock()
+	if cached != nil {
+		return cached, nil
+	}
+
+	states, err := FetchStates(country)
+	if err != nil {
+		return nil, err
+	}
+	if states == nil {
+		// Distinguish "fetched, none exist" from "not fetched yet" so a country
+		// with no regions is not re-requested on every browse.
+		states = []State{}
+	}
+
+	p.mu.Lock()
+	p.states = states
+	p.mu.Unlock()
+	return states, nil
+}
+
+func countryName(countries []Country, code string) string {
+	i := slices.IndexFunc(countries, func(c Country) bool { return c.Code == code })
+	if i < 0 {
+		return ""
+	}
+	return countries[i].Name
+}
+
+// stationTracks converts directory entries into playable stream tracks.
+func stationTracks(stations []CatalogStation) []playlist.Track {
+	tracks := make([]playlist.Track, 0, len(stations))
+	for _, s := range stations {
+		tracks = append(tracks, playlist.Track{
+			Path:     s.URL,
+			Title:    formatCatalogName(s),
+			Stream:   true,
+			Realtime: true,
+		})
+	}
+	return tracks
+}
+
+// placesLocked returns the places shown in the pane's Countries section: the
+// listener's own country first, then pinned places in the order they were
+// pinned. p.mu must be held.
+func (p *Provider) placesLocked() []Place {
+	var places []Place
+	if home := p.homeLocked(); home.Code != "" {
+		places = append(places, home)
+	}
+	for _, pin := range p.pins.Places() {
+		if !slices.ContainsFunc(places, func(c Place) bool { return c.ID() == pin.ID() }) {
+			places = append(places, pin)
+		}
+	}
+	return places
+}
+
+// Refresh drops the cached country index and the loaded catalog page so the
+// next browse and the next catalog page come from the directory again.
+func (p *Provider) Refresh() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.countries = nil
+	p.states = nil
+	p.catalog = nil
+}

--- a/external/radio/countries_test.go
+++ b/external/radio/countries_test.go
@@ -1,0 +1,353 @@
+package radio
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// directory is a stand-in Radio Browser server that records the query it was
+// asked, so tests can assert on how a request was narrowed.
+type directory struct {
+	countries []Country
+	states    []State
+	stations  []CatalogStation
+	lastPath  string
+	lastQuery url.Values
+}
+
+func (d *directory) serve(t *testing.T) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		d.lastPath, d.lastQuery = r.URL.Path, r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+
+		var body any
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/countries"):
+			body = d.countries
+		case strings.Contains(r.URL.Path, "/states/"):
+			body = d.states
+		default:
+			body = d.stations
+		}
+		if err := json.NewEncoder(w).Encode(body); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	installCatalogClient(t, srv.URL)
+}
+
+// newPlaceProvider builds a provider whose location question is already
+// answered: with a country when home is set, declined when it is empty. Tests
+// that want the unanswered state say so explicitly.
+func newPlaceProvider(t *testing.T, home string) *Provider {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	if home == "" {
+		home = CountryDeclined
+	}
+	return New(Options{Country: home})
+}
+
+func TestFetchCountriesMergesDuplicatesAndSortsByStationCount(t *testing.T) {
+	d := &directory{countries: []Country{
+		{Name: "Norway", Code: "NO", StationCount: 247},
+		{Name: "The United States Of America", Code: "US", StationCount: 7974},
+		{Name: "The United States Of America", Code: "us", StationCount: 1},
+		{Name: "", Code: "XX", StationCount: 1},
+		{Name: "Nowhere", Code: "", StationCount: 5},
+	}}
+	d.serve(t)
+
+	countries, err := FetchCountries()
+	if err != nil {
+		t.Fatalf("FetchCountries: %v", err)
+	}
+	if len(countries) != 2 {
+		t.Fatalf("countries = %+v, want US and NO only", countries)
+	}
+	// The lowercase duplicate folds into the uppercase entry, counts added.
+	if countries[0].Code != "US" || countries[0].StationCount != 7975 {
+		t.Errorf("first country = %+v, want US with 7975 stations", countries[0])
+	}
+	if countries[0].Name != "United States Of America" {
+		t.Errorf("name = %q, want the article trimmed", countries[0].Name)
+	}
+	if countries[1].Code != "NO" {
+		t.Errorf("second country = %+v, want NO", countries[1])
+	}
+}
+
+func TestFetchStatesDropsThePlaceholderBucket(t *testing.T) {
+	d := &directory{states: []State{
+		{Name: "- None -", Country: "Norway", StationCount: 1},
+		{Name: "Innlandet", Country: "Norway", StationCount: 16},
+		{Name: "oslo", Country: "Norway", StationCount: 11},
+		{Name: "Oslo", Country: "Norway", StationCount: 4},
+		{Name: "Møre og Romsdal", Country: "Norway", StationCount: 3},
+		{Name: "  ", Country: "Norway", StationCount: 3},
+		{Name: "Empty", Country: "Norway", StationCount: 0},
+	}}
+	d.serve(t)
+
+	states, err := FetchStates("Norway")
+	if err != nil {
+		t.Fatalf("FetchStates: %v", err)
+	}
+	if len(states) != 3 {
+		t.Fatalf("states = %+v, want Innlandet, Oslo and Møre og Romsdal", states)
+	}
+	// Sorted by station count: Innlandet 16, then Oslo 11+4.
+	if states[0].Name != "Innlandet" {
+		t.Errorf("states = %+v, want most stations first", states)
+	}
+	// "oslo" and "Oslo" are one region; the API matches them case-insensitively.
+	if states[1].Name != "Oslo" || states[1].StationCount != 15 {
+		t.Errorf("second state = %+v, want Oslo with both spellings counted", states[1])
+	}
+	// A local spelling that already carries capitals is left alone.
+	if states[2].Name != "Møre og Romsdal" {
+		t.Errorf("third state = %+v, want its original spelling", states[2])
+	}
+	if !strings.Contains(d.lastPath, "/states/Norway/") {
+		t.Errorf("path = %q, want the country name escaped into it", d.lastPath)
+	}
+}
+
+func TestFetchStatesWithoutACountryMakesNoRequest(t *testing.T) {
+	d := &directory{}
+	d.serve(t)
+	states, err := FetchStates("  ")
+	if err != nil || states != nil {
+		t.Fatalf("FetchStates(\"\") = (%+v, %v), want (nil, nil)", states, err)
+	}
+	if d.lastPath != "" {
+		t.Errorf("requested %q, want no request at all", d.lastPath)
+	}
+}
+
+func TestStationQueryValues(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		query  StationQuery
+		want   map[string]string
+		absent []string
+	}{
+		{
+			name:   "defaults",
+			query:  StationQuery{},
+			want:   map[string]string{"limit": "50", "offset": "0", "order": SortVotes, "reverse": "true", "hidebroken": "true"},
+			absent: []string{"name", "countrycode", "state"},
+		},
+		{
+			name:  "country and region are matched exactly",
+			query: StationQuery{CountryCode: "no", State: "Oslo", Limit: 25, Offset: 50},
+			want: map[string]string{
+				"countrycode": "NO", "state": "Oslo", "stateExact": "true",
+				"limit": "25", "offset": "50",
+			},
+		},
+		{
+			name:   "names sort ascending",
+			query:  StationQuery{Order: SortName},
+			want:   map[string]string{"order": SortName},
+			absent: []string{"reverse"},
+		},
+		{
+			name:   "random needs no direction",
+			query:  StationQuery{Order: SortRandom},
+			absent: []string{"reverse"},
+		},
+		{
+			name:   "an unusable country code is dropped, not sent",
+			query:  StationQuery{CountryCode: "XX"},
+			absent: []string{"countrycode"},
+		},
+		{
+			name:  "a negative offset is clamped",
+			query: StationQuery{Offset: -10},
+			want:  map[string]string{"offset": "0"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := tc.query.values()
+			for key, want := range tc.want {
+				if got := v.Get(key); got != want {
+					t.Errorf("%s = %q, want %q", key, got, want)
+				}
+			}
+			for _, key := range tc.absent {
+				if v.Has(key) {
+					t.Errorf("%s = %q, want it absent", key, v.Get(key))
+				}
+			}
+		})
+	}
+}
+
+func TestGenresListsCountriesGroupedByRegion(t *testing.T) {
+	d := &directory{countries: []Country{
+		{Name: "Germany", Code: "DE", StationCount: 6233},
+		{Name: "Norway", Code: "NO", StationCount: 247},
+		{Name: "Japan", Code: "JP", StationCount: 300},
+		{Name: "Ghost", Code: "GH", StationCount: 0},
+	}}
+	d.serve(t)
+
+	p := newPlaceProvider(t, "")
+	genres, err := p.Genres()
+	if err != nil {
+		t.Fatalf("Genres: %v", err)
+	}
+	if len(genres) != 3 {
+		t.Fatalf("genres = %+v, want the three countries with stations", genres)
+	}
+	if genres[0].ID != "DE" || genres[0].Name != "Germany (6233)" {
+		t.Errorf("first genre = %+v, want Germany with its station count", genres[0])
+	}
+	// Sorted by station count: Germany, Japan, Norway.
+	if genres[1].ID != "JP" || genres[1].Group != "Asia" {
+		t.Errorf("second genre = %+v, want Japan in Asia", genres[1])
+	}
+	if genres[2].ID != "NO" || genres[2].Group != "Europe" {
+		t.Errorf("third genre = %+v, want Norway in Europe", genres[2])
+	}
+	for _, g := range genres {
+		if g.Favorite {
+			t.Errorf("%s is marked pinned with an empty pin store", g.ID)
+		}
+	}
+}
+
+func TestGenresPutsTheHomeCountrysRegionsFirst(t *testing.T) {
+	d := &directory{
+		countries: []Country{
+			{Name: "Germany", Code: "DE", StationCount: 6233},
+			{Name: "Norway", Code: "NO", StationCount: 247},
+		},
+		states: []State{{Name: "Oslo", Country: "Norway", StationCount: 11}},
+	}
+	d.serve(t)
+
+	p := newPlaceProvider(t, "NO")
+	genres, err := p.Genres()
+	if err != nil {
+		t.Fatalf("Genres: %v", err)
+	}
+	if len(genres) != 3 {
+		t.Fatalf("genres = %+v, want Oslo plus the two countries", genres)
+	}
+	// The listener's own regions lead, grouped under their country's name so
+	// they read as one block.
+	if genres[0].ID != "NO/Oslo" || genres[0].Group != "Norway" {
+		t.Errorf("first genre = %+v, want Oslo grouped under Norway", genres[0])
+	}
+	if genres[0].Name != "Oslo (11)" {
+		t.Errorf("name = %q, want the station count", genres[0].Name)
+	}
+	if genres[1].ID != "DE" {
+		t.Errorf("countries should follow the home regions, got %+v", genres[1])
+	}
+}
+
+func TestGenresSurvivesAStateLookupFailure(t *testing.T) {
+	// Regions are a convenience; losing them must not cost the country list.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/states/") {
+			http.Error(w, "down", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"name":"Norway","iso_3166_1":"NO","stationcount":247}]`))
+	}))
+	defer srv.Close()
+	installCatalogClient(t, srv.URL)
+
+	p := newPlaceProvider(t, "NO")
+	genres, err := p.Genres()
+	if err != nil {
+		t.Fatalf("Genres: %v", err)
+	}
+	if len(genres) != 1 || genres[0].ID != "NO" {
+		t.Fatalf("genres = %+v, want just the country", genres)
+	}
+}
+
+func TestGenreTracksQueriesOnePlace(t *testing.T) {
+	d := &directory{stations: []CatalogStation{
+		{Name: "NRK P3", URL: "https://nrk.example/p3", Country: "Norway", Bitrate: 192},
+		{Name: "Hostile", URL: "ssh://attacker.example/payload"},
+	}}
+	d.serve(t)
+
+	p := newPlaceProvider(t, "")
+	tracks, err := p.GenreTracks("NO/Oslo", SortClicks)
+	if err != nil {
+		t.Fatalf("GenreTracks: %v", err)
+	}
+	if d.lastQuery.Get("countrycode") != "NO" || d.lastQuery.Get("state") != "Oslo" {
+		t.Errorf("query = %v, want it narrowed to NO/Oslo", d.lastQuery)
+	}
+	if d.lastQuery.Get("order") != SortClicks {
+		t.Errorf("order = %q, want %q", d.lastQuery.Get("order"), SortClicks)
+	}
+	// The non-HTTP entry is a command-execution risk, not a station.
+	if len(tracks) != 1 {
+		t.Fatalf("tracks = %+v, want only the streamable station", tracks)
+	}
+	if !tracks[0].Stream || !tracks[0].Realtime {
+		t.Errorf("track = %+v, want a realtime stream", tracks[0])
+	}
+	if tracks[0].Title != "NRK P3 [192k] · Norway" {
+		t.Errorf("title = %q, want the station's bitrate and country", tracks[0].Title)
+	}
+}
+
+func TestGenreTracksRejectsAnUnknownPlace(t *testing.T) {
+	p := newPlaceProvider(t, "")
+	if _, err := p.GenreTracks("browse:countries", SortVotes); err == nil {
+		t.Error("GenreTracks should reject an ID that is not a place")
+	}
+}
+
+func TestToggleGenreFavoriteNamesThePlaceFromTheIndex(t *testing.T) {
+	d := &directory{countries: []Country{{Name: "Norway", Code: "NO", StationCount: 247}}}
+	d.serve(t)
+
+	p := newPlaceProvider(t, "")
+	if _, err := p.Genres(); err != nil { // warms the country index
+		t.Fatalf("Genres: %v", err)
+	}
+
+	pinned, err := p.ToggleGenreFavorite("NO/Oslo")
+	if err != nil || !pinned {
+		t.Fatalf("ToggleGenreFavorite = (%v, %v), want pinned", pinned, err)
+	}
+	places := p.pins.Places()
+	if len(places) != 1 || places[0].Name != "Oslo, Norway" {
+		t.Fatalf("pins = %+v, want the region named with its country", places)
+	}
+
+	if pinned, err := p.ToggleGenreFavorite("NO/Oslo"); err != nil || pinned {
+		t.Fatalf("second toggle = (%v, %v), want unpinned", pinned, err)
+	}
+}
+
+func TestGenreSortTypesAreAcceptedByTheQueryBuilder(t *testing.T) {
+	p := newPlaceProvider(t, "")
+	valid := []string{SortVotes, SortClicks, SortTrend, SortName, SortRandom}
+	for _, sort := range p.GenreSortTypes() {
+		if !slices.Contains(valid, sort.ID) {
+			t.Errorf("sort %+v is not an order the directory accepts", sort)
+		}
+		if sort.Label == "" {
+			t.Errorf("sort %+v has no label", sort)
+		}
+	}
+}

--- a/external/radio/favorites.go
+++ b/external/radio/favorites.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/bjarneo/cliamp/internal/appdir"
+	"github.com/bjarneo/cliamp/internal/fileutil"
 	"github.com/bjarneo/cliamp/internal/tomlutil"
 )
 
@@ -90,8 +91,8 @@ func (f *Favorites) save() error {
 	}
 
 	// Build the full content in memory (writes to a Builder can't fail), then
-	// write a temp file and rename so a partial/failed write can never truncate
-	// or corrupt the existing favorites file.
+	// hand it to WriteFileAtomic so a partial or failed write can never
+	// truncate or corrupt the existing favorites file.
 	var b strings.Builder
 	for i, s := range f.stations {
 		if i > 0 {
@@ -117,11 +118,7 @@ func (f *Favorites) save() error {
 		}
 	}
 
-	tmp := f.path + ".tmp"
-	if err := os.WriteFile(tmp, []byte(b.String()), 0o644); err != nil {
-		return err
-	}
-	return os.Rename(tmp, f.path)
+	return fileutil.WriteFileAtomic(f.path, []byte(b.String()), 0o644)
 }
 
 // loadFavoriteStations parses the favorites TOML file.

--- a/external/radio/geo.go
+++ b/external/radio/geo.go
@@ -1,0 +1,170 @@
+package radio
+
+//go:generate go run geodata_gen.go
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"unicode"
+)
+
+// Region returns the broad region a country code belongs to ("Europe",
+// "Americas", …), or "" when the code is unknown. Codes are matched
+// case-insensitively: the Radio Browser directory holds a handful of
+// lowercase duplicates such as "de" next to "DE".
+func Region(code string) string {
+	return regionIndex()[normalizeCountryCode(code)]
+}
+
+var regionIndex = sync.OnceValue(func() map[string]string {
+	index := make(map[string]string, 256)
+	for region, codes := range regionCodes {
+		for code := range strings.FieldsSeq(codes) {
+			index[code] = region
+		}
+	}
+	return index
+})
+
+var zoneIndex = sync.OnceValue(func() map[string]string {
+	index := make(map[string]string, 448)
+	for line := range strings.SplitSeq(strings.TrimSpace(zoneCountries), "\n") {
+		zone, code, ok := strings.Cut(line, " ")
+		if !ok {
+			continue
+		}
+		index[zone] = normalizeCountryCode(code)
+	}
+	return index
+})
+
+// normalizeCountryCode upper-cases a country code and rejects anything that is
+// not two ASCII letters. "XX" is the directory's placeholder for "unknown" and
+// is treated as absent.
+func normalizeCountryCode(code string) string {
+	code = strings.ToUpper(strings.TrimSpace(code))
+	if len(code) != 2 || code == "XX" {
+		return ""
+	}
+	for i := range 2 {
+		if code[i] < 'A' || code[i] > 'Z' {
+			return ""
+		}
+	}
+	return code
+}
+
+// DetectHomeCountry guesses the listener's country as an ISO 3166-1 alpha-2
+// code, returning "" when it cannot tell.
+//
+// The timezone is consulted before the locale, and deliberately so: a desktop
+// set to en_US.UTF-8 in Europe/Oslo is the common case, not the exception, so
+// trusting the locale first would hand most users the wrong country. The
+// timezone is the setting people actually keep accurate.
+//
+// Nothing here touches the network. A geo-IP lookup would be more precise and
+// would also mean telling a third party where the user lives every launch,
+// which is not a trade this feature is worth.
+func DetectHomeCountry() string {
+	if code := countryFromZone(currentZone()); code != "" {
+		return code
+	}
+	return countryFromLocale(currentLocale())
+}
+
+// currentZone resolves the IANA timezone name from TZ, the /etc/localtime
+// symlink, or /etc/timezone. Go's time.Local reports itself as "Local" when TZ
+// is unset, so the name has to be recovered from the filesystem.
+func currentZone() string {
+	if tz := strings.TrimSpace(os.Getenv("TZ")); tz != "" {
+		return strings.TrimPrefix(tz, ":")
+	}
+	if target, err := os.Readlink("/etc/localtime"); err == nil {
+		if zone := zoneFromPath(target); zone != "" {
+			return zone
+		}
+	}
+	if data, err := os.ReadFile("/etc/timezone"); err == nil {
+		return strings.TrimSpace(string(data))
+	}
+	return ""
+}
+
+// zoneFromPath extracts "Europe/Oslo" from a zoneinfo path such as
+// /usr/share/zoneinfo/Europe/Oslo or ../usr/share/zoneinfo/Europe/Oslo.
+func zoneFromPath(path string) string {
+	path = filepath.ToSlash(path)
+	_, zone, ok := strings.Cut(path, "zoneinfo/")
+	if !ok {
+		return ""
+	}
+	// Some distributions symlink through a posix/ or right/ subtree.
+	for _, prefix := range []string{"posix/", "right/"} {
+		zone = strings.TrimPrefix(zone, prefix)
+	}
+	return zone
+}
+
+func countryFromZone(zone string) string {
+	return zoneIndex()[strings.TrimSpace(zone)]
+}
+
+// currentLocale returns the first locale setting that names a real locale.
+// POSIX ranks LC_ALL over the category over LANG.
+func currentLocale() string {
+	for _, key := range []string{"LC_ALL", "LC_MESSAGES", "LANG"} {
+		value := strings.TrimSpace(os.Getenv(key))
+		switch value {
+		case "", "C", "POSIX", "C.UTF-8", "C.utf8":
+			continue
+		}
+		return value
+	}
+	return ""
+}
+
+// countryFromLocale pulls NO out of "nb_NO.UTF-8". A locale without a
+// territory ("en", "nb") names a language only and yields "".
+func countryFromLocale(locale string) string {
+	_, rest, ok := strings.Cut(locale, "_")
+	if !ok {
+		return ""
+	}
+	// Trim the codeset and any @modifier: nb_NO.UTF-8@euro.
+	rest, _, _ = strings.Cut(rest, ".")
+	rest, _, _ = strings.Cut(rest, "@")
+	return normalizeCountryCode(rest)
+}
+
+// CountryName returns a readable name for a country code without a network
+// call, or "" when the code is unknown. The directory's own country index has
+// better names for a few entries, so it wins where it is loaded; this is what
+// the pane shows before then.
+func CountryName(code string) string {
+	return countryNames[normalizeCountryCode(code)]
+}
+
+// displayStateName capitalizes an all-lowercase region name ("oslo" becomes
+// "Oslo"). Names that already carry capitals are left alone, so local spellings
+// such as "Møre og Romsdal" survive intact.
+func displayStateName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" || strings.ToLower(name) != name {
+		return name
+	}
+	r := []rune(name)
+	return string(unicode.ToUpper(r[0])) + string(r[1:])
+}
+
+// displayCountryName trims the directory's officious country names down to
+// what a list can show: "The United States Of America" becomes "United States
+// Of America", which the width budget can then truncate sensibly.
+func displayCountryName(name string) string {
+	name = strings.TrimSpace(name)
+	if rest, ok := strings.CutPrefix(name, "The "); ok {
+		return rest
+	}
+	return name
+}

--- a/external/radio/geo_test.go
+++ b/external/radio/geo_test.go
@@ -1,0 +1,218 @@
+package radio
+
+import "testing"
+
+func TestNormalizeCountryCode(t *testing.T) {
+	for _, tc := range []struct {
+		in, want string
+	}{
+		{"NO", "NO"},
+		{"no", "NO"},
+		{" de ", "DE"},
+		{"XX", ""}, // the directory's placeholder for "unknown"
+		{"", ""},
+		{"NOR", ""},
+		{"N", ""},
+		{"N1", ""},
+	} {
+		if got := normalizeCountryCode(tc.in); got != tc.want {
+			t.Errorf("normalizeCountryCode(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestRegion(t *testing.T) {
+	for _, tc := range []struct {
+		code, want string
+	}{
+		{"NO", "Europe"},
+		{"no", "Europe"}, // lowercase duplicates exist in the directory
+		{"US", "Americas"},
+		{"BR", "Americas"},
+		{"JP", "Asia"},
+		{"KE", "Africa"},
+		{"NZ", "Oceania"},
+		{"XK", "Europe"},  // Kosovo has no zone.tab row of its own
+		{"IS", "Europe"},  // Atlantic/Reykjavik
+		{"MU", "Africa"},  // Indian/Mauritius
+		{"MV", "Asia"},    // Indian/Maldives
+		{"RU", "Europe"},  // transcontinental, most population in Europe
+		{"AU", "Oceania"}, // Australia/* plus an Antarctica/* row
+		{"ZZ", ""},        // not a country
+		{"", ""},
+	} {
+		if got := Region(tc.code); got != tc.want {
+			t.Errorf("Region(%q) = %q, want %q", tc.code, got, tc.want)
+		}
+	}
+}
+
+func TestRegionCoversEveryZoneCountry(t *testing.T) {
+	for zone, code := range zoneIndex() {
+		if Region(code) == "" {
+			t.Errorf("zone %s has country %s with no region", zone, code)
+		}
+	}
+}
+
+func TestZoneFromPath(t *testing.T) {
+	for _, tc := range []struct {
+		in, want string
+	}{
+		{"/usr/share/zoneinfo/Europe/Oslo", "Europe/Oslo"},
+		{"../usr/share/zoneinfo/America/New_York", "America/New_York"},
+		{"/var/db/timezone/zoneinfo/Asia/Tokyo", "Asia/Tokyo"},
+		{"/usr/share/zoneinfo/posix/Europe/Berlin", "Europe/Berlin"},
+		{"/etc/localtime", ""},
+		{"", ""},
+	} {
+		if got := zoneFromPath(tc.in); got != tc.want {
+			t.Errorf("zoneFromPath(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestCountryFromZone(t *testing.T) {
+	for _, tc := range []struct {
+		zone, want string
+	}{
+		{"Europe/Oslo", "NO"},
+		{"America/New_York", "US"},
+		{"Asia/Tokyo", "JP"},
+		{" Europe/Berlin ", "DE"},
+		{"Mars/Olympus", ""},
+		{"", ""},
+	} {
+		if got := countryFromZone(tc.zone); got != tc.want {
+			t.Errorf("countryFromZone(%q) = %q, want %q", tc.zone, got, tc.want)
+		}
+	}
+}
+
+func TestCountryFromLocale(t *testing.T) {
+	for _, tc := range []struct {
+		in, want string
+	}{
+		{"nb_NO.UTF-8", "NO"},
+		{"en_US", "US"},
+		{"de_DE.UTF-8@euro", "DE"},
+		{"pt_BR.iso88591", "BR"},
+		{"en", ""}, // a language with no territory
+		{"C", ""},
+		{"", ""},
+	} {
+		if got := countryFromLocale(tc.in); got != tc.want {
+			t.Errorf("countryFromLocale(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestCurrentLocaleSkipsPlaceholderLocales(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		lcAll, lcMsg, lang string
+		want               string
+	}{
+		{name: "LC_ALL wins", lcAll: "fr_FR.UTF-8", lcMsg: "nb_NO.UTF-8", lang: "en_US.UTF-8", want: "fr_FR.UTF-8"},
+		{name: "LC_MESSAGES over LANG", lcMsg: "nb_NO.UTF-8", lang: "en_US.UTF-8", want: "nb_NO.UTF-8"},
+		{name: "C is not a locale", lcAll: "C", lang: "nb_NO.UTF-8", want: "nb_NO.UTF-8"},
+		{name: "C.UTF-8 is not a locale", lcAll: "C.UTF-8", lang: "nb_NO.UTF-8", want: "nb_NO.UTF-8"},
+		{name: "nothing set", want: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("LC_ALL", tc.lcAll)
+			t.Setenv("LC_MESSAGES", tc.lcMsg)
+			t.Setenv("LANG", tc.lang)
+			if got := currentLocale(); got != tc.want {
+				t.Errorf("currentLocale() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The timezone is checked before the locale on purpose: a desktop left on
+// en_US.UTF-8 while sitting in Europe/Oslo is the common case, and trusting
+// the locale there would hand most users the wrong country.
+func TestDetectHomeCountryPrefersTimezoneOverLocale(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		tz, locale string
+		want       string
+	}{
+		{name: "timezone beats a mismatched locale", tz: "Europe/Oslo", locale: "en_US.UTF-8", want: "NO"},
+		{name: "locale fills in when the zone is unknown", tz: "Mars/Olympus", locale: "nb_NO.UTF-8", want: "NO"},
+		{name: "both agree", tz: "Asia/Tokyo", locale: "ja_JP.UTF-8", want: "JP"},
+		{name: "neither resolves", tz: "Mars/Olympus", locale: "C", want: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("TZ", tc.tz)
+			t.Setenv("LC_ALL", tc.locale)
+			t.Setenv("LC_MESSAGES", "")
+			t.Setenv("LANG", "")
+			if got := DetectHomeCountry(); got != tc.want {
+				t.Errorf("DetectHomeCountry() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCountryName(t *testing.T) {
+	for _, tc := range []struct {
+		code, want string
+	}{
+		{"NO", "Norway"},
+		{"no", "Norway"},
+		{"US", "United States"},
+		{"JP", "Japan"},
+		{"XX", ""},
+		{"", ""},
+		{"ZZ", ""},
+	} {
+		if got := CountryName(tc.code); got != tc.want {
+			t.Errorf("CountryName(%q) = %q, want %q", tc.code, got, tc.want)
+		}
+	}
+}
+
+// Every country the region table knows must also have a name, or the pane can
+// print a bare code where a country belongs.
+func TestEveryRegionCountryHasAName(t *testing.T) {
+	for code := range regionIndex() {
+		if CountryName(code) == "" {
+			t.Errorf("country %s has a region but no name", code)
+		}
+	}
+}
+
+func TestDisplayStateName(t *testing.T) {
+	for _, tc := range []struct {
+		in, want string
+	}{
+		{"oslo", "Oslo"},
+		{"Oslo", "Oslo"},
+		{"  rogaland  ", "Rogaland"},
+		{"Møre og Romsdal", "Møre og Romsdal"}, // already capitalized: left alone
+		{"østfold", "Østfold"},                 // the leading rune is not ASCII
+		{"", ""},
+	} {
+		if got := displayStateName(tc.in); got != tc.want {
+			t.Errorf("displayStateName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestDisplayCountryName(t *testing.T) {
+	for _, tc := range []struct {
+		in, want string
+	}{
+		{"The United States Of America", "United States Of America"},
+		{"Norway", "Norway"},
+		{"  Japan  ", "Japan"},
+		{"Theodora Islands", "Theodora Islands"}, // only the standalone article is trimmed
+		{"", ""},
+	} {
+		if got := displayCountryName(tc.in); got != tc.want {
+			t.Errorf("displayCountryName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/external/radio/geodata.go
+++ b/external/radio/geodata.go
@@ -1,0 +1,700 @@
+// Code generated from tzdata zone.tab; DO NOT EDIT.
+// Regenerate with: go generate ./external/radio
+
+package radio
+
+// regionCodes groups ISO 3166-1 alpha-2 country codes into the six broad
+// regions the country list is grouped by. Derived from the timezone area of
+// each country's zone.tab rows, with hand overrides where that area is an
+// ocean (Atlantic, Indian, Arctic) rather than a region, and for
+// transcontinental countries, where the region holding most of the
+// population wins.
+var regionCodes = map[string]string{
+	"Africa":     "AO BF BI BJ BW CD CF CG CI CM CV DJ DZ EG EH ER ET GA GH GM GN GQ GW KE KM LR LS LY MA MG ML MR MU MW MZ NA NE NG RE RW SC SD SH SL SN SO SS ST SZ TD TG TN TZ UG YT ZA ZM ZW",
+	"Americas":   "AG AI AR AW BB BL BM BO BQ BR BS BZ CA CL CO CR CU CW DM DO EC FK GD GF GL GP GS GT GY HN HT JM KN KY LC MF MQ MS MX NI PA PE PM PR PY SR SV SX TC TT US UY VC VE VG VI",
+	"Asia":       "AE AF AM AZ BD BH BN BT CN CY GE HK ID IL IN IO IQ IR JO JP KG KH KP KR KW KZ LA LB LK MM MN MO MV MY NP OM PH PK PS QA SA SG SY TH TJ TL TM TW UZ VN YE",
+	"Europe":     "AD AL AT AX BA BE BG BY CH CZ DE DK EE ES FI FO FR GB GG GI GR HR HU IE IM IS IT JE LI LT LU LV MC MD ME MK MT NL NO PL PT RO RS RU SE SI SJ SK SM TR UA VA XK",
+	"Oceania":    "AS AU CC CK CX FJ FM GU KI MH MP NC NF NR NU NZ PF PG PN PW SB TK TO TV UM VU WF WS",
+	"Antarctica": "AQ TF",
+}
+
+// zoneCountries maps IANA timezone names to the ISO 3166-1 alpha-2 code of
+// the country that owns them, one "Zone CC" pair per line. Taken from
+// tzdata's zone.tab, whose first column is exactly one country code.
+const zoneCountries = `
+Africa/Abidjan CI
+Africa/Accra GH
+Africa/Addis_Ababa ET
+Africa/Algiers DZ
+Africa/Asmara ER
+Africa/Bamako ML
+Africa/Bangui CF
+Africa/Banjul GM
+Africa/Bissau GW
+Africa/Blantyre MW
+Africa/Brazzaville CG
+Africa/Bujumbura BI
+Africa/Cairo EG
+Africa/Casablanca MA
+Africa/Ceuta ES
+Africa/Conakry GN
+Africa/Dakar SN
+Africa/Dar_es_Salaam TZ
+Africa/Djibouti DJ
+Africa/Douala CM
+Africa/El_Aaiun EH
+Africa/Freetown SL
+Africa/Gaborone BW
+Africa/Harare ZW
+Africa/Johannesburg ZA
+Africa/Juba SS
+Africa/Kampala UG
+Africa/Khartoum SD
+Africa/Kigali RW
+Africa/Kinshasa CD
+Africa/Lagos NG
+Africa/Libreville GA
+Africa/Lome TG
+Africa/Luanda AO
+Africa/Lubumbashi CD
+Africa/Lusaka ZM
+Africa/Malabo GQ
+Africa/Maputo MZ
+Africa/Maseru LS
+Africa/Mbabane SZ
+Africa/Mogadishu SO
+Africa/Monrovia LR
+Africa/Nairobi KE
+Africa/Ndjamena TD
+Africa/Niamey NE
+Africa/Nouakchott MR
+Africa/Ouagadougou BF
+Africa/Porto-Novo BJ
+Africa/Sao_Tome ST
+Africa/Tripoli LY
+Africa/Tunis TN
+Africa/Windhoek NA
+America/Adak US
+America/Anchorage US
+America/Anguilla AI
+America/Antigua AG
+America/Araguaina BR
+America/Argentina/Buenos_Aires AR
+America/Argentina/Catamarca AR
+America/Argentina/Cordoba AR
+America/Argentina/Jujuy AR
+America/Argentina/La_Rioja AR
+America/Argentina/Mendoza AR
+America/Argentina/Rio_Gallegos AR
+America/Argentina/Salta AR
+America/Argentina/San_Juan AR
+America/Argentina/San_Luis AR
+America/Argentina/Tucuman AR
+America/Argentina/Ushuaia AR
+America/Aruba AW
+America/Asuncion PY
+America/Atikokan CA
+America/Bahia BR
+America/Bahia_Banderas MX
+America/Barbados BB
+America/Belem BR
+America/Belize BZ
+America/Blanc-Sablon CA
+America/Boa_Vista BR
+America/Bogota CO
+America/Boise US
+America/Cambridge_Bay CA
+America/Campo_Grande BR
+America/Cancun MX
+America/Caracas VE
+America/Cayenne GF
+America/Cayman KY
+America/Chicago US
+America/Chihuahua MX
+America/Ciudad_Juarez MX
+America/Costa_Rica CR
+America/Coyhaique CL
+America/Creston CA
+America/Cuiaba BR
+America/Curacao CW
+America/Danmarkshavn GL
+America/Dawson CA
+America/Dawson_Creek CA
+America/Denver US
+America/Detroit US
+America/Dominica DM
+America/Edmonton CA
+America/Eirunepe BR
+America/El_Salvador SV
+America/Fort_Nelson CA
+America/Fortaleza BR
+America/Glace_Bay CA
+America/Goose_Bay CA
+America/Grand_Turk TC
+America/Grenada GD
+America/Guadeloupe GP
+America/Guatemala GT
+America/Guayaquil EC
+America/Guyana GY
+America/Halifax CA
+America/Havana CU
+America/Hermosillo MX
+America/Indiana/Indianapolis US
+America/Indiana/Knox US
+America/Indiana/Marengo US
+America/Indiana/Petersburg US
+America/Indiana/Tell_City US
+America/Indiana/Vevay US
+America/Indiana/Vincennes US
+America/Indiana/Winamac US
+America/Inuvik CA
+America/Iqaluit CA
+America/Jamaica JM
+America/Juneau US
+America/Kentucky/Louisville US
+America/Kentucky/Monticello US
+America/Kralendijk BQ
+America/La_Paz BO
+America/Lima PE
+America/Los_Angeles US
+America/Lower_Princes SX
+America/Maceio BR
+America/Managua NI
+America/Manaus BR
+America/Marigot MF
+America/Martinique MQ
+America/Matamoros MX
+America/Mazatlan MX
+America/Menominee US
+America/Merida MX
+America/Metlakatla US
+America/Mexico_City MX
+America/Miquelon PM
+America/Moncton CA
+America/Monterrey MX
+America/Montevideo UY
+America/Montserrat MS
+America/Nassau BS
+America/New_York US
+America/Nome US
+America/Noronha BR
+America/North_Dakota/Beulah US
+America/North_Dakota/Center US
+America/North_Dakota/New_Salem US
+America/Nuuk GL
+America/Ojinaga MX
+America/Panama PA
+America/Paramaribo SR
+America/Phoenix US
+America/Port-au-Prince HT
+America/Port_of_Spain TT
+America/Porto_Velho BR
+America/Puerto_Rico PR
+America/Punta_Arenas CL
+America/Rankin_Inlet CA
+America/Recife BR
+America/Regina CA
+America/Resolute CA
+America/Rio_Branco BR
+America/Santarem BR
+America/Santiago CL
+America/Santo_Domingo DO
+America/Sao_Paulo BR
+America/Scoresbysund GL
+America/Sitka US
+America/St_Barthelemy BL
+America/St_Johns CA
+America/St_Kitts KN
+America/St_Lucia LC
+America/St_Thomas VI
+America/St_Vincent VC
+America/Swift_Current CA
+America/Tegucigalpa HN
+America/Thule GL
+America/Tijuana MX
+America/Toronto CA
+America/Tortola VG
+America/Vancouver CA
+America/Whitehorse CA
+America/Winnipeg CA
+America/Yakutat US
+Antarctica/Casey AQ
+Antarctica/Davis AQ
+Antarctica/DumontDUrville AQ
+Antarctica/Macquarie AU
+Antarctica/Mawson AQ
+Antarctica/McMurdo AQ
+Antarctica/Palmer AQ
+Antarctica/Rothera AQ
+Antarctica/Syowa AQ
+Antarctica/Troll AQ
+Antarctica/Vostok AQ
+Arctic/Longyearbyen SJ
+Asia/Aden YE
+Asia/Almaty KZ
+Asia/Amman JO
+Asia/Anadyr RU
+Asia/Aqtau KZ
+Asia/Aqtobe KZ
+Asia/Ashgabat TM
+Asia/Atyrau KZ
+Asia/Baghdad IQ
+Asia/Bahrain BH
+Asia/Baku AZ
+Asia/Bangkok TH
+Asia/Barnaul RU
+Asia/Beirut LB
+Asia/Bishkek KG
+Asia/Brunei BN
+Asia/Chita RU
+Asia/Colombo LK
+Asia/Damascus SY
+Asia/Dhaka BD
+Asia/Dili TL
+Asia/Dubai AE
+Asia/Dushanbe TJ
+Asia/Famagusta CY
+Asia/Gaza PS
+Asia/Hebron PS
+Asia/Ho_Chi_Minh VN
+Asia/Hong_Kong HK
+Asia/Hovd MN
+Asia/Irkutsk RU
+Asia/Jakarta ID
+Asia/Jayapura ID
+Asia/Jerusalem IL
+Asia/Kabul AF
+Asia/Kamchatka RU
+Asia/Karachi PK
+Asia/Kathmandu NP
+Asia/Khandyga RU
+Asia/Kolkata IN
+Asia/Krasnoyarsk RU
+Asia/Kuala_Lumpur MY
+Asia/Kuching MY
+Asia/Kuwait KW
+Asia/Macau MO
+Asia/Magadan RU
+Asia/Makassar ID
+Asia/Manila PH
+Asia/Muscat OM
+Asia/Nicosia CY
+Asia/Novokuznetsk RU
+Asia/Novosibirsk RU
+Asia/Omsk RU
+Asia/Oral KZ
+Asia/Phnom_Penh KH
+Asia/Pontianak ID
+Asia/Pyongyang KP
+Asia/Qatar QA
+Asia/Qostanay KZ
+Asia/Qyzylorda KZ
+Asia/Riyadh SA
+Asia/Sakhalin RU
+Asia/Samarkand UZ
+Asia/Seoul KR
+Asia/Shanghai CN
+Asia/Singapore SG
+Asia/Srednekolymsk RU
+Asia/Taipei TW
+Asia/Tashkent UZ
+Asia/Tbilisi GE
+Asia/Tehran IR
+Asia/Thimphu BT
+Asia/Tokyo JP
+Asia/Tomsk RU
+Asia/Ulaanbaatar MN
+Asia/Urumqi CN
+Asia/Ust-Nera RU
+Asia/Vientiane LA
+Asia/Vladivostok RU
+Asia/Yakutsk RU
+Asia/Yangon MM
+Asia/Yekaterinburg RU
+Asia/Yerevan AM
+Atlantic/Azores PT
+Atlantic/Bermuda BM
+Atlantic/Canary ES
+Atlantic/Cape_Verde CV
+Atlantic/Faroe FO
+Atlantic/Madeira PT
+Atlantic/Reykjavik IS
+Atlantic/South_Georgia GS
+Atlantic/St_Helena SH
+Atlantic/Stanley FK
+Australia/Adelaide AU
+Australia/Brisbane AU
+Australia/Broken_Hill AU
+Australia/Darwin AU
+Australia/Eucla AU
+Australia/Hobart AU
+Australia/Lindeman AU
+Australia/Lord_Howe AU
+Australia/Melbourne AU
+Australia/Perth AU
+Australia/Sydney AU
+Europe/Amsterdam NL
+Europe/Andorra AD
+Europe/Astrakhan RU
+Europe/Athens GR
+Europe/Belgrade RS
+Europe/Berlin DE
+Europe/Bratislava SK
+Europe/Brussels BE
+Europe/Bucharest RO
+Europe/Budapest HU
+Europe/Busingen DE
+Europe/Chisinau MD
+Europe/Copenhagen DK
+Europe/Dublin IE
+Europe/Gibraltar GI
+Europe/Guernsey GG
+Europe/Helsinki FI
+Europe/Isle_of_Man IM
+Europe/Istanbul TR
+Europe/Jersey JE
+Europe/Kaliningrad RU
+Europe/Kirov RU
+Europe/Kyiv UA
+Europe/Lisbon PT
+Europe/Ljubljana SI
+Europe/London GB
+Europe/Luxembourg LU
+Europe/Madrid ES
+Europe/Malta MT
+Europe/Mariehamn AX
+Europe/Minsk BY
+Europe/Monaco MC
+Europe/Moscow RU
+Europe/Oslo NO
+Europe/Paris FR
+Europe/Podgorica ME
+Europe/Prague CZ
+Europe/Riga LV
+Europe/Rome IT
+Europe/Samara RU
+Europe/San_Marino SM
+Europe/Sarajevo BA
+Europe/Saratov RU
+Europe/Simferopol UA
+Europe/Skopje MK
+Europe/Sofia BG
+Europe/Stockholm SE
+Europe/Tallinn EE
+Europe/Tirane AL
+Europe/Ulyanovsk RU
+Europe/Vaduz LI
+Europe/Vatican VA
+Europe/Vienna AT
+Europe/Vilnius LT
+Europe/Volgograd RU
+Europe/Warsaw PL
+Europe/Zagreb HR
+Europe/Zurich CH
+Indian/Antananarivo MG
+Indian/Chagos IO
+Indian/Christmas CX
+Indian/Cocos CC
+Indian/Comoro KM
+Indian/Kerguelen TF
+Indian/Mahe SC
+Indian/Maldives MV
+Indian/Mauritius MU
+Indian/Mayotte YT
+Indian/Reunion RE
+Pacific/Apia WS
+Pacific/Auckland NZ
+Pacific/Bougainville PG
+Pacific/Chatham NZ
+Pacific/Chuuk FM
+Pacific/Easter CL
+Pacific/Efate VU
+Pacific/Fakaofo TK
+Pacific/Fiji FJ
+Pacific/Funafuti TV
+Pacific/Galapagos EC
+Pacific/Gambier PF
+Pacific/Guadalcanal SB
+Pacific/Guam GU
+Pacific/Honolulu US
+Pacific/Kanton KI
+Pacific/Kiritimati KI
+Pacific/Kosrae FM
+Pacific/Kwajalein MH
+Pacific/Majuro MH
+Pacific/Marquesas PF
+Pacific/Midway UM
+Pacific/Nauru NR
+Pacific/Niue NU
+Pacific/Norfolk NF
+Pacific/Noumea NC
+Pacific/Pago_Pago AS
+Pacific/Palau PW
+Pacific/Pitcairn PN
+Pacific/Pohnpei FM
+Pacific/Port_Moresby PG
+Pacific/Rarotonga CK
+Pacific/Saipan MP
+Pacific/Tahiti PF
+Pacific/Tarawa KI
+Pacific/Tongatapu TO
+Pacific/Wake UM
+Pacific/Wallis WF
+`
+
+// countryNames gives every country code a readable name without a network
+// call, so the pane can say "Norway" before the directory's own country
+// index has loaded. Taken from tzdata's iso3166.tab, whose names are
+// deliberately short ("Britain (UK)", not the directory's full legal title).
+var countryNames = map[string]string{
+	"AD": "Andorra",
+	"AE": "United Arab Emirates",
+	"AF": "Afghanistan",
+	"AG": "Antigua & Barbuda",
+	"AI": "Anguilla",
+	"AL": "Albania",
+	"AM": "Armenia",
+	"AO": "Angola",
+	"AQ": "Antarctica",
+	"AR": "Argentina",
+	"AS": "Samoa (American)",
+	"AT": "Austria",
+	"AU": "Australia",
+	"AW": "Aruba",
+	"AX": "Åland Islands",
+	"AZ": "Azerbaijan",
+	"BA": "Bosnia & Herzegovina",
+	"BB": "Barbados",
+	"BD": "Bangladesh",
+	"BE": "Belgium",
+	"BF": "Burkina Faso",
+	"BG": "Bulgaria",
+	"BH": "Bahrain",
+	"BI": "Burundi",
+	"BJ": "Benin",
+	"BL": "St Barthelemy",
+	"BM": "Bermuda",
+	"BN": "Brunei",
+	"BO": "Bolivia",
+	"BQ": "Caribbean NL",
+	"BR": "Brazil",
+	"BS": "Bahamas",
+	"BT": "Bhutan",
+	"BV": "Bouvet Island",
+	"BW": "Botswana",
+	"BY": "Belarus",
+	"BZ": "Belize",
+	"CA": "Canada",
+	"CC": "Cocos (Keeling) Islands",
+	"CD": "Congo (Dem. Rep.)",
+	"CF": "Central African Rep.",
+	"CG": "Congo (Rep.)",
+	"CH": "Switzerland",
+	"CI": "Côte d’Ivoire",
+	"CK": "Cook Islands",
+	"CL": "Chile",
+	"CM": "Cameroon",
+	"CN": "China",
+	"CO": "Colombia",
+	"CR": "Costa Rica",
+	"CU": "Cuba",
+	"CV": "Cape Verde",
+	"CW": "Curaçao",
+	"CX": "Christmas Island",
+	"CY": "Cyprus",
+	"CZ": "Czech Republic",
+	"DE": "Germany",
+	"DJ": "Djibouti",
+	"DK": "Denmark",
+	"DM": "Dominica",
+	"DO": "Dominican Republic",
+	"DZ": "Algeria",
+	"EC": "Ecuador",
+	"EE": "Estonia",
+	"EG": "Egypt",
+	"EH": "Western Sahara",
+	"ER": "Eritrea",
+	"ES": "Spain",
+	"ET": "Ethiopia",
+	"FI": "Finland",
+	"FJ": "Fiji",
+	"FK": "Falkland Islands",
+	"FM": "Micronesia",
+	"FO": "Faroe Islands",
+	"FR": "France",
+	"GA": "Gabon",
+	"GB": "Britain (UK)",
+	"GD": "Grenada",
+	"GE": "Georgia",
+	"GF": "French Guiana",
+	"GG": "Guernsey",
+	"GH": "Ghana",
+	"GI": "Gibraltar",
+	"GL": "Greenland",
+	"GM": "Gambia",
+	"GN": "Guinea",
+	"GP": "Guadeloupe",
+	"GQ": "Equatorial Guinea",
+	"GR": "Greece",
+	"GS": "South Georgia & the South Sandwich Islands",
+	"GT": "Guatemala",
+	"GU": "Guam",
+	"GW": "Guinea-Bissau",
+	"GY": "Guyana",
+	"HK": "Hong Kong",
+	"HM": "Heard Island & McDonald Islands",
+	"HN": "Honduras",
+	"HR": "Croatia",
+	"HT": "Haiti",
+	"HU": "Hungary",
+	"ID": "Indonesia",
+	"IE": "Ireland",
+	"IL": "Israel",
+	"IM": "Isle of Man",
+	"IN": "India",
+	"IO": "British Indian Ocean Territory",
+	"IQ": "Iraq",
+	"IR": "Iran",
+	"IS": "Iceland",
+	"IT": "Italy",
+	"JE": "Jersey",
+	"JM": "Jamaica",
+	"JO": "Jordan",
+	"JP": "Japan",
+	"KE": "Kenya",
+	"KG": "Kyrgyzstan",
+	"KH": "Cambodia",
+	"KI": "Kiribati",
+	"KM": "Comoros",
+	"KN": "St Kitts & Nevis",
+	"KP": "Korea (North)",
+	"KR": "Korea (South)",
+	"KW": "Kuwait",
+	"KY": "Cayman Islands",
+	"KZ": "Kazakhstan",
+	"LA": "Laos",
+	"LB": "Lebanon",
+	"LC": "St Lucia",
+	"LI": "Liechtenstein",
+	"LK": "Sri Lanka",
+	"LR": "Liberia",
+	"LS": "Lesotho",
+	"LT": "Lithuania",
+	"LU": "Luxembourg",
+	"LV": "Latvia",
+	"LY": "Libya",
+	"MA": "Morocco",
+	"MC": "Monaco",
+	"MD": "Moldova",
+	"ME": "Montenegro",
+	"MF": "St Martin (French)",
+	"MG": "Madagascar",
+	"MH": "Marshall Islands",
+	"MK": "North Macedonia",
+	"ML": "Mali",
+	"MM": "Myanmar (Burma)",
+	"MN": "Mongolia",
+	"MO": "Macau",
+	"MP": "Northern Mariana Islands",
+	"MQ": "Martinique",
+	"MR": "Mauritania",
+	"MS": "Montserrat",
+	"MT": "Malta",
+	"MU": "Mauritius",
+	"MV": "Maldives",
+	"MW": "Malawi",
+	"MX": "Mexico",
+	"MY": "Malaysia",
+	"MZ": "Mozambique",
+	"NA": "Namibia",
+	"NC": "New Caledonia",
+	"NE": "Niger",
+	"NF": "Norfolk Island",
+	"NG": "Nigeria",
+	"NI": "Nicaragua",
+	"NL": "Netherlands",
+	"NO": "Norway",
+	"NP": "Nepal",
+	"NR": "Nauru",
+	"NU": "Niue",
+	"NZ": "New Zealand",
+	"OM": "Oman",
+	"PA": "Panama",
+	"PE": "Peru",
+	"PF": "French Polynesia",
+	"PG": "Papua New Guinea",
+	"PH": "Philippines",
+	"PK": "Pakistan",
+	"PL": "Poland",
+	"PM": "St Pierre & Miquelon",
+	"PN": "Pitcairn",
+	"PR": "Puerto Rico",
+	"PS": "Palestine",
+	"PT": "Portugal",
+	"PW": "Palau",
+	"PY": "Paraguay",
+	"QA": "Qatar",
+	"RE": "Réunion",
+	"RO": "Romania",
+	"RS": "Serbia",
+	"RU": "Russia",
+	"RW": "Rwanda",
+	"SA": "Saudi Arabia",
+	"SB": "Solomon Islands",
+	"SC": "Seychelles",
+	"SD": "Sudan",
+	"SE": "Sweden",
+	"SG": "Singapore",
+	"SH": "St Helena",
+	"SI": "Slovenia",
+	"SJ": "Svalbard & Jan Mayen",
+	"SK": "Slovakia",
+	"SL": "Sierra Leone",
+	"SM": "San Marino",
+	"SN": "Senegal",
+	"SO": "Somalia",
+	"SR": "Suriname",
+	"SS": "South Sudan",
+	"ST": "Sao Tome & Principe",
+	"SV": "El Salvador",
+	"SX": "St Maarten (Dutch)",
+	"SY": "Syria",
+	"SZ": "Eswatini (Swaziland)",
+	"TC": "Turks & Caicos Is",
+	"TD": "Chad",
+	"TF": "French S. Terr.",
+	"TG": "Togo",
+	"TH": "Thailand",
+	"TJ": "Tajikistan",
+	"TK": "Tokelau",
+	"TL": "East Timor",
+	"TM": "Turkmenistan",
+	"TN": "Tunisia",
+	"TO": "Tonga",
+	"TR": "Turkey",
+	"TT": "Trinidad & Tobago",
+	"TV": "Tuvalu",
+	"TW": "Taiwan",
+	"TZ": "Tanzania",
+	"UA": "Ukraine",
+	"UG": "Uganda",
+	"UM": "US minor outlying islands",
+	"US": "United States",
+	"UY": "Uruguay",
+	"UZ": "Uzbekistan",
+	"VA": "Vatican City",
+	"VC": "St Vincent",
+	"VE": "Venezuela",
+	"VG": "Virgin Islands (UK)",
+	"VI": "Virgin Islands (US)",
+	"VN": "Vietnam",
+	"VU": "Vanuatu",
+	"WF": "Wallis & Futuna",
+	"WS": "Samoa (western)",
+	"XK": "Kosovo",
+	"YE": "Yemen",
+	"YT": "Mayotte",
+	"ZA": "South Africa",
+	"ZM": "Zambia",
+	"ZW": "Zimbabwe",
+}

--- a/external/radio/geodata_gen.go
+++ b/external/radio/geodata_gen.go
@@ -1,0 +1,208 @@
+//go:build ignore
+
+// Command geodata_gen regenerates geodata.go from the system's tzdata.
+//
+// Usage: go generate ./external/radio
+//
+// It reads /usr/share/zoneinfo/zone.tab, whose first column is exactly one
+// ISO 3166-1 alpha-2 country code and whose third is an IANA timezone name,
+// and emits two tables: which country each timezone belongs to, and which
+// broad region each country sits in.
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"go/format"
+	"log"
+	"maps"
+	"os"
+	"slices"
+	"strings"
+)
+
+const (
+	zoneTab    = "/usr/share/zoneinfo/zone.tab"
+	iso3166Tab = "/usr/share/zoneinfo/iso3166.tab"
+)
+
+// areaRegions maps a timezone's leading area to a region. Atlantic, Indian,
+// and Arctic are missing on purpose: they are oceans, and every country under
+// them is resolved by overrides instead.
+var areaRegions = map[string]string{
+	"Africa":     "Africa",
+	"America":    "Americas",
+	"Antarctica": "Antarctica",
+	"Asia":       "Asia",
+	"Australia":  "Oceania",
+	"Europe":     "Europe",
+	"Pacific":    "Oceania",
+}
+
+// overrides fix countries whose timezone area is an ocean, and
+// transcontinental countries, where the region holding most of the population
+// wins over the one holding most of the timezones.
+var overrides = map[string]string{
+	"AU": "Oceania", "BM": "Americas", "CC": "Oceania", "CL": "Americas",
+	"CV": "Africa", "CX": "Oceania", "EC": "Americas", "ES": "Europe",
+	"FK": "Americas", "FO": "Europe", "GS": "Americas", "IO": "Asia",
+	"IS": "Europe", "KM": "Africa", "MG": "Africa", "MU": "Africa",
+	"MV": "Asia", "PT": "Europe", "RE": "Africa", "RU": "Europe",
+	"SC": "Africa", "SH": "Africa", "SJ": "Europe", "TF": "Antarctica",
+	"US": "Americas", "YT": "Africa",
+}
+
+// extra covers countries tzdata has no row for, in either table. Kosovo is
+// filed under Europe/Belgrade, but the radio directory lists it separately.
+var extra = map[string]struct{ region, name string }{
+	"XK": {region: "Europe", name: "Kosovo"},
+}
+
+// regionOrder keeps the emitted table stable across runs.
+var regionOrder = []string{"Africa", "Americas", "Asia", "Europe", "Oceania", "Antarctica"}
+
+func main() {
+	zones, areas, err := readZoneTab(zoneTab)
+	if err != nil {
+		log.Fatal(err)
+	}
+	names, err := readISO3166(iso3166Tab)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	regions := map[string][]string{}
+	for code, byArea := range areas {
+		region, ok := overrides[code]
+		if !ok {
+			region, ok = areaRegions[topArea(byArea)]
+		}
+		if !ok {
+			log.Fatalf("%s: no region for timezone areas %v; add an override", code, slices.Sorted(maps.Keys(byArea)))
+		}
+		regions[region] = append(regions[region], code)
+	}
+	for code, e := range extra {
+		regions[e.region] = append(regions[e.region], code)
+		names[code] = e.name
+	}
+
+	if err := write("geodata.go", zones, regions, names); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// readZoneTab returns the zone-to-country pairs and, per country, how many
+// zones it has in each timezone area.
+func readZoneTab(path string) (zones [][2]string, areas map[string]map[string]int, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read %s (is tzdata installed?): %w", path, err)
+	}
+	defer f.Close()
+
+	areas = map[string]map[string]int{}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "#") || strings.TrimSpace(line) == "" {
+			continue
+		}
+		fields := strings.Split(line, "\t")
+		if len(fields) < 3 {
+			continue
+		}
+		code, zone := fields[0], fields[2]
+		area, _, _ := strings.Cut(zone, "/")
+		zones = append(zones, [2]string{zone, code})
+		if areas[code] == nil {
+			areas[code] = map[string]int{}
+		}
+		areas[code][area]++
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, nil, err
+	}
+	return zones, areas, nil
+}
+
+// topArea returns the area holding the most of a country's zones, breaking
+// ties by name so the output does not change between runs.
+func topArea(byArea map[string]int) string {
+	best := ""
+	for _, area := range slices.Sorted(maps.Keys(byArea)) {
+		if best == "" || byArea[area] > byArea[best] {
+			best = area
+		}
+	}
+	return best
+}
+
+// readISO3166 returns the short country name tzdata publishes for each code.
+func readISO3166(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s (is tzdata installed?): %w", path, err)
+	}
+	defer f.Close()
+
+	names := map[string]string{}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "#") || strings.TrimSpace(line) == "" {
+			continue
+		}
+		code, name, ok := strings.Cut(line, "\t")
+		if !ok {
+			continue
+		}
+		names[strings.TrimSpace(code)] = strings.TrimSpace(name)
+	}
+	return names, scanner.Err()
+}
+
+func write(path string, zones [][2]string, regions map[string][]string, names map[string]string) error {
+	var b strings.Builder
+	b.WriteString("// Code generated from tzdata zone.tab; DO NOT EDIT.\n")
+	b.WriteString("// Regenerate with: go generate ./external/radio\n\n")
+	b.WriteString("package radio\n\n")
+	b.WriteString("// regionCodes groups ISO 3166-1 alpha-2 country codes into the six broad\n")
+	b.WriteString("// regions the country list is grouped by. Derived from the timezone area of\n")
+	b.WriteString("// each country's zone.tab rows, with hand overrides where that area is an\n")
+	b.WriteString("// ocean (Atlantic, Indian, Arctic) rather than a region, and for\n")
+	b.WriteString("// transcontinental countries, where the region holding most of the\n")
+	b.WriteString("// population wins.\n")
+	b.WriteString("var regionCodes = map[string]string{\n")
+	for _, region := range regionOrder {
+		codes := regions[region]
+		slices.Sort(codes)
+		fmt.Fprintf(&b, "\t%q: %q,\n", region, strings.Join(codes, " "))
+	}
+	b.WriteString("}\n\n")
+	b.WriteString("// zoneCountries maps IANA timezone names to the ISO 3166-1 alpha-2 code of\n")
+	b.WriteString("// the country that owns them, one \"Zone CC\" pair per line. Taken from\n")
+	b.WriteString("// tzdata's zone.tab, whose first column is exactly one country code.\n")
+	b.WriteString("const zoneCountries = `\n")
+	slices.SortFunc(zones, func(a, c [2]string) int { return strings.Compare(a[0], c[0]) })
+	for _, z := range zones {
+		fmt.Fprintf(&b, "%s %s\n", z[0], z[1])
+	}
+	b.WriteString("`\n\n")
+	b.WriteString("// countryNames gives every country code a readable name without a network\n")
+	b.WriteString("// call, so the pane can say \"Norway\" before the directory's own country\n")
+	b.WriteString("// index has loaded. Taken from tzdata's iso3166.tab, whose names are\n")
+	b.WriteString("// deliberately short (\"Britain (UK)\", not the directory's full legal title).\n")
+	b.WriteString("var countryNames = map[string]string{\n")
+	for _, code := range slices.Sorted(maps.Keys(names)) {
+		fmt.Fprintf(&b, "\t%q: %q,\n", code, names[code])
+	}
+	b.WriteString("}\n")
+
+	// Format here so `go generate` leaves nothing for `make fmt` to change.
+	out, err := format.Source([]byte(b.String()))
+	if err != nil {
+		return fmt.Errorf("format generated source: %w", err)
+	}
+	return os.WriteFile(path, out, 0o644)
+}

--- a/external/radio/pins.go
+++ b/external/radio/pins.go
@@ -1,0 +1,152 @@
+package radio
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/bjarneo/cliamp/internal/appdir"
+	"github.com/bjarneo/cliamp/internal/fileutil"
+	"github.com/bjarneo/cliamp/internal/tomlutil"
+)
+
+const pinsFile = "radio_countries.toml"
+
+// Place is a country, or a region within one, that the listener has pinned.
+// State is empty for a whole country.
+type Place struct {
+	Code  string // ISO 3166-1 alpha-2
+	Name  string // display name, e.g. "Norway" or "Oslo, Norway"
+	State string
+}
+
+// ID is the stable identifier a Place is addressed by: "NO" for a country,
+// "NO/Oslo" for a region within one.
+func (p Place) ID() string {
+	if p.State == "" {
+		return p.Code
+	}
+	return p.Code + "/" + p.State
+}
+
+// parsePlaceID is the inverse of Place.ID. It returns ok=false for anything
+// that does not start with a usable country code.
+func parsePlaceID(id string) (code, state string, ok bool) {
+	code, state, _ = strings.Cut(id, "/")
+	code = normalizeCountryCode(code)
+	if code == "" {
+		return "", "", false
+	}
+	return code, strings.TrimSpace(state), true
+}
+
+// Pins is a persistent, ordered list of pinned places. A pin does two things:
+// it puts the place in the radio pane, and it joins the rotation the catalog
+// country filter cycles through.
+type Pins struct {
+	mu     sync.Mutex
+	places []Place
+	path   string
+}
+
+// LoadPins reads pinned places from ~/.config/cliamp/radio_countries.toml.
+// A missing or unreadable file yields an empty, still-usable set.
+func LoadPins() *Pins {
+	p := &Pins{}
+	dir, err := appdir.Dir()
+	if err != nil {
+		return p
+	}
+	p.path = filepath.Join(dir, pinsFile)
+	places, err := loadPlaces(p.path)
+	if err != nil {
+		return p
+	}
+	p.places = places
+	return p
+}
+
+// Places returns the pinned places in the order they were added.
+func (p *Pins) Places() []Place {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return slices.Clone(p.places)
+}
+
+// Contains reports whether the given place ID is pinned.
+func (p *Pins) Contains(id string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return slices.ContainsFunc(p.places, func(place Place) bool { return place.ID() == id })
+}
+
+// Toggle adds place when absent and removes it when present, persisting either
+// way. It reports whether the place is pinned after the call.
+//
+// Pins carries its own lock so that the write, which fsyncs the file and its
+// directory, never runs under the provider mutex the renderer reads through.
+func (p *Pins) Toggle(place Place) (pinned bool, err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	id := place.ID()
+	if i := slices.IndexFunc(p.places, func(c Place) bool { return c.ID() == id }); i >= 0 {
+		p.places = slices.Delete(p.places, i, i+1)
+		return false, p.save()
+	}
+	p.places = append(p.places, place)
+	return true, p.save()
+}
+
+// save persists the pin list. p.mu must be held.
+func (p *Pins) save() error {
+	if p.path == "" {
+		dir, err := appdir.Dir()
+		if err != nil {
+			return err
+		}
+		p.path = filepath.Join(dir, pinsFile)
+	}
+	var b strings.Builder
+	for i, place := range p.places {
+		if i > 0 {
+			fmt.Fprintln(&b)
+		}
+		fmt.Fprintln(&b, "[[country]]")
+		fmt.Fprintf(&b, "code = %q\n", place.Code)
+		fmt.Fprintf(&b, "name = %q\n", place.Name)
+		if place.State != "" {
+			fmt.Fprintf(&b, "state = %q\n", place.State)
+		}
+	}
+	return fileutil.WriteFileAtomic(p.path, []byte(b.String()), 0o644)
+}
+
+func loadPlaces(path string) ([]Place, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var places []Place
+	tomlutil.ParseSections(data, "country", func(f map[string]string) {
+		code := normalizeCountryCode(f["code"])
+		if code == "" {
+			return
+		}
+		place := Place{Code: code, Name: f["name"], State: strings.TrimSpace(f["state"])}
+		if place.Name == "" {
+			place.Name = code
+		}
+		places = append(places, place)
+	})
+	return places, nil
+}

--- a/external/radio/pins_test.go
+++ b/external/radio/pins_test.go
@@ -1,0 +1,128 @@
+package radio
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestPlaceID(t *testing.T) {
+	for _, tc := range []struct {
+		place Place
+		want  string
+	}{
+		{Place{Code: "NO", Name: "Norway"}, "NO"},
+		{Place{Code: "NO", Name: "Oslo, Norway", State: "Oslo"}, "NO/Oslo"},
+	} {
+		if got := tc.place.ID(); got != tc.want {
+			t.Errorf("Place%+v.ID() = %q, want %q", tc.place, got, tc.want)
+		}
+	}
+}
+
+func TestParsePlaceID(t *testing.T) {
+	for _, tc := range []struct {
+		id, code, state string
+		ok              bool
+	}{
+		{id: "NO", code: "NO", ok: true},
+		{id: "NO/Oslo", code: "NO", state: "Oslo", ok: true},
+		{id: "no/oslo", code: "NO", state: "oslo", ok: true},
+		{id: "NO/Møre og Romsdal", code: "NO", state: "Møre og Romsdal", ok: true},
+		{id: "XX", ok: false},
+		{id: "", ok: false},
+		{id: "browse:countries", ok: false},
+	} {
+		code, state, ok := parsePlaceID(tc.id)
+		if ok != tc.ok || code != tc.code || state != tc.state {
+			t.Errorf("parsePlaceID(%q) = (%q, %q, %v), want (%q, %q, %v)",
+				tc.id, code, state, ok, tc.code, tc.state, tc.ok)
+		}
+	}
+}
+
+func TestPinsToggleRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	pins := LoadPins()
+	if len(pins.Places()) != 0 {
+		t.Fatalf("fresh pins = %+v, want empty", pins.Places())
+	}
+
+	norway := Place{Code: "NO", Name: "Norway"}
+	oslo := Place{Code: "NO", Name: "Oslo, Norway", State: "Oslo"}
+
+	for _, place := range []Place{norway, oslo} {
+		pinned, err := pins.Toggle(place)
+		if err != nil {
+			t.Fatalf("Toggle(%s): %v", place.ID(), err)
+		}
+		if !pinned {
+			t.Errorf("Toggle(%s) = false, want pinned", place.ID())
+		}
+	}
+
+	// A country and one of its regions are distinct pins.
+	if got := len(pins.Places()); got != 2 {
+		t.Fatalf("pins = %+v, want 2", pins.Places())
+	}
+	if !pins.Contains("NO") || !pins.Contains("NO/Oslo") {
+		t.Errorf("pins = %+v, want both NO and NO/Oslo", pins.Places())
+	}
+
+	reloaded := LoadPins()
+	if len(reloaded.Places()) != 2 || !reloaded.Contains("NO/Oslo") {
+		t.Fatalf("reloaded pins = %+v", reloaded.Places())
+	}
+	if got := reloaded.Places()[1].Name; got != "Oslo, Norway" {
+		t.Errorf("reloaded name = %q, want %q", got, "Oslo, Norway")
+	}
+
+	if pinned, err := pins.Toggle(norway); err != nil || pinned {
+		t.Fatalf("un-toggle = (%v, %v), want (false, nil)", pinned, err)
+	}
+	if after := LoadPins(); after.Contains("NO") || !after.Contains("NO/Oslo") {
+		t.Errorf("after unpinning NO, pins = %+v", after.Places())
+	}
+}
+
+func TestLoadPinsSkipsUnusableRows(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	writeFile(t, filepath.Join(dir, ".config", "cliamp", pinsFile), `
+[[country]]
+code = "NO"
+name = "Norway"
+
+[[country]]
+code = "XX"
+name = "Unknown"
+
+[[country]]
+name = "No code at all"
+
+[[country]]
+code = "de"
+`)
+
+	pins := LoadPins()
+	if len(pins.Places()) != 2 {
+		t.Fatalf("pins = %+v, want 2 usable rows", pins.Places())
+	}
+	// A row with a code but no name falls back to the code, upper-cased.
+	if got := pins.Places()[1]; got.Code != "DE" || got.Name != "DE" {
+		t.Errorf("second pin = %+v, want code and name DE", got)
+	}
+}
+
+func TestPinsToggleSurvivesMissingConfigDir(t *testing.T) {
+	// LoadPins with an unresolvable home yields an empty but usable set.
+	pins := &Pins{}
+	if pins.Contains("NO") {
+		t.Error("zero Pins should contain nothing")
+	}
+	t.Setenv("HOME", t.TempDir())
+	if pinned, err := pins.Toggle(Place{Code: "NO", Name: "Norway"}); err != nil || !pinned {
+		t.Fatalf("Toggle on zero Pins = (%v, %v)", pinned, err)
+	}
+}

--- a/external/radio/places_test.go
+++ b/external/radio/places_test.go
@@ -1,0 +1,172 @@
+package radio
+
+import "testing"
+
+// Until the listener answers, the Countries section leads with the offer and
+// no country of theirs appears anywhere.
+func TestPlaylistsOffersLocationBeforeItIsAnswered(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("TZ", "Europe/Oslo")
+	p := New(Options{})
+
+	lists, err := p.Playlists()
+	if err != nil {
+		t.Fatalf("Playlists: %v", err)
+	}
+	if lists[0].ID != locationConsentID || lists[0].Name != "Use my location" {
+		t.Fatalf("first row = %+v, want the location offer", lists[0])
+	}
+	for _, list := range lists {
+		if list.ID == "p:0" {
+			t.Errorf("a country row appeared before the question was answered: %+v", list)
+		}
+	}
+	if p.LocationConsentID() != locationConsentID {
+		t.Errorf("LocationConsentID() = %q, want the offer row", p.LocationConsentID())
+	}
+}
+
+// Once answered, the offer is gone whichever way it was answered.
+func TestPlaylistsDropsTheOfferOnceAnswered(t *testing.T) {
+	for _, country := range []string{"NO", CountryDeclined} {
+		t.Run(country, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			p := New(Options{Country: country})
+
+			lists, err := p.Playlists()
+			if err != nil {
+				t.Fatalf("Playlists: %v", err)
+			}
+			for _, list := range lists {
+				if list.ID == locationConsentID {
+					t.Fatalf("the offer is still shown after answering %q", country)
+				}
+			}
+			if p.LocationConsentID() != "" {
+				t.Errorf("LocationConsentID() = %q, want empty", p.LocationConsentID())
+			}
+		})
+	}
+}
+
+// The offer row is a question; asking for its tracks is a caller error.
+func TestTracksRejectsTheLocationRow(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	p := New(Options{})
+	if _, err := p.Tracks(locationConsentID); err == nil {
+		t.Error("Tracks should refuse the location row")
+	}
+}
+
+func TestPlaylistsListsPlacesBeforeStations(t *testing.T) {
+	d := &directory{}
+	d.serve(t)
+
+	p := newPlaceProvider(t, "NO")
+	if _, err := p.pins.Toggle(Place{Code: "DE", Name: "Germany"}); err != nil {
+		t.Fatalf("pin Germany: %v", err)
+	}
+
+	lists, err := p.Playlists()
+	if err != nil {
+		t.Fatalf("Playlists: %v", err)
+	}
+	if len(lists) < 3 {
+		t.Fatalf("lists = %+v, want two places and the built-in station", lists)
+	}
+	// The home country leads and says why it is there; pins follow, starred.
+	if lists[0].ID != "p:0" || lists[0].Name != "Norway (near you)" {
+		t.Errorf("first row = %+v, want the home country", lists[0])
+	}
+	if lists[1].ID != "p:1" || lists[1].Name != "★ Germany" {
+		t.Errorf("second row = %+v, want the pinned country", lists[1])
+	}
+	if lists[2].ID != "l:0" || lists[2].Name != builtinName {
+		t.Errorf("third row = %+v, want the built-in station", lists[2])
+	}
+}
+
+func TestPlaylistsWithoutAHomeCountryOrPinsIsUnchanged(t *testing.T) {
+	p := newPlaceProvider(t, "")
+	lists, err := p.Playlists()
+	if err != nil {
+		t.Fatalf("Playlists: %v", err)
+	}
+	if len(lists) != 1 || lists[0].ID != "l:0" {
+		t.Fatalf("lists = %+v, want only the built-in station", lists)
+	}
+}
+
+func TestTracksExpandsAPlaceIntoItsStations(t *testing.T) {
+	d := &directory{stations: []CatalogStation{
+		{Name: "NRK P1", URL: "https://nrk.example/p1"},
+		{Name: "NRK P3", URL: "https://nrk.example/p3"},
+	}}
+	d.serve(t)
+
+	p := newPlaceProvider(t, "NO")
+	tracks, err := p.Tracks("p:0")
+	if err != nil {
+		t.Fatalf("Tracks: %v", err)
+	}
+	if len(tracks) != 2 {
+		t.Fatalf("tracks = %+v, want both of the country's stations", tracks)
+	}
+	if d.lastQuery.Get("countrycode") != "NO" {
+		t.Errorf("query = %v, want it narrowed to NO", d.lastQuery)
+	}
+
+	if _, err := p.Tracks("p:9"); err == nil {
+		t.Error("Tracks should reject an out-of-range place index")
+	}
+}
+
+func TestSectionTitle(t *testing.T) {
+	p := newPlaceProvider(t, "")
+	for prefix, want := range map[string]string{
+		"p":      "Countries",
+		"browse": "Countries",
+		"loc":    "Countries",
+		"l":      "Stations",
+		"f":      "Favorites",
+		"c":      "Catalog",
+		"s":      "Search Results",
+		"":       "",
+		"zzz":    "",
+	} {
+		if got := p.SectionTitle(prefix); got != want {
+			t.Errorf("SectionTitle(%q) = %q, want %q", prefix, got, want)
+		}
+	}
+}
+
+func TestRefreshDropsCachedDirectoryData(t *testing.T) {
+	d := &directory{countries: []Country{{Name: "Norway", Code: "NO", StationCount: 247}}}
+	d.serve(t)
+
+	p := newPlaceProvider(t, "")
+	if _, err := p.Genres(); err != nil {
+		t.Fatalf("Genres: %v", err)
+	}
+	if len(p.countries) != 1 {
+		t.Fatalf("countries = %+v, want the index cached", p.countries)
+	}
+	p.AppendCatalog([]CatalogStation{{Name: "Stale", URL: "https://stale.example/stream"}})
+
+	p.Refresh()
+	if p.countries != nil || p.catalog != nil {
+		t.Errorf("after Refresh: countries = %+v, catalog = %+v, want both dropped", p.countries, p.catalog)
+	}
+}
+
+func TestIsFavoritableIDExcludesPlaces(t *testing.T) {
+	p := newPlaceProvider(t, "")
+	for id, want := range map[string]bool{
+		"c:0": true, "f:0": true, "s:0": true,
+		"p:0": false, "l:0": false, "browse:countries": false,
+	} {
+		if got := p.IsFavoritableID(id); got != want {
+			t.Errorf("IsFavoritableID(%q) = %v, want %v", id, got, want)
+		}
+	}
+}

--- a/external/radio/provider.go
+++ b/external/radio/provider.go
@@ -23,25 +23,67 @@ import (
 
 // Compile-time interface checks.
 var (
-	_ provider.FavoriteToggler  = (*Provider)(nil)
-	_ provider.CatalogLoader    = (*Provider)(nil)
-	_ provider.CatalogSearcher  = (*Provider)(nil)
-	_ provider.RadioStatsLoader = (*Provider)(nil)
-	_ provider.SectionedList    = (*Provider)(nil)
+	_ provider.FavoriteToggler      = (*Provider)(nil)
+	_ provider.CatalogLoader        = (*Provider)(nil)
+	_ provider.CatalogSearcher      = (*Provider)(nil)
+	_ provider.RadioStatsLoader     = (*Provider)(nil)
+	_ provider.SectionedList        = (*Provider)(nil)
+	_ provider.SectionTitler        = (*Provider)(nil)
+	_ provider.GenreBrowser         = (*Provider)(nil)
+	_ provider.GenreFavoriteToggler = (*Provider)(nil)
+	_ provider.GenreLabeler         = (*Provider)(nil)
+	_ provider.LocationConsenter    = (*Provider)(nil)
+	_ provider.BrowseEntryProvider  = (*Provider)(nil)
+	_ playlist.Refresher            = (*Provider)(nil)
 )
 
 const builtinName = "cliamp radio"
 const builtinURL = "https://radio.cliamp.stream/streams.m3u"
 
+// Section headings for each ID prefix, shown above the rows they cover in the
+// radio pane. The browse shortcut shares the pinned-places heading so the two
+// render as one block.
+const (
+	sectionCountries = "Countries"
+	sectionStations  = "Stations"
+	sectionFavorites = "Favorites"
+	sectionCatalog   = "Catalog"
+	sectionSearch    = "Search Results"
+)
+
+// Options configures the provider at construction time.
+type Options struct {
+	// Country records what the listener has already said about their location:
+	// an ISO 3166-1 alpha-2 code to use, CountryDeclined to leave it alone, or
+	// empty for "not asked yet". Nothing is detected until this is a code, so
+	// a fresh install works out nobody's location on its own.
+	Country string
+	// SaveCountry persists the listener's answer so they are asked once rather
+	// than every launch. A nil SaveCountry keeps the answer for this run only.
+	SaveCountry func(code string) error
+}
+
+// CountryDeclined is the Country value recording that the listener said no to
+// location detection.
+const CountryDeclined = "none"
+
 // Provider serves radio stations as single-track playlists.
-// It combines local stations, user favorites, and catalog stations
-// from the Radio Browser API into a single unified list.
+// It combines local stations, pinned places, user favorites, and catalog
+// stations from the Radio Browser API into a single unified list.
 type Provider struct {
 	mu            sync.Mutex
 	stations      []station        // built-in + user-defined (radios.toml)
 	favorites     *Favorites       // user favorites (radio_favorites.toml)
+	pins          *Pins            // pinned countries and regions (radio_countries.toml)
+	home          Place            // listener's own country; zero when unknown
 	catalog       []CatalogStation // lazily loaded from Radio Browser API
 	searchResults []CatalogStation // non-nil when API search is active
+	countries     []Country        // cached country index, nil until first browse
+	states        []State          // cached regions of the home country
+	// locationSettled is false only until the listener answers the location
+	// question. It gates whether to ask, not whether p.home may be used.
+	locationSettled bool
+	saveCountry     func(string) error
 }
 
 type station struct {
@@ -50,30 +92,53 @@ type station struct {
 }
 
 // New creates a Provider with the built-in station plus any user-defined
-// stations from ~/.config/cliamp/radios.toml and favorites.
-func New() *Provider {
+// stations from ~/.config/cliamp/radios.toml, favorites, and pinned places.
+func New(opts Options) *Provider {
 	p := &Provider{
 		stations: []station{
 			{name: builtinName, url: builtinURL},
 		},
 	}
 
+	p.saveCountry = opts.SaveCountry
+
+	answer := strings.TrimSpace(opts.Country)
+	if code := normalizeCountryCode(answer); code != "" {
+		p.home = namedPlace(code)
+		p.locationSettled = true
+	} else if strings.EqualFold(answer, CountryDeclined) {
+		p.locationSettled = true
+	}
+
 	dir, err := appdir.Dir()
 	if err != nil {
 		p.favorites = &Favorites{byURL: make(map[string]struct{})}
+		p.pins = &Pins{}
 		return p
 	}
 	if extra, err := loadStations(filepath.Join(dir, "radios.toml")); err == nil {
 		p.stations = append(p.stations, extra...)
 	}
 	p.favorites = LoadFavorites()
+	p.pins = LoadPins()
 	return p
+}
+
+// namedPlace pairs a country code with the best name available without a
+// network call. The directory's own name replaces it once its index loads.
+func namedPlace(code string) Place {
+	name := CountryName(code)
+	if name == "" {
+		name = code
+	}
+	return Place{Code: code, Name: name}
 }
 
 func (p *Provider) Name() string { return "Radio" }
 
-// Playlists returns a unified list: local stations, then favorites (★ prefixed),
-// then catalog stations (with metadata). IDs are prefixed: "l:", "f:", "c:".
+// Playlists returns a unified list: pinned places, local stations, favorites
+// (★ prefixed), then catalog stations (with metadata). IDs are prefixed with
+// "p:", "l:", "f:", or "c:".
 func (p *Provider) Playlists() ([]playlist.PlaylistInfo, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -86,6 +151,29 @@ func (p *Provider) Playlists() ([]playlist.PlaylistInfo, error) {
 			out = append(out, p.catalogEntry("s", i, s))
 		}
 		return out, nil
+	}
+
+	// The location offer sits at the top of the Countries section, directly
+	// under the browse shortcut, and only until the listener has answered.
+	if !p.locationSettled {
+		out = append(out, playlist.PlaylistInfo{
+			ID:   locationConsentID,
+			Name: "Use my location",
+		})
+	}
+
+	// Places: the listener's own country first, then whatever they pinned.
+	for i, place := range p.placesLocked() {
+		name := place.Name
+		if i == 0 && place.ID() == p.homeLocked().ID() {
+			name += " (near you)"
+		} else {
+			name = "★ " + name
+		}
+		out = append(out, playlist.PlaylistInfo{
+			ID:   fmt.Sprintf("p:%d", i),
+			Name: name,
+		})
 	}
 
 	// Local stations.
@@ -124,15 +212,34 @@ func (p *Provider) catalogEntry(prefix string, idx int, s CatalogStation) playli
 	}
 }
 
-// Tracks returns a single-track playlist for the given station ID.
+// Tracks returns a playlist for the given ID: a single stream for a station,
+// or a country's or region's stations for a place.
 func (p *Provider) Tracks(id string) ([]playlist.Track, error) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
+	// The location offer is a question, not a playlist. The UI intercepts it
+	// before reaching here; refuse it by name so a caller that does not (an
+	// IPC client, say) gets a useful error rather than "invalid station ID".
+	if id == locationConsentID {
+		return nil, errors.New("radio: the location row is a prompt, not a playlist")
+	}
 
 	prefix, idx, err := parseStationID(id)
 	if err != nil {
 		return nil, err
 	}
+
+	// A place is not a station: it expands to that country's or region's
+	// stations, so next and previous scan through them. The directory call
+	// runs off the provider lock, which the UI needs to render the pane.
+	if prefix == "p" {
+		place, ok := p.placeAt(idx)
+		if !ok {
+			return nil, errors.New("invalid place index")
+		}
+		return p.GenreTracks(place.ID(), SortVotes)
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
 
 	var url, title string
 	switch prefix {
@@ -164,6 +271,17 @@ func (p *Provider) Tracks(id string) ([]playlist.Track, error) {
 	return []playlist.Track{{
 		Path: url, Title: title, Stream: true, Realtime: true,
 	}}, nil
+}
+
+// placeAt returns the place at index idx of the pane's Countries section.
+func (p *Provider) placeAt(idx int) (Place, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	places := p.placesLocked()
+	if idx < 0 || idx >= len(places) {
+		return Place{}, false
+	}
+	return places[idx], true
 }
 
 // AppendCatalog adds catalog stations fetched from the Radio Browser API.
@@ -275,10 +393,11 @@ func (p *Provider) IsSearching() bool {
 }
 
 // LoadCatalogPage fetches the next page of catalog entries from the Radio
-// Browser API and appends them to the provider's catalog.
+// Browser API, the directory's own top-voted feed, and appends them to the
+// provider's catalog.
 // Implements provider.CatalogLoader.
 func (p *Provider) LoadCatalogPage(offset, limit int) (int, error) {
-	stations, err := TopStationsOffset(offset, limit)
+	stations, err := Stations(StationQuery{Order: SortVotes, Offset: offset, Limit: limit})
 	if err != nil {
 		return 0, err
 	}
@@ -286,16 +405,39 @@ func (p *Provider) LoadCatalogPage(offset, limit int) (int, error) {
 	return len(stations), nil
 }
 
-// SearchCatalog performs a server-side station search via the Radio Browser API.
-// Results are reflected in subsequent Playlists() calls.
+// SearchCatalog performs a server-side station search via the Radio Browser
+// API. Results are reflected in subsequent Playlists() calls.
 // Implements provider.CatalogSearcher.
 func (p *Provider) SearchCatalog(query string) (int, error) {
-	stations, err := SearchStations(query, 200)
+	stations, err := Stations(StationQuery{Name: query, Order: SortVotes, Limit: searchLimit})
 	if err != nil {
 		return 0, err
 	}
 	p.SetSearchResults(stations)
 	return len(stations), nil
+}
+
+// searchLimit caps how many results one catalog search returns.
+const searchLimit = 200
+
+// SectionTitle names the pane section for an ID prefix. The provider owns this
+// wording because only it knows what its prefixes mean.
+// Implements provider.SectionTitler.
+func (*Provider) SectionTitle(prefix string) string {
+	switch prefix {
+	case "p", "browse", "loc":
+		return sectionCountries
+	case "l":
+		return sectionStations
+	case "f":
+		return sectionFavorites
+	case "c":
+		return sectionCatalog
+	case "s":
+		return sectionSearch
+	default:
+		return ""
+	}
 }
 
 // IsFavoritableID reports whether the given ID can be favorited.
@@ -309,7 +451,8 @@ func IsCatalogOrFavID(id string) bool {
 	return strings.HasPrefix(id, "c:") || strings.HasPrefix(id, "f:") || strings.HasPrefix(id, "s:")
 }
 
-// IDPrefix returns the type prefix of a provider list ID ("l", "f", "c", or "").
+// IDPrefix returns the type prefix of a provider list ID ("p", "l", "f", "c",
+// "s", "browse", or "").
 // Also implements provider.SectionedList when called as a method.
 func (p *Provider) IDPrefix(id string) string {
 	return idPrefix(id)
@@ -339,14 +482,17 @@ func parseStationID(id string) (prefix string, idx int, err error) {
 	return prefix, idx, nil
 }
 
-// formatCatalogName builds a display name from a CatalogStation.
+// formatCatalogName builds a display name from a CatalogStation. The country
+// is trimmed the same way the country browser trims it, so one station does
+// not read as being in "The United States Of America" while the country it was
+// picked from reads as "United States Of America".
 func formatCatalogName(s CatalogStation) string {
 	name := s.Name
 	if s.Bitrate > 0 {
 		name += fmt.Sprintf(" [%dk]", s.Bitrate)
 	}
-	if s.Country != "" {
-		name += " · " + s.Country
+	if country := displayCountryName(s.Country); country != "" {
+		name += " · " + country
 	}
 	return name
 }

--- a/external/radio/provider_test.go
+++ b/external/radio/provider_test.go
@@ -6,11 +6,13 @@ import (
 	"testing"
 )
 
+// newTestProvider builds a provider with the location question already
+// answered, so these tests see the station rows and not the offer row.
 func newTestProvider(t *testing.T) *Provider {
 	t.Helper()
 	// Point HOME at a temp dir so New() doesn't touch real state.
 	t.Setenv("HOME", t.TempDir())
-	return New()
+	return New(Options{Country: CountryDeclined})
 }
 
 func TestProviderNewHasBuiltinStation(t *testing.T) {
@@ -44,7 +46,7 @@ name = "Extra"
 url = "https://extra.example/stream"
 `)
 
-	p := New()
+	p := New(Options{Country: CountryDeclined})
 	infos, _ := p.Playlists()
 	if len(infos) < 2 {
 		t.Fatalf("expected builtin + extra, got %d", len(infos))

--- a/main.go
+++ b/main.go
@@ -85,7 +85,10 @@ func run(overrides config.Overrides, positional []string, daemon, visualizer60FP
 	}
 
 	// Build provider list: Radio is always available, Navidrome and Spotify if configured.
-	radioProv := radio.New()
+	radioProv := radio.New(radio.Options{
+		Country:     cfg.Radio.Country,
+		SaveCountry: config.SaveRadioCountry,
+	})
 	localProv := local.New()
 
 	var providers []model.ProviderEntry

--- a/provider/interfaces.go
+++ b/provider/interfaces.go
@@ -247,6 +247,30 @@ type CatalogSearcher interface {
 	IsSearching() bool
 }
 
+// LocationConsenter is implemented by providers that can make use of the
+// listener's approximate location. Working out where someone is counts as
+// using their location whether or not a network lookup is involved, so a
+// provider must not do it until the listener has said yes.
+type LocationConsenter interface {
+	// NeedsLocationConsent reports whether the listener has yet to answer.
+	// It is false once they have answered either way, and false when the
+	// answer is already recorded in configuration.
+	NeedsLocationConsent() bool
+	// LocationConsentID is the provider-list row that raises the question, or
+	// "" when the provider is offering no such row. Selecting that row must
+	// ask rather than load anything.
+	LocationConsentID() string
+	// LocationPrompt returns the question to put to the listener. It should
+	// say what the provider would do with the answer and where the location
+	// would come from.
+	LocationPrompt() string
+	// SetLocationConsent records the answer and persists it, so the listener
+	// is asked once rather than every launch. On true the provider may work
+	// out and use the location, and returns what it found ("" when it could
+	// not tell). On false it must not.
+	SetLocationConsent(allowed bool) (place string, err error)
+}
+
 // RadioStatsLoader is implemented by radio providers that expose aggregate
 // listener statistics for their built-in stations.
 type RadioStatsLoader interface {
@@ -276,6 +300,21 @@ type SectionedList interface {
 	IDPrefix(id string) string
 	// IsFavoritableID reports whether the given ID can be favorited.
 	IsFavoritableID(id string) bool
+}
+
+// SectionTitler is implemented by SectionedList providers whose section
+// headings change at runtime, such as a radio catalog narrowed to one country.
+// Returning "" leaves the heading to the UI's built-in name for that prefix.
+type SectionTitler interface {
+	SectionTitle(prefix string) string
+}
+
+// GenreLabeler is implemented by GenreBrowser providers whose categories are
+// not genres, so the browse overlay can name them correctly (for example
+// "Countries" for a radio directory).
+type GenreLabeler interface {
+	// GenreLabel returns the plural noun for the category level, e.g. "Countries".
+	GenreLabel() string
 }
 
 // Closer is implemented by providers that hold resources (sessions,

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>CLIAMP - Terminal Music Player</title>
-<meta name="description" content="A terminal music player based on Winamp 2.x. Play local files, YouTube, Spotify, Qobuz, Tidal, Plex, Jellyfin, Emby, Navidrome, Lyrion, SoundCloud, Mixcloud, NetEase, and more than 30,000 radio stations. Use a spectrum visualizer and 10-band equalizer.">
+<meta name="description" content="A terminal music player based on Winamp 2.x. Play local files, YouTube, Spotify, Qobuz, Tidal, Plex, Jellyfin, Emby, Navidrome, Lyrion, SoundCloud, Mixcloud, NetEase, and about 58,000 radio stations. Use a spectrum visualizer and 10-band equalizer.">
 <link rel="icon" type="image/svg+xml" href="favicon.svg">
 <link rel="apple-touch-icon" href="apple-touch-icon.png">
 <meta name="theme-color" content="#050505">
@@ -12,7 +12,7 @@
 <!-- Open Graph -->
 <meta property="og:type" content="website">
 <meta property="og:title" content="CLIAMP - Terminal Music Player">
-<meta property="og:description" content="A terminal music player based on Winamp 2.x. Play YouTube, Spotify, Qobuz, Tidal, Plex, Jellyfin, Emby, Navidrome, Lyrion, SoundCloud, Mixcloud, NetEase, and more than 30,000 radio stations. Use a spectrum visualizer and 10-band equalizer.">
+<meta property="og:description" content="A terminal music player based on Winamp 2.x. Play YouTube, Spotify, Qobuz, Tidal, Plex, Jellyfin, Emby, Navidrome, Lyrion, SoundCloud, Mixcloud, NetEase, and about 58,000 radio stations. Use a spectrum visualizer and 10-band equalizer.">
 <meta property="og:image" content="https://cliamp.stream/og-image.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
@@ -21,7 +21,7 @@
 <!-- Twitter Card -->
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="CLIAMP - Terminal Music Player">
-<meta name="twitter:description" content="A terminal music player based on Winamp 2.x. Play YouTube, Spotify, Qobuz, Tidal, Plex, Jellyfin, Emby, Navidrome, Lyrion, SoundCloud, Mixcloud, NetEase, and more than 30,000 radio stations. Use a spectrum visualizer and 10-band equalizer.">
+<meta name="twitter:description" content="A terminal music player based on Winamp 2.x. Play YouTube, Spotify, Qobuz, Tidal, Plex, Jellyfin, Emby, Navidrome, Lyrion, SoundCloud, Mixcloud, NetEase, and about 58,000 radio stations. Use a spectrum visualizer and 10-band equalizer.">
 <meta name="twitter:image" content="https://cliamp.stream/og-image.png">
 
 <style>
@@ -843,7 +843,7 @@ footer{padding:26px 0;border-top:1px solid var(--green);background:var(--ink)}
         <div class="hero-eyebrow"><span class="led"></span>~/audio/cliamp</div>
         <div class="hero-lockup"><img class="hero-logo" src="logo.svg" alt=""><h1 class="hero-word">cli<span>amp</span></h1></div>
         <p class="hero-sub"><em>Winamp</em> for the shell. No browser tab required.</p>
-        <p class="hero-desc">Use playlists, a 10-band EQ, visualizers, synced lyrics, remote control, and Lua plugins. Stream from <em>Spotify, Qobuz, Tidal, YouTube Music, Plex, Jellyfin, Emby, Navidrome, Lyrion</em>, and more than 30,000 radio stations.</p>
+        <p class="hero-desc">Use playlists, a 10-band EQ, visualizers, synced lyrics, remote control, and Lua plugins. Stream from <em>Spotify, Qobuz, Tidal, YouTube Music, Plex, Jellyfin, Emby, Navidrome, Lyrion</em>, and about 58,000 radio stations.</p>
         <div class="hero-cta">
           <a href="#install" class="btn btn-go">Install</a>
           <a href="https://github.com/bjarneo/cliamp" class="btn btn-ghost">View source</a>
@@ -1085,6 +1085,7 @@ user_id = "your-account-user-id"</code></pre>
       <div class="feature"><div class="feature-icon">♬</div><div class="feature-name">MPRIS / Media Keys</div><p>The app integrates with the desktop. Use hardware media keys and <code>playerctl</code>. The app shows embedded local cover art.</p></div>
       <div class="feature"><div class="feature-icon">⚙</div><div class="feature-name">Audio Quality</div><p>Set the sample rate and buffering time (up to 5 seconds). Use resampling.</p></div>
       <div class="feature"><div class="feature-icon">⌀</div><div class="feature-name">Live Radio Metadata</div><p>View ICY/Shoutcast metadata for the current internet-radio song. Get API-based now-playing data for FIP and NTS.</p></div>
+      <div class="feature"><div class="feature-icon">◎</div><div class="feature-name">Radio by Location</div><p>Cut 58,000 stations down by where they broadcast from. Press <kbd>N</kbd> to browse 241 countries grouped by region, and <kbd>f</kbd> to pin the ones you listen to; <kbd>Enter</kbd> on a country loads its stations as a playlist. cliamp never works out where you are on its own: a "Use my location" row offers it, and only if you accept does it read your country from the system timezone. Never a geo-IP lookup. <a href="https://github.com/bjarneo/cliamp/blob/main/docs/radio.md">Radio guide</a>.</p></div>
       <div class="feature"><div class="feature-icon">✎</div><div class="feature-name">Embedded Tag Reading</div><p>Read ID3v2, Vorbis comments, and MP4 atoms: artist, album, genre, year, lyrics, and cover art.</p></div>
       <div class="feature"><div class="feature-icon">▶</div><div class="feature-name">CLI Flags</div><p>Use flags to override volume, shuffle, repeat, theme, EQ, and sample rate for a session.</p></div>
       <div class="feature"><div class="feature-icon">⇥</div><div class="feature-name">Shell Completion</div><p>Generate completion scripts for Bash, Zsh, Fish, and PowerShell.</p></div>

--- a/ui/model/genre_browser_test.go
+++ b/ui/model/genre_browser_test.go
@@ -183,12 +183,75 @@ func TestGenreBrowseEntryAppearsInProviderPaneAndNavMenu(t *testing.T) {
 	if len(lists) != 1 || lists[0].ID != "browse:genres" {
 		t.Fatalf("provider lists = %+v", lists)
 	}
+	// A genre-only provider must be offered only the genre route. The album and
+	// artist rows would close the browser with no explanation when selected.
 	m := Model{navBrowser: navBrowserState{prov: p}}
 	menu := m.navMenuItems()
-	if len(menu) != 4 || menu[3].mode != provider.BrowseGenres {
+	if len(menu) != 1 || menu[0].mode != provider.BrowseGenres {
 		t.Fatalf("nav menu = %+v", menu)
 	}
 }
+
+func TestNavMenuListsOnlyRoutesTheProviderImplements(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		prov  playlist.Provider
+		modes []provider.BrowseMode
+	}{
+		{
+			name: "album, artist and genre browser",
+			prov: providerPaneBrowseProvider{},
+			modes: []provider.BrowseMode{
+				provider.BrowseAlbums, provider.BrowseArtists,
+				provider.BrowseArtistAlbums, provider.BrowseGenres,
+			},
+		},
+		{
+			name:  "genre browser only",
+			prov:  &genreBrowserProvider{},
+			modes: []provider.BrowseMode{provider.BrowseGenres},
+		},
+		{
+			name:  "no browse capability at all",
+			prov:  &commandsTestProvider{},
+			modes: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := Model{navBrowser: navBrowserState{prov: tc.prov}}
+			menu := m.navMenuItems()
+			if len(menu) != len(tc.modes) {
+				t.Fatalf("nav menu = %+v, want %d entries", menu, len(tc.modes))
+			}
+			for i, want := range tc.modes {
+				if menu[i].mode != want {
+					t.Errorf("menu[%d].mode = %v, want %v", i, menu[i].mode, want)
+				}
+			}
+		})
+	}
+}
+
+func TestGenreLabelerRenamesTheCategoryLevel(t *testing.T) {
+	m := Model{navBrowser: navBrowserState{prov: &placeBrowserProvider{}}}
+	if got := m.navLabels().genresTitle(); got != "Countries" {
+		t.Errorf("genresTitle() = %q, want Countries", got)
+	}
+	menu := m.navMenuItems()
+	if len(menu) != 1 || menu[0].label != "Countries" {
+		t.Fatalf("nav menu = %+v, want a single Countries row", menu)
+	}
+}
+
+// placeBrowserProvider browses places rather than genres, the way the radio
+// directory does.
+type placeBrowserProvider struct {
+	genreBrowserProvider
+}
+
+func (p *placeBrowserProvider) GenreLabel() string { return "Countries" }
+
+var _ provider.GenreLabeler = (*placeBrowserProvider)(nil)
 
 func TestGenreBrowseEntriesAreUniqueAndGenreOnlyProvidersCanBrowse(t *testing.T) {
 	p := &genreBrowserProvider{}

--- a/ui/model/inline_overlays_nav.go
+++ b/ui/model/inline_overlays_nav.go
@@ -142,14 +142,15 @@ func (m Model) renderNavBody() string {
 	case navViewTracks:
 		return m.renderNavTrackBody(budget)
 	case navViewGenres:
+		genres := m.navLabels().genresLower()
 		if m.navBrowser.loading && len(m.navBrowser.genres) == 0 {
-			return bodyLines([]string{loadingLine("Loading genres…")}, budget)
+			return bodyLines([]string{loadingLine("Loading " + genres + "…")}, budget)
 		}
 		if m.navBrowser.search != "" && len(m.navBrowser.searchIdx) == 0 {
 			return bodyMessage("No matches.", budget)
 		}
 		if len(m.navBrowser.genres) == 0 {
-			return bodyMessage("No genres found.", budget)
+			return bodyMessage("No "+genres+" found.", budget)
 		}
 		items := m.navScrollItems(len(m.navBrowser.genres), func(i int) string {
 			genre := m.navBrowser.genres[i]
@@ -166,7 +167,7 @@ func (m Model) renderNavBody() string {
 		return strings.Join(items, "\n")
 	case navViewGenreSorts:
 		if len(m.navBrowser.genreSorts) == 0 {
-			return bodyMessage("No genre views found.", budget)
+			return bodyMessage("No views found.", budget)
 		}
 		items := m.navScrollItems(len(m.navBrowser.genreSorts), func(i int) string {
 			return truncate(m.navBrowser.genreSorts[i].Label, ui.PanelWidth-6)

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -108,20 +108,22 @@ func (m *Model) providerRowsFromScroll(scroll, cursor int) int {
 
 	rows := 0
 	sl, isRadio := m.provider.(provider.SectionedList)
+	// Must resolve the same heading the renderer does, or the two disagree on
+	// how many rows a window holds and the cursor scrolls out of view.
+	headerAt := func(i int) string {
+		if isRadio {
+			return m.providerSectionTitle(sl.IDPrefix(m.providerLists[i].ID))
+		}
+		return m.providerLists[i].Section
+	}
+
 	prevHeader := ""
 	if scroll > 0 {
-		if isRadio {
-			prevHeader = sl.IDPrefix(m.providerLists[scroll-1].ID)
-		} else {
-			prevHeader = m.providerLists[scroll-1].Section
-		}
+		prevHeader = headerAt(scroll - 1)
 	}
 
 	for i := scroll; i <= cursor && i < total; i++ {
-		header := m.providerLists[i].Section
-		if isRadio {
-			header = sl.IDPrefix(m.providerLists[i].ID)
-		}
+		header := headerAt(i)
 		if header != "" && header != prevHeader {
 			rows++ // section header row
 		}
@@ -341,6 +343,21 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 	}
 
 	if m.focus == focusProvider {
+		// The location question owns the keyboard until it is answered: it is
+		// a yes/no about the listener's own data, so it must not be dismissed
+		// by a stray key that happens to mean something else in this pane.
+		if m.provAskLoc {
+			switch msg.String() {
+			case "y", "Y", "enter":
+				return m.answerLocationPrompt(true)
+			case "n", "N", "esc":
+				return m.answerLocationPrompt(false)
+			case "ctrl+c":
+				return m.quit()
+			}
+			return nil
+		}
+
 		switch msg.String() {
 		case "q", "ctrl+c":
 			return m.quit()

--- a/ui/model/keys_nav.go
+++ b/ui/model/keys_nav.go
@@ -81,15 +81,23 @@ type navMenuItem struct {
 	mode  provider.BrowseMode
 }
 
+// navMenuItems lists only the routes the browsed provider can actually serve.
+// Offering a level the provider does not implement is not a harmless extra
+// row: selecting it closes the browser with no explanation.
 func (m Model) navMenuItems() []navMenuItem {
 	labels := m.navLabels()
-	items := []navMenuItem{
-		{label: "By " + labels.album, mode: provider.BrowseAlbums},
-		{label: "By " + labels.artist, mode: provider.BrowseArtists},
-		{label: "By " + labels.artist + " / " + labels.album, mode: provider.BrowseArtistAlbums},
+	var items []navMenuItem
+	if _, ok := m.navBrowser.prov.(provider.AlbumBrowser); ok {
+		items = append(items, navMenuItem{label: "By " + labels.album, mode: provider.BrowseAlbums})
+	}
+	if _, ok := m.navBrowser.prov.(provider.ArtistBrowser); ok {
+		items = append(items,
+			navMenuItem{label: "By " + labels.artist, mode: provider.BrowseArtists},
+			navMenuItem{label: "By " + labels.artist + " / " + labels.album, mode: provider.BrowseArtistAlbums},
+		)
 	}
 	if _, ok := m.navBrowser.prov.(provider.GenreBrowser); ok {
-		items = append(items, navMenuItem{label: "Genres", mode: provider.BrowseGenres})
+		items = append(items, navMenuItem{label: labels.genresTitle(), mode: provider.BrowseGenres})
 	}
 	return items
 }

--- a/ui/model/keys_radio.go
+++ b/ui/model/keys_radio.go
@@ -26,6 +26,34 @@ func (m *Model) maybeLoadCatalogBatch() tea.Cmd {
 	return nil
 }
 
+// answerLocationPrompt records the listener's answer to the location question
+// and refreshes the pane, where the offer row is replaced by their country.
+func (m *Model) answerLocationPrompt(allowed bool) tea.Cmd {
+	m.provAskLoc = false
+	consenter, ok := m.provider.(provider.LocationConsenter)
+	if !ok {
+		return nil
+	}
+
+	place, err := consenter.SetLocationConsent(allowed)
+	if err != nil {
+		// The answer holds for this run even when it could not be written.
+		m.status.Errorf(statusTTLDefault, "Could not save the choice: %s", err)
+	}
+	switch {
+	case !allowed:
+		m.status.Show("Location off. Pin countries with f in Countries.", statusTTLLong)
+	case place == "":
+		m.status.Warning("Could not tell which country you are in. Pin countries with f in Countries.", statusTTLLong)
+	default:
+		m.status.Showf(statusTTLMedium, "Nearby radio: %s", place)
+	}
+
+	// The offer row is gone and, on a yes, a country row has taken its place.
+	m.provLoading = true
+	return m.fetchProviderPlaylists()
+}
+
 // toggleProviderFavorite toggles favorite status for the current entry in the
 // provider list (only works for providers implementing FavoriteToggler + SectionedList).
 func (m *Model) toggleProviderFavorite() tea.Cmd {

--- a/ui/model/location_consent_test.go
+++ b/ui/model/location_consent_test.go
@@ -1,0 +1,187 @@
+package model
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/bjarneo/cliamp/playlist"
+	"github.com/bjarneo/cliamp/provider"
+)
+
+// locationProvider is a radio-shaped provider: a Countries section whose first
+// row offers to work out where the listener is.
+type locationProvider struct {
+	asking   bool
+	detected string
+	consent  *bool
+	err      error
+}
+
+const testConsentID = "loc:ask"
+
+func (p *locationProvider) Name() string { return "Radio" }
+
+func (p *locationProvider) Playlists() ([]playlist.PlaylistInfo, error) {
+	var lists []playlist.PlaylistInfo
+	if p.asking {
+		lists = append(lists, playlist.PlaylistInfo{ID: testConsentID, Name: "Use my location"})
+	}
+	if p.consent != nil && *p.consent && p.detected != "" {
+		lists = append(lists, playlist.PlaylistInfo{ID: "p:0", Name: p.detected + " (near you)"})
+	}
+	return append(lists, playlist.PlaylistInfo{ID: "l:0", Name: "cliamp radio"}), nil
+}
+
+func (p *locationProvider) Tracks(id string) ([]playlist.Track, error) {
+	if id == testConsentID {
+		panic("Tracks must never be called for the location row")
+	}
+	return nil, nil
+}
+
+func (p *locationProvider) NeedsLocationConsent() bool { return p.asking }
+func (p *locationProvider) LocationPrompt() string     { return "Use your location?" }
+
+func (p *locationProvider) LocationConsentID() string {
+	if !p.asking {
+		return ""
+	}
+	return testConsentID
+}
+
+func (p *locationProvider) SetLocationConsent(allowed bool) (string, error) {
+	p.asking = false
+	p.consent = &allowed
+	if !allowed {
+		return "", p.err
+	}
+	return p.detected, p.err
+}
+
+var (
+	_ playlist.Provider          = (*locationProvider)(nil)
+	_ provider.LocationConsenter = (*locationProvider)(nil)
+)
+
+func newLocationModel(p *locationProvider) Model {
+	m := Model{provider: p, playlist: playlist.New(), plVisible: 10, focus: focusProvider}
+	lists, _ := p.Playlists()
+	m.providerLists = providerListsWithBrowse(p, lists)
+	return m
+}
+
+// Selecting the offer row must ask, and must not load anything or work out
+// where the listener is on the way.
+func TestSelectingTheLocationRowAsksFirst(t *testing.T) {
+	p := &locationProvider{asking: true, detected: "Norway"}
+	m := newLocationModel(p)
+
+	if got := m.providerLists[0].ID; got != testConsentID {
+		t.Fatalf("first row = %q, want the location offer", got)
+	}
+	if cmd := m.openProviderList(0); cmd != nil {
+		t.Error("selecting the offer should ask, not fetch")
+	}
+	if !m.provAskLoc {
+		t.Fatal("the location question was not raised")
+	}
+	if p.consent != nil {
+		t.Error("consent was recorded before the listener answered")
+	}
+	if m.provLoading {
+		t.Error("a load was started for a row that is a question")
+	}
+}
+
+func TestLocationPromptAnsweredYes(t *testing.T) {
+	p := &locationProvider{asking: true, detected: "Norway"}
+	m := newLocationModel(p)
+	m.openProviderList(0)
+
+	if cmd := m.answerLocationPrompt(true); cmd == nil {
+		t.Error("agreeing should refresh the pane")
+	}
+	if m.provAskLoc {
+		t.Error("the question is still on screen")
+	}
+	if p.consent == nil || !*p.consent {
+		t.Fatalf("consent = %v, want true", p.consent)
+	}
+	// The offer is spent: it must not come back on the next render.
+	if p.LocationConsentID() != "" {
+		t.Error("the offer row is still being advertised")
+	}
+}
+
+func TestLocationPromptAnsweredNo(t *testing.T) {
+	p := &locationProvider{asking: true, detected: "Norway"}
+	m := newLocationModel(p)
+	m.openProviderList(0)
+
+	m.answerLocationPrompt(false)
+
+	if m.provAskLoc {
+		t.Error("the question is still on screen")
+	}
+	if p.consent == nil || *p.consent {
+		t.Fatalf("consent = %v, want false", p.consent)
+	}
+	if p.LocationConsentID() != "" {
+		t.Error("declining should retire the offer, not repeat it")
+	}
+}
+
+// The question owns the keyboard while it is up: keys that mean something else
+// in this pane must not dismiss it by accident.
+func TestLocationPromptKeys(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		key          tea.KeyPressMsg
+		wantAnswer   *bool
+		wantOnScreen bool
+	}{
+		{name: "y", key: tea.KeyPressMsg{Text: "y"}, wantAnswer: ptr(true)},
+		{name: "Y", key: tea.KeyPressMsg{Text: "Y"}, wantAnswer: ptr(true)},
+		{name: "enter", key: tea.KeyPressMsg{Code: tea.KeyEnter}, wantAnswer: ptr(true)},
+		{name: "n", key: tea.KeyPressMsg{Text: "n"}, wantAnswer: ptr(false)},
+		{name: "N", key: tea.KeyPressMsg{Text: "N"}, wantAnswer: ptr(false)},
+		{name: "esc", key: tea.KeyPressMsg{Code: tea.KeyEscape}, wantAnswer: ptr(false)},
+		{name: "j scrolls elsewhere", key: tea.KeyPressMsg{Text: "j"}, wantOnScreen: true},
+		{name: "f favorites elsewhere", key: tea.KeyPressMsg{Text: "f"}, wantOnScreen: true},
+		{name: "slash searches elsewhere", key: tea.KeyPressMsg{Text: "/"}, wantOnScreen: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &locationProvider{asking: true, detected: "Norway"}
+			m := newLocationModel(p)
+			m.openProviderList(0)
+
+			m.handleKey(tc.key)
+
+			switch {
+			case tc.wantAnswer == nil && p.consent != nil:
+				t.Errorf("%s answered the question with %v", tc.name, *p.consent)
+			case tc.wantAnswer != nil && p.consent == nil:
+				t.Errorf("%s did not answer the question", tc.name)
+			case tc.wantAnswer != nil && *p.consent != *tc.wantAnswer:
+				t.Errorf("%s answered %v, want %v", tc.name, *p.consent, *tc.wantAnswer)
+			}
+			if m.provAskLoc != tc.wantOnScreen {
+				t.Errorf("%s left the question on screen = %v, want %v", tc.name, m.provAskLoc, tc.wantOnScreen)
+			}
+		})
+	}
+}
+
+// A provider that never offers the row is untouched by any of this.
+func TestProviderWithoutLocationConsentIsUnaffected(t *testing.T) {
+	m := Model{provider: &commandsTestProvider{}, playlist: playlist.New(), focus: focusProvider}
+	if cmd := m.answerLocationPrompt(true); cmd != nil {
+		t.Error("answering should be inert for a provider that never asked")
+	}
+	if m.provAskLoc {
+		t.Error("no question should be on screen")
+	}
+}
+
+func ptr[T any](v T) *T { return &v }

--- a/ui/model/model.go
+++ b/ui/model/model.go
@@ -267,6 +267,7 @@ type Model struct {
 	provScroll    int
 	provLoading   bool
 	provSignIn    bool            // true when provider needs interactive sign-in
+	provAskLoc    bool            // true while the location question is on screen
 	provAuthURL   string          // OAuth URL to display while interactive auth is in flight
 	providers     []ProviderEntry // all available providers
 	provPillIdx   int             // selected pill index

--- a/ui/model/nav_labels.go
+++ b/ui/model/nav_labels.go
@@ -6,19 +6,25 @@ import (
 	"github.com/bjarneo/cliamp/provider"
 )
 
-// navLabels holds the vocabulary the browse overlay uses for the two catalog
+// navLabels holds the vocabulary the browse overlay uses for the catalog
 // levels. Music providers keep the defaults; others supply their own via
-// provider.BrowseLabeler.
+// provider.BrowseLabeler and provider.GenreLabeler.
 type navLabels struct {
 	artist string
 	album  string
+	genre  string
 }
 
 func (m Model) navLabels() navLabels {
-	l := navLabels{artist: "Artist", album: "Album"}
+	l := navLabels{artist: "Artist", album: "Album", genre: "Genres"}
 	if bl, ok := m.navBrowser.prov.(provider.BrowseLabeler); ok {
 		if artist, album := bl.BrowseLabels(); artist != "" && album != "" {
 			l.artist, l.album = artist, album
+		}
+	}
+	if gl, ok := m.navBrowser.prov.(provider.GenreLabeler); ok {
+		if genre := gl.GenreLabel(); genre != "" {
+			l.genre = genre
 		}
 	}
 	return l
@@ -31,3 +37,8 @@ func (l navLabels) albumsTitle() string { return l.album + "s" }
 func (l navLabels) artistsLower() string { return strings.ToLower(l.artistsTitle()) }
 
 func (l navLabels) albumsLower() string { return strings.ToLower(l.albumsTitle()) }
+
+// genresTitle is already plural: providers name the level, not one item.
+func (l navLabels) genresTitle() string { return l.genre }
+
+func (l navLabels) genresLower() string { return strings.ToLower(l.genre) }

--- a/ui/model/providers.go
+++ b/ui/model/providers.go
@@ -367,6 +367,15 @@ func (m *Model) openProviderList(index int) tea.Cmd {
 		return nil
 	}
 	item := m.providerLists[index]
+	// The location offer is a question, not a list. Selecting it raises the
+	// question; nothing about the listener's location is worked out until they
+	// answer it.
+	if consenter, ok := m.provider.(provider.LocationConsenter); ok {
+		if id := consenter.LocationConsentID(); id != "" && id == item.ID {
+			m.provAskLoc = true
+			return nil
+		}
+	}
 	if entry, ok := providerBrowseEntryForID(m.provider, item.ID); ok {
 		m.activeProviderPlaylistID = ""
 		cmd := m.openNavBrowserEntry(m.provider, entry)

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -740,6 +740,9 @@ func (m Model) renderProviderList() string {
 		}
 		return strings.Join(lines, "\n")
 	}
+	if m.provAskLoc {
+		return m.renderLocationPrompt(visibleBudget)
+	}
 	if len(m.providerLists) == 0 {
 		return m.renderProviderEmptyState(visibleBudget)
 	}
@@ -794,9 +797,12 @@ func (m Model) renderProviderList() string {
 			scroll = m.provCursor - visibleBudget + 1
 		}
 
-		prevPrefix := ""
+		// Headers are deduplicated on the resolved title, not the ID prefix:
+		// distinct prefixes can share one heading (the country browse shortcut
+		// sits under the same "Countries" heading as the pinned places).
+		prevTitle := ""
 		if isRadio && scroll > 0 {
-			prevPrefix = sl.IDPrefix(m.providerLists[scroll-1].ID)
+			prevTitle = m.providerSectionTitle(sl.IDPrefix(m.providerLists[scroll-1].ID))
 		}
 		prevSection := ""
 		if hasSections && scroll > 0 {
@@ -807,21 +813,12 @@ func (m Model) renderProviderList() string {
 			p := m.providerLists[j]
 
 			if isRadio {
-				pfx := sl.IDPrefix(p.ID)
-				if pfx != prevPrefix {
-					var header string
-					switch pfx {
-					case "f":
-						header = labeledSeparator("  ", "Favorites")
-					case "c":
-						header = labeledSeparator("  ", "Catalog")
-					case "s":
-						header = labeledSeparator("  ", "Search Results")
+				title := m.providerSectionTitle(sl.IDPrefix(p.ID))
+				if title != prevTitle {
+					if title != "" && len(lines) < visibleBudget {
+						lines = append(lines, dimStyle.Render(labeledSeparator("  ", title)))
 					}
-					if header != "" && len(lines) < visibleBudget {
-						lines = append(lines, dimStyle.Render(header))
-					}
-					prevPrefix = pfx
+					prevTitle = title
 				}
 			} else if hasSections && p.Section != prevSection {
 				header := labeledSeparator("  ", p.Section)
@@ -846,6 +843,37 @@ func (m Model) renderProviderList() string {
 	}
 
 	return strings.Join(fitLines(lines, visibleBudget), "\n")
+}
+
+// renderLocationPrompt puts the provider's location question to the listener.
+// The wording comes from the provider, which is the only thing that knows what
+// it would do with the answer and where the location would come from.
+func (m Model) renderLocationPrompt(budget int) string {
+	question := "Use your location?"
+	if consenter, ok := m.provider.(provider.LocationConsenter); ok {
+		if prompt := consenter.LocationPrompt(); prompt != "" {
+			question = prompt
+		}
+	}
+
+	lines := []string{""}
+	for _, line := range wrapText(question, ui.PanelWidth-6) {
+		lines = append(lines, "  "+line)
+	}
+	lines = append(lines, "", playlistSelectedStyle.Render("  y  Yes"), dimStyle.Render("  n  No, don't"))
+	return strings.Join(fitLines(lines, budget), "\n")
+}
+
+// providerSectionTitle names a SectionedList pane section. The provider owns
+// the wording: only it knows what its ID prefixes mean, and only it knows the
+// live state a heading may need to carry, such as the radio catalog's active
+// country filter. A provider that supplies no title gets no heading.
+func (m Model) providerSectionTitle(prefix string) string {
+	titler, ok := m.provider.(provider.SectionTitler)
+	if !ok {
+		return ""
+	}
+	return titler.SectionTitle(prefix)
 }
 
 func (m Model) renderPlaylist() string {

--- a/ui/model/view_helpers.go
+++ b/ui/model/view_helpers.go
@@ -125,6 +125,33 @@ func truncate(s string, maxW int) string {
 	return ansi.Truncate(s, maxW, "…")
 }
 
+// wrapText breaks s into lines no wider than maxW, splitting on spaces.
+// Widths are measured with lipgloss so wide glyphs and accents count once.
+// A single word longer than maxW is truncated rather than left to overflow
+// the panel.
+func wrapText(s string, maxW int) []string {
+	if maxW <= 0 {
+		return nil
+	}
+	var lines []string
+	line := ""
+	for _, word := range strings.Fields(s) {
+		switch {
+		case line == "":
+			line = word
+		case lipgloss.Width(line)+1+lipgloss.Width(word) <= maxW:
+			line += " " + word
+		default:
+			lines = append(lines, truncate(line, maxW))
+			line = word
+		}
+	}
+	if line != "" {
+		lines = append(lines, truncate(line, maxW))
+	}
+	return lines
+}
+
 // cursorLine renders a list item with "> " prefix when active, "  " otherwise.
 func cursorLine(label string, active bool) string {
 	if active {

--- a/ui/model/view_nav.go
+++ b/ui/model/view_nav.go
@@ -62,7 +62,7 @@ func (m Model) navBreadcrumb() string {
 				parts = append(parts, m.navBrowser.selAlbum.Name)
 			}
 		case navBrowseModeByGenre:
-			parts = append(parts, "Genres")
+			parts = append(parts, labels.genresTitle())
 			if m.navBrowser.selGenre.Name != "" {
 				parts = append(parts, m.navBrowser.selGenre.Name)
 			}
@@ -72,12 +72,12 @@ func (m Model) navBreadcrumb() string {
 		}
 		parts = append(parts, "Tracks")
 	case navViewGenres:
-		parts = append(parts, "Genres")
+		parts = append(parts, labels.genresTitle())
 		if m.navBrowser.genreQuery != "" {
 			parts = append(parts, "Search: "+m.navBrowser.genreQuery)
 		}
 	case navViewGenreSorts:
-		parts = append(parts, "Genres")
+		parts = append(parts, labels.genresTitle())
 		if m.navBrowser.selGenre.Name != "" {
 			parts = append(parts, m.navBrowser.selGenre.Name)
 		}


### PR DESCRIPTION
The Radio Browser directory holds about 58,000 stations across 241 countries. A flat top-voted list is not a way to find anything in it, so add location as the axis to cut it down by.

Countries are modelled as provider.GenreBrowser, which reuses the browse overlay wholesale: its / filter, its f toggle, and its sort submenu all work with no new UI. "Browse all countries" in the radio pane lists every country grouped by region with station counts, preceded by the regions of your own country when it is known. Picking one loads up to 200 of its stations as a playlist, ordered by votes, clicks, trend, name, or random, so next and previous scan between stations of one place.

f pins a country or region. Pinned places get their own row in the pane and persist to radio_countries.toml.

Location is opt-in and asked for, never assumed. A fresh install works out nobody's country: the pane offers a "Use my location" row, and only if you accept does it read the country from the system timezone, then the locale. Detection lives behind that one call and nowhere else. The answer is written to [radio] country either way, so the question is asked once; delete the line to be asked again, or set it to "none" up front. There is deliberately no geo-IP lookup, which would be more precise and would also mean telling a third party where you live every launch.

Location is expressed as a country, not a radius, because that is what the directory's data supports. Measured over 1000 top stations: countrycode is present on 98.7%, state on 44.4%, and coordinates on only 11.9%. The API also ignores every distance ordering it is offered, so a radius search would hide most of the catalog and return the rest unsorted. Regions are fetched for the home country alone, where 44% coverage still earns its request.

geodata.go is generated from tzdata's zone.tab and iso3166.tab by geodata_gen.go, giving timezone-to-country, country-to-region, and country names with no network call and no new dependency.

Also fixes the browse menu offering routes a provider cannot serve: navMenuItems listed "By Album" and "By Artist" unconditionally, and selecting one on a provider that implements neither closed the browser with no explanation.

## Summary

<!-- What does this PR do and why? -->

## Screenshots / video

<!-- Drag-and-drop screenshots or a short screen recording for UI changes. -->

## How to test

1.

## Checklist

- [ ] `make check` passes
- [ ] `docs/` and `site/index.html` updated for user-facing changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browse approximately 58,000 radio stations by country and region.
  * Pin favorite countries or regions for quick access.
  * Load a selected country or region as a playlist.
  * Optionally use the system timezone to suggest a home country, with explicit consent.
  * Configure and persist the preferred radio country.
  * View improved station, country, region, and genre labels.

* **Documentation**
  * Added comprehensive radio and configuration guidance.
  * Updated keybindings and station-directory information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->