### PR TITLE
fix(ui): keep footer a single row so status notifications don't shift the layout

### DIFF
--- a/ui/model/layout.go
+++ b/ui/model/layout.go
@@ -48,7 +48,7 @@ func (m *Model) recomputeLayout() {
 		panelWidth: max(1, width-2*paddingH),
 		paddingH:   paddingH,
 		paddingV:   paddingV,
-		footerRows: 1,
+		footerRows: 2,
 	}
 	switch {
 	case width < 40 || height < 10:

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -271,13 +271,7 @@ func (m Model) mainSections(playlist string, includeTransient, contentFirst bool
 	if !m.hideHelpBar {
 		sections = append(sections, m.renderTierHelp())
 	}
-	sections = append(sections, m.renderBottomStatus())
-
-	if includeTransient {
-		if line := m.renderTransient(); line != "" {
-			sections = append(sections, line)
-		}
-	}
+	sections = append(sections, m.renderFooterStatus())
 
 	return trimTrailingEmpty(sections)
 }
@@ -1098,4 +1092,15 @@ func (m Model) renderBottomStatus() string {
 		return left
 	}
 	return left + strings.Repeat(" ", gap) + right
+}
+
+// renderFooterStatus renders the single always-present footer row. An active
+// transient (error, save activity, status notification, last log line)
+// replaces the speed/network status so the frame height never changes when a
+// notification appears or expires.
+func (m Model) renderFooterStatus() string {
+	if line := m.renderTransient(); line != "" {
+		return line
+	}
+	return m.renderBottomStatus()
 }

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -203,9 +203,7 @@ func (m Model) mainSections(playlist string, includeTransient, contentFirst bool
 			m.renderSeekBar(),
 		}
 		if includeTransient {
-			if line := m.renderTransient(); line != "" {
-				sections = append(sections, line)
-			}
+			sections = append(sections, m.renderFooter()...)
 		}
 		return sections
 	}
@@ -267,11 +265,12 @@ func (m Model) mainSections(playlist string, includeTransient, contentFirst bool
 	if playlist != "" {
 		sections = append(sections, playlist)
 	}
-	sections = append(sections, "")
 	if !m.hideHelpBar {
 		sections = append(sections, m.renderTierHelp())
 	}
-	sections = append(sections, m.renderFooterStatus())
+	if includeTransient {
+		sections = append(sections, m.renderFooter()...)
+	}
 
 	return trimTrailingEmpty(sections)
 }
@@ -1094,13 +1093,15 @@ func (m Model) renderBottomStatus() string {
 	return left + strings.Repeat(" ", gap) + right
 }
 
-// renderFooterStatus renders the single always-present footer row. An active
-// transient (error, save activity, status notification, last log line)
-// replaces the speed/network status so the frame height never changes when a
-// notification appears or expires.
-func (m Model) renderFooterStatus() string {
-	if line := m.renderTransient(); line != "" {
-		return line
+// renderFooter returns the two fixed footer rows: the bottom status line
+// (speed + network/stream stats, always visible) followed by a notification
+// row. The notification row is rendered on every frame — blank when idle —
+// so the frame height never changes when a transient error, save activity,
+// status message, or log line appears or expires.
+func (m Model) renderFooter() []string {
+	transient := m.renderTransient()
+	if transient == "" {
+		transient = strings.Repeat(" ", m.layout.panelWidth)
 	}
-	return m.renderBottomStatus()
+	return []string{m.renderBottomStatus(), transient}
 }

--- a/ui/model/view_state_test.go
+++ b/ui/model/view_state_test.go
@@ -310,33 +310,44 @@ Line 119: %q (index %d)`, line9, ninthLineTrackIndex, line99, ninetyNinthLineTra
 func TestFooterNotificationDoesNotChangeFrameHeight(t *testing.T) {
 	withFrameWidth(t, 80)
 
-	m := Model{
-		player:   &playbackFakeEngine{},
-		playlist: playlist.New(),
-		focus:    focusPlaylist,
-		layout:   frameLayout{tier: layoutFull, panelWidth: 80},
-	}
+	for _, tc := range []struct {
+		name       string
+		simplified bool
+	}{
+		{name: "full"},
+		{name: "simplified", simplified: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := Model{
+				player:     &playbackFakeEngine{},
+				playlist:   playlist.New(),
+				focus:      focusPlaylist,
+				simplified: tc.simplified,
+				layout:     frameLayout{tier: layoutFull, panelWidth: 80},
+			}
 
-	render := func() string {
-		return strings.Join(m.mainSections("body", true, true), "\n")
-	}
+			render := func() string {
+				return strings.Join(m.mainSections("body", true, true), "\n")
+			}
 
-	idle := render()
-	m.status.Showf(statusTTLDefault, "%s %s", favAddedMark, "Alpha")
-	active := render()
+			idle := render()
+			m.status.Showf(statusTTLDefault, "%s %s", favAddedMark, "Alpha")
+			active := render()
 
-	idleHeight := lipgloss.Height(idle)
-	activeHeight := lipgloss.Height(active)
-	if idleHeight != activeHeight {
-		t.Fatalf("footer notification changed frame height: idle=%d lines, active=%d lines", idleHeight, activeHeight)
-	}
+			idleHeight := lipgloss.Height(idle)
+			activeHeight := lipgloss.Height(active)
+			if idleHeight != activeHeight {
+				t.Fatalf("footer notification changed frame height: idle=%d lines, active=%d lines", idleHeight, activeHeight)
+			}
 
-	idleText := stripAnsi(idle)
-	activeText := stripAnsi(active)
-	if got := strings.LastIndex(activeText, "Alpha"); got < 0 {
-		t.Fatalf("active footer = %q, want favorite notification text", activeText)
-	}
-	if strings.Contains(idleText, "Alpha") {
-		t.Fatalf("idle footer = %q, must not show notification", idleText)
+			idleText := stripAnsi(idle)
+			activeText := stripAnsi(active)
+			if got := strings.LastIndex(activeText, "Alpha"); got < 0 {
+				t.Fatalf("active footer = %q, want favorite notification text", activeText)
+			}
+			if strings.Contains(idleText, "Alpha") {
+				t.Fatalf("idle footer = %q, must not show notification", idleText)
+			}
+		})
 	}
 }

--- a/ui/model/view_state_test.go
+++ b/ui/model/view_state_test.go
@@ -306,3 +306,37 @@ Line 99: %q (index %d)
 Line 119: %q (index %d)`, line9, ninthLineTrackIndex, line99, ninetyNinthLineTrackIndex, line119, oneHundredNineteenthLineTrackIndex)
 	}
 }
+
+func TestFooterNotificationDoesNotChangeFrameHeight(t *testing.T) {
+	withFrameWidth(t, 80)
+
+	m := Model{
+		player:   &playbackFakeEngine{},
+		playlist: playlist.New(),
+		focus:    focusPlaylist,
+		layout:   frameLayout{tier: layoutFull, panelWidth: 80},
+	}
+
+	render := func() string {
+		return strings.Join(m.mainSections("body", true, true), "\n")
+	}
+
+	idle := render()
+	m.status.Showf(statusTTLDefault, "%s %s", favAddedMark, "Alpha")
+	active := render()
+
+	idleHeight := lipgloss.Height(idle)
+	activeHeight := lipgloss.Height(active)
+	if idleHeight != activeHeight {
+		t.Fatalf("footer notification changed frame height: idle=%d lines, active=%d lines", idleHeight, activeHeight)
+	}
+
+	idleText := stripAnsi(idle)
+	activeText := stripAnsi(active)
+	if got := strings.LastIndex(activeText, "Alpha"); got < 0 {
+		t.Fatalf("active footer = %q, want favorite notification text", activeText)
+	}
+	if strings.Contains(idleText, "Alpha") {
+		t.Fatalf("idle footer = %q, must not show notification", idleText)
+	}
+}


### PR DESCRIPTION
Fixes #408

## What

The transient notification row (favorites, bookmarks, save feedback, errors, log lines) was appended **below** the bottom status line as an extra, conditionally-present row. The layout only budgets one footer row (`footerRows: 1`), so an active notification made the frame one row taller and `centerFrame` re-centered the whole UI up by a row for the notification's TTL (~3s), then back down.

The footer is now a single, always-present row: `renderFooterStatus` shows the transient notification when one is active, otherwise the SPD/network status. Frame height is constant, so notifications no longer shift the layout.

## Changes

- `ui/model/view.go`: `mainSections` renders one footer row via `renderFooterStatus` (replaces `renderBottomStatus` + conditional `renderTransient`).
- `ui/model/view_state_test.go`: `TestFooterNotificationDoesNotChangeFrameHeight` — frame height stable with and without an active notification.

## Verification

- `make check` (gofmt + vet + full test suite) passes.

## Test plan

1. `make check`
2. Launch the TUI, play a track, press `n` to favorite/unfavorite — no vertical jump while the notification is visible or after it expires.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Notifications and status messages now appear in a dedicated footer row without changing the overall interface height.
  - Footer content remains aligned consistently across standard and simplified layouts.
  - Help information is displayed consistently alongside footer status details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->