### PR TITLE
fix(nix): bump nixpkgs for Go 1.26.6 and refresh vendorHash

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787135253,
-        "narHash": "sha256-RD2kNWCG+Bjo6h+JVjWVNntZs2GtRoeY2xHjts/FNkA=",
+        "lastModified": 1788179007,
+        "narHash": "sha256-hn1oU2rue2SYK8dAr8+WNZWtbsz1S2W5mnHlSEuh3bo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
+        "rev": "34ab99075ac4f7e40cf037eef32cb1c360bb85e9",
         "type": "github"
       },
       "original": {

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -18,7 +18,7 @@ buildGoModule {
   inherit version;
 
   src = lib.cleanSource ../.;
-  vendorHash = "sha256-/c2MOMnG8twpr2/9plFanXkJwoIYNwC0mPksTklIcRw=";
+  vendorHash = "sha256-rtwUWbft5XGEbuBCn0OMCn4TS5Ul+UXJNIqNOzXfU+M=";
 
   nativeBuildInputs = [
     makeWrapper


### PR DESCRIPTION
## Summary

`nix build` / `nix run github:bjarneo/cliamp` currently fails:

```
go: go.mod requires go >= 1.26.6 (running go 1.26.5; GOTOOLCHAIN=local)
```

The nixpkgs pinned in `flake.lock` shipped Go 1.26.5 while `go.mod` asked for exactly 1.26.6. Normally Go would download the right toolchain, but the Nix sandbox has no network and sets `GOTOOLCHAIN=local`, so it hard-fails. Once past that, the `vendorHash` was also stale from the last dependency bump, which is the next error.

This bumps `flake.lock` to a nixpkgs with Go 1.26.7 and refreshes the hash. No Go code changes.

Background on why this will recur, and some options for preventing it, in #413.

### Chaining

This is the **base of three related Nix PRs** and is the only one with no dependencies. Please merge it first, since neither of the others can build without it:

1. **this PR** — unblocks the build on Linux
2. #415 — adds aarch64-darwin
3. #416 — fixes silent audio on non-NixOS hosts

Those two are independent of each other. Both branch off this one, so each currently shows this commit in its diff. That disappears when this merges. Whichever of the two goes second needs a trivial rebase, since all three touch `nix/package.nix`.

## Screenshots / video

N/A, packaging only.

## How to test

1. `nix build .#default` on Linux. It fails on `main` with the toolchain error above and succeeds here.
2. `./result/bin/cliamp --version`.

## Checklist

- [x] `make check` passes
- [x] `docs/` and `site/index.html` updated for user-facing changes (N/A, no user-facing change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package dependency integrity information to ensure reliable builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->