### PR TITLE
feat(nix): add aarch64-darwin support to the flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787135253,
-        "narHash": "sha256-RD2kNWCG+Bjo6h+JVjWVNntZs2GtRoeY2xHjts/FNkA=",
+        "lastModified": 1788179007,
+        "narHash": "sha256-hn1oU2rue2SYK8dAr8+WNZWtbsz1S2W5mnHlSEuh3bo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
+        "rev": "34ab99075ac4f7e40cf037eef32cb1c360bb85e9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,11 @@
   outputs =
     { self, nixpkgs }:
     let
+      # x86_64-darwin is intentionally absent: nixpkgs 26.11 (nixos-unstable)
+      # dropped support for it. Intel Macs can still use nix/package.nix via a
+      # nixpkgs-26.05-darwin channel with callPackage.
       systems = [
+        "aarch64-darwin"
         "aarch64-linux"
         "x86_64-linux"
       ];
@@ -47,17 +51,21 @@
         {
           default = pkgs.mkShell {
             name = "cliamp-dev";
-            buildInputs = with pkgs; [
-              go
-              pkg-config
-              alsa-lib
-              flac
-              libogg
-              libvorbis
-              mpg123
-              ffmpeg-headless
-              yt-dlp
-            ];
+            buildInputs =
+              with pkgs;
+              [
+                go
+                pkg-config
+                flac
+                libogg
+                libvorbis
+                mpg123
+                ffmpeg-headless
+                yt-dlp
+              ]
+              ++ lib.optionals stdenv.hostPlatform.isLinux [
+                alsa-lib
+              ];
             shellHook = ''
               echo "🎵 cliamp dev shell loaded"
             '';

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -18,7 +18,7 @@ buildGoModule {
   inherit version;
 
   src = lib.cleanSource ../.;
-  vendorHash = "sha256-/c2MOMnG8twpr2/9plFanXkJwoIYNwC0mPksTklIcRw=";
+  vendorHash = "sha256-rtwUWbft5XGEbuBCn0OMCn4TS5Ul+UXJNIqNOzXfU+M=";
 
   nativeBuildInputs = [
     makeWrapper

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -9,6 +9,7 @@
   makeWrapper,
   mpg123,
   pkg-config,
+  stdenv,
   version ? "dev",
   yt-dlp,
 }:
@@ -26,12 +27,16 @@ buildGoModule {
   ];
 
   buildInputs = [
-    alsa-lib
     flac
     libogg
     libvorbis
     mpg123
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    alsa-lib
   ];
+  # On darwin the CoreAudio/MediaPlayer/AppKit frameworks referenced by the
+  # cgo files come from the Apple SDK that stdenv provides by default.
 
   ldflags = [
     "-s"
@@ -39,12 +44,20 @@ buildGoModule {
     "-X=main.version=${version}"
   ];
 
+  # Many provider tests stand up an httptest server on loopback. The darwin
+  # build sandbox denies that by default, so the check phase dies with
+  # "bind: operation not permitted". This is the standard nixpkgs opt-in for
+  # tests that need loopback; it has no effect on Linux.
+  __darwinAllowLocalNetworking = true;
+
   postInstall = ''
     wrapProgram "$out/bin/cliamp" \
       --prefix PATH : ${lib.makeBinPath [
         ffmpeg-headless
         yt-dlp
       ]}
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
     install -Dm644 Cliamp.png "$out/share/icons/hicolor/512x512/apps/cliamp.png"
     install -Dm644 cliamp.desktop "$out/share/applications/cliamp.desktop"
   '';
@@ -54,6 +67,6 @@ buildGoModule {
     homepage = "https://github.com/bjarneo/cliamp";
     license = lib.licenses.mit;
     mainProgram = "cliamp";
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 }


### PR DESCRIPTION
## Summary

Installing the flake on a Mac fails, because it only declares Linux systems:

```
error: flake does not provide attribute 'packages.aarch64-darwin.default'
```

This adds `aarch64-darwin` and makes the package actually build there:

- `alsa-lib` is Linux-only, so it is gated on `stdenv.hostPlatform.isLinux` in both the package and the dev shell.
- The CoreAudio / MediaPlayer / AppKit frameworks the cgo files reference come from the Apple SDK that stdenv already provides, so nothing extra is needed.
- The `.desktop` file and hicolor icon are only installed on Linux.
- `meta.platforms` becomes linux ++ darwin.
- `__darwinAllowLocalNetworking = true`. Without it the darwin build sandbox denies loopback binds and the check phase dies with `panic: httptest: failed to listen on a port: bind: operation not permitted` in `external/lyrion`. 19 test files stand up an httptest server, so skipping them is not practical. This is the standard nixpkgs opt-in for the situation and has no effect on Linux.

`x86_64-darwin` is deliberately **not** added: nixpkgs 26.11, which `nixos-unstable` now points at, has dropped support for it, and adding it would break evaluation for everyone. `nix/package.nix` still evaluates for Intel Macs via `callPackage` from a nixpkgs-26.05 tree.

### Chaining

One of **three related Nix PRs**. This one depends on the base:

1. #414 — Go toolchain / vendorHash. **Merge first**, nothing builds without it.
2. **this PR** — aarch64-darwin
3. #416 — silent audio on non-NixOS hosts

This branches off the base, so its commit shows in the diff here and will drop out once it merges. This PR and the ALSA one are independent of each other and can go in either order, but both touch `nix/package.nix`, so the second one will need a small rebase.

## Screenshots / video

N/A, packaging only.

## How to test

On an Apple Silicon Mac:

1. `nix run github:bjarneo/cliamp` (or build the branch directly). It fails on `main` with the missing-attribute error and builds here.
2. On Linux, confirm no regression: `nix build .#default` still succeeds and still installs the `.desktop` file and icon.

Verified on aarch64-darwin and x86_64-linux.

## Checklist

- [x] `make check` passes
- [x] `docs/` and `site/index.html` updated for user-facing changes (N/A, no user-facing change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for building and developing on Apple Silicon macOS.
  * Declared package support for both Linux and Darwin platforms.

* **Bug Fixes**
  * Improved cross-platform builds by limiting Linux-specific audio dependencies and assets to Linux.
  * Enabled local networking for tests on Darwin systems.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->