### PR TITLE
fix(nix): ship ALSA pipewire/pulse plugins so audio works on non-NixOS

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787135253,
-        "narHash": "sha256-RD2kNWCG+Bjo6h+JVjWVNntZs2GtRoeY2xHjts/FNkA=",
+        "lastModified": 1788179007,
+        "narHash": "sha256-hn1oU2rue2SYK8dAr8+WNZWtbsz1S2W5mnHlSEuh3bo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
+        "rev": "34ab99075ac4f7e40cf037eef32cb1c360bb85e9",
         "type": "github"
       },
       "original": {

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -18,7 +18,7 @@ buildGoModule {
   inherit version;
 
   src = lib.cleanSource ../.;
-  vendorHash = "sha256-/c2MOMnG8twpr2/9plFanXkJwoIYNwC0mPksTklIcRw=";
+  vendorHash = "sha256-rtwUWbft5XGEbuBCn0OMCn4TS5Ul+UXJNIqNOzXfU+M=";
 
   nativeBuildInputs = [
     makeWrapper

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,5 +1,6 @@
 {
   alsa-lib,
+  alsa-plugins,
   buildGoModule,
   ffmpeg-headless,
   flac,
@@ -8,10 +9,28 @@
   libvorbis,
   makeWrapper,
   mpg123,
+  pipewire,
   pkg-config,
+  symlinkJoin,
   version ? "dev",
   yt-dlp,
 }:
+
+let
+  # The audio backend talks to ALSA, and on PipeWire/PulseAudio systems the
+  # host's /etc/alsa/conf.d routes the default device through a plugin named
+  # by bare filename ("libasound_module_pcm_pipewire.so"). Nix's libasound only
+  # searches its own store path for plugins, so on non-NixOS hosts that lookup
+  # fails and cliamp plays into silence. Ship both plugins and point libasound
+  # at them.
+  alsaPluginDir = symlinkJoin {
+    name = "cliamp-alsa-plugins";
+    paths = [
+      "${alsa-plugins}/lib/alsa-lib"
+      "${pipewire}/lib/alsa-lib"
+    ];
+  };
+in
 
 buildGoModule {
   pname = "cliamp";
@@ -44,7 +63,8 @@ buildGoModule {
       --prefix PATH : ${lib.makeBinPath [
         ffmpeg-headless
         yt-dlp
-      ]}
+      ]} \
+      --set-default ALSA_PLUGIN_DIR ${alsaPluginDir}
     install -Dm644 Cliamp.png "$out/share/icons/hicolor/512x512/apps/cliamp.png"
     install -Dm644 cliamp.desktop "$out/share/applications/cliamp.desktop"
   '';


### PR DESCRIPTION
## Summary

Installing the flake on Ubuntu produces **silent playback**. cliamp reports `playing` and the position advances, but nothing reaches the sound server. On stderr:

```
ALSA lib dlmisc.c:339:(snd_dlobj_cache_get0) Cannot open shared library
libasound_module_pcm_pipewire.so (/nix/store/...-alsa-lib/lib/alsa-lib/
libasound_module_pcm_pipewire.so: No such file or directory)
```

Nix's libasound honours the host's `/etc/alsa/conf.d`, where `pipewire-alsa` (or `pulseaudio-alsa`) routes `pcm.default` through a plugin referenced by bare filename. libasound only searches its own store path for plugins, and that directory contains none, so opening the default device fails. NixOS avoids this by writing absolute plugin paths into its own conf.d, which is why the package worked there and nowhere else.

The README already tells people to install `pipewire-alsa` / `pulseaudio-alsa`, but that does not help a Nix install: the distro's plugin is not in the store path the Nix-built libasound searches.

Fix: build a `symlinkJoin` of the pipewire and alsa-plugins (pulse) ALSA modules and point `ALSA_PLUGIN_DIR` at it in the wrapper. `--set-default` keeps any value the user already exported. Both plugins speak stable wire protocols to the host's daemon, so the nixpkgs version does not need to match the host's, the same reason this works for Flatpak. The pipewire module is included rather than pulse alone, because device switching relies on `PIPEWIRE_NODE`.

One trade-off worth flagging: the closure grows from **719 MiB to 940 MiB**, since pipewire's runtime dependencies come along. Happy to put it behind an `alsaPlugins ? true` argument if you would rather people opt in, though the default-on version is what makes a plain `nix profile install` work.

### Chaining

One of **three related Nix PRs**. This one depends on the base:

1. #414 — Go toolchain / vendorHash. **Merge first**, nothing builds without it.
2. #415 — aarch64-darwin support
3. **this PR** — silent audio on non-NixOS hosts

This branches off the base, so its commit shows in the diff here and will drop out once it merges. This PR and the darwin one are independent of each other and can go in either order, but both touch `nix/package.nix`, so the second one will need a small rebase.

## Screenshots / video

N/A, packaging only. The symptom is the absence of sound, which does not screenshot well.

## How to test

On a PipeWire or PulseAudio Linux host that is **not** NixOS:

1. `nix profile install github:bjarneo/cliamp` and play any local file. On `main` it reports `playing` in silence, with the ALSA error above on stderr.
2. Same on this branch: audio plays and stderr is clean.

To reproduce on NixOS, point `ALSA_CONFIG_PATH` at a config that resolves the plugin by bare name the way a distro's `pipewire-alsa` does. The error appears without the wrapper flag and disappears with it. That is how this was verified here, alongside a normal NixOS run to confirm no regression.

## Checklist

- [x] `make check` passes
- [x] `docs/` and `site/index.html` updated for user-facing changes (N/A, no user-facing change; the README troubleshooting entry stays correct for non-Nix installs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio plugin discovery when running the Nix package on non-NixOS systems.
  * Enabled reliable PipeWire and PulseAudio integration for ALSA-based audio output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->