### PR TITLE
feat(ui): use filled/outline star markers like cliamp-mobile

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -76,7 +76,7 @@ and `Esc` clears it.
 | Key | Action |
 |---|---|
 | `f` | Toggle bookmark ★ on the selected track. In the radio browser, favorite the selected station. In the country browser, pin the selected country or region. |
-| `n` | Toggle favorite ♥ on the selected track. Favorited tracks appear in the cross-playlist "Favorites" virtual playlist. |
+| `n` | Toggle favorite ★ on the selected track. Favorited tracks show a filled, theme-colored star (dim outline ☆ when not favorited) and gather in the cross-playlist "Favorites" virtual playlist. |
 | `Ctrl+F` | Search with the active provider (Spotify, Qobuz, Tidal, Navidrome, Lyrion, Jellyfin, Emby, Plex, Audiobookshelf, Mixcloud, NetEase, Local), or search YouTube. Available in playlist and provider-browser views. |
 | `u` | Load URL (stream/playlist) |
 | `y` | Show or close lyrics |

--- a/docs/playlists.md
+++ b/docs/playlists.md
@@ -424,6 +424,7 @@ stores the "Favorites" playlist. Like "Recently Played", it is a virtual
 playlist that you cannot rename, delete, or change in the playlist manager. Use
 `n` again to remove a favorite.
 
-Favorited tracks show a small red `♥` marker in the track list. The bookmark
-system is separate: it uses the `f` key and `★` marker. Bookmarks apply to one
+Favorited tracks show a filled, red star (`★`) in the track list; unfavorited
+rows show a dim outline star (`☆`). The bookmark system is separate: it uses
+the `f` key and a `★` marker in the same column. Bookmarks apply to one
 playlist. Favorites apply to all playlists.

--- a/ui/model/command_registry.go
+++ b/ui/model/command_registry.go
@@ -105,7 +105,7 @@ var commandRegistry = []commandSpec{
 	{Mode: commandModeMain, Keys: []string{"shift+up", "shift+down"}, KeyLabel: "Shift+Up Down", Label: "Move track up/down", Keymap: true},
 	{Mode: commandModeMain, Keys: []string{"h", "l"}, KeyLabel: "h l", Label: "EQ cursor left/right", Keymap: true},
 	{Mode: commandModeMain, Keys: []string{"enter"}, KeyLabel: "Enter", Label: "Play selected track", Keymap: true, ContextHelp: true, Primary: true},
-	{Mode: commandModeMain, Keys: []string{"f", "n"}, KeyLabel: "f/n", Label: "★/" + favHeart, Keymap: true, ContextHelp: true},
+	{Mode: commandModeMain, Keys: []string{"f", "n"}, KeyLabel: "f/n", Label: "★ Bookmark / ★ Favorite", Keymap: true, ContextHelp: true},
 	{Mode: commandModeMain, Keys: []string{"a"}, KeyLabel: "a", Label: "Toggle queue (play next)", Keymap: true, ContextHelp: true},
 	{Mode: commandModeMain, Keys: []string{"A"}, KeyLabel: "A", Label: "Queue manager", Keymap: true},
 	{Mode: commandModeMain, Keys: []string{"x"}, KeyLabel: "x", Label: "Remove selected track from playlist", Destructive: true, Keymap: true},
@@ -221,7 +221,7 @@ var commandRegistry = []commandSpec{
 			return false
 		}
 	}},
-	{Mode: commandModePlaylistManager, Keys: []string{"f", "n"}, KeyLabel: "f/n", Label: "★/" + favHeart, ContextHelp: true, Enabled: func(m Model) bool {
+	{Mode: commandModePlaylistManager, Keys: []string{"f", "n"}, KeyLabel: "f/n", Label: "★ Bookmark / ★ Favorite", ContextHelp: true, Enabled: func(m Model) bool {
 		return m.plManager.visible && m.plManager.screen == plMgrScreenTracks
 	}},
 	{Mode: commandModePlaylistManager, Keys: []string{"[", "]"}, KeyLabel: "[ ]", Label: "Reorder", ContextHelp: true, Enabled: func(m Model) bool {

--- a/ui/model/dirs_screen_test.go
+++ b/ui/model/dirs_screen_test.go
@@ -393,7 +393,7 @@ func TestPlMgrNKeyRemovesRowFromFavoritesScreen(t *testing.T) {
 		t.Fatalf("tracks = %+v, want only /b.mp3", m.plManager.tracks)
 	}
 	if !strings.HasPrefix(m.status.text, favRemovedMark) {
-		t.Fatalf("status = %q, want dimmed heart prefix %q", m.status.text, favRemovedMark)
+		t.Fatalf("status = %q, want dimmed star prefix %q", m.status.text, favRemovedMark)
 	}
 	if cmd == nil {
 		t.Fatal("expected a provider-playlist refresh command")
@@ -888,7 +888,7 @@ func TestNKeyTogglesFavorite(t *testing.T) {
 		t.Fatal("favSet should contain /song.mp3 after toggle")
 	}
 	if !strings.HasPrefix(m.status.text, favAddedMark) {
-		t.Fatalf("status = %q, want red heart prefix %q", m.status.text, favAddedMark)
+		t.Fatalf("status = %q, want red star prefix %q", m.status.text, favAddedMark)
 	}
 
 	// Toggle off.
@@ -902,7 +902,7 @@ func TestNKeyTogglesFavorite(t *testing.T) {
 		}
 	}
 	if !strings.HasPrefix(m.status.text, favRemovedMark) {
-		t.Fatalf("status = %q, want dimmed heart prefix %q", m.status.text, favRemovedMark)
+		t.Fatalf("status = %q, want dimmed star prefix %q", m.status.text, favRemovedMark)
 	}
 }
 

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -271,13 +271,7 @@ func (m Model) mainSections(playlist string, includeTransient, contentFirst bool
 	if !m.hideHelpBar {
 		sections = append(sections, m.renderTierHelp())
 	}
-	sections = append(sections, m.renderBottomStatus())
-
-	if includeTransient {
-		if line := m.renderTransient(); line != "" {
-			sections = append(sections, line)
-		}
-	}
+	sections = append(sections, m.renderFooterStatus())
 
 	return trimTrailingEmpty(sections)
 }
@@ -1098,4 +1092,15 @@ func (m Model) renderBottomStatus() string {
 		return left
 	}
 	return left + strings.Repeat(" ", gap) + right
+}
+
+// renderFooterStatus renders the single always-present footer row. An active
+// transient (error, save activity, status notification, last log line)
+// replaces the speed/network status so the frame height never changes when a
+// notification appears or expires.
+func (m Model) renderFooterStatus() string {
+	if line := m.renderTransient(); line != "" {
+		return line
+	}
+	return m.renderBottomStatus()
 }

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -24,25 +24,30 @@ var (
 	seekDimStyle  = lipgloss.NewStyle().Foreground(ui.ColorDim)
 	volBarStyle   = lipgloss.NewStyle().Foreground(ui.ColorVolume)
 	activeToggle  = lipgloss.NewStyle().Foreground(ui.ColorAccent).Bold(true)
-	// favMarkerStyle paints the favorite heart in the theme's red so it
+	// favMarkerStyle paints the favorite star in the theme's red so it
 	// reads as a deliberate accent instead of inheriting the dim/unavailable
-	// look. The glyph carries U+FE0E (text presentation) so terminals render
-	// it as a compact font glyph rather than a large color emoji.
+	// look. Favorited rows show this filled star.
 	favMarkerStyle = lipgloss.NewStyle().Foreground(ui.ColorError)
-	// favRemovedStyle mutes the same filled heart for unfavorite feedback:
-	// identical attractive glyph, faded to signal the removed state instead
-	// of switching to a thin outline glyph.
+	// favRemovedStyle paints the outline star used for unfavorite feedback
+	// and for tracks that are not favorited, mirroring the tinted outline
+	// star cliamp-mobile shows for non-favorites.
 	favRemovedStyle = lipgloss.NewStyle().Foreground(ui.ColorDim)
 )
 
-// favHeart is the small, text-presentation favorite heart used everywhere the
-// UI shows favorite state (track rows, header badge, status messages).
-const favHeart = "♥\uFE0E"
+// favStar is the filled star used everywhere the UI shows favorite state
+// (track rows, header badge, status messages); favStarOutline is its
+// one-cell outline counterpart. They mirror cliamp-mobile's StarFilled and
+// Star icons: filled with the theme color when favorited, outline and dim
+// when not.
+const (
+	favStar        = "★"
+	favStarOutline = "☆"
+)
 
 // Pre-rendered toggle feedback marks for the status bar.
 var (
-	favAddedMark   = favMarkerStyle.Render(favHeart)
-	favRemovedMark = favRemovedStyle.Render(favHeart)
+	favAddedMark   = favMarkerStyle.Render(favStar)
+	favRemovedMark = favRemovedStyle.Render(favStarOutline)
 )
 
 // providerEmptyStateHint, keyed by lowercase provider Name(), returns the
@@ -697,7 +702,7 @@ func (m Model) renderPlaylistHeader() string {
 	var favStr string
 	// Render from the cached favSet: the render path must not hit disk.
 	if count := len(m.favSet); count > 0 {
-		favStr = " " + activeToggle.Render(fmt.Sprintf("[%s %d]", favHeart, count))
+		favStr = " " + activeToggle.Render(fmt.Sprintf("[%s %d]", favStar, count))
 	}
 
 	var themeStr string
@@ -955,10 +960,13 @@ func (m Model) renderPlaylist() string {
 		if t.Bookmark {
 			bookmarkMarker = "★"
 		}
-		favMarker := " "
+		// Every row shows a star like cliamp-mobile: a dim outline star when
+		// not favorited, and the theme's filled star when favorited. Both
+		// glyphs are one cell wide so rows stay column-aligned.
+		favMarker := favRemovedStyle.Render(favStarOutline)
 		if m.favSet != nil {
 			if _, ok := m.favSet[t.Path]; ok {
-				favMarker = favHeart
+				favMarker = favMarkerStyle.Render(favStar)
 			}
 		}
 		unavailableMarker := " "
@@ -1002,7 +1010,7 @@ func (m Model) renderPlaylist() string {
 
 		numStr := fmt.Sprintf("%*d. ", numWidth, i+1)
 		line := dimStyle.Render(cursorMarker) + playlistActiveStyle.Render(playingMarker) +
-			activeToggle.Render(queueMarker+bookmarkMarker) + favMarkerStyle.Render(favMarker) +
+			activeToggle.Render(queueMarker+bookmarkMarker) + favMarker +
 			playlistUnavailableStyle.Render(unavailableMarker) +
 			" " + style.Render(numStr)
 		line += style.Render(name)

--- a/ui/model/view_state_test.go
+++ b/ui/model/view_state_test.go
@@ -306,3 +306,37 @@ Line 99: %q (index %d)
 Line 119: %q (index %d)`, line9, ninthLineTrackIndex, line99, ninetyNinthLineTrackIndex, line119, oneHundredNineteenthLineTrackIndex)
 	}
 }
+
+func TestFooterNotificationDoesNotChangeFrameHeight(t *testing.T) {
+	withFrameWidth(t, 80)
+
+	m := Model{
+		player:   &playbackFakeEngine{},
+		playlist: playlist.New(),
+		focus:    focusPlaylist,
+		layout:   frameLayout{tier: layoutFull, panelWidth: 80},
+	}
+
+	render := func() string {
+		return strings.Join(m.mainSections("body", true, true), "\n")
+	}
+
+	idle := render()
+	m.status.Showf(statusTTLDefault, "%s %s", favAddedMark, "Alpha")
+	active := render()
+
+	idleHeight := lipgloss.Height(idle)
+	activeHeight := lipgloss.Height(active)
+	if idleHeight != activeHeight {
+		t.Fatalf("footer notification changed frame height: idle=%d lines, active=%d lines", idleHeight, activeHeight)
+	}
+
+	idleText := stripAnsi(idle)
+	activeText := stripAnsi(active)
+	if got := strings.LastIndex(activeText, "Alpha"); got < 0 {
+		t.Fatalf("active footer = %q, want favorite notification text", activeText)
+	}
+	if strings.Contains(idleText, "Alpha") {
+		t.Fatalf("idle footer = %q, must not show notification", idleText)
+	}
+}

--- a/ui/model/visual_hierarchy_test.go
+++ b/ui/model/visual_hierarchy_test.go
@@ -46,6 +46,41 @@ func TestPlaylistStateMarkersStayVisibleWithoutColor(t *testing.T) {
 	}
 }
 
+func TestFavoritedRowsKeepMarkerColumnAlignment(t *testing.T) {
+	oldPanelWidth := ui.PanelWidth
+	ui.PanelWidth = 80
+	t.Cleanup(func() { ui.PanelWidth = oldPanelWidth })
+
+	favPath := "fav:1"
+	p := playlist.New()
+	p.Add(playlist.Track{Title: "Favorited", Path: favPath})
+	p.Add(playlist.Track{Title: "Normal"})
+	m := Model{
+		player:    &playbackFakeEngine{},
+		playlist:  p,
+		focus:     focusPlaylist,
+		plVisible: 2,
+		favSet:    map[string]struct{}{favPath: {}},
+	}
+
+	plain := ansi.Strip(m.renderPlaylist())
+	lines := strings.Split(plain, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("playlist = %q, want at least two rows", plain)
+	}
+	if !strings.Contains(lines[0], "★") || strings.Contains(lines[0], "☆") {
+		t.Fatalf("favorited row = %q, want filled star marker", lines[0])
+	}
+	if !strings.Contains(lines[1], "☆") || strings.Contains(lines[1], "★") {
+		t.Fatalf("plain row = %q, want dim outline star marker", lines[1])
+	}
+	favCol := ansi.StringWidth(lines[0][:strings.Index(lines[0], "Favorited")])
+	normCol := ansi.StringWidth(lines[1][:strings.Index(lines[1], "Normal")])
+	if favCol != normCol {
+		t.Fatalf("track names misaligned: favorited starts at cell %d, plain row at %d (%q)", favCol, normCol, plain)
+	}
+}
+
 func TestPlaylistShowsKnownTrackDuration(t *testing.T) {
 	oldPanelWidth := ui.PanelWidth
 	ui.PanelWidth = 80


### PR DESCRIPTION
## Summary

Favorites (`n`) used to be marked with a `♥` heart. They now use a star pair that mirrors cliamp-mobile's `StarFilled` / `Star` icons:

- **Favorited** track rows show a full star (`★`) painted in the theme's error color and bold, matching the filled star look.
- **Unfavorited** rows, and the unfavorite status feedback, show a dim outline star (`☆`).
- Both glyphs are one cell wide, so favorited and plain rows stay column-aligned.

The keymap label, header badge, and status messages all use the star marks.

> Note: this branch is based on #409 (footer notification height fix). That commit lands here too; it is separate so this PR contributes the star-marker change. If #409 merges first, this PR may carry a duplicate of it, in which case it can be dropped before merging.

## Changes

- `ui/model/view.go`: `favHeart` → `favStar` (filled) + `favStarOutline` (dim outline) pair; row marker shows outline ☆ by default and filled ★ when the track is in `favSet`; header badge `[★ count]`.
- `ui/model/command_registry.go`: `f/n` keymap label → `★ Bookmark / ★ Favorite`.
- `ui/model/visual_hierarchy_test.go`: `TestFavoritedRowsKeepMarkerColumnAlignment` — filled star on the favorited row, outline star on the plain row, names aligned.
- `docs/keybindings.md`, `docs/playlists.md`: `♥` → star references.

## Verification

- `make check` (gofmt + vet + full test suite) passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Favorite indicators now use filled and outline star symbols instead of hearts.
  - Favorite markers are color-coded and maintain consistent alignment across track rows.
  - Footer notifications display without changing the main view’s height.

- **Documentation**
  - Updated keybinding and playlist documentation to describe the new star-based favorite indicators.

- **Tests**
  - Added coverage for footer height stability and favorite-marker alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->