### PR TITLE
fix(navidrome): stop truncating large playlist responses 

### DIFF
--- a/external/navidrome/client.go
+++ b/external/navidrome/client.go
@@ -35,8 +35,10 @@ var (
 // httpClient is used for all Navidrome API calls with a finite timeout.
 var httpClient = &http.Client{Timeout: 30 * time.Second}
 
-// maxResponseBody limits JSON API responses to 10 MB to prevent unbounded memory growth.
-const maxResponseBody = 10 << 20
+// maxResponseBody limits JSON API responses to 128 MB to prevent unbounded
+// memory growth. A getPlaylist response runs roughly 1.2 KB per entry, so this
+// leaves room for playlists of ~100k tracks.
+const maxResponseBody = 128 << 20
 
 // Sort type constants for album browsing (Subsonic getAlbumList2 "type" parameter).
 const (
@@ -215,9 +217,16 @@ func (c *NavidromeClient) subsonicGet(endpoint string, params url.Values, result
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("navidrome: %s: http status %s", endpoint, resp.Status)
 	}
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBody))
+	// Read one byte past the cap so an oversized response is reported rather
+	// than silently truncated: io.LimitReader alone would cut mid-object and
+	// hand json.Unmarshal a partial body, which fails as the opaque
+	// "unexpected end of JSON input".
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBody+1))
 	if err != nil {
 		return fmt.Errorf("navidrome: %s: %w", endpoint, err)
+	}
+	if len(body) > maxResponseBody {
+		return fmt.Errorf("navidrome: %s: response exceeds %d bytes", endpoint, maxResponseBody)
 	}
 	// Check for API-level errors.
 	var env struct {

--- a/external/navidrome/client_test.go
+++ b/external/navidrome/client_test.go
@@ -1,6 +1,7 @@
 package navidrome
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -601,4 +602,81 @@ func trackWithNavidromeMeta(id string) playlist.Track {
 		meta[provider.MetaNavidromeID] = id
 	}
 	return playlist.Track{ProviderMeta: meta}
+}
+
+// largePlaylistBody builds a valid getPlaylist response whose encoded size
+// exceeds sizeBytes, mimicking a Navidrome playlist with many thousands of
+// entries. Each entry is padded so the test stays cheap to generate. It
+// returns the body and the number of entries written.
+func largePlaylistBody(sizeBytes int) ([]byte, int) {
+	pad := strings.Repeat("x", 4000)
+	var b strings.Builder
+	b.WriteString(`{"subsonic-response":{"status":"ok","playlist":{"entry":[`)
+	n := 0
+	for ; b.Len() < sizeBytes; n++ {
+		if n > 0 {
+			b.WriteString(",")
+		}
+		fmt.Fprintf(&b, `{"id":"song-%d","title":"Track %d","artist":"A","album":"%s","year":2020,"track":%d,"genre":"G","duration":180}`, n, n, pad, n)
+	}
+	b.WriteString(`]}}}`)
+	return []byte(b.String()), n
+}
+
+// TestTracks_LargePlaylist guards against silently truncating the response
+// body. A playlist bigger than the read cap must not be cut mid-JSON and
+// surfaced as "unexpected end of JSON input".
+func TestTracks_LargePlaylist(t *testing.T) {
+	// 16 MB mirrors a real ~13k-track Navidrome playlist, which used to be
+	// truncated by the read cap. Fixed size, not derived from the cap, so the
+	// test keeps its meaning if the cap moves.
+	body, want := largePlaylistBody(16 << 20)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(body)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "u", "p")
+	tracks, err := c.Tracks("pl-big")
+	if err != nil {
+		t.Fatalf("Tracks() on %d-byte playlist: %v", len(body), err)
+	}
+	// Assert the exact count and the last entry, not just a non-empty slice:
+	// a decoder that stopped early would otherwise pass.
+	if len(tracks) != want {
+		t.Fatalf("len(tracks) = %d, want %d", len(tracks), want)
+	}
+	if tracks[0].Title != "Track 0" {
+		t.Errorf("tracks[0].Title = %q, want %q", tracks[0].Title, "Track 0")
+	}
+	if lastTitle := fmt.Sprintf("Track %d", want-1); tracks[want-1].Title != lastTitle {
+		t.Errorf("tracks[%d].Title = %q, want %q", want-1, tracks[want-1].Title, lastTitle)
+	}
+}
+
+// TestSubsonicGet_OversizeResponse checks that a response too large to read
+// fails with an explicit size error instead of a confusing JSON parse error.
+func TestSubsonicGet_OversizeResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"subsonic-response":{"status":"ok","playlist":{"entry":[`))
+		chunk := strings.Repeat("x", 1<<20)
+		for written := 0; written < maxResponseBody+(1<<20); written += len(chunk) {
+			w.Write([]byte(chunk))
+		}
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "u", "p")
+	_, err := c.Tracks("pl-huge")
+	if err == nil {
+		t.Fatal("expected an error for an oversize response, got nil")
+	}
+	if strings.Contains(err.Error(), "unexpected end of JSON input") {
+		t.Errorf("got opaque truncation error %q, want an explicit size error", err)
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("error = %q, want it to mention the size limit", err)
+	}
 }


### PR DESCRIPTION
## Summary

`subsonicGet` caps API responses at 10 MB with `io.LimitReader`. That reader truncates *silently* — it returns `io.EOF` at the cap rather than an error — so `io.ReadAll` reports `err == nil` and hands `json.Unmarshal` a body that stops mid-object. The user sees:

```
ERR: navidrome: getPlaylist: unexpected end of JSON input
```

which points at malformed JSON when the real cause is a size limit.

Every Subsonic endpoint shares that path, but `getPlaylist` hits it first: Navidrome returns roughly 1.2 KB per entry, putting the cliff around 8,500 tracks. Measured against a live server, playlists of 12,785 and 11,243 tracks return 15.0 MB and 13.2 MB and both fail; a 3,273-track playlist returns 3.8 MB and works.

Two changes, and the silent truncation is the actual defect — the specific cap is secondary:

1. Read one byte past the cap so an oversize body is detectable, and return an explicit size error.
2. Raise the cap to 128 MB, leaving room for roughly 100k tracks.

The shape and error wording follow the sites that already do this: `resolve/resolve.go` (`maxPlaylistBody+1`, `"pls playlist exceeds %d bytes"`) and `pluginmgr/pluginmgr.go` (`maxPluginSize+1`).

Not addressed here, to keep the diff narrow: `httpClient` uses a 30s total timeout that also covers the body read. 15 MB is comfortable on a LAN but could time out over a slow link.

## Screenshots / video

Not applicable — no UI change. The visible difference is an error that no longer appears.

## How to test

1. `go test ./external/navidrome/` — two new tests cover it. `TestTracks_LargePlaylist` fails on `main` with `unexpected end of JSON input` and passes here; `TestSubsonicGet_OversizeResponse` asserts a genuinely oversize body reports a size error rather than a parse error.
2. Against a real server: point cliamp at a Navidrome playlist of more than ~8,500 tracks and open it. On `main` it fails with `ERR: navidrome: getPlaylist: unexpected end of JSON input`; on this branch it loads.
3. Confirm nothing regressed for normal playlists — smaller ones were always under the cap and are unaffected.

Verified on a server whose largest playlist is 12,785 tracks: every playlist now loads with a track count matching the server's declared `songCount`.

## Checklist

- [x] `make check` passes
- [x] `docs/` and `site/index.html` updated for user-facing changes — n/a, no user-facing surface changes here (no config key, keybinding, or provider behavior); neither file documents a response size limit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Increased the supported response size for large playlists to 128 MB.
  - Added clear error handling when a playlist response exceeds the maximum size, instead of reporting a misleading truncated-data error.
  - Improved reliability when loading large playlist responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->