### PR TITLE
feat: YouTube-style autoplay continuation when the queue runs out

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -27,6 +27,7 @@ mono = false
 
 # Continue playback with YouTube Mix "related" tracks when the queue runs out
 # (YouTube-style autoplay). Toggle at runtime with the c key.
+# Player only: headless daemon mode (--daemon) ignores this key.
 autoplay_radio = false
 
 # Initial directory for the file browser ('o' key). 

--- a/config.toml.example
+++ b/config.toml.example
@@ -25,6 +25,10 @@ shuffle = false
 # Start with mono output (L+R downmix)
 mono = false
 
+# Continue playback with YouTube Mix "related" tracks when the queue runs out
+# (YouTube-style autoplay). Toggle at runtime with the c key.
+autoplay_radio = false
+
 # Initial directory for the file browser ('o' key). 
 # Supports environment variables ($HOME) and tilde expansion (~/Music).
 # initial_directory = "~/Music"

--- a/config/config.go
+++ b/config/config.go
@@ -351,6 +351,7 @@ type Config struct {
 	Mono             bool
 	Speed            float64                      // playback speed ratio: 0.25–2.0 (default 1.0)
 	AutoPlay         bool                         // start playback automatically on launch (radio streams, CLI tracks)
+	AutoplayRadio    bool                         // continue with YouTube Mix related tracks when the queue runs out
 	SeekStepLarge    int                          // seconds for Shift+Left/Right seek jumps
 	Provider         string                       // default provider: "radio", "podcast", "navidrome", "lyrion", "spotify", "qobuz", "tidal", "plex", "jellyfin", "emby", "audiobookshelf", "soundcloud", "mixcloud", "netease", "yandex", "ytmusic" (default "radio")
 	Theme            string                       // theme name, or "" for ANSI default
@@ -400,6 +401,7 @@ func defaultConfig() Config {
 		VisVolumeLinked: true,
 		Repeat:          "off",
 		AutoPlay:        false,
+		AutoplayRadio:   false,
 		Speed:           1.0,
 		SeekStepLarge:   30,
 		SampleRate:      0,
@@ -696,6 +698,8 @@ func Load() (Config, error) {
 				cfg.Mono = val == "true"
 			case "auto_play":
 				cfg.AutoPlay = val == "true"
+			case "autoplay_radio":
+				cfg.AutoplayRadio = val == "true"
 			case "seek_large_step_sec":
 				if v, err := strconv.Atoi(val); err == nil {
 					cfg.SeekStepLarge = v

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -871,3 +871,26 @@ func TestApplyPlaylist(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadAutoplayRadio(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	path := filepath.Join(os.Getenv("HOME"), ".config", "cliamp", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("autoplay_radio = true\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.AutoplayRadio {
+		t.Error("autoplay_radio = true not parsed")
+	}
+	if defaultConfig().AutoplayRadio {
+		t.Error("AutoplayRadio should default to false")
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,6 +47,7 @@ mono = false
 
 # Continue playback with YouTube Mix "related" tracks when the queue runs out
 # (YouTube-style autoplay). Toggle at runtime with the c key.
+# Player only: headless daemon mode (--daemon) ignores this key.
 autoplay_radio = false
 
 # Initial directory for the file browser ('o' key)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,6 +45,10 @@ shuffle = false
 # Start with mono output (L+R downmix)
 mono = false
 
+# Continue playback with YouTube Mix "related" tracks when the queue runs out
+# (YouTube-style autoplay). Toggle at runtime with the c key.
+autoplay_radio = false
+
 # Initial directory for the file browser ('o' key)
 initial_directory = "~/Music"
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -18,6 +18,7 @@ library commands.
 | `+` `-` | Volume up/down |
 | `]` `[` | Change speed by 0.25x |
 | `m` | Toggle mono |
+| `c` | Toggle autoplay radio (continue with YouTube Mix related tracks) |
 | `Ctrl+J` | Jump to time |
 
 ## Navigation

--- a/docs/yt-dlp.md
+++ b/docs/yt-dlp.md
@@ -32,7 +32,8 @@ In the TUI, press `Ctrl+F` to search the active provider. This searches YouTube 
 With `autoplay_radio = true` (or the `c` key in the player), cliamp keeps the
 music going when the queue runs out: it loads the YouTube Mix seeded from the
 last track — the same "related tracks" radio YouTube's own autoplay uses — and
-appends up to 20 tracks that are not already in the queue. This works for any
+appends the top 5 entries that are not already in the queue. When those run
+out, the last of them seeds the next batch. This works for any
 YouTube or YouTube Music track, including single tracks played from `Ctrl+F`
 search. Repeat modes take precedence: autoplay only fires when repeat is off
 and the queue is exhausted. Tracks from other sources (SoundCloud, local

--- a/docs/yt-dlp.md
+++ b/docs/yt-dlp.md
@@ -35,7 +35,10 @@ last track — the same "related tracks" radio YouTube's own autoplay uses — a
 appends the top 5 entries that are not already in the queue. When those run
 out, the last of them seeds the next batch. This works for any
 YouTube or YouTube Music track, including single tracks played from `Ctrl+F`
-search. Repeat modes take precedence: autoplay only fires when repeat is off
+search. Playing a new track yourself ends the run: the related tracks autoplay
+queued are removed, so the track you picked plays from the end of the queue
+instead of behind a stale Mix. Tracks you added yourself are never touched.
+Repeat modes take precedence: autoplay only fires when repeat is off
 and the queue is exhausted. Tracks from other sources (SoundCloud, local
 files, …) end playback as before.
 

--- a/docs/yt-dlp.md
+++ b/docs/yt-dlp.md
@@ -35,9 +35,10 @@ last track — the same "related tracks" radio YouTube's own autoplay uses — a
 appends the top 5 entries that are not already in the queue. When those run
 out, the last of them seeds the next batch. This works for any
 YouTube or YouTube Music track, including single tracks played from `Ctrl+F`
-search. Playing a new track yourself ends the run: the related tracks autoplay
-queued are removed, so the track you picked plays from the end of the queue
-instead of behind a stale Mix. Tracks you added yourself are never touched.
+search. Playing a new track yourself ends the run: the previously played track
+and the related tracks autoplay queued behind it are removed, so the track you
+picked reuses that slot instead of stacking up at the end of the queue. Tracks
+you appended or queued yourself, and bookmarked tracks, are never touched.
 Repeat modes take precedence: autoplay only fires when repeat is off
 and the queue is exhausted. Tracks from other sources (SoundCloud, local
 files, …) end playback as before.

--- a/docs/yt-dlp.md
+++ b/docs/yt-dlp.md
@@ -33,15 +33,19 @@ With `autoplay_radio = true` (or the `c` key in the player), cliamp keeps the
 music going when the queue runs out: it loads the YouTube Mix seeded from the
 last track — the same "related tracks" radio YouTube's own autoplay uses — and
 appends the top 5 entries that are not already in the queue. When those run
-out, the last of them seeds the next batch. This works for any
-YouTube or YouTube Music track, including single tracks played from `Ctrl+F`
-search. Playing a new track yourself ends the run: the previously played track
-and the related tracks autoplay queued behind it are removed, so the track you
-picked reuses that slot instead of stacking up at the end of the queue. Tracks
-you appended or queued yourself, and bookmarked tracks, are never touched.
-Repeat modes take precedence: autoplay only fires when repeat is off
-and the queue is exhausted. Tracks from other sources (SoundCloud, local
-files, …) end playback as before.
+out, the last of them seeds the next batch. This works for any YouTube or
+YouTube Music track, including single tracks played from `Ctrl+F` search.
+
+Playing a new track yourself ends the run: the previously played track and the
+related tracks autoplay queued behind it are removed, so the track you picked
+reuses that slot instead of stacking up at the end of the queue. Tracks you
+appended or queued yourself, and bookmarked tracks, are never touched.
+
+Autoplay is a player feature: headless daemon mode (`--daemon`) has its own
+track-advance path and ignores `autoplay_radio`. Repeat modes take precedence:
+autoplay only fires when repeat is off and the queue is exhausted. Live streams
+reconnect as before, and tracks from other sources (SoundCloud, local files, …)
+end playback as before.
 
 ## Disclaimer
 

--- a/docs/yt-dlp.md
+++ b/docs/yt-dlp.md
@@ -27,6 +27,17 @@ cliamp search-sc "lofi beats"                  # search SoundCloud
 
 In the TUI, press `Ctrl+F` to search the active provider. This searches YouTube for YouTube/YT-Music, SoundCloud for SoundCloud, Mixcloud for Mixcloud, and NetEase for NetEase. These providers have signed-in playback guides: [SoundCloud](soundcloud.md), [Mixcloud](mixcloud.md), and [NetEase](netease.md).
 
+## Autoplay
+
+With `autoplay_radio = true` (or the `c` key in the player), cliamp keeps the
+music going when the queue runs out: it loads the YouTube Mix seeded from the
+last track — the same "related tracks" radio YouTube's own autoplay uses — and
+appends up to 20 tracks that are not already in the queue. This works for any
+YouTube or YouTube Music track, including single tracks played from `Ctrl+F`
+search. Repeat modes take precedence: autoplay only fires when repeat is off
+and the queue is exhausted. Tracks from other sources (SoundCloud, local
+files, …) end playback as before.
+
 ## Disclaimer
 
 **Use at your own risk.** Downloading or streaming copyrighted content can violate the terms of service of these platforms. You are responsible for use of this feature.

--- a/external/ytmusic/cache_ephemeral_test.go
+++ b/external/ytmusic/cache_ephemeral_test.go
@@ -1,0 +1,37 @@
+package ytmusic
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/bjarneo/cliamp/playlist"
+)
+
+// The Ephemeral flag marks queue entries the player owns for the current
+// session. It must never survive a cache round trip, or restored tracks would
+// be silently deleted the next time the user plays something.
+func TestYTCacheDropsEphemeralFlag(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	scope := "test-scope"
+	cache := newYTCache(scope)
+	cache.setTracks("list", []playlist.Track{{Path: "https://music.youtube.com/watch?v=abcdefghijk", Title: "Cached", Ephemeral: true}})
+
+	data := cache.snapshot()
+	if bytes.Contains(data, []byte("Ephemeral")) {
+		t.Errorf("snapshot serialized the Ephemeral field: %s", data)
+	}
+	saveSnapshot(data)
+
+	loaded := loadYTCache(scope)
+	tracks, ok := loaded.tracksFresh("list")
+	if !ok || len(tracks) != 1 {
+		t.Fatalf("tracksFresh: ok=%v len=%d, want true and 1", ok, len(tracks))
+	}
+	if tracks[0].Ephemeral {
+		t.Error("cached track restored with Ephemeral = true")
+	}
+	if tracks[0].Title != "Cached" {
+		t.Errorf("Title = %q, want %q", tracks[0].Title, "Cached")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -568,6 +568,9 @@ func run(overrides config.Overrides, positional []string, daemon, visualizer60FP
 	if cfg.AutoPlay && !restoredJellyfinChoice {
 		m.SetAutoPlay(true)
 	}
+	if cfg.AutoplayRadio {
+		m.SetAutoplayRadio(true)
+	}
 	if cfg.LowPower {
 		m.SetLowPower(true)
 	}

--- a/playlist/playlist.go
+++ b/playlist/playlist.go
@@ -56,8 +56,10 @@ type Track struct {
 	// current listening session: a "play now" track and the related tracks
 	// autoplay appended after it. Those entries are dropped when the user
 	// starts something else. Entries the user added or queued are never
-	// marked. Runtime-only, never persisted.
-	Ephemeral bool
+	// marked. Runtime-only: json:"-" keeps it out of caches that serialize
+	// tracks (for example ytmusic_cache.json), so a restored track can never
+	// come back marked.
+	Ephemeral bool `json:"-"`
 
 	EmbeddedLyrics string // embedded lyrics from local file tags, when present
 	AlbumArtURL    string // file:// URL for cached embedded album art, when present

--- a/playlist/playlist.go
+++ b/playlist/playlist.go
@@ -52,6 +52,13 @@ type Track struct {
 
 	DirSourced bool // true when expanded from a [[dir]] playlist section; re-derived on load, never persisted
 
+	// Ephemeral marks an entry the player queued on the user's behalf for the
+	// current listening session: a "play now" track and the related tracks
+	// autoplay appended after it. Those entries are dropped when the user
+	// starts something else. Entries the user added or queued are never
+	// marked. Runtime-only, never persisted.
+	Ephemeral bool
+
 	EmbeddedLyrics string // embedded lyrics from local file tags, when present
 	AlbumArtURL    string // file:// URL for cached embedded album art, when present
 

--- a/resolve/radio.go
+++ b/resolve/radio.go
@@ -30,6 +30,13 @@ func YouTubeVideoID(rawURL string) string {
 	if err != nil || u.Host == "" {
 		return ""
 	}
+	// Only real web URLs describe a playable YouTube video; anything else
+	// (ftp://, scheme-relative, custom schemes) is not one of ours.
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+	default:
+		return ""
+	}
 	host := strings.ToLower(u.Hostname())
 	host = strings.TrimPrefix(host, "www.")
 	host = strings.TrimPrefix(host, "m.")

--- a/resolve/radio.go
+++ b/resolve/radio.go
@@ -5,6 +5,24 @@ import (
 	"strings"
 )
 
+// isYouTubeVideoID reports whether s looks like a video ID rather than a
+// handle, path, or other identifier. YouTube IDs are base64url-ish, so any
+// separator ("/", "@", "?", …) means the caller matched something else, such
+// as youtu.be/@channel or a watch?v= value carrying extra path segments.
+func isYouTubeVideoID(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 // YouTubeVideoID extracts the video ID from a YouTube, YouTube Music, or
 // youtu.be track URL. Returns "" when no video ID is present.
 func YouTubeVideoID(rawURL string) string {
@@ -18,10 +36,14 @@ func YouTubeVideoID(rawURL string) string {
 	switch host {
 	case "youtube.com", "music.youtube.com":
 		if u.Path == "/watch" {
-			return u.Query().Get("v")
+			if id := u.Query().Get("v"); isYouTubeVideoID(id) {
+				return id
+			}
 		}
 	case "youtu.be":
-		return strings.Trim(u.Path, "/")
+		if id := strings.Trim(u.Path, "/"); isYouTubeVideoID(id) {
+			return id
+		}
 	}
 	return ""
 }

--- a/resolve/radio.go
+++ b/resolve/radio.go
@@ -1,0 +1,39 @@
+package resolve
+
+import (
+	"net/url"
+	"strings"
+)
+
+// YouTubeVideoID extracts the video ID from a YouTube, YouTube Music, or
+// youtu.be track URL. Returns "" when no video ID is present.
+func YouTubeVideoID(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	host := strings.ToLower(u.Hostname())
+	host = strings.TrimPrefix(host, "www.")
+	host = strings.TrimPrefix(host, "m.")
+	switch host {
+	case "youtube.com", "music.youtube.com":
+		if u.Path == "/watch" {
+			return u.Query().Get("v")
+		}
+	case "youtu.be":
+		return strings.Trim(u.Path, "/")
+	}
+	return ""
+}
+
+// RadioMixURL returns the YouTube auto-generated Mix ("radio") playlist URL
+// seeded from trackURL, or ok=false when the track is not a YouTube video.
+// The RD<videoID> list is the same source YouTube's own autoplay uses;
+// resolveYTDL already handles RD lists via yt-dlp --flat-playlist.
+func RadioMixURL(trackURL string) (string, bool) {
+	id := YouTubeVideoID(trackURL)
+	if id == "" {
+		return "", false
+	}
+	return "https://www.youtube.com/watch?v=" + id + "&list=RD" + id, true
+}

--- a/resolve/radio_test.go
+++ b/resolve/radio_test.go
@@ -19,6 +19,10 @@ func TestYouTubeVideoID(t *testing.T) {
 		{"short link root", "https://youtu.be/", ""},
 		{"watch v with slash", "https://www.youtube.com/watch?v=abc/def", ""},
 		{"watch v empty", "https://www.youtube.com/watch?v=", ""},
+		{"ftp scheme", "ftp://youtu.be/dQw4w9WgXcQ", ""},
+		{"ftp scheme watch", "ftp://www.youtube.com/watch?v=dQw4w9WgXcQ", ""},
+		{"scheme relative", "//www.youtube.com/watch?v=dQw4w9WgXcQ", ""},
+		{"http scheme", "http://www.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"},
 		{"empty", "", ""},
 	}
 	for _, tc := range cases {
@@ -46,9 +50,11 @@ func TestRadioMixURL(t *testing.T) {
 		"https://youtu.be/@somechannel",
 		"https://youtu.be/dQw4w9WgXcQ/extra",
 		"https://www.youtube.com/watch?v=abc/def",
+		"ftp://youtu.be/dQw4w9WgXcQ",
 	} {
-		if got, ok := RadioMixURL(bad); ok {
-			t.Errorf("RadioMixURL(%q) = %q, ok = true; want ok = false", bad, got)
+		got, ok := RadioMixURL(bad)
+		if ok || got != "" {
+			t.Errorf("RadioMixURL(%q) = (%q, %v), want (\"\", false)", bad, got, ok)
 		}
 	}
 }

--- a/resolve/radio_test.go
+++ b/resolve/radio_test.go
@@ -14,6 +14,11 @@ func TestYouTubeVideoID(t *testing.T) {
 		{"soundcloud", "https://soundcloud.com/artist/track", ""},
 		{"local file", "/home/user/Music/song.mp3", ""},
 		{"channel url", "https://www.youtube.com/@somechannel", ""},
+		{"short link to handle", "https://youtu.be/@somechannel", ""},
+		{"short link extra segment", "https://youtu.be/dQw4w9WgXcQ/extra", ""},
+		{"short link root", "https://youtu.be/", ""},
+		{"watch v with slash", "https://www.youtube.com/watch?v=abc/def", ""},
+		{"watch v empty", "https://www.youtube.com/watch?v=", ""},
 		{"empty", "", ""},
 	}
 	for _, tc := range cases {
@@ -36,5 +41,14 @@ func TestRadioMixURL(t *testing.T) {
 	}
 	if _, ok := RadioMixURL("https://soundcloud.com/a/b"); ok {
 		t.Error("RadioMixURL(soundcloud): ok = true, want false")
+	}
+	for _, bad := range []string{
+		"https://youtu.be/@somechannel",
+		"https://youtu.be/dQw4w9WgXcQ/extra",
+		"https://www.youtube.com/watch?v=abc/def",
+	} {
+		if got, ok := RadioMixURL(bad); ok {
+			t.Errorf("RadioMixURL(%q) = %q, ok = true; want ok = false", bad, got)
+		}
 	}
 }

--- a/resolve/radio_test.go
+++ b/resolve/radio_test.go
@@ -1,0 +1,40 @@
+package resolve
+
+import "testing"
+
+func TestYouTubeVideoID(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"youtube watch", "https://www.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"},
+		{"music watch", "https://music.youtube.com/watch?v=abc123XYZ_-", "abc123XYZ_-"},
+		{"mobile host", "https://m.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"},
+		{"short link", "https://youtu.be/dQw4w9WgXcQ", "dQw4w9WgXcQ"},
+		{"watch with list", "https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=RDdQw4w9WgXcQ", "dQw4w9WgXcQ"},
+		{"soundcloud", "https://soundcloud.com/artist/track", ""},
+		{"local file", "/home/user/Music/song.mp3", ""},
+		{"channel url", "https://www.youtube.com/@somechannel", ""},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := YouTubeVideoID(tc.in); got != tc.want {
+				t.Errorf("YouTubeVideoID(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRadioMixURL(t *testing.T) {
+	got, ok := RadioMixURL("https://music.youtube.com/watch?v=dQw4w9WgXcQ")
+	if !ok {
+		t.Fatal("RadioMixURL: ok = false, want true")
+	}
+	want := "https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=RDdQw4w9WgXcQ"
+	if got != want {
+		t.Errorf("RadioMixURL = %q, want %q", got, want)
+	}
+	if _, ok := RadioMixURL("https://soundcloud.com/a/b"); ok {
+		t.Error("RadioMixURL(soundcloud): ok = true, want false")
+	}
+}

--- a/site/index.html
+++ b/site/index.html
@@ -643,7 +643,7 @@ var SOURCES=[
   {name:"Spotify",kind:"streaming",note:"Premium · OAuth"},
   {name:"Qobuz",kind:"streaming",note:"lossless FLAC · OAuth"},
   {name:"Tidal",kind:"streaming",note:"lossless FLAC · device code"},
-  {name:"YouTube",kind:"streaming",note:"search & play · yt-dlp"},
+  {name:"YouTube",kind:"streaming",note:"search & play · autoplay radio · yt-dlp"},
   {name:"YouTube Music",kind:"streaming",note:"playlists & likes · cookies"},
   {name:"SoundCloud",kind:"streaming",note:"search & genres · yt-dlp"},
   {name:"Mixcloud",kind:"streaming",note:"shows & creators · yt-dlp"},
@@ -669,7 +669,7 @@ var KIND={streaming:"var(--accent)","self-hosted":"var(--warm)",local:"var(--blu
 var KEYS=[
   ["Space","play / pause"],["> / <","next / prev"],["+ / -","volume"],["← / →","seek 5s"],
   ["e","EQ preset"],["v / V","visualizer / full screen"],["y","lyrics"],["t","theme"],
-  ["/","search playlist"],["Ctrl+F","search provider"],["z / r","shuffle / repeat"],["a","queue next"],
+  ["/","search playlist"],["Ctrl+F","search provider"],["z / r","shuffle / repeat"],["a","queue next"],["c","autoplay radio"],
   ["o","file browser"],["R / O","radio / podcasts"],["?","all keybindings"]
 ];
 

--- a/ui/model/autoplay.go
+++ b/ui/model/autoplay.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"time"
+
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/bjarneo/cliamp/playlist"
@@ -61,6 +63,35 @@ func (m *Model) continueWithAutoplay() (tea.Cmd, bool) {
 	m.autoplayLoading = true
 	m.status.Activity("Autoplay: finding related tracks…", statusTTLLong)
 	return fetchAutoplayCmd(mixURL, track.Path, nextRequest(&m.requests.autoplay)), true
+}
+
+// autoplayPrefetchLeadTime starts the Mix fetch well before the final track
+// ends so related tracks can arrive and the gapless preloader can arm the
+// transition (yt-dlp resolve typically takes a few seconds).
+const autoplayPrefetchLeadTime = 45 * time.Second
+
+// maybePrefetchAutoplay fetches related tracks while the last queue track is
+// still playing so the autoplay transition is gapless. The tick loop retries
+// preloadNext every pass, so this fires once per exhaustion thanks to the
+// autoplayLoading guard (and autoplayFailedSeed after a failed fetch).
+func (m *Model) maybePrefetchAutoplay() tea.Cmd {
+	if m.autoplayLoading {
+		return nil
+	}
+	mixURL, ok := m.autoplayEligibleSeed()
+	if !ok {
+		return nil
+	}
+	dur := m.player.Duration()
+	if dur <= 0 {
+		return nil
+	}
+	if dur-m.player.Position() > autoplayPrefetchLeadTime {
+		return nil
+	}
+	track, _ := m.currentPlaybackTrack()
+	m.autoplayLoading = true
+	return fetchAutoplayCmd(mixURL, track.Path, nextRequest(&m.requests.autoplay))
 }
 
 // appendAutoplayTracks appends Mix tracks that are not already in the

--- a/ui/model/autoplay.go
+++ b/ui/model/autoplay.go
@@ -129,6 +129,12 @@ func (m *Model) appendAutoplayTracks(tracks []playlist.Track) int {
 	if len(fresh) == 0 {
 		return 0
 	}
+	if m.autoplayAdded == nil {
+		m.autoplayAdded = make(map[string]bool, len(fresh))
+	}
+	for _, t := range fresh {
+		m.autoplayAdded[autoplayDedupeKey(t.Path)] = true
+	}
 	m.playlist.Add(fresh...)
 	m.loadedPlaylist = ""
 	m.addToHeaderState(fresh)
@@ -148,6 +154,37 @@ func (m *Model) toggleAutoplayRadio() {
 	if err := m.configSaver.Save("autoplay_radio", fmt.Sprintf("%v", m.autoplayRadio)); err != nil {
 		m.status.Errorf(statusTTLDefault, "Config save failed: %s", err)
 	}
+}
+
+// discardAutoplayTracks removes every track autoplay appended, so a new
+// user-chosen track lands at the end of the queue instead of behind a trail
+// of stale related tracks. Tracks the user added stay put. Returns how many
+// tracks were removed.
+func (m *Model) discardAutoplayTracks() int {
+	if len(m.autoplayAdded) == 0 {
+		return 0
+	}
+	removed := 0
+	for i := m.playlist.Len() - 1; i >= 0; i-- {
+		t, ok := m.playlist.Track(i)
+		if !ok || !m.autoplayAdded[autoplayDedupeKey(t.Path)] {
+			continue
+		}
+		if m.playlist.Remove(i) {
+			removed++
+		}
+	}
+	m.autoplayAdded = nil
+	if removed == 0 {
+		return 0
+	}
+	m.normalizeQueueOverlay()
+	if newLen := m.playlist.Len(); newLen == 0 {
+		m.plCursor = 0
+	} else if m.plCursor >= newLen {
+		m.plCursor = newLen - 1
+	}
+	return removed
 }
 
 func autoplayDedupeKey(path string) string {

--- a/ui/model/autoplay.go
+++ b/ui/model/autoplay.go
@@ -42,14 +42,19 @@ func fetchAutoplayCmd(mixURL, seedPath string, gen uint64) tea.Cmd {
 
 // autoplayEligibleSeed returns the Mix URL seeded from the active playback
 // track when autoplay is able to continue playback: the feature is on,
-// playback is attached, the track is a YouTube video, and its Mix has not
-// already come back empty or failed.
+// playback is attached, the track is a non-live YouTube video, and its Mix
+// has not already come back empty or failed.
 func (m *Model) autoplayEligibleSeed() (string, bool) {
 	if !m.autoplayRadio || m.playbackDetached {
 		return "", false
 	}
 	track, idx := m.currentPlaybackTrack()
 	if idx < 0 || track.Path == m.autoplayFailedSeed {
+		return "", false
+	}
+	// Live streams (24/7 YouTube radios) have no track boundary: they
+	// reconnect instead of advancing, so a Mix must never be seeded from one.
+	if m.currentPlaybackIsLive(track) {
 		return "", false
 	}
 	return resolve.RadioMixURL(track.Path)
@@ -129,11 +134,10 @@ func (m *Model) appendAutoplayTracks(tracks []playlist.Track) int {
 	if len(fresh) == 0 {
 		return 0
 	}
-	if m.autoplayAdded == nil {
-		m.autoplayAdded = make(map[string]bool, len(fresh))
-	}
-	for _, t := range fresh {
-		m.autoplayAdded[autoplayDedupeKey(t.Path)] = true
+	for i := range fresh {
+		// Mark the entry itself, so cleanup can never remove a copy of the
+		// same video the user added or queued by hand.
+		fresh[i].Ephemeral = true
 	}
 	m.playlist.Add(fresh...)
 	m.loadedPlaylist = ""
@@ -162,25 +166,16 @@ func (m *Model) toggleAutoplayRadio() {
 // user added or queued themselves stay put, as do bookmarked ones. Returns
 // how many tracks were removed.
 func (m *Model) discardAutoplayTracks() int {
-	if len(m.autoplayAdded) == 0 && m.playNowKey == "" {
-		return 0
-	}
 	removed := 0
 	for i := m.playlist.Len() - 1; i >= 0; i-- {
 		t, ok := m.playlist.Track(i)
-		if !ok || t.Bookmark {
-			continue
-		}
-		key := autoplayDedupeKey(t.Path)
-		if !m.autoplayAdded[key] && key != m.playNowKey {
+		if !ok || !t.Ephemeral || t.Bookmark {
 			continue
 		}
 		if m.playlist.Remove(i) {
 			removed++
 		}
 	}
-	m.autoplayAdded = nil
-	m.playNowKey = ""
 	if removed == 0 {
 		return 0
 	}

--- a/ui/model/autoplay.go
+++ b/ui/model/autoplay.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"fmt"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -122,6 +123,21 @@ func (m *Model) appendAutoplayTracks(tracks []playlist.Track) int {
 	m.loadedPlaylist = ""
 	m.addToHeaderState(fresh)
 	return len(fresh)
+}
+
+// toggleAutoplayRadio flips autoplay continuation and persists the choice,
+// mirroring the shuffle (z) and repeat (r) toggles.
+func (m *Model) toggleAutoplayRadio() {
+	m.autoplayRadio = !m.autoplayRadio
+	state := "off"
+	if m.autoplayRadio {
+		state = "on"
+	}
+	m.autoplayFailedSeed = ""
+	m.status.Showf(statusTTLDefault, "Autoplay radio %s", state)
+	if err := m.configSaver.Save("autoplay_radio", fmt.Sprintf("%v", m.autoplayRadio)); err != nil {
+		m.status.Errorf(statusTTLDefault, "Config save failed: %s", err)
+	}
 }
 
 func autoplayDedupeKey(path string) string {

--- a/ui/model/autoplay.go
+++ b/ui/model/autoplay.go
@@ -156,18 +156,23 @@ func (m *Model) toggleAutoplayRadio() {
 	}
 }
 
-// discardAutoplayTracks removes every track autoplay appended, so a new
-// user-chosen track lands at the end of the queue instead of behind a trail
-// of stale related tracks. Tracks the user added stay put. Returns how many
-// tracks were removed.
+// discardAutoplayTracks removes the previous "play now" track together with
+// every related track autoplay queued behind it, so a newly played track
+// reuses that slot instead of piling up at the end of the queue. Tracks the
+// user added or queued themselves stay put, as do bookmarked ones. Returns
+// how many tracks were removed.
 func (m *Model) discardAutoplayTracks() int {
-	if len(m.autoplayAdded) == 0 {
+	if len(m.autoplayAdded) == 0 && m.playNowKey == "" {
 		return 0
 	}
 	removed := 0
 	for i := m.playlist.Len() - 1; i >= 0; i-- {
 		t, ok := m.playlist.Track(i)
-		if !ok || !m.autoplayAdded[autoplayDedupeKey(t.Path)] {
+		if !ok || t.Bookmark {
+			continue
+		}
+		key := autoplayDedupeKey(t.Path)
+		if !m.autoplayAdded[key] && key != m.playNowKey {
 			continue
 		}
 		if m.playlist.Remove(i) {
@@ -175,6 +180,7 @@ func (m *Model) discardAutoplayTracks() int {
 		}
 	}
 	m.autoplayAdded = nil
+	m.playNowKey = ""
 	if removed == 0 {
 		return 0
 	}

--- a/ui/model/autoplay.go
+++ b/ui/model/autoplay.go
@@ -14,6 +14,13 @@ import (
 // matches the initial batch used for pasted Radio/Mix URLs.
 const autoplayFetchCount = resolve.YTDLRadioInitialItems
 
+// autoplayMaxAppend caps how many related tracks are appended per refill.
+// The Mix is fetched with more headroom than this so duplicates already in
+// the queue can be dropped and still leave a full batch; the first
+// autoplayMaxAppend fresh entries — the closest matches YouTube returns —
+// are kept. Refills happen again when these run out.
+const autoplayMaxAppend = 5
+
 // autoplayTracksMsg carries related tracks fetched for autoplay continuation.
 // gen must match requests.autoplay or the result is stale and dropped.
 type autoplayTracksMsg struct {
@@ -107,7 +114,7 @@ func (m *Model) appendAutoplayTracks(tracks []playlist.Track) int {
 		}
 		seen[autoplayDedupeKey(t.Path)] = true
 	}
-	var fresh []playlist.Track
+	fresh := make([]playlist.Track, 0, autoplayMaxAppend)
 	for _, t := range tracks {
 		key := autoplayDedupeKey(t.Path)
 		if seen[key] {
@@ -115,6 +122,9 @@ func (m *Model) appendAutoplayTracks(tracks []playlist.Track) int {
 		}
 		seen[key] = true
 		fresh = append(fresh, t)
+		if len(fresh) == autoplayMaxAppend {
+			break
+		}
 	}
 	if len(fresh) == 0 {
 		return 0

--- a/ui/model/autoplay.go
+++ b/ui/model/autoplay.go
@@ -1,0 +1,101 @@
+package model
+
+import (
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/bjarneo/cliamp/playlist"
+	"github.com/bjarneo/cliamp/resolve"
+)
+
+// autoplayFetchCount is how many Mix entries are requested per refill. It
+// matches the initial batch used for pasted Radio/Mix URLs.
+const autoplayFetchCount = resolve.YTDLRadioInitialItems
+
+// autoplayTracksMsg carries related tracks fetched for autoplay continuation.
+// gen must match requests.autoplay or the result is stale and dropped.
+type autoplayTracksMsg struct {
+	gen    uint64
+	seed   string
+	tracks []playlist.Track
+	err    error
+}
+
+// fetchAutoplayCmd resolves the Mix playlist seeded from the finished track.
+// resolve.ResolveYTDLBatch shells out to yt-dlp --flat-playlist with a 30s
+// timeout and per-host browser cookies, same as pasted RD... URLs.
+func fetchAutoplayCmd(mixURL, seedPath string, gen uint64) tea.Cmd {
+	return func() tea.Msg {
+		tracks, err := resolve.ResolveYTDLBatch(mixURL, 0, autoplayFetchCount)
+		return autoplayTracksMsg{gen: gen, seed: seedPath, tracks: tracks, err: err}
+	}
+}
+
+// autoplayEligibleSeed returns the Mix URL seeded from the active playback
+// track when autoplay is able to continue playback: the feature is on,
+// playback is attached, the track is a YouTube video, and its Mix has not
+// already come back empty or failed.
+func (m *Model) autoplayEligibleSeed() (string, bool) {
+	if !m.autoplayRadio || m.playbackDetached {
+		return "", false
+	}
+	track, idx := m.currentPlaybackTrack()
+	if idx < 0 || track.Path == m.autoplayFailedSeed {
+		return "", false
+	}
+	return resolve.RadioMixURL(track.Path)
+}
+
+// continueWithAutoplay reports whether autoplay will supply more tracks after
+// queue exhaustion. pending=true means either a fetch was just started
+// (cmd != nil) or one is already in flight (cmd == nil); the
+// autoplayTracksMsg handler advances playback when the result lands.
+func (m *Model) continueWithAutoplay() (tea.Cmd, bool) {
+	if m.autoplayLoading {
+		return nil, true
+	}
+	mixURL, ok := m.autoplayEligibleSeed()
+	if !ok {
+		return nil, false
+	}
+	track, _ := m.currentPlaybackTrack()
+	m.autoplayLoading = true
+	m.status.Activity("Autoplay: finding related tracks…", statusTTLLong)
+	return fetchAutoplayCmd(mixURL, track.Path, nextRequest(&m.requests.autoplay)), true
+}
+
+// appendAutoplayTracks appends Mix tracks that are not already in the
+// playlist, keyed by YouTube video ID so www./music./youtu.be URL variants
+// match. Returns how many tracks were added.
+func (m *Model) appendAutoplayTracks(tracks []playlist.Track) int {
+	seen := make(map[string]bool, m.playlist.Len()+len(tracks))
+	for i := 0; i < m.playlist.Len(); i++ {
+		t, ok := m.playlist.Track(i)
+		if !ok {
+			continue
+		}
+		seen[autoplayDedupeKey(t.Path)] = true
+	}
+	var fresh []playlist.Track
+	for _, t := range tracks {
+		key := autoplayDedupeKey(t.Path)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		fresh = append(fresh, t)
+	}
+	if len(fresh) == 0 {
+		return 0
+	}
+	m.playlist.Add(fresh...)
+	m.loadedPlaylist = ""
+	m.addToHeaderState(fresh)
+	return len(fresh)
+}
+
+func autoplayDedupeKey(path string) string {
+	if id := resolve.YouTubeVideoID(path); id != "" {
+		return id
+	}
+	return path
+}

--- a/ui/model/autoplay_test.go
+++ b/ui/model/autoplay_test.go
@@ -376,3 +376,69 @@ func TestDiscardAutoplayTracksIsIdempotent(t *testing.T) {
 		t.Errorf("playlist len = %d, want 1", m.playlist.Len())
 	}
 }
+
+func TestPlayTrackImmediateReplacesPreviousPlayNowTrack(t *testing.T) {
+	m := autoplayTestModel("/home/user/mine.mp3")
+
+	_ = m.playTrackImmediate(playlist.Track{Path: "https://www.youtube.com/watch?v=first0000001", Title: "first search"})
+	m.appendAutoplayTracks([]playlist.Track{
+		{Path: "https://www.youtube.com/watch?v=auto0000001"},
+		{Path: "https://www.youtube.com/watch?v=auto0000002"},
+	})
+	if m.playlist.Len() != 4 {
+		t.Fatalf("setup len = %d, want 4", m.playlist.Len())
+	}
+
+	_ = m.playTrackImmediate(playlist.Track{Path: "https://www.youtube.com/watch?v=second000001", Title: "second search"})
+
+	if m.playlist.Len() != 2 {
+		t.Fatalf("playlist len = %d, want 2 (user track + newest search)", m.playlist.Len())
+	}
+	first, _ := m.playlist.Track(0)
+	if first.Path != "/home/user/mine.mp3" {
+		t.Errorf("track 0 = %q, want the user's own track", first.Path)
+	}
+	cur, idx := m.playlist.Current()
+	if idx != 1 {
+		t.Errorf("current index = %d, want 1", idx)
+	}
+	if cur.Path != "https://www.youtube.com/watch?v=second000001" {
+		t.Errorf("current = %q, want the newest searched track", cur.Path)
+	}
+}
+
+func TestPlayTrackImmediateKeepsBookmarkedPlayNowTrack(t *testing.T) {
+	m := autoplayTestModel("/home/user/mine.mp3")
+	_ = m.playTrackImmediate(playlist.Track{Path: "https://www.youtube.com/watch?v=first0000001", Title: "first search"})
+
+	kept, ok := m.playlist.Track(1)
+	if !ok {
+		t.Fatal("missing search track")
+	}
+	kept.Bookmark = true
+	m.playlist.SetTrack(1, kept)
+
+	_ = m.playTrackImmediate(playlist.Track{Path: "https://www.youtube.com/watch?v=second000001"})
+
+	if m.playlist.Len() != 3 {
+		t.Fatalf("playlist len = %d, want 3 (bookmarked track survives)", m.playlist.Len())
+	}
+	got, _ := m.playlist.Track(1)
+	if got.Path != "https://www.youtube.com/watch?v=first0000001" {
+		t.Errorf("track 1 = %q, want the bookmarked search track", got.Path)
+	}
+}
+
+func TestAppendedTracksAreNotTreatedAsPlayNow(t *testing.T) {
+	m := autoplayTestModel()
+	_ = m.appendTrack(playlist.Track{Path: "https://www.youtube.com/watch?v=append000001", Title: "appended"})
+	_ = m.playTrackImmediate(playlist.Track{Path: "https://www.youtube.com/watch?v=search000001"})
+
+	if m.playlist.Len() != 2 {
+		t.Fatalf("playlist len = %d, want 2 (appended track kept)", m.playlist.Len())
+	}
+	got, _ := m.playlist.Track(0)
+	if got.Path != "https://www.youtube.com/watch?v=append000001" {
+		t.Errorf("track 0 = %q, want the appended track", got.Path)
+	}
+}

--- a/ui/model/autoplay_test.go
+++ b/ui/model/autoplay_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
+
 	"github.com/bjarneo/cliamp/playlist"
 )
 
@@ -214,5 +216,52 @@ func TestMaybePrefetchAutoplay(t *testing.T) {
 	}
 	if cmd := m.maybePrefetchAutoplay(); cmd != nil {
 		t.Error("duplicate prefetch while one is in flight")
+	}
+}
+
+type autoplaySaverStub struct{ saved map[string]string }
+
+func (s *autoplaySaverStub) Save(key, value string) error {
+	if s.saved == nil {
+		s.saved = map[string]string{}
+	}
+	s.saved[key] = value
+	return nil
+}
+
+func TestAutoplayToggleKeyPersists(t *testing.T) {
+	saver := &autoplaySaverStub{}
+	m := autoplayTestModel("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+	m.autoplayRadio = false
+	m.configSaver = saver
+
+	m.toggleAutoplayRadio()
+	if !m.autoplayRadio {
+		t.Error("toggle did not enable autoplay")
+	}
+	if saver.saved["autoplay_radio"] != "true" {
+		t.Errorf("saved autoplay_radio = %q, want \"true\"", saver.saved["autoplay_radio"])
+	}
+	m.toggleAutoplayRadio()
+	if m.autoplayRadio {
+		t.Error("toggle did not disable autoplay")
+	}
+	if saver.saved["autoplay_radio"] != "false" {
+		t.Errorf("saved autoplay_radio = %q, want \"false\"", saver.saved["autoplay_radio"])
+	}
+}
+
+func TestAutoplayToggleKeyDispatch(t *testing.T) {
+	saver := &autoplaySaverStub{}
+	m := autoplayTestModel("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+	m.autoplayRadio = false
+	m.configSaver = saver
+
+	m.handleKey(tea.KeyPressMsg{Text: "c"})
+	if !m.autoplayRadio {
+		t.Error("c key did not enable autoplay radio")
+	}
+	if saver.saved["autoplay_radio"] != "true" {
+		t.Errorf("saved autoplay_radio = %q, want \"true\"", saver.saved["autoplay_radio"])
 	}
 }

--- a/ui/model/autoplay_test.go
+++ b/ui/model/autoplay_test.go
@@ -1,0 +1,103 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/bjarneo/cliamp/playlist"
+)
+
+func autoplayTestModel(paths ...string) *Model {
+	pl := playlist.New()
+	for _, p := range paths {
+		pl.Add(playlist.Track{Path: p, Title: p})
+	}
+	m := &Model{player: &playbackFakeEngine{}, playlist: pl, autoplayRadio: true}
+	return m
+}
+
+func TestAutoplayEligibleSeed(t *testing.T) {
+	m := autoplayTestModel("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+	m.playlist.SetIndex(0)
+	track, _ := m.playlist.Current()
+	m.setPlaybackTrack(track)
+
+	mixURL, ok := m.autoplayEligibleSeed()
+	if !ok {
+		t.Fatal("eligible seed: ok = false, want true")
+	}
+	want := "https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=RDdQw4w9WgXcQ"
+	if mixURL != want {
+		t.Errorf("mixURL = %q, want %q", mixURL, want)
+	}
+
+	m.autoplayRadio = false
+	if _, ok := m.autoplayEligibleSeed(); ok {
+		t.Error("disabled autoplay: ok = true, want false")
+	}
+	m.autoplayRadio = true
+
+	m.autoplayFailedSeed = track.Path
+	if _, ok := m.autoplayEligibleSeed(); ok {
+		t.Error("failed seed: ok = true, want false")
+	}
+}
+
+func TestAutoplayEligibleSeedNonYouTube(t *testing.T) {
+	m := autoplayTestModel("/home/user/song.mp3")
+	m.playlist.SetIndex(0)
+	track, _ := m.playlist.Current()
+	m.setPlaybackTrack(track)
+	if _, ok := m.autoplayEligibleSeed(); ok {
+		t.Error("local file seed: ok = true, want false")
+	}
+}
+
+func TestContinueWithAutoplayStartsFetchOnce(t *testing.T) {
+	m := autoplayTestModel("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+	m.playlist.SetIndex(0)
+	track, _ := m.playlist.Current()
+	m.setPlaybackTrack(track)
+
+	cmd, pending := m.continueWithAutoplay()
+	if !pending || cmd == nil {
+		t.Fatalf("first call: cmd=%v pending=%v, want non-nil cmd + pending", cmd, pending)
+	}
+	if !m.autoplayLoading {
+		t.Error("autoplayLoading not set")
+	}
+	// Second call while in flight: pending, but no duplicate fetch.
+	cmd2, pending2 := m.continueWithAutoplay()
+	if !pending2 || cmd2 != nil {
+		t.Errorf("second call: cmd=%v pending=%v, want nil cmd + pending", cmd2, pending2)
+	}
+}
+
+func TestAppendAutoplayTracksDedupes(t *testing.T) {
+	m := autoplayTestModel("https://www.youtube.com/watch?v=seed00000001")
+	added := m.appendAutoplayTracks([]playlist.Track{
+		{Path: "https://www.youtube.com/watch?v=seed00000001", Title: "seed again"},   // dup of queue entry
+		{Path: "https://music.youtube.com/watch?v=seed00000001", Title: "seed music"}, // same ID, other host
+		{Path: "https://www.youtube.com/watch?v=fresh0000001", Title: "fresh 1"},
+		{Path: "https://www.youtube.com/watch?v=fresh0000002", Title: "fresh 2"},
+		{Path: "https://www.youtube.com/watch?v=fresh0000001", Title: "fresh 1 dup"},
+	})
+	if added != 2 {
+		t.Errorf("added = %d, want 2", added)
+	}
+	if m.playlist.Len() != 3 {
+		t.Errorf("playlist len = %d, want 3", m.playlist.Len())
+	}
+}
+
+func TestAppendAutoplayTracksAllDuplicates(t *testing.T) {
+	m := autoplayTestModel("https://www.youtube.com/watch?v=seed00000001")
+	added := m.appendAutoplayTracks([]playlist.Track{
+		{Path: "https://www.youtube.com/watch?v=seed00000001"},
+	})
+	if added != 0 {
+		t.Errorf("added = %d, want 0", added)
+	}
+	if m.playlist.Len() != 1 {
+		t.Errorf("playlist len = %d, want 1", m.playlist.Len())
+	}
+}

--- a/ui/model/autoplay_test.go
+++ b/ui/model/autoplay_test.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"testing"
+	"time"
 
 	"github.com/bjarneo/cliamp/playlist"
 )
@@ -186,5 +187,32 @@ func TestAutoplayTracksMsgEmptyResultStops(t *testing.T) {
 	}
 	if got.autoplayFailedSeed != track.Path {
 		t.Errorf("autoplayFailedSeed = %q, want %q", got.autoplayFailedSeed, track.Path)
+	}
+}
+
+func TestMaybePrefetchAutoplay(t *testing.T) {
+	engine := &playbackFakeEngine{playing: true, duration: 3 * time.Minute}
+	pl := playlist.New()
+	pl.Add(playlist.Track{Path: "https://www.youtube.com/watch?v=dQw4w9WgXcQ", Stream: true})
+	pl.SetIndex(0)
+	m := &Model{player: engine, playlist: pl, autoplayRadio: true}
+	track, _ := pl.Current()
+	m.setPlaybackTrack(track)
+
+	// Far from the end: no fetch yet.
+	engine.position = 1 * time.Minute
+	if cmd := m.maybePrefetchAutoplay(); cmd != nil {
+		t.Error("prefetch fired with >45s remaining")
+	}
+	// Inside the lead window: fetch starts once.
+	engine.position = 3*time.Minute - 30*time.Second
+	if cmd := m.maybePrefetchAutoplay(); cmd == nil {
+		t.Fatal("prefetch did not fire inside lead window")
+	}
+	if !m.autoplayLoading {
+		t.Error("autoplayLoading not set")
+	}
+	if cmd := m.maybePrefetchAutoplay(); cmd != nil {
+		t.Error("duplicate prefetch while one is in flight")
 	}
 }

--- a/ui/model/autoplay_test.go
+++ b/ui/model/autoplay_test.go
@@ -442,3 +442,123 @@ func TestAppendedTracksAreNotTreatedAsPlayNow(t *testing.T) {
 		t.Errorf("track 0 = %q, want the appended track", got.Path)
 	}
 }
+
+// Regression: cleanup must key off entry origin, not the video ID, so a
+// user-owned copy of an autoplay track survives.
+func TestDiscardKeepsUserOwnedEquivalentTrack(t *testing.T) {
+	m := autoplayTestModel("/home/user/mine.mp3")
+	m.appendAutoplayTracks([]playlist.Track{
+		{Path: "https://www.youtube.com/watch?v=shared000001", Title: "auto copy"},
+	})
+	// The user adds the same video by hand (different URL host, same ID).
+	_ = m.appendTrack(playlist.Track{Path: "https://music.youtube.com/watch?v=shared000001", Title: "user copy"})
+	if m.playlist.Len() != 3 {
+		t.Fatalf("setup len = %d, want 3", m.playlist.Len())
+	}
+
+	removed := m.discardAutoplayTracks()
+	if removed != 1 {
+		t.Errorf("removed = %d, want 1 (only the autoplay entry)", removed)
+	}
+	if m.playlist.Len() != 2 {
+		t.Fatalf("playlist len = %d, want 2", m.playlist.Len())
+	}
+	got, _ := m.playlist.Track(1)
+	if got.Path != "https://music.youtube.com/watch?v=shared000001" {
+		t.Errorf("track 1 = %q, want the user-added copy", got.Path)
+	}
+}
+
+func TestPlayTrackImmediateKeepsUserOwnedEquivalentTrack(t *testing.T) {
+	m := autoplayTestModel()
+	_ = m.playTrackImmediate(playlist.Track{Path: "https://www.youtube.com/watch?v=shared000001", Title: "played"})
+	_ = m.appendTrack(playlist.Track{Path: "https://youtu.be/shared000001", Title: "user copy"})
+
+	_ = m.playTrackImmediate(playlist.Track{Path: "https://www.youtube.com/watch?v=next00000001"})
+
+	if m.playlist.Len() != 2 {
+		t.Fatalf("playlist len = %d, want 2 (user copy + new track)", m.playlist.Len())
+	}
+	got, _ := m.playlist.Track(0)
+	if got.Path != "https://youtu.be/shared000001" {
+		t.Errorf("track 0 = %q, want the user-added copy", got.Path)
+	}
+}
+
+func TestAutoplayEligibleSeedRejectsLiveStream(t *testing.T) {
+	pl := playlist.New()
+	pl.Add(playlist.Track{Path: "https://www.youtube.com/watch?v=live00000001", Stream: true, Realtime: true})
+	pl.SetIndex(0)
+	m := &Model{player: &playbackFakeEngine{}, playlist: pl, autoplayRadio: true}
+	track, _ := pl.Current()
+	m.setPlaybackTrack(track)
+
+	if _, ok := m.autoplayEligibleSeed(); ok {
+		t.Error("live track: ok = true, want false")
+	}
+	if cmd := m.nextTrack(); cmd != nil {
+		t.Error("nextTrack started an autoplay fetch for a live track")
+	}
+}
+
+func TestAutoplayEligibleSeedRejectsRuntimeDetectedLiveStream(t *testing.T) {
+	pl := playlist.New()
+	pl.Add(playlist.Track{Path: "https://www.youtube.com/watch?v=live00000002", Stream: true})
+	pl.SetIndex(0)
+	m := &Model{player: &playbackFakeEngine{live: true}, playlist: pl, autoplayRadio: true}
+	track, _ := pl.Current()
+	m.setPlaybackTrack(track)
+
+	if _, ok := m.autoplayEligibleSeed(); ok {
+		t.Error("runtime-detected live track: ok = true, want false")
+	}
+}
+
+func TestAutoplayTracksMsgDroppedWhenDisabledMidFlight(t *testing.T) {
+	m := autoplayTestModel("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+	m.playlist.SetIndex(0)
+	track, _ := m.playlist.Current()
+	m.setPlaybackTrack(track)
+	_ = m.nextTrack()
+
+	m.autoplayRadio = false // user pressed `c` while the fetch was in flight
+	updated, cmd := m.Update(autoplayTracksMsg{
+		gen:    m.requests.autoplay,
+		seed:   track.Path,
+		tracks: []playlist.Track{{Path: "https://www.youtube.com/watch?v=fresh0000001"}},
+	})
+	got := updated.(Model)
+	if got.playlist.Len() != 1 {
+		t.Errorf("playlist len = %d, want 1 (result discarded)", got.playlist.Len())
+	}
+	if cmd != nil {
+		t.Error("cmd != nil, want nil")
+	}
+	if got.autoplayLoading || got.autoplayAdvance {
+		t.Error("autoplay flags not cleared")
+	}
+}
+
+func TestAutoplayTracksMsgDroppedWhenSeedNoLongerActive(t *testing.T) {
+	m := autoplayTestModel("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+	m.playlist.SetIndex(0)
+	track, _ := m.playlist.Current()
+	m.setPlaybackTrack(track)
+	_ = m.nextTrack()
+
+	updated, cmd := m.Update(autoplayTracksMsg{
+		gen:    m.requests.autoplay,
+		seed:   "https://www.youtube.com/watch?v=someother001", // stale seed
+		tracks: []playlist.Track{{Path: "https://www.youtube.com/watch?v=fresh0000001"}},
+	})
+	got := updated.(Model)
+	if got.playlist.Len() != 1 {
+		t.Errorf("playlist len = %d, want 1 (result discarded)", got.playlist.Len())
+	}
+	if cmd != nil {
+		t.Error("cmd != nil, want nil")
+	}
+	if got.autoplayLoading || got.autoplayAdvance {
+		t.Error("autoplay flags not cleared")
+	}
+}

--- a/ui/model/autoplay_test.go
+++ b/ui/model/autoplay_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -263,5 +264,38 @@ func TestAutoplayToggleKeyDispatch(t *testing.T) {
 	}
 	if saver.saved["autoplay_radio"] != "true" {
 		t.Errorf("saved autoplay_radio = %q, want \"true\"", saver.saved["autoplay_radio"])
+	}
+}
+
+func TestAppendAutoplayTracksCapsAtMax(t *testing.T) {
+	m := autoplayTestModel("https://www.youtube.com/watch?v=seed00000001")
+	var mix []playlist.Track
+	mix = append(mix, playlist.Track{Path: "https://www.youtube.com/watch?v=seed00000001", Title: "seed"})
+	for i := 0; i < 15; i++ {
+		mix = append(mix, playlist.Track{
+			Path:  fmt.Sprintf("https://www.youtube.com/watch?v=fresh%07d", i),
+			Title: fmt.Sprintf("fresh %d", i),
+		})
+	}
+	added := m.appendAutoplayTracks(mix)
+	if added != autoplayMaxAppend {
+		t.Errorf("added = %d, want %d", added, autoplayMaxAppend)
+	}
+	if m.playlist.Len() != 1+autoplayMaxAppend {
+		t.Errorf("playlist len = %d, want %d", m.playlist.Len(), 1+autoplayMaxAppend)
+	}
+	// The kept tracks must be the first five non-duplicate Mix entries, in order.
+	for i := 0; i < autoplayMaxAppend; i++ {
+		got, _ := m.playlist.Track(1 + i)
+		want := fmt.Sprintf("https://www.youtube.com/watch?v=fresh%07d", i)
+		if got.Path != want {
+			t.Errorf("track %d = %q, want %q", 1+i, got.Path, want)
+		}
+	}
+}
+
+func TestAutoplayMaxAppendIsFive(t *testing.T) {
+	if autoplayMaxAppend != 5 {
+		t.Errorf("autoplayMaxAppend = %d, want 5", autoplayMaxAppend)
 	}
 }

--- a/ui/model/autoplay_test.go
+++ b/ui/model/autoplay_test.go
@@ -101,3 +101,90 @@ func TestAppendAutoplayTracksAllDuplicates(t *testing.T) {
 		t.Errorf("playlist len = %d, want 1", m.playlist.Len())
 	}
 }
+
+func TestNextTrackTriggersAutoplayAtQueueEnd(t *testing.T) {
+	m := autoplayTestModel("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+	m.playlist.SetIndex(0)
+	track, _ := m.playlist.Current()
+	m.setPlaybackTrack(track)
+
+	cmd := m.nextTrack()
+	if cmd == nil {
+		t.Fatal("nextTrack at queue end with autoplay on: cmd = nil, want fetch cmd")
+	}
+	if !m.autoplayAdvance {
+		t.Error("autoplayAdvance not set")
+	}
+	if !m.playingTrackActive {
+		t.Error("playback track cleared while autoplay fetch pending")
+	}
+}
+
+func TestNextTrackStopsWhenAutoplayOff(t *testing.T) {
+	m := autoplayTestModel("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+	m.autoplayRadio = false
+	m.playlist.SetIndex(0)
+	track, _ := m.playlist.Current()
+	m.setPlaybackTrack(track)
+
+	if cmd := m.nextTrack(); cmd != nil {
+		t.Errorf("autoplay off: cmd = %v, want nil (stop)", cmd)
+	}
+	if m.playingTrackActive {
+		t.Error("playback track not cleared")
+	}
+}
+
+func TestAutoplayTracksMsgAppendsAndAdvances(t *testing.T) {
+	m := autoplayTestModel("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+	m.playlist.SetIndex(0)
+	track, _ := m.playlist.Current()
+	m.setPlaybackTrack(track)
+	_ = m.nextTrack() // arms autoplayAdvance, sets gen
+
+	updated, _ := m.Update(autoplayTracksMsg{
+		gen:  m.requests.autoplay,
+		seed: track.Path,
+		tracks: []playlist.Track{
+			{Path: "https://www.youtube.com/watch?v=fresh0000001", Title: "fresh", Stream: true},
+		},
+	})
+	got := updated.(Model)
+	if got.playlist.Len() != 2 {
+		t.Fatalf("playlist len = %d, want 2", got.playlist.Len())
+	}
+	if got.autoplayAdvance {
+		t.Error("autoplayAdvance not cleared")
+	}
+	cur, _ := got.playlist.Current()
+	if cur.Path != "https://www.youtube.com/watch?v=fresh0000001" {
+		t.Errorf("current = %q, want the appended track", cur.Path)
+	}
+}
+
+func TestAutoplayTracksMsgStaleGenerationDropped(t *testing.T) {
+	m := autoplayTestModel("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+	m.requests.autoplay = 5
+	updated, _ := m.Update(autoplayTracksMsg{gen: 3, tracks: []playlist.Track{{Path: "x"}}})
+	got := updated.(Model)
+	if got.playlist.Len() != 1 {
+		t.Errorf("stale msg mutated playlist: len = %d, want 1", got.playlist.Len())
+	}
+}
+
+func TestAutoplayTracksMsgEmptyResultStops(t *testing.T) {
+	m := autoplayTestModel("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+	m.playlist.SetIndex(0)
+	track, _ := m.playlist.Current()
+	m.setPlaybackTrack(track)
+	_ = m.nextTrack()
+
+	updated, _ := m.Update(autoplayTracksMsg{gen: m.requests.autoplay, seed: track.Path})
+	got := updated.(Model)
+	if got.playingTrackActive {
+		t.Error("playback not stopped after empty autoplay result")
+	}
+	if got.autoplayFailedSeed != track.Path {
+		t.Errorf("autoplayFailedSeed = %q, want %q", got.autoplayFailedSeed, track.Path)
+	}
+}

--- a/ui/model/autoplay_test.go
+++ b/ui/model/autoplay_test.go
@@ -299,3 +299,80 @@ func TestAutoplayMaxAppendIsFive(t *testing.T) {
 		t.Errorf("autoplayMaxAppend = %d, want 5", autoplayMaxAppend)
 	}
 }
+
+func TestPlayTrackImmediateDiscardsAutoplayTracks(t *testing.T) {
+	m := autoplayTestModel("https://www.youtube.com/watch?v=seed00000001")
+	added := m.appendAutoplayTracks([]playlist.Track{
+		{Path: "https://www.youtube.com/watch?v=auto0000001", Title: "auto 1"},
+		{Path: "https://www.youtube.com/watch?v=auto0000002", Title: "auto 2"},
+		{Path: "https://www.youtube.com/watch?v=auto0000003", Title: "auto 3"},
+	})
+	if added != 3 || m.playlist.Len() != 4 {
+		t.Fatalf("setup: added=%d len=%d, want 3 and 4", added, m.playlist.Len())
+	}
+
+	_ = m.playTrackImmediate(playlist.Track{Path: "https://www.youtube.com/watch?v=search000001", Title: "searched"})
+
+	if m.playlist.Len() != 2 {
+		t.Fatalf("playlist len = %d, want 2 (seed + searched)", m.playlist.Len())
+	}
+	first, _ := m.playlist.Track(0)
+	if first.Path != "https://www.youtube.com/watch?v=seed00000001" {
+		t.Errorf("track 0 = %q, want the pre-existing user track", first.Path)
+	}
+	cur, idx := m.playlist.Current()
+	if idx != 1 {
+		t.Errorf("current index = %d, want 1 (last index)", idx)
+	}
+	if cur.Path != "https://www.youtube.com/watch?v=search000001" {
+		t.Errorf("current = %q, want the searched track", cur.Path)
+	}
+	if m.plCursor != 1 {
+		t.Errorf("plCursor = %d, want 1", m.plCursor)
+	}
+}
+
+func TestPlayTrackImmediateKeepsUserTracks(t *testing.T) {
+	m := autoplayTestModel(
+		"/home/user/a.mp3",
+		"https://www.youtube.com/watch?v=user00000001",
+	)
+	m.appendAutoplayTracks([]playlist.Track{
+		{Path: "https://www.youtube.com/watch?v=auto0000001", Title: "auto 1"},
+		{Path: "https://www.youtube.com/watch?v=auto0000002", Title: "auto 2"},
+	})
+	if m.playlist.Len() != 4 {
+		t.Fatalf("setup len = %d, want 4", m.playlist.Len())
+	}
+
+	_ = m.playTrackImmediate(playlist.Track{Path: "https://www.youtube.com/watch?v=search000001"})
+
+	if m.playlist.Len() != 3 {
+		t.Fatalf("playlist len = %d, want 3 (2 user + searched)", m.playlist.Len())
+	}
+	want := []string{
+		"/home/user/a.mp3",
+		"https://www.youtube.com/watch?v=user00000001",
+		"https://www.youtube.com/watch?v=search000001",
+	}
+	for i, w := range want {
+		got, _ := m.playlist.Track(i)
+		if got.Path != w {
+			t.Errorf("track %d = %q, want %q", i, got.Path, w)
+		}
+	}
+}
+
+func TestDiscardAutoplayTracksIsIdempotent(t *testing.T) {
+	m := autoplayTestModel("https://www.youtube.com/watch?v=seed00000001")
+	m.appendAutoplayTracks([]playlist.Track{{Path: "https://www.youtube.com/watch?v=auto0000001"}})
+	if n := m.discardAutoplayTracks(); n != 1 {
+		t.Errorf("first discard removed %d, want 1", n)
+	}
+	if n := m.discardAutoplayTracks(); n != 0 {
+		t.Errorf("second discard removed %d, want 0", n)
+	}
+	if m.playlist.Len() != 1 {
+		t.Errorf("playlist len = %d, want 1", m.playlist.Len())
+	}
+}

--- a/ui/model/command_registry.go
+++ b/ui/model/command_registry.go
@@ -96,6 +96,7 @@ var commandRegistry = []commandSpec{
 	{Mode: commandModeMain | commandModeSpeed, Keys: []string{"]", "["}, KeyLabel: "] [", Label: "Speed up/down (+/-0.25x)", Keymap: true},
 	{Mode: commandModeMain | commandModeVolume | commandModeShuffle | commandModeRepeat, Keys: []string{"z"}, KeyLabel: "z", Label: "Toggle shuffle", Keymap: true},
 	{Mode: commandModeMain | commandModeVolume | commandModeShuffle | commandModeRepeat, Keys: []string{"r"}, KeyLabel: "r", Label: "Cycle repeat", Keymap: true},
+	{Mode: commandModeMain, Keys: []string{"c"}, KeyLabel: "c", Label: "Toggle autoplay radio (YouTube Mix)", Keymap: true},
 	{Mode: commandModeMain, Keys: []string{"m"}, KeyLabel: "m", Label: "Toggle mono", Keymap: true},
 	{Mode: commandModeMain, Keys: []string{"e"}, KeyLabel: "e", Label: "Cycle EQ preset", Enabled: func(m Model) bool { return !m.simplified }, Keymap: true},
 	{Mode: commandModeMain, Keys: []string{"t"}, KeyLabel: "t", Label: "Choose theme", Keymap: true},

--- a/ui/model/init.go
+++ b/ui/model/init.go
@@ -109,6 +109,9 @@ func (m *Model) findProviderWith(check func(playlist.Provider) bool) playlist.Pr
 // SetAutoPlay makes the player start playback immediately on Init.
 func (m *Model) SetAutoPlay(v bool) { m.autoPlay = v }
 
+// SetAutoplayRadio enables YouTube-style autoplay continuation from config.
+func (m *Model) SetAutoplayRadio(v bool) { m.autoplayRadio = v }
+
 // SetLowPower lowers UI cadences without affecting normal mode.
 func (m *Model) SetLowPower(v bool) { m.lowPower = v }
 

--- a/ui/model/ipc_podcast_test.go
+++ b/ui/model/ipc_podcast_test.go
@@ -520,6 +520,10 @@ func TestIPCTrackActionsNonFeed(t *testing.T) {
 					if op == "track.queue" {
 						queued = append(queued, track)
 						wantIndex = 0
+					} else {
+						// track.play fills the "play now" slot, which the next
+						// play-now (or autoplay cleanup) may reclaim.
+						track.Ephemeral = true
 					}
 					if !reflect.DeepEqual(m.playlist.Tracks(), append(original, track)) || !reflect.DeepEqual(m.playlist.QueueTracks(), queued) || m.playlist.Index() != wantIndex {
 						t.Fatal("non-feed single-track behavior changed")

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -811,6 +811,9 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 		m.saveConfigKey("shuffle", fmt.Sprintf("%v", m.playlist.Shuffled()))
 		return m.rearmPreload()
 
+	case "c":
+		m.toggleAutoplayRadio()
+
 	case "tab":
 		m.focus = m.nextMainFocus(m.focus)
 	case "shift+tab":

--- a/ui/model/model.go
+++ b/ui/model/model.go
@@ -480,12 +480,10 @@ type Model struct {
 	heightExpanded  bool // tracks whether manual 'x' expansion is active
 
 	// YouTube-style autoplay continuation (see autoplay.go).
-	autoplayRadio      bool            // continue with YouTube Mix related tracks when the queue runs out
-	autoplayLoading    bool            // a Mix fetch is in flight
-	autoplayAdvance    bool            // playback drained while fetching; advance when tracks arrive
-	autoplayFailedSeed string          // seed path whose Mix fetch failed or added nothing; blocks refetch loops
-	autoplayAdded      map[string]bool // dedupe keys of tracks autoplay appended; dropped on the next manual play
-	playNowKey         string          // dedupe key of the last "play now" track; replaced by the next one
+	autoplayRadio      bool   // continue with YouTube Mix related tracks when the queue runs out
+	autoplayLoading    bool   // a Mix fetch is in flight
+	autoplayAdvance    bool   // playback drained while fetching; advance when tracks arrive
+	autoplayFailedSeed string // seed path whose Mix fetch failed or added nothing; blocks refetch loops
 
 	// Cached per-tick to avoid repeated speaker.Lock() calls in View().
 	cachedPos  time.Duration

--- a/ui/model/model.go
+++ b/ui/model/model.go
@@ -470,14 +470,19 @@ type Model struct {
 	// Full-screen visualizer mode (Shift+V)
 	fullVis bool
 
-	autoPlay        bool // start playing immediately on launch
-	lowPower        bool // lower UI/render cadences in low-power mode
-	visualizer60FPS bool // render a visible visualizer at the animation cadence
-	simplified      bool // simplified playback view: track summary and time strip
-	hideHelpBar     bool // hide the key-binding hint bar above the status line
-	hideSettings    bool // close the two-column settings pane beside the playlist
-	showMetadata    bool // expand highlighted-track metadata below settings
-	heightExpanded  bool // tracks whether manual 'x' expansion is active
+	autoPlay bool // start playing immediately on launch
+
+	autoplayRadio      bool   // continue with YouTube Mix related tracks when the queue runs out
+	autoplayLoading    bool   // a Mix fetch is in flight
+	autoplayAdvance    bool   // playback drained while fetching; advance when tracks arrive
+	autoplayFailedSeed string // seed path whose Mix fetch failed or added nothing; blocks refetch loops
+	lowPower           bool   // lower UI/render cadences in low-power mode
+	visualizer60FPS    bool   // render a visible visualizer at the animation cadence
+	simplified         bool   // simplified playback view: track summary and time strip
+	hideHelpBar        bool   // hide the key-binding hint bar above the status line
+	hideSettings       bool   // close the two-column settings pane beside the playlist
+	showMetadata       bool   // expand highlighted-track metadata below settings
+	heightExpanded     bool   // tracks whether manual 'x' expansion is active
 
 	// Cached per-tick to avoid repeated speaker.Lock() calls in View().
 	cachedPos  time.Duration

--- a/ui/model/model.go
+++ b/ui/model/model.go
@@ -485,6 +485,7 @@ type Model struct {
 	autoplayAdvance    bool            // playback drained while fetching; advance when tracks arrive
 	autoplayFailedSeed string          // seed path whose Mix fetch failed or added nothing; blocks refetch loops
 	autoplayAdded      map[string]bool // dedupe keys of tracks autoplay appended; dropped on the next manual play
+	playNowKey         string          // dedupe key of the last "play now" track; replaced by the next one
 
 	// Cached per-tick to avoid repeated speaker.Lock() calls in View().
 	cachedPos  time.Duration

--- a/ui/model/model.go
+++ b/ui/model/model.go
@@ -480,10 +480,11 @@ type Model struct {
 	heightExpanded  bool // tracks whether manual 'x' expansion is active
 
 	// YouTube-style autoplay continuation (see autoplay.go).
-	autoplayRadio      bool   // continue with YouTube Mix related tracks when the queue runs out
-	autoplayLoading    bool   // a Mix fetch is in flight
-	autoplayAdvance    bool   // playback drained while fetching; advance when tracks arrive
-	autoplayFailedSeed string // seed path whose Mix fetch failed or added nothing; blocks refetch loops
+	autoplayRadio      bool            // continue with YouTube Mix related tracks when the queue runs out
+	autoplayLoading    bool            // a Mix fetch is in flight
+	autoplayAdvance    bool            // playback drained while fetching; advance when tracks arrive
+	autoplayFailedSeed string          // seed path whose Mix fetch failed or added nothing; blocks refetch loops
+	autoplayAdded      map[string]bool // dedupe keys of tracks autoplay appended; dropped on the next manual play
 
 	// Cached per-tick to avoid repeated speaker.Lock() calls in View().
 	cachedPos  time.Duration

--- a/ui/model/model.go
+++ b/ui/model/model.go
@@ -470,19 +470,20 @@ type Model struct {
 	// Full-screen visualizer mode (Shift+V)
 	fullVis bool
 
-	autoPlay bool // start playing immediately on launch
+	autoPlay        bool // start playing immediately on launch
+	lowPower        bool // lower UI/render cadences in low-power mode
+	visualizer60FPS bool // render a visible visualizer at the animation cadence
+	simplified      bool // simplified playback view: track summary and time strip
+	hideHelpBar     bool // hide the key-binding hint bar above the status line
+	hideSettings    bool // close the two-column settings pane beside the playlist
+	showMetadata    bool // expand highlighted-track metadata below settings
+	heightExpanded  bool // tracks whether manual 'x' expansion is active
 
+	// YouTube-style autoplay continuation (see autoplay.go).
 	autoplayRadio      bool   // continue with YouTube Mix related tracks when the queue runs out
 	autoplayLoading    bool   // a Mix fetch is in flight
 	autoplayAdvance    bool   // playback drained while fetching; advance when tracks arrive
 	autoplayFailedSeed string // seed path whose Mix fetch failed or added nothing; blocks refetch loops
-	lowPower           bool   // lower UI/render cadences in low-power mode
-	visualizer60FPS    bool   // render a visible visualizer at the animation cadence
-	simplified         bool   // simplified playback view: track summary and time strip
-	hideHelpBar        bool   // hide the key-binding hint bar above the status line
-	hideSettings       bool   // close the two-column settings pane beside the playlist
-	showMetadata       bool   // expand highlighted-track metadata below settings
-	heightExpanded     bool   // tracks whether manual 'x' expansion is active
 
 	// Cached per-tick to avoid repeated speaker.Lock() calls in View().
 	cachedPos  time.Duration

--- a/ui/model/playback.go
+++ b/ui/model/playback.go
@@ -189,10 +189,11 @@ func (m *Model) playTrackImmediate(track playlist.Track) tea.Cmd {
 	m.player.Stop()
 	m.player.ClearPreload()
 	// Starting a new track by hand ends the previous autoplay run: drop the
-	// related tracks it queued so this one plays from the end of the queue
-	// instead of behind a stale Mix.
+	// previously played track and the related tracks autoplay queued behind
+	// it, so this one reuses that slot instead of stacking up at the end.
 	m.discardAutoplayTracks()
 	m.playlist.Add(track)
+	m.playNowKey = autoplayDedupeKey(track.Path)
 	m.loadedPlaylist = ""
 	m.addToHeaderState([]playlist.Track{track})
 	idx := m.playlist.Len() - 1

--- a/ui/model/playback.go
+++ b/ui/model/playback.go
@@ -192,8 +192,8 @@ func (m *Model) playTrackImmediate(track playlist.Track) tea.Cmd {
 	// previously played track and the related tracks autoplay queued behind
 	// it, so this one reuses that slot instead of stacking up at the end.
 	m.discardAutoplayTracks()
+	track.Ephemeral = true
 	m.playlist.Add(track)
-	m.playNowKey = autoplayDedupeKey(track.Path)
 	m.loadedPlaylist = ""
 	m.addToHeaderState([]playlist.Track{track})
 	idx := m.playlist.Len() - 1

--- a/ui/model/playback.go
+++ b/ui/model/playback.go
@@ -188,6 +188,10 @@ func (m *Model) playCurrentTrack() tea.Cmd {
 func (m *Model) playTrackImmediate(track playlist.Track) tea.Cmd {
 	m.player.Stop()
 	m.player.ClearPreload()
+	// Starting a new track by hand ends the previous autoplay run: drop the
+	// related tracks it queued so this one plays from the end of the queue
+	// instead of behind a stale Mix.
+	m.discardAutoplayTracks()
 	m.playlist.Add(track)
 	m.loadedPlaylist = ""
 	m.addToHeaderState([]playlist.Track{track})

--- a/ui/model/playback.go
+++ b/ui/model/playback.go
@@ -107,6 +107,14 @@ func (m *Model) nextTrack() tea.Cmd {
 	track, ok := m.playlist.Next()
 	m.normalizeQueueOverlay()
 	if !ok {
+		if cmd, pending := m.continueWithAutoplay(); pending {
+			// Queue exhausted but autoplay will refill it. Stop audio (the
+			// drain path already did) but keep the finished track visible as
+			// the seed while the Mix fetch is in flight.
+			m.player.Stop()
+			m.autoplayAdvance = true
+			return cmd
+		}
 		m.player.Stop()
 		m.clearPlaybackTrack()
 		return nil
@@ -538,6 +546,10 @@ func (m *Model) beginPlaybackTrack(track playlist.Track) (playlist.Track, tea.Cm
 	}
 	nextRequest(&m.requests.preload)
 	m.preloading = false
+	nextRequest(&m.requests.autoplay)
+	m.autoplayLoading = false
+	m.autoplayAdvance = false
+	m.autoplayFailedSeed = ""
 	nextRequest(&m.requests.lyrics)
 	track = playlist.RefreshEmbeddedMetadata(track)
 	context, index := track.PlaybackContext()

--- a/ui/model/preload.go
+++ b/ui/model/preload.go
@@ -62,7 +62,9 @@ func (m *Model) preloadNext() tea.Cmd {
 		next, ok = m.playlist.PeekNext()
 	}
 	if !ok {
-		return nil
+		// No next track: with autoplay on, refill the queue with the Mix
+		// seeded from the current track before it ends.
+		return m.maybePrefetchAutoplay()
 	}
 	isYTDL := playlist.IsYTDL(next.Path)
 	if isYTDL && currentIdx >= 0 && next.Path == current.Path {

--- a/ui/model/state.go
+++ b/ui/model/state.go
@@ -266,6 +266,7 @@ type requestState struct {
 	catalog      uint64
 	stream       uint64
 	preload      uint64
+	autoplay     uint64
 }
 
 func nextRequest(gen *uint64) uint64 {

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -645,6 +645,40 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case autoplayTracksMsg:
+		if msg.gen != m.requests.autoplay {
+			return m, nil
+		}
+		m.autoplayLoading = false
+		added := m.appendAutoplayTracks(msg.tracks)
+		if msg.err != nil || added == 0 {
+			m.autoplayFailedSeed = msg.seed
+			if m.autoplayAdvance {
+				m.autoplayAdvance = false
+				m.player.Stop()
+				m.clearPlaybackTrack()
+			}
+			if msg.err != nil {
+				m.status.Errorf(statusTTLDefault, "Autoplay: %s", msg.err)
+			} else {
+				m.status.Warning("Autoplay: no new related tracks", statusTTLDefault)
+			}
+			m.notifyAll()
+			return m, nil
+		}
+		m.status.Showf(statusTTLMedium, "Autoplay: added %d related tracks", added)
+		var autoplayCmd tea.Cmd
+		if m.autoplayAdvance {
+			m.autoplayAdvance = false
+			autoplayCmd = m.nextTrack()
+		} else {
+			// Early prefetch landed while the last track is still playing:
+			// re-arm the gapless preloader so the transition is seamless.
+			autoplayCmd = m.rearmPreload()
+		}
+		m.notifyAll()
+		return m, autoplayCmd
+
 	case netSearchResultsMsg:
 		if msg.gen != m.requests.netSearch || !m.netSearch.active || msg.query != m.netSearch.request {
 			return m, nil

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -650,6 +650,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.autoplayLoading = false
+		// The world may have moved on while yt-dlp ran: the user can have
+		// turned autoplay off, or playback can have left the seed behind.
+		// Either way the result is no longer wanted; never touch the queue.
+		active, activeIdx := m.currentPlaybackTrack()
+		if !m.autoplayRadio || activeIdx < 0 || active.Path != msg.seed {
+			m.autoplayAdvance = false
+			return m, nil
+		}
 		added := m.appendAutoplayTracks(msg.tracks)
 		if msg.err != nil || added == 0 {
 			m.autoplayFailedSeed = msg.seed


### PR DESCRIPTION
## Problem

Play a song from `Ctrl+F` search, let it finish, and playback silently stops.

The search flow calls `playTrackImmediate()`, which appends a **single** track. When it drains, `nextTrack()` → `playlist.Next()` returns `ok=false` (last track, repeat off) → `Stop()` + `clearPlaybackTrack()`. There is nothing left to play, so the player goes quiet.

## Solution

YouTube-style autoplay continuation, opt-in via `autoplay_radio` (default `false`).

When the queue is exhausted and the finished track is a YouTube / YouTube Music video, cliamp fetches the auto-generated **Mix** (`watch?v=<id>&list=RD<id>`) — the same "related tracks" radio YouTube's own autoplay uses — drops entries already in the queue (keyed by video ID, so `www.`/`music.`/`youtu.be` variants match), appends the top 5, and keeps playing. Continuation is recursive: when those run out, the newly finished track seeds the next Mix.

No new yt-dlp plumbing was needed. `resolve` already routes `list=RD...` URLs to `resolveYTDL` with `--flat-playlist`, and `ResolveYTDLBatch` is already exported for the incremental loader.

### Details

- **Early prefetch.** While the last queue track plays, once ≤45 s remain, `preloadNext()`'s no-next branch starts the Mix fetch in the background so the tracks land before the drain and the existing gapless preloader can arm the transition.
- **Failure handling.** A fetch error, or 0 new tracks after dedupe, warns once, stops playback as before, and latches the failed seed in `autoplayFailedSeed` so the tick loop cannot spin up a yt-dlp loop for the same track.
- **Generation guarding.** `requests.autoplay` invalidates in-flight fetches; `beginPlaybackTrack` bumps it and clears the latch whenever a track starts, so a manual action always wins.
- **Unaffected paths.** Repeat one/all (`Next()` never fails), live streams (they reconnect instead of advancing), non-YouTube sources (SoundCloud, local files, …) all behave exactly as before. Autoplay is off unless enabled.

### Usage

```toml
# ~/.config/cliamp/config.toml
autoplay_radio = false   # set true, or press `c` in the player
```

`c` toggles it at runtime in main mode and persists the choice, like `z` (shuffle) and `r` (repeat). The key was free in main mode — the registry only bound `c` inside the queue overlay ("Clear").

Status line: `Autoplay: finding related tracks…` → `Autoplay: added N related tracks`.

## Changes

| Area | Change |
|---|---|
| `resolve/radio.go` | New `YouTubeVideoID()` and `RadioMixURL()` helpers |
| `config/config.go` | `AutoplayRadio` field + `autoplay_radio` parse case |
| `ui/model/autoplay.go` | State, fetch command, eligibility, dedupe/append, prefetch, toggle |
| `ui/model/playback.go` | `nextTrack()` exhaustion branch; autoplay reset in `beginPlaybackTrack` |
| `ui/model/update.go` | `autoplayTracksMsg` handler |
| `ui/model/preload.go` | Early-prefetch hook |
| `ui/model/keys.go`, `command_registry.go` | `c` toggle |
| `main.go` | Config wiring |
| docs, `config.toml.example`, `site/index.html` | User-facing documentation |

## Testing

TDD throughout — 13 new tests in `resolve/radio_test.go` and `ui/model/autoplay_test.go` covering URL parsing, eligibility gating, single-flight fetching, dedupe and the 5-track cap, the exhaustion branch, message handling (append/advance, stale generation, empty result), prefetch windowing, and the `c` toggle including key dispatch and config persistence.

CI parity, run locally:

```
gofmt -l .          # clean
go vet ./...        # clean
staticcheck ./...   # clean
govulncheck ./...   # 0 vulnerabilities affecting this code
go test -race ./... # all pass
```

Manually verified end to end against live yt-dlp: the Mix for a search-played track resolved 20 entries, the seed was correctly deduped, and playback continued onto the next related track. Also smoke-tested in a real TUI session — `autoplay_radio = true` loaded at launch and `c` rewrote the key to `false` in the config file.

Existing end-of-playlist and preload tests are untouched and still pass: they construct models with `autoplayRadio` unset, so the stop-at-end behavior is unchanged when the feature is off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional autoplay for YouTube and YouTube Music Mix recommendations when the queue is exhausted.
  * Autoplay adds up to five non-duplicate tracks and continues loading recommendations as needed.
  * Added the `c` key to toggle autoplay during playback; the setting is saved for future sessions.
  * Autoplay applies only to eligible YouTube tracks and is disabled when repeat mode is enabled.
  * Selecting a new track manually removes pending autoplay recommendations.

* **Documentation**
  * Added configuration, keybinding, and YouTube autoplay documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->