### PR TITLE
feat(player): native Termux/Android audio backend via PulseAudio

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A retro terminal music player inspired by Winamp. Play local files, streams, pod
 
 **[cliamp.stream](https://cliamp.stream)** | **[docs](https://whiterose.org.contextowl.co/docs/cliamp)**
 
-cliamp uses [Bubbletea](https://github.com/charmbracelet/bubbletea), [Lip Gloss](https://github.com/charmbracelet/lipgloss), [Beep](https://github.com/gopxl/beep), and [go-librespot](https://github.com/devgianlu/go-librespot).
+cliamp uses [Bubbletea](https://github.com/charmbracelet/bubbletea), [Lip Gloss](https://github.com/charmbracelet/lipgloss), [Beep](https://github.com/gopxl/beep), and [go-librespot](https://github.com/devgianlu/go-librespot). Runs natively on Linux, macOS, Windows, and Termux (Android).
 
 
 https://github.com/user-attachments/assets/fbc33d20-e3ac-4a62-a991-8a2f0243c8ea
@@ -76,6 +76,10 @@ Download from [GitHub Releases](https://github.com/bjarneo/cliamp/releases/lates
 > **Linux:** Pre-built binaries link FLAC, Vorbis, Ogg, and mpg123 statically. No
 > extra codec packages are required. You can still need an ALSA bridge for your
 > sound server. See [Troubleshooting](#troubleshooting).
+>
+> **Termux (Android):** Build from source with `-tags=termux` for a native
+> PulseAudio backend. No ALSA bridge needed; cliamp speaks the PulseAudio
+> protocol directly. See [Termux build instructions](#building-from-source).
 >
 > **Windows:** Download and extract `cliamp-windows-amd64.zip` from Releases. It
 > includes the codec DLLs that Spotify requires. If `HOME` is not set, cliamp stores
@@ -158,6 +162,19 @@ sudo dnf install alsa-lib-devel flac-devel libvorbis-devel libogg-devel mpg123-d
 sudo pacman -S alsa-lib flac libvorbis libogg mpg123
 ```
 
+**Termux (Android):**
+
+```sh
+pkg install pulseaudio golang
+go build -tags=termux -trimpath -ldflags='-s -w' -o cliamp .
+```
+
+The `termux` build tag selects a pure-Go PulseAudio backend. cliamp
+discovers the daemon's Unix socket automatically and falls back to
+`pulseaudio --start` when the daemon is not running. No ALSA bridge
+or `pactl` is required. Set `CLIAMP_DEBUG_PULSE=1` to diagnose audio
+issues.
+
 **macOS:** `brew install flac libvorbis libogg mpg123 pkg-config`
 
 **Windows:** The core player needs no extra SDKs. It uses pure-Go audio decoding. `ffmpeg.exe` and `yt-dlp.exe` remain optional runtime dependencies for the same formats and providers as other platforms.
@@ -204,7 +221,7 @@ Full documentation is hosted at **[whiterose.org.contextowl.co/docs/cliamp](http
 
 ## Troubleshooting
 
-**No audio output (silence with no errors)**
+**No audio output (silence with no errors) on Linux desktop**
 
 On Linux systems that use PipeWire or PulseAudio, the cliamp ALSA backend needs a bridge package to route audio through the sound server:
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/gopxl/beep/v2 v2.1.1
 	github.com/jfreymuth/oggvorbis v1.0.5
+	github.com/jfreymuth/pulse v0.1.3
 	github.com/kkdai/youtube/v2 v2.10.6
 	github.com/urfave/cli/v3 v3.11.0
 	github.com/yuin/gopher-lua v1.1.2
@@ -51,7 +52,6 @@ require (
 	github.com/googleapis/gax-go/v2 v2.24.0 // indirect
 	github.com/hajimehoshi/go-mp3 v0.3.4 // indirect
 	github.com/icza/bitio v1.1.0 // indirect
-	github.com/jfreymuth/pulse v0.1.3 // indirect
 	github.com/jfreymuth/vorbis v1.0.2 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.1 // indirect
 	github.com/mattn/go-runewidth v0.0.28 // indirect

--- a/player/player.go
+++ b/player/player.go
@@ -1159,5 +1159,5 @@ func (p *Player) resumeSpeaker() {
 // Close fully stops the speaker and cleans up all resources.
 func (p *Player) Close() {
 	p.Stop()
-	SpeakerClear()
+	SpeakerClose()
 }

--- a/player/player.go
+++ b/player/player.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/gopxl/beep/v2"
-	"github.com/gopxl/beep/v2/speaker"
 )
 
 // Quality holds configurable audio output parameters.
@@ -40,7 +39,7 @@ type Player struct {
 	nextPipeline    *trackPipeline // preloaded track's resources
 	started         bool           // true after first speaker.Play()
 	suspendMu       sync.Mutex     // guards suspended and speaker suspend/resume calls
-	suspended       bool           // true when speaker.Suspend() has been called
+	suspended       bool           // true when SpeakerSuspend() has been called
 	ctrl            *beep.Ctrl
 	volMin          atomic.Uint64     // dB floor stored as Float64bits, range [-90, 0]
 	volume          atomic.Uint64     // dB stored as Float64bits, range [volMin, +6]
@@ -100,7 +99,7 @@ func New(q Quality) (*Player, error) {
 			q.SampleRate, q.BufferMs, q.ResampleQuality)
 	}
 	sr := beep.SampleRate(q.SampleRate)
-	if err := speaker.Init(sr, sr.N(time.Duration(q.BufferMs)*time.Millisecond)); err != nil {
+	if err := SpeakerInit(sr, sr.N(time.Duration(q.BufferMs)*time.Millisecond)); err != nil {
 		return nil, fmt.Errorf("speaker init: %w", err)
 	}
 	bitDepth := q.BitDepth
@@ -119,7 +118,7 @@ func New(q Quality) (*Player, error) {
 	p.gapless = &gaplessStreamer{}
 	// Suspend the speaker immediately; the ALSA audio callback goroutine
 	// burns ~2% CPU even on silence. Resume is called on every Play().
-	_ = speaker.Suspend()
+	_ = SpeakerSuspend()
 	p.suspended = true
 	p.gapless.onSwap = func(token uint64) {
 		// Called from audio thread (goroutine) when gapless transition occurs.
@@ -294,7 +293,7 @@ func (p *Player) playPipelineForGeneration(tp *trackPipeline, generation uint64)
 		// call before we swap the source and unpause. The ctrl.Paused write
 		// must happen under the speaker lock because the audio thread reads it
 		// on every Stream() call.
-		speaker.Lock()
+		SpeakerLock()
 		p.gapless.Replace(tp.stream)
 		p.gaplessAdvance.Store(false)
 		p.ctrl.Paused = false
@@ -306,7 +305,7 @@ func (p *Player) playPipelineForGeneration(tp *trackPipeline, generation uint64)
 		p.playing.Store(true)
 		p.paused.Store(false)
 		p.mu.Unlock()
-		speaker.Unlock()
+		SpeakerUnlock()
 	} else {
 		p.mu.Lock()
 		p.gapless.Replace(tp.stream)
@@ -332,7 +331,7 @@ func (p *Player) playPipelineForGeneration(tp *trackPipeline, generation uint64)
 	}
 
 	if !started {
-		speaker.Play(p.ctrl)
+		SpeakerPlay(p.ctrl)
 	}
 	p.lifecycleMu.Unlock()
 	// Start API-based now-playing polling for streams without ICY metadata
@@ -399,11 +398,11 @@ func (p *Player) preloadPipeline(tp *trackPipeline) error {
 func (p *Player) preloadPipelineForGeneration(tp *trackPipeline, generation uint64) error {
 	// Lock speaker to atomically swap the gapless next stream, ensuring no
 	// in-flight transition reads from the old pipeline we're about to close.
-	speaker.Lock()
+	SpeakerLock()
 	p.mu.Lock()
 	if generation != 0 && p.preloadGen.Load() != generation {
 		p.mu.Unlock()
-		speaker.Unlock()
+		SpeakerUnlock()
 		go tp.close()
 		return nil
 	}
@@ -413,7 +412,7 @@ func (p *Player) preloadPipelineForGeneration(tp *trackPipeline, generation uint
 	// respect to the asynchronous transition callback.
 	tp.gaplessToken = p.gapless.SetNext(tp.stream)
 	p.mu.Unlock()
-	speaker.Unlock()
+	SpeakerUnlock()
 
 	if old != nil {
 		old.close()
@@ -426,9 +425,9 @@ func (p *Player) preloadPipelineForGeneration(tp *trackPipeline, generation uint
 // pipeline we're about to close.
 func (p *Player) ClearPreload() {
 	p.preloadGen.Add(1)
-	speaker.Lock()
+	SpeakerLock()
 	p.gapless.SetNext(nil)
-	speaker.Unlock()
+	SpeakerUnlock()
 
 	p.mu.Lock()
 	old := p.nextPipeline
@@ -449,11 +448,11 @@ func (p *Player) GaplessAdvanced() bool {
 // When pausing, the speaker is suspended to save CPU; when unpausing
 // it is resumed so the audio callback drains the queued samples.
 func (p *Player) TogglePause() {
-	speaker.Lock()
+	SpeakerLock()
 	if p.ctrl != nil {
 		p.ctrl.Paused = !p.ctrl.Paused
 		paused := p.ctrl.Paused
-		speaker.Unlock()
+		SpeakerUnlock()
 		p.paused.Store(paused)
 		if paused {
 			p.suspendSpeaker()
@@ -461,7 +460,7 @@ func (p *Player) TogglePause() {
 			p.resumeSpeaker()
 		}
 	} else {
-		speaker.Unlock()
+		SpeakerUnlock()
 	}
 }
 
@@ -481,7 +480,7 @@ func (p *Player) Stop() {
 	// Lock speaker to ensure the goroutine finishes any in-progress Stream()
 	// call, then clear the source and pause. After unlock, the speaker will
 	// only see silence from the gapless streamer (paused ctrl).
-	speaker.Lock()
+	SpeakerLock()
 	p.gapless.Clear()
 	p.gaplessAdvance.Store(false)
 	if p.ctrl != nil {
@@ -495,7 +494,7 @@ func (p *Player) Stop() {
 	p.playing.Store(false)
 	p.paused.Store(false)
 	p.mu.Unlock()
-	speaker.Unlock()
+	SpeakerUnlock()
 	p.lifecycleMu.Unlock()
 
 	// Now safe to close decoder resources: speaker cannot be reading them.
@@ -540,18 +539,18 @@ func (p *Player) Seek(d time.Duration) error {
 	}
 
 	p.lifecycleMu.Lock()
-	speaker.Lock()
+	SpeakerLock()
 	p.mu.Lock()
 	if p.current != cur {
 		p.mu.Unlock()
-		speaker.Unlock()
+		SpeakerUnlock()
 		p.lifecycleMu.Unlock()
 		return nil
 	}
 	p.mu.Unlock()
 	newSample := relativeSeekSample(cur, d)
 	if err := cur.decoder.Seek(newSample); err != nil {
-		speaker.Unlock()
+		SpeakerUnlock()
 		p.lifecycleMu.Unlock()
 		return err
 	}
@@ -563,7 +562,7 @@ func (p *Player) Seek(d time.Duration) error {
 	old := p.nextPipeline
 	p.nextPipeline = nil
 	p.mu.Unlock()
-	speaker.Unlock()
+	SpeakerUnlock()
 	p.lifecycleMu.Unlock()
 	if old != nil {
 		old.close()
@@ -603,12 +602,12 @@ func (p *Player) commitPreparedSeek(cur *trackPipeline, seeker preparedFFmpegSee
 	p.gapless.SetNext(nil)
 	seeker.interrupt()
 
-	speaker.Lock()
+	SpeakerLock()
 	p.mu.Lock()
 	current = p.current == cur && seeker.seekMatches(prepared)
 	if !current {
 		p.mu.Unlock()
-		speaker.Unlock()
+		SpeakerUnlock()
 		p.lifecycleMu.Unlock()
 		_ = prepared.close()
 		return nil
@@ -620,7 +619,7 @@ func (p *Player) commitPreparedSeek(cur *trackPipeline, seeker preparedFFmpegSee
 	p.mu.Unlock()
 	p.gapless.Replace(cur.stream)
 	p.gaplessAdvance.Store(false)
-	speaker.Unlock()
+	SpeakerUnlock()
 	p.lifecycleMu.Unlock()
 
 	_ = oldPipe.stop()
@@ -653,11 +652,11 @@ func (p *Player) SeekYTDL(d time.Duration) error {
 	// silence while the new pipeline is being built (which blocks on Peek
 	// waiting for yt-dlp data). Without this, the old audio keeps playing
 	// at the pre-seek position during the rebuild.
-	speaker.Lock()
+	SpeakerLock()
 	curPos := cur.format.SampleRate.D(cur.decoder.Position()) + cur.streamOffset
 	p.gapless.Replace(nil)
 	p.gaplessAdvance.Store(false)
-	speaker.Unlock()
+	SpeakerUnlock()
 
 	newPos := max(curPos+d, 0)
 	if cur.knownDuration > 0 && newPos >= cur.knownDuration {
@@ -686,11 +685,11 @@ func (p *Player) SeekYTDL(d time.Duration) error {
 // to the active track. It must validate under the same locks used for the swap
 // because playback can change while yt-dlp is starting.
 func (p *Player) commitYTDLSeek(cur, replacement *trackPipeline, gen int64) bool {
-	speaker.Lock()
+	SpeakerLock()
 	p.mu.Lock()
 	if p.seekGen.Load() != gen || p.current != cur {
 		p.mu.Unlock()
-		speaker.Unlock()
+		SpeakerUnlock()
 		return false
 	}
 	p.gapless.Replace(replacement.stream)
@@ -701,7 +700,7 @@ func (p *Player) commitYTDLSeek(cur, replacement *trackPipeline, gen int64) bool
 	p.current = replacement
 	p.nextPipeline = nil
 	p.mu.Unlock()
-	speaker.Unlock()
+	SpeakerUnlock()
 	// Clean up old pipelines async to avoid blocking on process wait.
 	go closePipelines(old, oldNext)
 	return true
@@ -714,7 +713,7 @@ func (p *Player) restoreYTDLSeekSource(cur *trackPipeline, gen int64) {
 	if cur == nil || p.seekGen.Load() != gen {
 		return
 	}
-	speaker.Lock()
+	SpeakerLock()
 	p.mu.Lock()
 	stillCurrent := p.current == cur && p.seekGen.Load() == gen
 	if stillCurrent {
@@ -722,7 +721,7 @@ func (p *Player) restoreYTDLSeekSource(cur *trackPipeline, gen int64) {
 		p.gaplessAdvance.Store(false)
 	}
 	p.mu.Unlock()
-	speaker.Unlock()
+	SpeakerUnlock()
 }
 
 // IsYTDLSeek reports whether the current track uses yt-dlp seek-by-restart.
@@ -741,8 +740,8 @@ func (p *Player) IsStreamSeek() bool {
 // Position returns the current playback position.
 // streamOffset is added for yt-dlp streams restarted at a time offset.
 func (p *Player) Position() time.Duration {
-	speaker.Lock()
-	defer speaker.Unlock()
+	SpeakerLock()
+	defer SpeakerUnlock()
 	p.mu.Lock()
 	cur := p.current
 	p.mu.Unlock()
@@ -760,8 +759,8 @@ func (p *Player) Position() time.Duration {
 // For HTTP streams where the decoder reports Len()==0, the metadata hint
 // stored at pipeline build time (knownDuration) is returned instead.
 func (p *Player) Duration() time.Duration {
-	speaker.Lock()
-	defer speaker.Unlock()
+	SpeakerLock()
+	defer SpeakerUnlock()
 	p.mu.Lock()
 	cur := p.current
 	p.mu.Unlock()
@@ -783,8 +782,8 @@ func (p *Player) Duration() time.Duration {
 // PositionAndDuration returns both position and duration under a single
 // speaker lock, avoiding two separate lock acquisitions per tick.
 func (p *Player) PositionAndDuration() (time.Duration, time.Duration) {
-	speaker.Lock()
-	defer speaker.Unlock()
+	SpeakerLock()
+	defer SpeakerUnlock()
 	p.mu.Lock()
 	cur := p.current
 	p.mu.Unlock()
@@ -1133,7 +1132,7 @@ func (p *Player) suspendSpeaker() {
 	if p.suspended {
 		return
 	}
-	if err := speaker.Suspend(); err != nil {
+	if err := SpeakerSuspend(); err != nil {
 		// Non-fatal: the ALSA driver may return an error if the context
 		// has already hit a terminal error. Continue without tracking
 		// the suspended state so we don't try to resume a dead context.
@@ -1151,7 +1150,7 @@ func (p *Player) resumeSpeaker() {
 	if !p.suspended {
 		return
 	}
-	if err := speaker.Resume(); err != nil {
+	if err := SpeakerResume(); err != nil {
 		return
 	}
 	p.suspended = false
@@ -1160,5 +1159,5 @@ func (p *Player) resumeSpeaker() {
 // Close fully stops the speaker and cleans up all resources.
 func (p *Player) Close() {
 	p.Stop()
-	speaker.Clear()
+	SpeakerClear()
 }

--- a/player/player_test.go
+++ b/player/player_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/gopxl/beep/v2"
-	"github.com/gopxl/beep/v2/speaker"
 )
 
 // newTestPlayer returns a Player with only the atomic accessors wired up.
@@ -481,10 +480,10 @@ func blockedNavPlayback(t *testing.T) (*trackPipeline, <-chan struct{}, <-chan s
 	started := make(chan struct{})
 	done := make(chan struct{})
 	go func() {
-		speaker.Lock()
+		SpeakerLock()
 		close(started)
 		decoder.Stream(make([][2]float64, 1))
-		speaker.Unlock()
+		SpeakerUnlock()
 		close(done)
 	}()
 	return tp, started, done, func() { _ = writer.Close() }
@@ -545,20 +544,20 @@ printf '10\n'
 			p.gapless.Replace(tp.stream)
 			p.gapless.SetNext(preloaded.stream)
 
-			speaker.Lock()
+			SpeakerLock()
 			seekDone := make(chan error, 1)
 			go func() { seekDone <- p.Seek(time.Second) }()
 			if !waitForPath(readyPath) {
-				speaker.Unlock()
+				SpeakerUnlock()
 				t.Fatalf("timed out waiting for %s", readyPath)
 			}
 			select {
 			case err := <-seekDone:
-				speaker.Unlock()
+				SpeakerUnlock()
 				t.Fatalf("Seek completed before speaker commit lock was available: %v", err)
 			default:
 			}
-			speaker.Unlock()
+			SpeakerUnlock()
 
 			select {
 			case err := <-seekDone:

--- a/player/pulse_termux.go
+++ b/player/pulse_termux.go
@@ -120,6 +120,9 @@ func (c *termuxPulseClient) monitor() {
 	for {
 		select {
 		case <-ticker.C:
+			if !c.hasActivePlayback() {
+				continue
+			}
 			var reply pulseproto.GetServerInfoReply
 			if err := c.protocol.Request(&pulseproto.GetServerInfo{}, &reply); err != nil {
 				c.markLost(err)
@@ -129,6 +132,17 @@ func (c *termuxPulseClient) monitor() {
 			return
 		}
 	}
+}
+
+func (c *termuxPulseClient) hasActivePlayback() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, stream := range c.playback {
+		if stream.isRunning() {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *termuxPulseClient) newPlayback(sampleRate beep.SampleRate, bufferSize int, fill func([]float32) (int, error)) (*termuxPulsePlayback, error) {
@@ -411,7 +425,7 @@ func (p *termuxPulsePlayback) deliverRequest(length int) {
 
 func (p *termuxPulsePlayback) notifyStarted() {
 	p.stateMu.RLock()
-	ready := p.state == termuxPulseRunning && !p.underflow
+	ready := p.state == termuxPulseRunning
 	p.stateMu.RUnlock()
 	if !ready {
 		return

--- a/player/pulse_termux.go
+++ b/player/pulse_termux.go
@@ -1,0 +1,481 @@
+//go:build termux
+
+package player
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+	"unsafe"
+
+	"github.com/gopxl/beep/v2"
+	pulseproto "github.com/jfreymuth/pulse/proto"
+)
+
+var (
+	errTermuxPulseConnectionClosed = errors.New("pulseaudio: connection closed")
+	errTermuxPulseClientClosed     = errors.New("pulseaudio: client closed")
+)
+
+const termuxPulseHealthInterval = 250 * time.Millisecond
+
+type termuxPulseClient struct {
+	protocol *pulseproto.Client
+	conn     net.Conn
+
+	mu       sync.Mutex
+	playback map[uint32]*termuxPulsePlayback
+
+	done     chan struct{}
+	lostOnce sync.Once
+}
+
+func newTermuxSession(sampleRate beep.SampleRate, bufferSize int, fill func([]float32) (int, error)) (*termuxSession, error) {
+	client, err := newTermuxPulseClient(pulseServerOption())
+	if err != nil {
+		return nil, err
+	}
+	stream, err := client.newPlayback(sampleRate, bufferSize, fill)
+	if err != nil {
+		client.Close()
+		return nil, err
+	}
+	return &termuxSession{
+		stream: stream,
+		closeFn: func() {
+			stream.Close()
+			client.Close()
+		},
+	}, nil
+}
+
+func newTermuxPulseClient(server string) (*termuxPulseClient, error) {
+	protocol, conn, err := pulseproto.Connect(server)
+	if err != nil {
+		return nil, err
+	}
+	client := &termuxPulseClient{
+		protocol: protocol,
+		conn:     conn,
+		playback: make(map[uint32]*termuxPulsePlayback),
+		done:     make(chan struct{}),
+	}
+	protocol.Callback = client.callback
+
+	props := pulseproto.PropList{
+		"media.name":                 pulseproto.PropListString("cliamp"),
+		"application.name":           pulseproto.PropListString("cliamp"),
+		"application.icon_name":      pulseproto.PropListString("audio-x-generic"),
+		"application.process.id":     pulseproto.PropListString(strconv.Itoa(os.Getpid())),
+		"application.process.binary": pulseproto.PropListString(os.Args[0]),
+		"window.x11.display":         pulseproto.PropListString(os.Getenv("DISPLAY")),
+	}
+	if err := protocol.Request(&pulseproto.SetClientName{Props: props}, &pulseproto.SetClientNameReply{}); err != nil {
+		client.Close()
+		return nil, err
+	}
+	if err := protocol.Request(&pulseproto.Subscribe{Mask: pulseproto.SubscriptionMaskSinkInput}, nil); err != nil {
+		client.Close()
+		return nil, err
+	}
+	go client.monitor()
+	return client, nil
+}
+
+func (c *termuxPulseClient) callback(message interface{}) {
+	switch message := message.(type) {
+	case *pulseproto.Request:
+		c.mu.Lock()
+		stream := c.playback[message.StreamIndex]
+		c.mu.Unlock()
+		if stream != nil {
+			stream.deliverRequest(int(message.Length))
+		}
+	case *pulseproto.Started:
+		c.mu.Lock()
+		stream := c.playback[message.StreamIndex]
+		c.mu.Unlock()
+		if stream != nil {
+			stream.notifyStarted()
+		}
+	case *pulseproto.Underflow:
+		c.mu.Lock()
+		stream := c.playback[message.StreamIndex]
+		c.mu.Unlock()
+		if stream != nil {
+			stream.markUnderflow()
+		}
+	case *pulseproto.ConnectionClosed:
+		c.markLost(errTermuxPulseConnectionClosed)
+	}
+}
+
+func (c *termuxPulseClient) monitor() {
+	ticker := time.NewTicker(termuxPulseHealthInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			var reply pulseproto.GetServerInfoReply
+			if err := c.protocol.Request(&pulseproto.GetServerInfo{}, &reply); err != nil {
+				c.markLost(err)
+				return
+			}
+		case <-c.done:
+			return
+		}
+	}
+}
+
+func (c *termuxPulseClient) newPlayback(sampleRate beep.SampleRate, bufferSize int, fill func([]float32) (int, error)) (*termuxPulsePlayback, error) {
+	targetLength := uint32(bufferSize) * 2 * 4
+	request := pulseproto.CreatePlaybackStream{
+		SampleSpec: pulseproto.SampleSpec{
+			Format:   pulseproto.FormatFloat32LE,
+			Channels: 2,
+			Rate:     uint32(sampleRate),
+		},
+		ChannelMap:            pulseproto.ChannelMap{pulseproto.ChannelLeft, pulseproto.ChannelRight},
+		SinkIndex:             pulseproto.Undefined,
+		BufferMaxLength:       targetLength * 2,
+		Corked:                true,
+		BufferTargetLength:    targetLength,
+		BufferPrebufferLength: pulseproto.Undefined,
+		BufferMinimumRequest:  pulseproto.Undefined,
+		ChannelVolumes:        pulseproto.ChannelVolumes{0x100, 0x100},
+		AdjustLatency:         true,
+		Properties: pulseproto.PropList{
+			"media.name": pulseproto.PropListString("cliamp"),
+		},
+	}
+	var reply pulseproto.CreatePlaybackStreamReply
+	if err := c.protocol.Request(&request, &reply); err != nil {
+		return nil, err
+	}
+
+	stream := &termuxPulsePlayback{
+		client:             c,
+		index:              reply.StreamIndex,
+		bufferTargetLength: reply.BufferTargetLength,
+		bufferMaxLength:    reply.BufferMaxLength,
+		reader:             termuxPulseFloat32Reader(fill),
+		request:            make(chan int),
+		started:            make(chan struct{}, 1),
+		done:               make(chan struct{}),
+		state:              termuxPulseIdle,
+	}
+	if stream.bufferTargetLength == 0 {
+		stream.bufferTargetLength = targetLength
+	}
+	if stream.bufferMaxLength == 0 {
+		stream.bufferMaxLength = targetLength * 2
+	}
+	c.mu.Lock()
+	c.playback[stream.index] = stream
+	c.mu.Unlock()
+	go stream.run()
+	return stream, nil
+}
+
+func (c *termuxPulseClient) remove(stream *termuxPulsePlayback) {
+	c.mu.Lock()
+	delete(c.playback, stream.index)
+	c.mu.Unlock()
+}
+
+func (c *termuxPulseClient) markLost(err error) {
+	if err == nil {
+		err = errTermuxPulseConnectionClosed
+	}
+	c.lostOnce.Do(func() {
+		c.mu.Lock()
+		streams := make([]*termuxPulsePlayback, 0, len(c.playback))
+		for _, stream := range c.playback {
+			streams = append(streams, stream)
+		}
+		c.playback = make(map[uint32]*termuxPulsePlayback)
+		c.mu.Unlock()
+
+		for _, stream := range streams {
+			stream.markLost(err)
+		}
+		_ = c.conn.Close()
+		close(c.done)
+	})
+}
+
+func (c *termuxPulseClient) Close() {
+	c.markLost(errTermuxPulseClientClosed)
+}
+
+type termuxPulsePlaybackState uint8
+
+const (
+	termuxPulseIdle termuxPulsePlaybackState = iota
+	termuxPulseRunning
+	termuxPulsePaused
+	termuxPulseLost
+	termuxPulseClosed
+)
+
+type termuxPulsePlayback struct {
+	client             *termuxPulseClient
+	index              uint32
+	bufferTargetLength uint32
+	bufferMaxLength    uint32
+	reader             termuxPulseReader
+	request            chan int
+	started            chan struct{}
+	done               chan struct{}
+
+	stateMu   sync.RWMutex
+	state     termuxPulsePlaybackState
+	err       error
+	underflow bool
+
+	startMu sync.Mutex
+	closeMu sync.Once
+	doneMu  sync.Once
+}
+
+func (p *termuxPulsePlayback) StartContext(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	p.startMu.Lock()
+	defer p.startMu.Unlock()
+
+	p.stateMu.Lock()
+	switch p.state {
+	case termuxPulseClosed, termuxPulseLost:
+		err := p.err
+		p.stateMu.Unlock()
+		if err == nil {
+			err = errTermuxPulseConnectionClosed
+		}
+		return err
+	case termuxPulseRunning, termuxPulsePaused:
+		p.stateMu.Unlock()
+		return nil
+	default:
+		p.state = termuxPulseRunning
+		p.err = nil
+		p.underflow = false
+	}
+	p.stateMu.Unlock()
+
+	if err := p.client.protocol.Request(&pulseproto.FlushPlaybackStream{StreamIndex: p.index}, nil); err != nil {
+		p.fail(err)
+		return err
+	}
+	select {
+	case p.request <- int(p.bufferTargetLength):
+	case <-p.done:
+		return p.Error()
+	case <-ctx.Done():
+		p.resetIdle()
+		return ctx.Err()
+	}
+	if err := p.client.protocol.Request(&pulseproto.CorkPlaybackStream{StreamIndex: p.index, Corked: false}, nil); err != nil {
+		p.fail(err)
+		return err
+	}
+	select {
+	case <-p.started:
+		return nil
+	case <-p.done:
+		return p.Error()
+	case <-ctx.Done():
+		p.resetIdle()
+		return ctx.Err()
+	}
+}
+
+func (p *termuxPulsePlayback) Done() <-chan struct{} { return p.done }
+
+func (p *termuxPulsePlayback) Pause() {
+	p.stateMu.RLock()
+	running := p.state == termuxPulseRunning
+	p.stateMu.RUnlock()
+	if !running {
+		return
+	}
+	if err := p.client.protocol.Request(&pulseproto.CorkPlaybackStream{StreamIndex: p.index, Corked: true}, nil); err != nil {
+		p.client.markLost(err)
+		return
+	}
+	p.stateMu.Lock()
+	if p.state == termuxPulseRunning {
+		p.state = termuxPulsePaused
+	}
+	p.stateMu.Unlock()
+}
+
+func (p *termuxPulsePlayback) Resume() {
+	p.stateMu.RLock()
+	paused := p.state == termuxPulsePaused
+	p.stateMu.RUnlock()
+	if !paused {
+		return
+	}
+	if err := p.client.protocol.Request(&pulseproto.CorkPlaybackStream{StreamIndex: p.index, Corked: false}, nil); err != nil {
+		p.client.markLost(err)
+		return
+	}
+	p.stateMu.Lock()
+	if p.state == termuxPulsePaused {
+		p.state = termuxPulseRunning
+		p.underflow = false
+	}
+	p.stateMu.Unlock()
+}
+
+func (p *termuxPulsePlayback) Close() {
+	p.closeMu.Do(func() {
+		p.stateMu.Lock()
+		p.state = termuxPulseClosed
+		if p.err == nil {
+			p.err = errTermuxPulseClientClosed
+		}
+		p.stateMu.Unlock()
+		p.signalDone()
+		p.client.remove(p)
+		_ = p.client.protocol.Request(&pulseproto.DeletePlaybackStream{StreamIndex: p.index}, nil)
+	})
+}
+
+func (p *termuxPulsePlayback) Error() error {
+	p.stateMu.RLock()
+	err := p.err
+	p.stateMu.RUnlock()
+	if err == nil {
+		return errTermuxPulseConnectionClosed
+	}
+	return err
+}
+
+func (p *termuxPulsePlayback) run() {
+	requested := 0
+	front := make([]byte, p.bufferMaxLength)
+	back := make([]byte, p.bufferMaxLength)
+	for {
+		select {
+		case bufferLength := <-p.request:
+			if !p.isRunning() {
+				requested = 0
+				continue
+			}
+			requested += bufferLength
+			for requested > 0 {
+				if requested > len(front) {
+					front = make([]byte, requested)
+					back = make([]byte, requested)
+				}
+				readCount, err := p.reader.Read(front[:requested])
+				if err != nil {
+					p.fail(err)
+					return
+				}
+				if readCount > 0 {
+					if err := p.client.protocol.Send(p.index, front[:readCount]); err != nil {
+						p.client.markLost(err)
+						return
+					}
+					requested -= readCount
+					front, back = back, front
+				}
+				select {
+				case nextLength := <-p.request:
+					requested += nextLength
+				case <-p.done:
+					return
+				default:
+				}
+			}
+		case <-p.done:
+			return
+		}
+	}
+}
+
+func (p *termuxPulsePlayback) deliverRequest(length int) {
+	select {
+	case p.request <- length:
+	case <-p.done:
+	}
+}
+
+func (p *termuxPulsePlayback) notifyStarted() {
+	p.stateMu.RLock()
+	ready := p.state == termuxPulseRunning && !p.underflow
+	p.stateMu.RUnlock()
+	if !ready {
+		return
+	}
+	select {
+	case p.started <- struct{}{}:
+	default:
+	}
+}
+
+func (p *termuxPulsePlayback) markUnderflow() {
+	p.stateMu.Lock()
+	if p.state == termuxPulseRunning {
+		p.underflow = true
+	}
+	p.stateMu.Unlock()
+}
+
+func (p *termuxPulsePlayback) markLost(err error) {
+	p.stateMu.Lock()
+	if p.state != termuxPulseClosed {
+		p.state = termuxPulseLost
+		p.err = err
+	}
+	p.stateMu.Unlock()
+	p.signalDone()
+}
+
+func (p *termuxPulsePlayback) fail(err error) {
+	p.markLost(err)
+}
+
+func (p *termuxPulsePlayback) resetIdle() {
+	p.stateMu.Lock()
+	if p.state == termuxPulseRunning {
+		p.state = termuxPulseIdle
+	}
+	p.stateMu.Unlock()
+}
+
+func (p *termuxPulsePlayback) isRunning() bool {
+	p.stateMu.RLock()
+	running := p.state == termuxPulseRunning
+	p.stateMu.RUnlock()
+	return running
+}
+
+func (p *termuxPulsePlayback) signalDone() {
+	p.doneMu.Do(func() { close(p.done) })
+}
+
+type termuxPulseReader interface {
+	Read([]byte) (int, error)
+}
+
+type termuxPulseFloat32Reader func([]float32) (int, error)
+
+func (r termuxPulseFloat32Reader) Read(buf []byte) (int, error) {
+	if len(buf) == 0 {
+		return 0, nil
+	}
+	values := unsafe.Slice((*float32)(unsafe.Pointer(&buf[0])), len(buf)/4)
+	n, err := r(values)
+	return n * 4, err
+}
+
+func (termuxPulseFloat32Reader) Format() byte { return pulseproto.FormatFloat32LE }

--- a/player/speaker.go
+++ b/player/speaker.go
@@ -1,0 +1,55 @@
+package player
+
+import "github.com/gopxl/beep/v2"
+
+// Speaker abstracts the audio output backend so cliamp can swap the
+// implementation: gopxl/beep/v2/speaker (ALSA/CoreAudio/WinMM) on regular
+// Linux/macOS/Windows, or jfreymuth/pulse on Android/Termux.
+//
+// The interface mirrors the subset of gopxl/beep/v2/speaker's surface that
+// cliamp actually uses. Lock/Unlock protect the underlying mixer from
+// concurrent mutation while an audio callback may be reading from it; the
+// implementation is not reentrant.
+type Speaker interface {
+	Init(sampleRate beep.SampleRate, bufferSize int) error
+	Play(s ...beep.Streamer)
+	Clear()
+	Lock()
+	Unlock()
+	Suspend() error
+	Resume() error
+}
+
+// backend is populated by init() in either speaker_beep.go (default) or
+// speaker_termux.go (build tag termux).
+var backend Speaker
+
+// SpeakerInit initializes the audio output backend. Must be called once
+// before any other Speaker* call. sampleRate is in Hz, bufferSize is in
+// samples (matches gopxl/beep/v2/speaker.Init semantics).
+func SpeakerInit(sampleRate beep.SampleRate, bufferSize int) error {
+	return backend.Init(sampleRate, bufferSize)
+}
+
+// SpeakerPlay registers Streamers for playback. On the first call the backend
+// begins driving the audio callback goroutine; subsequent calls add to the
+// mixer without restarting it.
+func SpeakerPlay(s ...beep.Streamer) { backend.Play(s...) }
+
+// SpeakerClear removes all currently playing Streamers from the mixer.
+func SpeakerClear() { backend.Clear() }
+
+// SpeakerLock locks the backend's mixer against concurrent reads/writes.
+// Pair with SpeakerUnlock. Not reentrant.
+func SpeakerLock() { backend.Lock() }
+
+// SpeakerUnlock releases the lock taken by SpeakerLock.
+func SpeakerUnlock() { backend.Unlock() }
+
+// SpeakerSuspend pauses audio output without dropping the connection.
+// Safe to call before any Play; implementations may treat it as a no-op
+// until playback has started.
+func SpeakerSuspend() error { return backend.Suspend() }
+
+// SpeakerResume restarts audio output after a SpeakerSuspend.
+func SpeakerResume() error { return backend.Resume() }

--- a/player/speaker.go
+++ b/player/speaker.go
@@ -40,7 +40,7 @@ func SpeakerPlay(s ...beep.Streamer) { backend.Play(s...) }
 // SpeakerClear removes all currently playing Streamers from the mixer.
 func SpeakerClear() { backend.Clear() }
 
-// SpeakerClose stops audio playback and releases backend resources.
+// SpeakerClose stops audio playback and releases backend resources when supported.
 func SpeakerClose() { backend.Close() }
 
 // SpeakerLock locks the backend's mixer against concurrent reads/writes.

--- a/player/speaker.go
+++ b/player/speaker.go
@@ -14,6 +14,7 @@ type Speaker interface {
 	Init(sampleRate beep.SampleRate, bufferSize int) error
 	Play(s ...beep.Streamer)
 	Clear()
+	Close()
 	Lock()
 	Unlock()
 	Suspend() error
@@ -38,6 +39,9 @@ func SpeakerPlay(s ...beep.Streamer) { backend.Play(s...) }
 
 // SpeakerClear removes all currently playing Streamers from the mixer.
 func SpeakerClear() { backend.Clear() }
+
+// SpeakerClose stops audio playback and releases backend resources.
+func SpeakerClose() { backend.Close() }
 
 // SpeakerLock locks the backend's mixer against concurrent reads/writes.
 // Pair with SpeakerUnlock. Not reentrant.

--- a/player/speaker_beep.go
+++ b/player/speaker_beep.go
@@ -17,7 +17,7 @@ func (beepSpeaker) Init(sampleRate beep.SampleRate, bufferSize int) error {
 
 func (beepSpeaker) Play(s ...beep.Streamer) { bspe.Play(s...) }
 func (beepSpeaker) Clear()                  { bspe.Clear() }
-func (beepSpeaker) Close()                  { bspe.Close() }
+func (beepSpeaker) Close()                  { bspe.Clear() }
 func (beepSpeaker) Lock()                   { bspe.Lock() }
 func (beepSpeaker) Unlock()                 { bspe.Unlock() }
 func (beepSpeaker) Suspend() error          { return bspe.Suspend() }

--- a/player/speaker_beep.go
+++ b/player/speaker_beep.go
@@ -1,0 +1,25 @@
+//go:build !termux
+
+package player
+
+import (
+	"github.com/gopxl/beep/v2"
+	bspe "github.com/gopxl/beep/v2/speaker"
+)
+
+// beepSpeaker wraps gopxl/beep/v2/speaker so the default build of cliamp
+// keeps using ALSA/CoreAudio/WinMM without any change in behavior.
+type beepSpeaker struct{}
+
+func (beepSpeaker) Init(sampleRate beep.SampleRate, bufferSize int) error {
+	return bspe.Init(sampleRate, bufferSize)
+}
+
+func (beepSpeaker) Play(s ...beep.Streamer) { bspe.Play(s...) }
+func (beepSpeaker) Clear()                  { bspe.Clear() }
+func (beepSpeaker) Lock()                   { bspe.Lock() }
+func (beepSpeaker) Unlock()                 { bspe.Unlock() }
+func (beepSpeaker) Suspend() error          { return bspe.Suspend() }
+func (beepSpeaker) Resume() error           { return bspe.Resume() }
+
+func init() { backend = beepSpeaker{} }

--- a/player/speaker_beep.go
+++ b/player/speaker_beep.go
@@ -17,6 +17,7 @@ func (beepSpeaker) Init(sampleRate beep.SampleRate, bufferSize int) error {
 
 func (beepSpeaker) Play(s ...beep.Streamer) { bspe.Play(s...) }
 func (beepSpeaker) Clear()                  { bspe.Clear() }
+func (beepSpeaker) Close()                  { bspe.Close() }
 func (beepSpeaker) Lock()                   { bspe.Lock() }
 func (beepSpeaker) Unlock()                 { bspe.Unlock() }
 func (beepSpeaker) Suspend() error          { return bspe.Suspend() }

--- a/player/speaker_termux.go
+++ b/player/speaker_termux.go
@@ -10,11 +10,9 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/gopxl/beep/v2"
-	"github.com/jfreymuth/pulse"
 )
 
 // CLIAMP_DEBUG_PULSE=1 prints diagnostic information about the audio
@@ -31,175 +29,396 @@ func debugPulseLog(format string, args ...any) {
 	fmt.Fprintf(os.Stderr, "[cliamp:pulse] "+format+"\n", args...)
 }
 
-// termuxSpeaker drives a beep.Mixer through a PulseAudio playback stream
-// using jfreymuth/pulse (pure-Go, no CGO, no ALSA). The PulseAudio daemon
-// is expected to be running on Termux with a usable sink (e.g. OpenSL_ES).
+type termuxPlayback interface {
+	StartContext(context.Context) error
+	Done() <-chan struct{}
+	Pause()
+	Resume()
+	Close()
+}
+
+type termuxSession struct {
+	stream   termuxPlayback
+	closeFn  func()
+	closeOne sync.Once
+}
+
+func (s *termuxSession) Close() {
+	if s == nil {
+		return
+	}
+	s.closeOne.Do(func() {
+		if s.closeFn != nil {
+			s.closeFn()
+			return
+		}
+		if s.stream != nil {
+			s.stream.Close()
+		}
+	})
+}
+
+type termuxSessionFactory func(beep.SampleRate, int, func([]float32) (int, error)) (*termuxSession, error)
+
+// termuxSpeaker drives a beep.Mixer through one supervised PulseAudio
+// playback session. The mixer lock is intentionally separate from the
+// lifecycle lock: PulseAudio requests can block, while the mixer callback
+// must remain compatible with SpeakerLock/ SpeakerUnlock.
 type termuxSpeaker struct {
-	mu         sync.Mutex
-	mixer      beep.Mixer
-	client     *pulse.Client
-	stream     *pulse.PlaybackStream
-	sampleRate beep.SampleRate // remembered so Play can lazily recreate after errors
-	bufferSize int
-	started    atomic.Bool
-	errored    atomic.Bool
-	frameBuf   [][2]float64 // reused across callbacks; guarded by mu
+	mu       sync.Mutex
+	mixer    beep.Mixer
+	frameBuf [][2]float64 // reused across callbacks; guarded by mu
+
+	lifecycleMu    sync.Mutex
+	session        *termuxSession
+	sampleRate     beep.SampleRate
+	bufferSize     int
+	wantPlayback   bool
+	suspended      bool
+	closed         bool
+	startupCancel  context.CancelFunc
+	wake           chan struct{}
+	stop           chan struct{}
+	supervisorDone chan struct{}
+	factory        termuxSessionFactory
 }
 
 func (t *termuxSpeaker) Init(sampleRate beep.SampleRate, bufferSize int) error {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	return t.initLocked(sampleRate, bufferSize)
-}
-
-// initLocked is Init's body. Caller must hold t.mu. Idempotent: a previous
-// client/stream is closed first so the speaker can be reinitialized without
-// leaking the PulseAudio socket. After it returns successfully, t.stream is
-// non-nil and ready to be started by the next Play.
-func (t *termuxSpeaker) initLocked(sampleRate beep.SampleRate, bufferSize int) error {
-	t.closeLocked()
-
-	client, err := pulse.NewClient(t.newClientOptions()...)
-	if err != nil {
-		debugPulseLog("pulse.NewClient failed: %v", err)
-		return err
+	t.lifecycleMu.Lock()
+	defer t.lifecycleMu.Unlock()
+	if t.supervisorDone != nil {
+		return fmt.Errorf("speaker already initialized")
 	}
-	debugPulseLog("pulse.NewClient succeeded")
-	stream, err := client.NewPlayback(
-		pulse.Float32Reader(t.fillSamples),
-		pulse.PlaybackStereo,
-		pulse.PlaybackSampleRate(int(sampleRate)),
-		pulse.PlaybackLatency(float64(bufferSize)/float64(sampleRate)),
-		pulse.PlaybackMediaName("cliamp"),
-	)
-	if err != nil {
-		client.Close()
-		return err
-	}
-	t.client = client
-	t.stream = stream
+
 	t.sampleRate = sampleRate
 	t.bufferSize = bufferSize
-	t.frameBuf = make([][2]float64, bufferSize)
-	t.started.Store(false)
-	t.errored.Store(false)
+	factory := t.factory
+	if factory == nil {
+		factory = newTermuxSession
+	}
+	session, err := factory(sampleRate, bufferSize, t.fillSamples)
+	if err != nil {
+		debugPulseLog("PulseAudio session initialization failed: %v", err)
+		return err
+	}
+	if session == nil || session.stream == nil {
+		if session != nil {
+			session.Close()
+		}
+		return fmt.Errorf("PulseAudio session initialization returned no stream")
+	}
+
+	t.session = session
+	t.wantPlayback = false
+	t.suspended = false
+	t.closed = false
+	t.wake = make(chan struct{}, 1)
+	t.stop = make(chan struct{})
+	t.supervisorDone = make(chan struct{})
+	go t.runLifecycle(t.supervisorDone)
 	return nil
-}
-
-// closeLocked releases the current PulseAudio client and stream. Caller must
-// hold t.mu. After it returns, t.stream and t.client are nil and the next
-// Play will lazily recreate via initLocked.
-func (t *termuxSpeaker) closeLocked() {
-	if t.stream != nil {
-		t.stream.Close()
-		t.stream = nil
-	}
-	if t.client != nil {
-		t.client.Close()
-		t.client = nil
-	}
-}
-
-func (t *termuxSpeaker) newClientOptions() []pulse.ClientOption {
-	opts := []pulse.ClientOption{pulse.ClientApplicationName("cliamp")}
-	if server := pulseServerOption(); server != "" {
-		opts = append(opts, pulse.ClientServerString(server))
-	}
-	return opts
 }
 
 func (t *termuxSpeaker) Play(s ...beep.Streamer) {
 	t.mu.Lock()
-
-	// Recovery path: if the previous stream was torn down (Init failure or
-	// post-Start error) the next streamer is added straight away, so we
-	// re-establish the PulseAudio connection lazily. If the daemon went
-	// away after Start succeeded, Closed() reports serverLost; rebuild
-	// before the user notices silence.
-	if t.stream == nil && t.sampleRate != 0 {
-		if err := t.initLocked(t.sampleRate, t.bufferSize); err != nil {
-			debugPulseLog("Play: recovery init failed: %v", err)
-			t.mu.Unlock()
-			return
-		}
-	} else if t.stream != nil && t.stream.Closed() {
-		t.closeLocked()
-		t.started.Store(false)
-		t.errored.Store(false)
-		if err := t.initLocked(t.sampleRate, t.bufferSize); err != nil {
-			debugPulseLog("Play: recovery init failed: %v", err)
-			t.mu.Unlock()
-			return
-		}
-	}
-
 	t.mixer.Add(s...)
-	stream := t.stream
 	t.mu.Unlock()
 
-	if stream != nil && t.started.CompareAndSwap(false, true) {
-		go t.runStream(stream)
+	t.lifecycleMu.Lock()
+	if !t.closed {
+		t.wantPlayback = true
+		t.signalWakeLocked()
 	}
+	t.lifecycleMu.Unlock()
 }
 
-// runStream calls Start(), which blocks until the PulseAudio daemon has
-// begun requesting samples (the unbuffered "<-started" handoff inside
-// PlaybackStream.Start). Operates exclusively on the snapshot passed by
-// Play. If Start returns successfully and Error() reports a failure (for
-// example the daemon disconnected during startup), the stream and client
-// are released so the next Play can recreate them — otherwise started
-// would stay set forever and the speaker would silently drop new audio.
-func (t *termuxSpeaker) runStream(stream *pulse.PlaybackStream) {
-	stream.Start()
-	if err := stream.Error(); err != nil {
-		debugPulseLog("stream error after Start: %v", err)
-		t.errored.Store(true)
-		t.mu.Lock()
-		if t.stream == stream {
-			t.closeLocked()
-			t.started.Store(false)
-		}
-		t.mu.Unlock()
-	}
-}
-
-// Clear mirrors gopxl/beep/v2/speaker.Clear: it empties the mixer and leaves
-// the PulseAudio stream running. The stream does NOT need to be restarted
-// after a Clear — the next Play just adds fresh streamers to the mixer and
-// the audio callback resumes pulling from it. Critically, Clear must not
-// reset started while a runStream goroutine may still be blocked inside
-// PlaybackStream.Start; doing so would let a subsequent Play launch a
-// second runStream on the same stream and deadlock on the unbuffered
-// started notification (jfreymuth/pulse only emits one per stream).
 func (t *termuxSpeaker) Clear() {
 	t.mu.Lock()
 	t.mixer.Clear()
 	t.mu.Unlock()
+
+	t.lifecycleMu.Lock()
+	t.wantPlayback = false
+	t.signalWakeLocked()
+	t.lifecycleMu.Unlock()
 }
 
 func (t *termuxSpeaker) Lock()   { t.mu.Lock() }
 func (t *termuxSpeaker) Unlock() { t.mu.Unlock() }
 
 func (t *termuxSpeaker) Suspend() error {
-	if t.errored.Load() || !t.started.Load() {
-		return nil
+	t.lifecycleMu.Lock()
+	t.suspended = true
+	if t.startupCancel != nil {
+		t.startupCancel()
 	}
-	if t.stream == nil {
-		return nil
-	}
-	t.stream.Pause()
+	t.signalWakeLocked()
+	t.lifecycleMu.Unlock()
 	return nil
 }
 
 func (t *termuxSpeaker) Resume() error {
-	if t.errored.Load() || !t.started.Load() {
-		return nil
-	}
-	if t.stream == nil {
-		return nil
-	}
-	t.stream.Resume()
+	t.lifecycleMu.Lock()
+	t.suspended = false
+	t.signalWakeLocked()
+	t.lifecycleMu.Unlock()
 	return nil
+}
+
+func (t *termuxSpeaker) Close() {
+	t.lifecycleMu.Lock()
+	done := t.supervisorDone
+	if done == nil {
+		t.closed = true
+		t.lifecycleMu.Unlock()
+		t.clearMixer()
+		return
+	}
+	if !t.closed {
+		t.closed = true
+		close(t.stop)
+		if t.startupCancel != nil {
+			t.startupCancel()
+		}
+	}
+	t.lifecycleMu.Unlock()
+	<-done
+
+	t.lifecycleMu.Lock()
+	t.session = nil
+	t.supervisorDone = nil
+	t.startupCancel = nil
+	t.wake = nil
+	t.stop = nil
+	t.wantPlayback = false
+	t.suspended = false
+	t.lifecycleMu.Unlock()
+	t.clearMixer()
+}
+
+func (t *termuxSpeaker) clearMixer() {
+	t.mu.Lock()
+	t.mixer.Clear()
+	t.mu.Unlock()
+}
+
+func (t *termuxSpeaker) signalWakeLocked() {
+	if t.wake == nil {
+		return
+	}
+	select {
+	case t.wake <- struct{}{}:
+	default:
+	}
+}
+
+func (t *termuxSpeaker) lifecycleState() (want, suspended, closed bool) {
+	t.lifecycleMu.Lock()
+	want = t.wantPlayback
+	suspended = t.suspended
+	closed = t.closed
+	t.lifecycleMu.Unlock()
+	return
+}
+
+func (t *termuxSpeaker) waitLifecycle() bool {
+	t.lifecycleMu.Lock()
+	wake := t.wake
+	stop := t.stop
+	closed := t.closed
+	t.lifecycleMu.Unlock()
+	if closed {
+		return false
+	}
+	select {
+	case <-wake:
+		return true
+	case <-stop:
+		return false
+	}
+}
+
+func (t *termuxSpeaker) waitRecovery(delay time.Duration) bool {
+	t.lifecycleMu.Lock()
+	wake := t.wake
+	stop := t.stop
+	closed := t.closed
+	t.lifecycleMu.Unlock()
+	if closed {
+		return false
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-wake:
+		return true
+	case <-stop:
+		return false
+	}
+}
+
+func (t *termuxSpeaker) createSession() (*termuxSession, error) {
+	t.lifecycleMu.Lock()
+	factory := t.factory
+	sampleRate := t.sampleRate
+	bufferSize := t.bufferSize
+	t.lifecycleMu.Unlock()
+	if factory == nil {
+		factory = newTermuxSession
+	}
+	return factory(sampleRate, bufferSize, t.fillSamples)
+}
+
+func (t *termuxSpeaker) installSession(session *termuxSession) bool {
+	t.lifecycleMu.Lock()
+	defer t.lifecycleMu.Unlock()
+	if t.closed {
+		return false
+	}
+	t.session = session
+	return true
+}
+
+func (t *termuxSpeaker) forgetSession(session *termuxSession) {
+	t.lifecycleMu.Lock()
+	if t.session == session {
+		t.session = nil
+	}
+	t.lifecycleMu.Unlock()
+}
+
+func (t *termuxSpeaker) setStartupCancel(cancel context.CancelFunc) {
+	t.lifecycleMu.Lock()
+	t.startupCancel = cancel
+	t.lifecycleMu.Unlock()
+}
+
+func (t *termuxSpeaker) clearStartupCancel() {
+	t.lifecycleMu.Lock()
+	t.startupCancel = nil
+	t.lifecycleMu.Unlock()
+}
+
+func (t *termuxSpeaker) applySessionState(session *termuxSession, started bool) bool {
+	_, suspended, closed := t.lifecycleState()
+	if closed {
+		return false
+	}
+	if started && suspended {
+		session.stream.Pause()
+	}
+	if started && !suspended {
+		session.stream.Resume()
+	}
+	return true
+}
+
+func (t *termuxSpeaker) runLifecycle(done chan struct{}) {
+	defer close(done)
+	t.lifecycleMu.Lock()
+	session := t.session
+	t.lifecycleMu.Unlock()
+	started := false
+	backoff := 100 * time.Millisecond
+
+	for {
+		if session == nil {
+			want, suspended, closed := t.lifecycleState()
+			if closed {
+				return
+			}
+			if !want || suspended {
+				if !t.waitLifecycle() {
+					return
+				}
+				continue
+			}
+
+			created, err := t.createSession()
+			if err != nil {
+				debugPulseLog("PulseAudio session recovery failed: %v", err)
+				if !t.waitRecovery(backoff) {
+					return
+				}
+				backoff = min(backoff*2, time.Second)
+				continue
+			}
+			if !t.installSession(created) {
+				created.Close()
+				return
+			}
+			session = created
+			started = false
+			backoff = 100 * time.Millisecond
+		}
+
+		if !started {
+			want, suspended, closed := t.lifecycleState()
+			if closed {
+				session.Close()
+				return
+			}
+			if !want || suspended {
+				if !t.waitLifecycle() {
+					session.Close()
+					return
+				}
+				continue
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			t.setStartupCancel(cancel)
+			err := session.stream.StartContext(ctx)
+			cancel()
+			t.clearStartupCancel()
+			if err != nil {
+				session.Close()
+				t.forgetSession(session)
+				session = nil
+				started = false
+				if _, _, closed := t.lifecycleState(); closed {
+					return
+				}
+				if !t.waitRecovery(backoff) {
+					return
+				}
+				backoff = min(backoff*2, time.Second)
+				continue
+			}
+			started = true
+			if !t.applySessionState(session, started) {
+				session.Close()
+				return
+			}
+		}
+
+		select {
+		case <-session.stream.Done():
+			session.Close()
+			t.forgetSession(session)
+			session = nil
+			started = false
+			if _, _, closed := t.lifecycleState(); closed {
+				return
+			}
+			if !t.waitRecovery(backoff) {
+				return
+			}
+			backoff = min(backoff*2, time.Second)
+		case <-t.stop:
+			session.Close()
+			t.forgetSession(session)
+			return
+		case <-t.wake:
+			if !t.applySessionState(session, started) {
+				session.Close()
+				t.forgetSession(session)
+				return
+			}
+		}
+	}
 }
 
 // fillSamples is invoked by PulseAudio's internal goroutine when the daemon

--- a/player/speaker_termux.go
+++ b/player/speaker_termux.go
@@ -3,6 +3,7 @@
 package player
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -78,41 +79,45 @@ func (t *termuxSpeaker) newClientOptions() []pulse.ClientOption {
 func (t *termuxSpeaker) Play(s ...beep.Streamer) {
 	t.mu.Lock()
 	t.mixer.Add(s...)
+	stream := t.stream // snapshot; defensive against any future change that
+	// might invalidate t.stream concurrently with the runStream goroutine.
 	t.mu.Unlock()
 
-	if t.started.CompareAndSwap(false, true) {
-		go t.runStream()
+	if stream != nil && t.started.CompareAndSwap(false, true) {
+		go t.runStream(stream)
 	}
 }
 
 // runStream calls Start() which blocks until the daemon has begun requesting
-// samples. There is no server-side close supervision: if PulseAudio dies
-// mid-session the user has to restart cliamp.
-func (t *termuxSpeaker) runStream() {
-	t.stream.Start()
-	if err := t.stream.Error(); err != nil {
+// samples. Operates exclusively on the snapshot passed by Play; never
+// touches t.stream directly. If PulseAudio dies mid-session the user has
+// to restart cliamp.
+func (t *termuxSpeaker) runStream(stream *pulse.PlaybackStream) {
+	stream.Start()
+	if err := stream.Error(); err != nil {
 		t.errored.Store(true)
 	}
 }
 
 func (t *termuxSpeaker) Clear() {
+	// Mirror gopxl/beep/v2/speaker.Clear: clear the mixer and reset state.
+	// We intentionally do NOT close stream/client because:
+	//   1. jfreymuth/pulse's stream.Close()/client.Close() can race with
+	//      a concurrent runStream blocked on stream.Start(): closing
+	//      p.request under it leads to a "send on closed channel" panic
+	//      inside Start, and the <-started channel is never written to on
+	//      connection drop.
+	//   2. The Linux speaker (gopxl/beep/v2/speaker) does not close
+	//      anything in Clear() either.
+	// Audio thread + PulseAudio stream stay alive across Clear so
+	// subsequent Play can re-add streamers to the mixer. Resources are
+	// released at process exit (Player.Close → SpeakerClear → process
+	// exit → OS reaps the socket).
 	t.mu.Lock()
 	t.mixer.Clear()
-	stream := t.stream
-	client := t.client
-	t.stream = nil
-	t.client = nil
+	t.started.Store(false)
+	t.errored.Store(false)
 	t.mu.Unlock()
-
-	// SpeakerClear is invoked exactly once per Player lifetime
-	// (from Player.Close). Release the PulseAudio resources now so the
-	// daemon doesn't keep our sink input registered.
-	if stream != nil {
-		stream.Close()
-	}
-	if client != nil {
-		client.Close()
-	}
 }
 
 func (t *termuxSpeaker) Lock()   { t.mu.Lock() }
@@ -122,12 +127,18 @@ func (t *termuxSpeaker) Suspend() error {
 	if t.errored.Load() || !t.started.Load() {
 		return nil
 	}
+	if t.stream == nil {
+		return nil
+	}
 	t.stream.Pause()
 	return nil
 }
 
 func (t *termuxSpeaker) Resume() error {
 	if t.errored.Load() || !t.started.Load() {
+		return nil
+	}
+	if t.stream == nil {
 		return nil
 	}
 	t.stream.Resume()
@@ -245,7 +256,16 @@ func discoverPulseSocketWithProbe(probe func() string) string {
 		if !nowFunc().Before(deadline) {
 			return ""
 		}
-		sleepFunc(backoff)
+		// Cap each sleep to the remaining deadline so we never overshoot.
+		remaining := deadline.Sub(nowFunc())
+		if remaining <= 0 {
+			return ""
+		}
+		sleepFor := backoff
+		if sleepFor > remaining {
+			sleepFor = remaining
+		}
+		sleepFunc(sleepFor)
 		backoff *= 2
 		if backoff > discoveryMaxBackoff {
 			backoff = discoveryMaxBackoff
@@ -345,6 +365,12 @@ func isUnixSocket(path string) bool {
 // trySpawnPulseaudioImpl; tests can swap it for a deterministic stub.
 var spawnPulseaudioFn = trySpawnPulseaudioImpl
 
+// pulseaudioSpawnTimeout bounds how long trySpawnPulseaudioImpl will wait
+// for `pulseaudio --start` to return. Without this, a stalled daemon
+// could block Player.New indefinitely. 5s is generous (a healthy
+// daemon completes the spawn in well under a second).
+const pulseaudioSpawnTimeout = 5 * time.Second
+
 // trySpawnPulseaudio invokes `pulseaudio --start`, the same way libpulse's
 // autospawn does (see pulseaudio/src/pulse/context.c context_autospawn).
 // The parent returns 0 once the daemon has forked and bound its socket.
@@ -360,7 +386,9 @@ func trySpawnPulseaudioImpl() bool {
 		debugPulseLog("pulseaudio not in PATH: %v", err)
 		return false
 	}
-	cmd := exec.Command(bin, "--start")
+	ctx, cancel := context.WithTimeout(context.Background(), pulseaudioSpawnTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin, "--start")
 	if err := cmd.Run(); err != nil {
 		debugPulseLog("pulseaudio --start failed: %v", err)
 		return false

--- a/player/speaker_termux.go
+++ b/player/speaker_termux.go
@@ -321,6 +321,7 @@ func (t *termuxSpeaker) runLifecycle(done chan struct{}) {
 	session := t.session
 	t.lifecycleMu.Unlock()
 	started := false
+	startedAt := time.Time{}
 	backoff := 100 * time.Millisecond
 
 	for {
@@ -351,7 +352,7 @@ func (t *termuxSpeaker) runLifecycle(done chan struct{}) {
 			}
 			session = created
 			started = false
-			backoff = 100 * time.Millisecond
+			startedAt = time.Time{}
 		}
 
 		if !started {
@@ -378,6 +379,7 @@ func (t *termuxSpeaker) runLifecycle(done chan struct{}) {
 				t.forgetSession(session)
 				session = nil
 				started = false
+				startedAt = time.Time{}
 				if _, _, closed := t.lifecycleState(); closed {
 					return
 				}
@@ -388,6 +390,7 @@ func (t *termuxSpeaker) runLifecycle(done chan struct{}) {
 				continue
 			}
 			started = true
+			startedAt = time.Now()
 			if !t.applySessionState(session, started) {
 				session.Close()
 				return
@@ -396,10 +399,14 @@ func (t *termuxSpeaker) runLifecycle(done chan struct{}) {
 
 		select {
 		case <-session.stream.Done():
+			if !startedAt.IsZero() && time.Since(startedAt) >= termuxSessionStableTime {
+				backoff = 100 * time.Millisecond
+			}
 			session.Close()
 			t.forgetSession(session)
 			session = nil
 			started = false
+			startedAt = time.Time{}
 			if _, _, closed := t.lifecycleState(); closed {
 				return
 			}
@@ -483,6 +490,7 @@ const (
 	discoveryTotalDeadline  = 500 * time.Millisecond
 	discoveryInitialBackoff = 25 * time.Millisecond
 	discoveryMaxBackoff     = 100 * time.Millisecond
+	termuxSessionStableTime = time.Second
 )
 
 // nowFunc and sleepFunc are swapped in tests so retry behavior can be

--- a/player/speaker_termux.go
+++ b/player/speaker_termux.go
@@ -390,7 +390,7 @@ func (t *termuxSpeaker) runLifecycle(done chan struct{}) {
 				continue
 			}
 			started = true
-			startedAt = time.Now()
+			startedAt = nowFunc()
 			if !t.applySessionState(session, started) {
 				session.Close()
 				return
@@ -399,7 +399,7 @@ func (t *termuxSpeaker) runLifecycle(done chan struct{}) {
 
 		select {
 		case <-session.stream.Done():
-			if !startedAt.IsZero() && time.Since(startedAt) >= termuxSessionStableTime {
+			if !startedAt.IsZero() && nowFunc().Sub(startedAt) >= termuxSessionStableTime {
 				backoff = 100 * time.Millisecond
 			}
 			session.Close()

--- a/player/speaker_termux.go
+++ b/player/speaker_termux.go
@@ -1,0 +1,372 @@
+//go:build termux
+
+package player
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gopxl/beep/v2"
+	"github.com/jfreymuth/pulse"
+)
+
+// CLIAMP_DEBUG_PULSE=1 prints diagnostic information about the audio
+// backend selection. Useful for diagnosing Termux installs where
+// PulseAudio isn't running or the runtime socket is in an unexpected
+// location. Disabled by default because the TUI cannot tolerate stray
+// stderr writes.
+const debugPulseEnv = "CLIAMP_DEBUG_PULSE"
+
+func debugPulseLog(format string, args ...any) {
+	if os.Getenv(debugPulseEnv) == "" {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "[cliamp:pulse] "+format+"\n", args...)
+}
+
+// termuxSpeaker drives a beep.Mixer through a PulseAudio playback stream
+// using jfreymuth/pulse (pure-Go, no CGO, no ALSA). The PulseAudio daemon
+// is expected to be running on Termux with a usable sink (e.g. OpenSL_ES).
+type termuxSpeaker struct {
+	mu       sync.Mutex
+	mixer    beep.Mixer
+	client   *pulse.Client
+	stream   *pulse.PlaybackStream
+	started  atomic.Bool
+	errored  atomic.Bool
+	frameBuf [][2]float64 // reused across callbacks; guarded by mu
+}
+
+func (t *termuxSpeaker) Init(sampleRate beep.SampleRate, bufferSize int) error {
+	client, err := pulse.NewClient(t.newClientOptions()...)
+	if err != nil {
+		debugPulseLog("pulse.NewClient failed: %v", err)
+		return err
+	}
+	debugPulseLog("pulse.NewClient succeeded")
+	stream, err := client.NewPlayback(
+		pulse.Float32Reader(t.fillSamples),
+		pulse.PlaybackStereo,
+		pulse.PlaybackSampleRate(int(sampleRate)),
+		pulse.PlaybackLatency(float64(bufferSize)/float64(sampleRate)),
+		pulse.PlaybackMediaName("cliamp"),
+	)
+	if err != nil {
+		client.Close()
+		return err
+	}
+	t.client = client
+	t.stream = stream
+	t.frameBuf = make([][2]float64, bufferSize)
+	return nil
+}
+
+func (t *termuxSpeaker) newClientOptions() []pulse.ClientOption {
+	opts := []pulse.ClientOption{pulse.ClientApplicationName("cliamp")}
+	if server := pulseServerOption(); server != "" {
+		opts = append(opts, pulse.ClientServerString(server))
+	}
+	return opts
+}
+
+func (t *termuxSpeaker) Play(s ...beep.Streamer) {
+	t.mu.Lock()
+	t.mixer.Add(s...)
+	t.mu.Unlock()
+
+	if t.started.CompareAndSwap(false, true) {
+		go t.runStream()
+	}
+}
+
+// runStream calls Start() which blocks until the daemon has begun requesting
+// samples. There is no server-side close supervision: if PulseAudio dies
+// mid-session the user has to restart cliamp.
+func (t *termuxSpeaker) runStream() {
+	t.stream.Start()
+	if err := t.stream.Error(); err != nil {
+		t.errored.Store(true)
+	}
+}
+
+func (t *termuxSpeaker) Clear() {
+	t.mu.Lock()
+	t.mixer.Clear()
+	stream := t.stream
+	client := t.client
+	t.stream = nil
+	t.client = nil
+	t.mu.Unlock()
+
+	// SpeakerClear is invoked exactly once per Player lifetime
+	// (from Player.Close). Release the PulseAudio resources now so the
+	// daemon doesn't keep our sink input registered.
+	if stream != nil {
+		stream.Close()
+	}
+	if client != nil {
+		client.Close()
+	}
+}
+
+func (t *termuxSpeaker) Lock()   { t.mu.Lock() }
+func (t *termuxSpeaker) Unlock() { t.mu.Unlock() }
+
+func (t *termuxSpeaker) Suspend() error {
+	if t.errored.Load() || !t.started.Load() {
+		return nil
+	}
+	t.stream.Pause()
+	return nil
+}
+
+func (t *termuxSpeaker) Resume() error {
+	if t.errored.Load() || !t.started.Load() {
+		return nil
+	}
+	t.stream.Resume()
+	return nil
+}
+
+// fillSamples is invoked by PulseAudio's internal goroutine when the daemon
+// needs more bytes. It pulls stereo frames out of beep.Mixer under our mutex
+// and writes them as interleaved float32, matching the Float32Reader format
+// registered in Init.
+func (t *termuxSpeaker) fillSamples(buf []float32) (int, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	frames := len(buf) / 2
+	if cap(t.frameBuf) < frames {
+		t.frameBuf = make([][2]float64, frames)
+	}
+	frameSlice := t.frameBuf[:frames]
+	n, _ := t.mixer.Stream(frameSlice)
+	for i := 0; i < n; i++ {
+		l := frameSlice[i][0]
+		r := frameSlice[i][1]
+		if l > 1 {
+			l = 1
+		} else if l < -1 {
+			l = -1
+		}
+		if r > 1 {
+			r = 1
+		} else if r < -1 {
+			r = -1
+		}
+		buf[i*2+0] = float32(l)
+		buf[i*2+1] = float32(r)
+	}
+	return n * 2, nil
+}
+
+// pulseServerOption returns the explicit server string to pass to
+// pulse.ClientServerString, or "" when jfreymuth/pulse should use the
+// user's PULSE_SERVER or its built-in defaultServerStrings fallback.
+//
+// Priority order:
+//  1. PULSE_SERVER env var (any value) → "" (respect user setting).
+//  2. Termux-friendly base dirs → "unix:<absolute path>".
+//  3. Nothing → "" (let jfreymuth/pulse fail with a clear error).
+func pulseServerOption() string {
+	if v, ok := os.LookupEnv("PULSE_SERVER"); ok {
+		debugPulseLog("PULSE_SERVER=%q set; deferring to user configuration", v)
+		return ""
+	}
+	if addr := discoverPulseSocket(); addr != "" {
+		debugPulseLog("discovered pulse socket: %q", addr)
+		return "unix:" + addr
+	}
+	debugPulseLog("no pulse socket found")
+	return ""
+}
+
+// Discovery budget. PulseAudio creates its runtime socket asynchronously,
+// so cliamp may boot a few milliseconds before the daemon does. The retry
+// wrapper polls with exponential backoff up to discoveryTotalDeadline. If
+// the socket exists on the first attempt we return immediately — no fixed
+// sleep is added.
+const (
+	discoveryTotalDeadline  = 500 * time.Millisecond
+	discoveryInitialBackoff = 25 * time.Millisecond
+	discoveryMaxBackoff     = 100 * time.Millisecond
+)
+
+// nowFunc and sleepFunc are swapped in tests so retry behavior can be
+// exercised without real waits.
+var (
+	nowFunc   = time.Now
+	sleepFunc = time.Sleep
+)
+
+// discoverPulseSocket locates the PulseAudio daemon's Unix socket on Termux
+// without invoking pactl, hardcoding the random runtime-dir suffix, or
+// falling back to TCP. Returns the absolute socket path, or "" if not
+// found within the discovery deadline.
+//
+// The retry is needed because PulseAudio creates its runtime dir and
+// socket asynchronously after spawning. On a slow Termux boot we may
+// read the directory before the socket appears; the wrapper waits up
+// to discoveryTotalDeadline with exponential backoff.
+//
+// If the socket is still not visible, we try the libpulse "autospawn"
+// fallback: invoke `pulseaudio --start` (exactly what libpulse's
+// autospawn does) so the daemon creates the runtime dir + socket,
+// then retry the discovery once more. We do not extend the per-phase
+// deadline or chain additional retries; one spawn attempt is enough.
+func discoverPulseSocket() string {
+	debugPulseLog("PULSE_SERVER unset; bases=%v", pulseSocketBases())
+
+	if addr := discoverPulseSocketWithProbe(discoverPulseSocketOnce); addr != "" {
+		return addr
+	}
+	if !trySpawnPulseaudio() {
+		return ""
+	}
+	return discoverPulseSocketWithProbe(discoverPulseSocketOnce)
+}
+
+// discoverPulseSocketWithProbe retries probe up to discoveryTotalDeadline
+// with exponential backoff (capped). Returns the first non-empty result.
+// Used directly by tests with a controllable probe.
+func discoverPulseSocketWithProbe(probe func() string) string {
+	deadline := nowFunc().Add(discoveryTotalDeadline)
+	backoff := discoveryInitialBackoff
+	for {
+		if addr := probe(); addr != "" {
+			return addr
+		}
+		if !nowFunc().Before(deadline) {
+			return ""
+		}
+		sleepFunc(backoff)
+		backoff *= 2
+		if backoff > discoveryMaxBackoff {
+			backoff = discoveryMaxBackoff
+		}
+	}
+}
+
+// discoverPulseSocketOnce makes a single attempt to find the socket,
+// without any retry. Returns "" if no socket is currently visible.
+//
+// Strategy:
+//  1. Try the canonical path pulse/native in each candidate base directory.
+//  2. Fall back to scanning each base directory for any subdirectory whose
+//     name starts with "pulse" and which contains a Unix socket named
+//     "native". We use os.ReadDir + os.Stat directly because filepath.Glob
+//     is unreliable on some Android/Termux filesystems.
+func discoverPulseSocketOnce() string {
+	for _, base := range pulseSocketBases() {
+		if path := filepath.Join(base, "pulse", "native"); isUnixSocket(path) {
+			return path
+		}
+	}
+	for _, base := range pulseSocketBases() {
+		if path := findPulseSocketInDir(base); path != "" {
+			return path
+		}
+	}
+	return ""
+}
+
+// findPulseSocketInDir scans base for a Unix socket at <subdir>/native
+// where subdir's name starts with "pulse".
+func findPulseSocketInDir(base string) string {
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		return ""
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasPrefix(name, "pulse") {
+			continue
+		}
+		if !entry.IsDir() {
+			continue
+		}
+		candidate := filepath.Join(base, name, "native")
+		info, statErr := os.Stat(candidate)
+		if statErr != nil {
+			continue
+		}
+		if info.Mode()&os.ModeSocket != 0 {
+			return candidate
+		}
+	}
+	return ""
+}
+
+// pulseSocketBases returns the directories where the PulseAudio runtime
+// socket might live, in priority order. De-duplicated.
+func pulseSocketBases() []string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(p string) {
+		if p == "" || seen[p] {
+			return
+		}
+		seen[p] = true
+		out = append(out, p)
+	}
+
+	// Standard freedesktop spec.
+	add(os.Getenv("XDG_RUNTIME_DIR"))
+
+	// POSIX fallback. Termux sets $TMPDIR but not $XDG_RUNTIME_DIR, so
+	// pulseaudio uses $TMPDIR for its runtime dir.
+	add(os.Getenv("TMPDIR"))
+
+	// Termux-only fallback: $PREFIX/tmp. The PREFIX env var contains
+	// "com.termux" on real Termux installs; we restrict the fallback to
+	// that case so unrelated Linux installs aren't pointlessly probed.
+	if prefix := os.Getenv("PREFIX"); strings.Contains(prefix, "com.termux") {
+		add(filepath.Join(prefix, "tmp"))
+	}
+
+	return out
+}
+
+func isUnixSocket(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeSocket != 0
+}
+
+// spawnPulseaudioFn is the autospawn trigger. Production calls
+// trySpawnPulseaudioImpl; tests can swap it for a deterministic stub.
+var spawnPulseaudioFn = trySpawnPulseaudioImpl
+
+// trySpawnPulseaudio invokes `pulseaudio --start`, the same way libpulse's
+// autospawn does (see pulseaudio/src/pulse/context.c context_autospawn).
+// The parent returns 0 once the daemon has forked and bound its socket.
+// We do NOT pass --exit-idle-time=-1 (libpulse doesn't either); the
+// daemon persists according to PulseAudio's standard lifecycle rules.
+func trySpawnPulseaudio() bool {
+	return spawnPulseaudioFn()
+}
+
+func trySpawnPulseaudioImpl() bool {
+	bin, err := exec.LookPath("pulseaudio")
+	if err != nil {
+		debugPulseLog("pulseaudio not in PATH: %v", err)
+		return false
+	}
+	cmd := exec.Command(bin, "--start")
+	if err := cmd.Run(); err != nil {
+		debugPulseLog("pulseaudio --start failed: %v", err)
+		return false
+	}
+	debugPulseLog("pulseaudio --start succeeded")
+	return true
+}
+
+func init() { backend = &termuxSpeaker{} }

--- a/player/speaker_termux.go
+++ b/player/speaker_termux.go
@@ -35,16 +35,30 @@ func debugPulseLog(format string, args ...any) {
 // using jfreymuth/pulse (pure-Go, no CGO, no ALSA). The PulseAudio daemon
 // is expected to be running on Termux with a usable sink (e.g. OpenSL_ES).
 type termuxSpeaker struct {
-	mu       sync.Mutex
-	mixer    beep.Mixer
-	client   *pulse.Client
-	stream   *pulse.PlaybackStream
-	started  atomic.Bool
-	errored  atomic.Bool
-	frameBuf [][2]float64 // reused across callbacks; guarded by mu
+	mu         sync.Mutex
+	mixer      beep.Mixer
+	client     *pulse.Client
+	stream     *pulse.PlaybackStream
+	sampleRate beep.SampleRate // remembered so Play can lazily recreate after errors
+	bufferSize int
+	started    atomic.Bool
+	errored    atomic.Bool
+	frameBuf   [][2]float64 // reused across callbacks; guarded by mu
 }
 
 func (t *termuxSpeaker) Init(sampleRate beep.SampleRate, bufferSize int) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.initLocked(sampleRate, bufferSize)
+}
+
+// initLocked is Init's body. Caller must hold t.mu. Idempotent: a previous
+// client/stream is closed first so the speaker can be reinitialized without
+// leaking the PulseAudio socket. After it returns successfully, t.stream is
+// non-nil and ready to be started by the next Play.
+func (t *termuxSpeaker) initLocked(sampleRate beep.SampleRate, bufferSize int) error {
+	t.closeLocked()
+
 	client, err := pulse.NewClient(t.newClientOptions()...)
 	if err != nil {
 		debugPulseLog("pulse.NewClient failed: %v", err)
@@ -64,8 +78,26 @@ func (t *termuxSpeaker) Init(sampleRate beep.SampleRate, bufferSize int) error {
 	}
 	t.client = client
 	t.stream = stream
+	t.sampleRate = sampleRate
+	t.bufferSize = bufferSize
 	t.frameBuf = make([][2]float64, bufferSize)
+	t.started.Store(false)
+	t.errored.Store(false)
 	return nil
+}
+
+// closeLocked releases the current PulseAudio client and stream. Caller must
+// hold t.mu. After it returns, t.stream and t.client are nil and the next
+// Play will lazily recreate via initLocked.
+func (t *termuxSpeaker) closeLocked() {
+	if t.stream != nil {
+		t.stream.Close()
+		t.stream = nil
+	}
+	if t.client != nil {
+		t.client.Close()
+		t.client = nil
+	}
 }
 
 func (t *termuxSpeaker) newClientOptions() []pulse.ClientOption {
@@ -78,9 +110,31 @@ func (t *termuxSpeaker) newClientOptions() []pulse.ClientOption {
 
 func (t *termuxSpeaker) Play(s ...beep.Streamer) {
 	t.mu.Lock()
+
+	// Recovery path: if the previous stream was torn down (Init failure or
+	// post-Start error) the next streamer is added straight away, so we
+	// re-establish the PulseAudio connection lazily. If the daemon went
+	// away after Start succeeded, Closed() reports serverLost; rebuild
+	// before the user notices silence.
+	if t.stream == nil && t.sampleRate != 0 {
+		if err := t.initLocked(t.sampleRate, t.bufferSize); err != nil {
+			debugPulseLog("Play: recovery init failed: %v", err)
+			t.mu.Unlock()
+			return
+		}
+	} else if t.stream != nil && t.stream.Closed() {
+		t.closeLocked()
+		t.started.Store(false)
+		t.errored.Store(false)
+		if err := t.initLocked(t.sampleRate, t.bufferSize); err != nil {
+			debugPulseLog("Play: recovery init failed: %v", err)
+			t.mu.Unlock()
+			return
+		}
+	}
+
 	t.mixer.Add(s...)
-	stream := t.stream // snapshot; defensive against any future change that
-	// might invalidate t.stream concurrently with the runStream goroutine.
+	stream := t.stream
 	t.mu.Unlock()
 
 	if stream != nil && t.started.CompareAndSwap(false, true) {
@@ -88,35 +142,38 @@ func (t *termuxSpeaker) Play(s ...beep.Streamer) {
 	}
 }
 
-// runStream calls Start() which blocks until the daemon has begun requesting
-// samples. Operates exclusively on the snapshot passed by Play; never
-// touches t.stream directly. If PulseAudio dies mid-session the user has
-// to restart cliamp.
+// runStream calls Start(), which blocks until the PulseAudio daemon has
+// begun requesting samples (the unbuffered "<-started" handoff inside
+// PlaybackStream.Start). Operates exclusively on the snapshot passed by
+// Play. If Start returns successfully and Error() reports a failure (for
+// example the daemon disconnected during startup), the stream and client
+// are released so the next Play can recreate them — otherwise started
+// would stay set forever and the speaker would silently drop new audio.
 func (t *termuxSpeaker) runStream(stream *pulse.PlaybackStream) {
 	stream.Start()
 	if err := stream.Error(); err != nil {
+		debugPulseLog("stream error after Start: %v", err)
 		t.errored.Store(true)
+		t.mu.Lock()
+		if t.stream == stream {
+			t.closeLocked()
+			t.started.Store(false)
+		}
+		t.mu.Unlock()
 	}
 }
 
+// Clear mirrors gopxl/beep/v2/speaker.Clear: it empties the mixer and leaves
+// the PulseAudio stream running. The stream does NOT need to be restarted
+// after a Clear — the next Play just adds fresh streamers to the mixer and
+// the audio callback resumes pulling from it. Critically, Clear must not
+// reset started while a runStream goroutine may still be blocked inside
+// PlaybackStream.Start; doing so would let a subsequent Play launch a
+// second runStream on the same stream and deadlock on the unbuffered
+// started notification (jfreymuth/pulse only emits one per stream).
 func (t *termuxSpeaker) Clear() {
-	// Mirror gopxl/beep/v2/speaker.Clear: clear the mixer and reset state.
-	// We intentionally do NOT close stream/client because:
-	//   1. jfreymuth/pulse's stream.Close()/client.Close() can race with
-	//      a concurrent runStream blocked on stream.Start(): closing
-	//      p.request under it leads to a "send on closed channel" panic
-	//      inside Start, and the <-started channel is never written to on
-	//      connection drop.
-	//   2. The Linux speaker (gopxl/beep/v2/speaker) does not close
-	//      anything in Clear() either.
-	// Audio thread + PulseAudio stream stay alive across Clear so
-	// subsequent Play can re-add streamers to the mixer. Resources are
-	// released at process exit (Player.Close → SpeakerClear → process
-	// exit → OS reaps the socket).
 	t.mu.Lock()
 	t.mixer.Clear()
-	t.started.Store(false)
-	t.errored.Store(false)
 	t.mu.Unlock()
 }
 

--- a/player/speaker_termux_test.go
+++ b/player/speaker_termux_test.go
@@ -104,11 +104,13 @@ func TestDiscoverPulseSocket_TMPDIRFallback(t *testing.T) {
 }
 
 func TestDiscoverPulseSocket_TermuxPREFIXPath(t *testing.T) {
-	// $PREFIX/tmp is the canonical Termux runtime location when XDG
-	// and TMPDIR are absent; the PREFIX contains "com.termux" so the
-	// Termux-specific fallback engages.
-	const termuxRoot = "/tmp/cliamp-com.termux-test"
-	prefixPath := termuxRoot + "/files/usr"
+	// $PREFIX/tmp is the canonical Termux runtime location when XDG and
+	// TMPDIR are absent; the PREFIX contains "com.termux" so the
+	// Termux-specific fallback engages. We construct the prefix path under
+	// t.TempDir() with a "com.termux" segment so pulseSocketBases'
+	// strings.Contains check fires, without depending on a hardcoded /tmp
+	// path that could collide with parallel runs or system state.
+	prefixPath := filepath.Join(t.TempDir(), "com.termux-test", "files", "usr")
 	tmpDir := filepath.Join(prefixPath, "tmp")
 	sockPath := filepath.Join(tmpDir, "pulse-AbC", "native")
 	if err := os.MkdirAll(filepath.Dir(sockPath), 0o700); err != nil {
@@ -388,5 +390,109 @@ func TestTermuxSpeakerInit_DoesNotReturnNoValidServer(t *testing.T) {
 	}
 	if msg := err.Error(); strings.Contains(msg, "no valid server") {
 		t.Fatalf("Init returned %q: our server-string selection must have failed", msg)
+	}
+}
+
+// --- Lifecycle invariants ---
+
+// runClearWithTimeout invokes Clear in a goroutine and waits up to the
+// timeout for it to return. Clear can take ~1s on a fake server because
+// stream.Close / client.Close do proto.Request calls that block until
+// the 1s Request timeout fires. The timeout gives the test a deterministic
+// bound so a regression that turns Clear into an infinite hang fails fast.
+func runClearWithTimeout(t *testing.T, sp *termuxSpeaker) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		sp.Clear()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Clear hung beyond reasonable timeout")
+	}
+}
+
+// TestClear_DoesNotTouchStream verifies that Clear mirrors
+// gopxl/beep/v2/speaker.Clear: it clears the mixer and resets state
+// without closing the PulseAudio stream or client. Closing them under
+// a concurrent runStream would race with stream.Start's <-started
+// receive and could panic on a closed request channel.
+func TestClear_DoesNotTouchStream(t *testing.T) {
+	dir := makeSocket(t, "pulse-AbCd", "native")
+	clearEnv(t, "XDG_RUNTIME_DIR", "TMPDIR", "PREFIX", "PULSE_SERVER")
+	withEnv(t, map[string]string{"TMPDIR": dir})
+
+	sp := &termuxSpeaker{}
+	if err := sp.Init(44100, 4096); err != nil {
+		t.Skipf("Init failed (expected on fake socket): %v", err)
+	}
+
+	runClearWithTimeout(t, sp)
+
+	sp.mu.Lock()
+	stream := sp.stream
+	sp.mu.Unlock()
+	if stream == nil {
+		t.Errorf("Clear must not nil out t.stream (would race with runStream)")
+	}
+}
+
+// TestClear_ResetsStartedAndErrored verifies the post-Clear state that
+// enables subsequent Play to re-establish a runStream goroutine.
+func TestClear_ResetsStartedAndErrored(t *testing.T) {
+	dir := makeSocket(t, "pulse-AbCd", "native")
+	clearEnv(t, "XDG_RUNTIME_DIR", "TMPDIR", "PREFIX", "PULSE_SERVER")
+	withEnv(t, map[string]string{"TMPDIR": dir})
+
+	sp := &termuxSpeaker{}
+	if err := sp.Init(44100, 4096); err != nil {
+		t.Skipf("Init failed (expected on fake socket): %v", err)
+	}
+
+	sp.started.Store(true)
+	sp.errored.Store(true)
+
+	runClearWithTimeout(t, sp)
+
+	if sp.started.Load() {
+		t.Errorf("started must be false after Clear")
+	}
+	if sp.errored.Load() {
+		t.Errorf("errored must be false after Clear")
+	}
+}
+
+// TestPlay_NoGoroutineWhenStreamNil verifies that Play is safe to call
+// before Init (or after an Init failure): the snapshot is nil, so no
+// goroutine is spawned and no panic occurs.
+func TestPlay_NoGoroutineWhenStreamNil(t *testing.T) {
+	sp := &termuxSpeaker{} // no Init; client and stream are nil
+
+	sp.Play()
+
+	if sp.started.Load() {
+		t.Errorf("started must remain false when stream is nil")
+	}
+}
+
+// --- Retry deadline ---
+
+// TestDiscoverPulseSocketWithProbe_RespectsDeadline verifies the retry
+// budget: even with a probe that always fails, total elapsed time stays
+// within discoveryTotalDeadline plus a small slack. Each sleep is
+// capped to the remaining deadline so we never overshoot.
+func TestDiscoverPulseSocketWithProbe_RespectsDeadline(t *testing.T) {
+	useFakeClock(t)
+
+	const slack = time.Millisecond
+	probe := func() string { return "" }
+	start := nowFunc()
+	_ = discoverPulseSocketWithProbe(probe)
+	elapsed := nowFunc().Sub(start)
+
+	if elapsed > discoveryTotalDeadline+slack {
+		t.Errorf("elapsed = %v, want <= %v (deadline + %v slack)", elapsed, discoveryTotalDeadline, slack)
 	}
 }

--- a/player/speaker_termux_test.go
+++ b/player/speaker_termux_test.go
@@ -680,6 +680,45 @@ func TestTermuxSpeaker_CloseAllowsReinitialization(t *testing.T) {
 	second.releaseStart()
 }
 
+func TestTermuxPulseClient_HasActivePlayback(t *testing.T) {
+	stream := &termuxPulsePlayback{state: termuxPulseIdle}
+	client := &termuxPulseClient{
+		playback: map[uint32]*termuxPulsePlayback{1: stream},
+	}
+
+	if client.hasActivePlayback() {
+		t.Fatal("idle playback must not trigger health checks")
+	}
+	stream.stateMu.Lock()
+	stream.state = termuxPulseRunning
+	stream.stateMu.Unlock()
+	if !client.hasActivePlayback() {
+		t.Fatal("running playback must trigger health checks")
+	}
+	stream.stateMu.Lock()
+	stream.state = termuxPulsePaused
+	stream.stateMu.Unlock()
+	if client.hasActivePlayback() {
+		t.Fatal("paused playback must not trigger health checks")
+	}
+}
+
+func TestTermuxPulsePlayback_StartedAfterUnderflow(t *testing.T) {
+	stream := &termuxPulsePlayback{
+		started:   make(chan struct{}, 1),
+		done:      make(chan struct{}),
+		state:     termuxPulseRunning,
+		underflow: true,
+	}
+
+	stream.notifyStarted()
+	select {
+	case <-stream.started:
+	default:
+		t.Fatal("Started notification must not be suppressed by an earlier underflow")
+	}
+}
+
 // --- Retry deadline ---
 
 // TestDiscoverPulseSocketWithProbe_RespectsDeadline verifies the retry

--- a/player/speaker_termux_test.go
+++ b/player/speaker_termux_test.go
@@ -1,0 +1,392 @@
+//go:build termux
+
+package player
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// makeSocket creates a real Unix domain socket at <dir>/<sub>/<name> and
+// returns the directory path. The socket is closed on test cleanup.
+func makeSocket(t *testing.T, sub, name string) string {
+	t.Helper()
+	dir := t.TempDir()
+	subDir := filepath.Join(dir, sub)
+	if err := os.MkdirAll(subDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	sockPath := filepath.Join(subDir, name)
+	ln, err := net.ListenUnix("unix", mustAddr(t, sockPath))
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	return dir
+}
+
+// withEnv sets env vars for the duration of a test, restoring on cleanup.
+func withEnv(t *testing.T, kv map[string]string) {
+	t.Helper()
+	for k, v := range kv {
+		old, had := os.LookupEnv(k)
+		if err := os.Setenv(k, v); err != nil {
+			t.Fatalf("setenv %s: %v", k, err)
+		}
+		if had {
+			t.Cleanup(func() { _ = os.Setenv(k, old) })
+		} else {
+			t.Cleanup(func() { _ = os.Unsetenv(k) })
+		}
+	}
+}
+
+// clearEnv unsets env vars for the duration of a test.
+func clearEnv(t *testing.T, keys ...string) {
+	t.Helper()
+	for _, k := range keys {
+		old, had := os.LookupEnv(k)
+		_ = os.Unsetenv(k)
+		if had {
+			t.Cleanup(func() { _ = os.Setenv(k, old) })
+		}
+	}
+}
+
+func mustAddr(t *testing.T, path string) *net.UnixAddr {
+	t.Helper()
+	a, err := net.ResolveUnixAddr("unix", path)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	return a
+}
+
+// --- PulseAudio discovery ---
+
+func TestDiscoverPulseSocket_CanonicalPath(t *testing.T) {
+	dir := makeSocket(t, "pulse", "native")
+	withEnv(t, map[string]string{"XDG_RUNTIME_DIR": dir, "TMPDIR": ""})
+
+	got := discoverPulseSocket()
+	want := filepath.Join(dir, "pulse", "native")
+	if got != want {
+		t.Errorf("discoverPulseSocket() = %q, want %q", got, want)
+	}
+}
+
+func TestDiscoverPulseSocket_RandomizedSuffix(t *testing.T) {
+	// PulseAudio's default runtime dir has a random hash suffix.
+	dir := makeSocket(t, "pulse-AbCd1234", "native")
+	withEnv(t, map[string]string{"XDG_RUNTIME_DIR": dir, "TMPDIR": ""})
+
+	want := filepath.Join(dir, "pulse-AbCd1234", "native")
+	if got := discoverPulseSocket(); got != want {
+		t.Errorf("discoverPulseSocket() = %q, want %q (must match the random suffix without hardcoding)", got, want)
+	}
+}
+
+func TestDiscoverPulseSocket_TMPDIRFallback(t *testing.T) {
+	// Termux sets $TMPDIR but not $XDG_RUNTIME_DIR; pulseaudio creates
+	// its runtime dir there.
+	dir := makeSocket(t, "pulse-XyZ987", "native")
+	clearEnv(t, "XDG_RUNTIME_DIR", "TMPDIR", "PREFIX")
+	withEnv(t, map[string]string{"TMPDIR": dir})
+
+	want := filepath.Join(dir, "pulse-XyZ987", "native")
+	if got := discoverPulseSocket(); got != want {
+		t.Errorf("discoverPulseSocket() = %q, want %q (TMPDIR fallback)", got, want)
+	}
+}
+
+func TestDiscoverPulseSocket_TermuxPREFIXPath(t *testing.T) {
+	// $PREFIX/tmp is the canonical Termux runtime location when XDG
+	// and TMPDIR are absent; the PREFIX contains "com.termux" so the
+	// Termux-specific fallback engages.
+	const termuxRoot = "/tmp/cliamp-com.termux-test"
+	prefixPath := termuxRoot + "/files/usr"
+	tmpDir := filepath.Join(prefixPath, "tmp")
+	sockPath := filepath.Join(tmpDir, "pulse-AbC", "native")
+	if err := os.MkdirAll(filepath.Dir(sockPath), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	ln, err := net.ListenUnix("unix", mustAddr(t, sockPath))
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	clearEnv(t, "XDG_RUNTIME_DIR", "TMPDIR", "PREFIX")
+	withEnv(t, map[string]string{"PREFIX": prefixPath})
+
+	if got := discoverPulseSocket(); got != sockPath {
+		t.Errorf("discoverPulseSocket() = %q, want %q (PREFIX/tmp fallback)", got, sockPath)
+	}
+}
+
+func TestDiscoverPulseSocket_NoSocket(t *testing.T) {
+	dir := t.TempDir()
+	clearEnv(t, "XDG_RUNTIME_DIR", "TMPDIR", "PREFIX")
+	withEnv(t, map[string]string{"XDG_RUNTIME_DIR": dir})
+
+	// Stub the spawn so we don't accidentally exec a real pulseaudio
+	// binary if one happens to be on the test host's PATH.
+	withStubSpawn(t, func() bool { return false })
+	useFakeClock(t)
+	if got := discoverPulseSocket(); got != "" {
+		t.Errorf("discoverPulseSocket() = %q, want empty", got)
+	}
+}
+
+func TestDiscoverPulseSocket_IgnoresRegularFile(t *testing.T) {
+	// A regular file named "native" must not be mistaken for the socket.
+	dir := t.TempDir()
+	pulseDir := filepath.Join(dir, "pulse")
+	if err := os.MkdirAll(pulseDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pulseDir, "native"), []byte("not a socket"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	withEnv(t, map[string]string{"XDG_RUNTIME_DIR": dir, "TMPDIR": ""})
+
+	withStubSpawn(t, func() bool { return false })
+	useFakeClock(t)
+	if got := discoverPulseSocket(); got != "" {
+		t.Errorf("discoverPulseSocket() = %q, want empty (regular file should be ignored)", got)
+	}
+}
+
+// --- PULSE_SERVER env var ---
+
+func TestPulseServerOption_HonorsPULSESERVER(t *testing.T) {
+	// PULSE_SERVER wins even when a local socket is reachable.
+	dir := makeSocket(t, "pulse-AbCd", "native")
+	clearEnv(t, "XDG_RUNTIME_DIR", "TMPDIR", "PREFIX", "PULSE_SERVER")
+	withEnv(t, map[string]string{
+		"XDG_RUNTIME_DIR": dir,
+		"PULSE_SERVER":    "unix:/some/explicit/path",
+	})
+
+	if got := pulseServerOption(); got != "" {
+		t.Errorf("pulseServerOption() = %q, want empty (PULSE_SERVER must win)", got)
+	}
+}
+
+func TestPulseServerOption_HonorsEmptyPULSESERVER(t *testing.T) {
+	// An empty PULSE_SERVER is still an explicit setting.
+	dir := makeSocket(t, "pulse-AbCd", "native")
+	clearEnv(t, "XDG_RUNTIME_DIR", "TMPDIR", "PREFIX", "PULSE_SERVER")
+	withEnv(t, map[string]string{
+		"XDG_RUNTIME_DIR": dir,
+		"PULSE_SERVER":    "",
+	})
+
+	if got := pulseServerOption(); got != "" {
+		t.Errorf("pulseServerOption() = %q, want empty", got)
+	}
+}
+
+// --- Retry budget ---
+
+type fakeClock struct{ t time.Time }
+
+func (c *fakeClock) now() time.Time        { return c.t }
+func (c *fakeClock) sleep(d time.Duration) { c.t = c.t.Add(d) }
+
+func useFakeClock(t *testing.T) *fakeClock {
+	t.Helper()
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0).UTC()}
+	nowFunc = clk.now
+	sleepFunc = clk.sleep
+	t.Cleanup(func() {
+		nowFunc = time.Now
+		sleepFunc = time.Sleep
+	})
+	return clk
+}
+
+func TestDiscoverPulseSocketWithProbe_NoRetryWhenFoundImmediately(t *testing.T) {
+	var calls int
+	probe := func() string {
+		calls++
+		return "/tmp/pulse-AbCd/native"
+	}
+
+	if got := discoverPulseSocketWithProbe(probe); got != "/tmp/pulse-AbCd/native" {
+		t.Errorf("got %q, want \"/tmp/pulse-AbCd/native\"", got)
+	}
+	if calls != 1 {
+		t.Errorf("probe calls = %d, want 1 (no retry when first attempt succeeds)", calls)
+	}
+}
+
+func TestDiscoverPulseSocketWithProbe_RetriesUntilFound(t *testing.T) {
+	clk := useFakeClock(t)
+
+	var calls int
+	probe := func() string {
+		calls++
+		if calls < 4 {
+			return ""
+		}
+		return "/tmp/pulse-ZzZ/native"
+	}
+
+	if got := discoverPulseSocketWithProbe(probe); got != "/tmp/pulse-ZzZ/native" {
+		t.Errorf("got %q, want \"/tmp/pulse-ZzZ/native\"", got)
+	}
+	if calls != 4 {
+		t.Errorf("probe calls = %d, want 4", calls)
+	}
+	// The backoff schedule (capped): 25ms, 50ms, 100ms.
+	// Total elapsed: discoveryInitialBackoff + 2*discoveryInitialBackoff + discoveryMaxBackoff.
+	wantElapsed := discoveryInitialBackoff + 2*discoveryInitialBackoff + discoveryMaxBackoff
+	if elapsed := clk.t.Sub(time.Unix(1_700_000_000, 0).UTC()); elapsed != wantElapsed {
+		t.Errorf("elapsed = %v, want %v", elapsed, wantElapsed)
+	}
+}
+
+func TestDiscoverPulseSocketWithProbe_EmptyAfterDeadline(t *testing.T) {
+	useFakeClock(t)
+
+	probe := func() string { return "" }
+	if got := discoverPulseSocketWithProbe(probe); got != "" {
+		t.Errorf("got %q, want empty after deadline", got)
+	}
+}
+
+// --- Autospawn ---
+
+func withStubSpawn(t *testing.T, fn func() bool) {
+	t.Helper()
+	saved := spawnPulseaudioFn
+	spawnPulseaudioFn = fn
+	t.Cleanup(func() { spawnPulseaudioFn = saved })
+}
+
+func TestDiscoverPulseSocket_DoesNotSpawnWhenSocketExists(t *testing.T) {
+	dir := makeSocket(t, "pulse-AbCd", "native")
+	clearEnv(t, "XDG_RUNTIME_DIR", "TMPDIR", "PREFIX", "PULSE_SERVER")
+	withEnv(t, map[string]string{"TMPDIR": dir})
+
+	spawnCalls := 0
+	withStubSpawn(t, func() bool {
+		spawnCalls++
+		return true
+	})
+	useFakeClock(t)
+
+	if got := discoverPulseSocket(); got == "" {
+		t.Errorf("discoverPulseSocket() = empty, want socket")
+	}
+	if spawnCalls != 0 {
+		t.Errorf("spawn called %d times, want 0 (daemon already running)", spawnCalls)
+	}
+}
+
+func TestDiscoverPulseSocket_SpawnsOnceWhenFirstPhaseFails(t *testing.T) {
+	// No socket initially; spawn is invoked and succeeds (but doesn't
+	// create a socket, to keep the test hermetic). discoverPulseSocket
+	// returns "" and spawn is called exactly once.
+	dir := t.TempDir()
+	clearEnv(t, "XDG_RUNTIME_DIR", "TMPDIR", "PREFIX", "PULSE_SERVER")
+	withEnv(t, map[string]string{"TMPDIR": dir})
+
+	spawnCalls := 0
+	withStubSpawn(t, func() bool {
+		spawnCalls++
+		return true
+	})
+	useFakeClock(t)
+
+	if got := discoverPulseSocket(); got != "" {
+		t.Errorf("got %q, want empty (no socket after spawn)", got)
+	}
+	if spawnCalls != 1 {
+		t.Errorf("spawn called %d times, want exactly 1", spawnCalls)
+	}
+}
+
+func TestDiscoverPulseSocket_SpawnThenSucceeds(t *testing.T) {
+	// No socket initially. The stub for spawnPulseaudioFn creates the
+	// socket (mirroring what the real pulseaudio --start does). The
+	// second discovery phase finds it.
+	dir := t.TempDir()
+	clearEnv(t, "XDG_RUNTIME_DIR", "TMPDIR", "PREFIX", "PULSE_SERVER")
+	withEnv(t, map[string]string{"TMPDIR": dir})
+
+	withStubSpawn(t, func() bool {
+		sub := filepath.Join(dir, "pulse-VVVV")
+		if err := os.MkdirAll(sub, 0o700); err != nil {
+			return false
+		}
+		sockPath := filepath.Join(sub, "native")
+		ln, err := net.ListenUnix("unix", mustAddr(t, sockPath))
+		if err != nil {
+			return false
+		}
+		t.Cleanup(func() { _ = ln.Close() })
+		return true
+	})
+	useFakeClock(t)
+
+	want := filepath.Join(dir, "pulse-VVVV", "native")
+	if got := discoverPulseSocket(); got != want {
+		t.Errorf("got %q, want %q (spawn must enable discovery on second phase)", got, want)
+	}
+}
+
+func TestDiscoverPulseSocket_FailedSpawnReturnsEmpty(t *testing.T) {
+	// Spawn fails (binary missing, exit code != 0, etc). There is no
+	// point in retrying discovery.
+	dir := t.TempDir()
+	clearEnv(t, "XDG_RUNTIME_DIR", "TMPDIR", "PREFIX", "PULSE_SERVER")
+	withEnv(t, map[string]string{"TMPDIR": dir})
+
+	spawnCalls := 0
+	withStubSpawn(t, func() bool {
+		spawnCalls++
+		return false
+	})
+	useFakeClock(t)
+
+	if got := discoverPulseSocket(); got != "" {
+		t.Errorf("got %q, want empty (spawn failed)", got)
+	}
+	if spawnCalls != 1 {
+		t.Errorf("spawn called %d times, want exactly 1", spawnCalls)
+	}
+}
+
+func TestTrySpawnPulseaudioImpl_NotInPath(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	if got := trySpawnPulseaudioImpl(); got {
+		t.Errorf("trySpawnPulseaudioImpl() = true, want false (pulseaudio not in PATH)")
+	}
+}
+
+// --- Integration with jfreymuth/pulse ---
+
+func TestTermuxSpeakerInit_DoesNotReturnNoValidServer(t *testing.T) {
+	// Regression guard: with a real Unix socket present and PULSE_SERVER
+	// unset, termuxSpeaker.Init must reach the protocol stage. The fake
+	// socket only accepts; it does not speak PulseAudio, so we expect
+	// an error — just not the "no valid server" error that would mean
+	// our server string never reached proto.Connect.
+	dir := makeSocket(t, "pulse-AbCd", "native")
+	clearEnv(t, "XDG_RUNTIME_DIR", "TMPDIR", "PREFIX", "PULSE_SERVER")
+	withEnv(t, map[string]string{"TMPDIR": dir})
+
+	err := (&termuxSpeaker{}).Init(44100, 4096)
+	if err == nil {
+		t.Fatal("expected error from fake socket (no real PulseAudio protocol)")
+	}
+	if msg := err.Error(); strings.Contains(msg, "no valid server") {
+		t.Fatalf("Init returned %q: our server-string selection must have failed", msg)
+	}
+}

--- a/player/speaker_termux_test.go
+++ b/player/speaker_termux_test.go
@@ -3,12 +3,17 @@
 package player
 
 import (
+	"context"
 	"net"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/gopxl/beep/v2"
 )
 
 // makeSocket creates a real Unix domain socket at <dir>/<sub>/<name> and
@@ -396,10 +401,7 @@ func TestTermuxSpeakerInit_DoesNotReturnNoValidServer(t *testing.T) {
 // --- Lifecycle invariants ---
 
 // runClearWithTimeout invokes Clear in a goroutine and waits up to the
-// timeout for it to return. Clear can take ~1s on a fake server because
-// stream.Close / client.Close do proto.Request calls that block until
-// the 1s Request timeout fires. The timeout gives the test a deterministic
-// bound so a regression that turns Clear into an infinite hang fails fast.
+// timeout for it to return.
 func runClearWithTimeout(t *testing.T, sp *termuxSpeaker) {
 	t.Helper()
 	done := make(chan struct{})
@@ -414,87 +416,146 @@ func runClearWithTimeout(t *testing.T, sp *termuxSpeaker) {
 	}
 }
 
-// TestClear_DoesNotTouchStream verifies that Clear mirrors
-// gopxl/beep/v2/speaker.Clear: it clears the mixer and resets state
-// without closing the PulseAudio stream or client. Closing them under
-// a concurrent runStream would race with stream.Start's <-started
-// receive and could panic on a closed request channel.
+type fakeTermuxPlayback struct {
+	startEntered  chan struct{}
+	startRelease  chan struct{}
+	startReturned chan struct{}
+	done          chan struct{}
+
+	startOnce        sync.Once
+	startReleaseOnce sync.Once
+	startReturnOnce  sync.Once
+	doneOnce         sync.Once
+	startCalls       atomic.Int32
+	closeCalls       atomic.Int32
+}
+
+func newFakeTermuxPlayback() *fakeTermuxPlayback {
+	return &fakeTermuxPlayback{
+		startEntered:  make(chan struct{}),
+		startRelease:  make(chan struct{}),
+		startReturned: make(chan struct{}),
+		done:          make(chan struct{}),
+	}
+}
+
+func (f *fakeTermuxPlayback) StartContext(ctx context.Context) error {
+	f.startCalls.Add(1)
+	f.startOnce.Do(func() { close(f.startEntered) })
+	var err error
+	select {
+	case <-f.startRelease:
+	case <-f.done:
+		err = errTermuxPulseConnectionClosed
+	case <-ctx.Done():
+		err = ctx.Err()
+	}
+	f.startReturnOnce.Do(func() { close(f.startReturned) })
+	return err
+}
+
+func (f *fakeTermuxPlayback) Done() <-chan struct{} { return f.done }
+
+func (f *fakeTermuxPlayback) Pause()  {}
+func (f *fakeTermuxPlayback) Resume() {}
+
+func (f *fakeTermuxPlayback) Close() {
+	f.closeCalls.Add(1)
+	f.disconnect()
+}
+
+func (f *fakeTermuxPlayback) releaseStart() {
+	f.startReleaseOnce.Do(func() { close(f.startRelease) })
+}
+
+func (f *fakeTermuxPlayback) disconnect() {
+	f.doneOnce.Do(func() { close(f.done) })
+}
+
+type fakeTermuxSessionFactory struct {
+	mu       sync.Mutex
+	sessions []*fakeTermuxPlayback
+	created  chan *fakeTermuxPlayback
+}
+
+func newFakeTermuxSessionFactory() *fakeTermuxSessionFactory {
+	return &fakeTermuxSessionFactory{created: make(chan *fakeTermuxPlayback, 8)}
+}
+
+func (f *fakeTermuxSessionFactory) newSession(beep.SampleRate, int, func([]float32) (int, error)) (*termuxSession, error) {
+	stream := newFakeTermuxPlayback()
+	f.mu.Lock()
+	f.sessions = append(f.sessions, stream)
+	f.mu.Unlock()
+	f.created <- stream
+	return &termuxSession{stream: stream}, nil
+}
+
+func (f *fakeTermuxSessionFactory) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.sessions)
+}
+
+func waitForFakeSession(t *testing.T, created <-chan *fakeTermuxPlayback) *fakeTermuxPlayback {
+	t.Helper()
+	select {
+	case stream := <-created:
+		return stream
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for fake PulseAudio session")
+		return nil
+	}
+}
+
+func newFakeTermuxSpeaker(t *testing.T) (*termuxSpeaker, *fakeTermuxSessionFactory, *fakeTermuxPlayback) {
+	t.Helper()
+	factory := newFakeTermuxSessionFactory()
+	sp := &termuxSpeaker{factory: factory.newSession}
+	if err := sp.Init(44100, 4096); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	first := waitForFakeSession(t, factory.created)
+	t.Cleanup(sp.Close)
+	return sp, factory, first
+}
+
+// TestClear_DoesNotTouchStream verifies that Clear only empties the mixer and
+// leaves the current session owned by the lifecycle supervisor.
 func TestClear_DoesNotTouchStream(t *testing.T) {
-	dir := makeSocket(t, "pulse-AbCd", "native")
-	clearEnv(t, "XDG_RUNTIME_DIR", "TMPDIR", "PREFIX", "PULSE_SERVER")
-	withEnv(t, map[string]string{"TMPDIR": dir})
-
-	sp := &termuxSpeaker{}
-	if err := sp.Init(44100, 4096); err != nil {
-		t.Skipf("Init failed (expected on fake socket): %v", err)
-	}
-
+	sp, _, first := newFakeTermuxSpeaker(t)
 	runClearWithTimeout(t, sp)
 
-	sp.mu.Lock()
-	stream := sp.stream
-	sp.mu.Unlock()
-	if stream == nil {
-		t.Errorf("Clear must not nil out t.stream (would race with runStream)")
+	sp.lifecycleMu.Lock()
+	current := sp.session
+	sp.lifecycleMu.Unlock()
+	if current == nil || current.stream != first {
+		t.Errorf("Clear replaced the current PulseAudio session")
 	}
 }
 
-// TestClear_DoesNotResetStarted verifies that Clear preserves the started
-// flag so a subsequent Play cannot launch a second runStream on the same
-// PulseAudio stream. The previous design reset started in Clear, which let
-// Play → Clear → Play deadlock on jfreymuth/pulse's unbuffered started
-// notification (only one is emitted per stream).
-func TestClear_DoesNotResetStarted(t *testing.T) {
-	dir := makeSocket(t, "pulse-AbCd", "native")
-	clearEnv(t, "XDG_RUNTIME_DIR", "TMPDIR", "PREFIX", "PULSE_SERVER")
-	withEnv(t, map[string]string{"TMPDIR": dir})
-
-	sp := &termuxSpeaker{}
-	if err := sp.Init(44100, 4096); err != nil {
-		t.Skipf("Init failed (expected on fake socket): %v", err)
-	}
-
-	sp.started.Store(true)
-	sp.errored.Store(true)
-
-	runClearWithTimeout(t, sp)
-
-	if !sp.started.Load() {
-		t.Errorf("Clear must not reset started (lets Play spawn a competing runStream)")
-	}
-	if !sp.errored.Load() {
-		t.Errorf("Clear must not reset errored (Suspend/Resume skip when errored)")
-	}
-}
-
-// TestPlay_ClearThenPlay_PreservesStarted is the regression guard for the
-// Play → Clear → Play deadlock: a prior Play schedules a runStream goroutine
-// that is still pending PlaybackStream.Start (blocking on the unbuffered
-// started channel). Clear must leave started set so the next Play's
-// CompareAndSwap fails and no second runStream is spawned — otherwise both
-// goroutines would race into Start and one would wait forever for a
-// "started" notification that jfreymuth/pulse only emits once per stream.
-func TestPlay_ClearThenPlay_PreservesStarted(t *testing.T) {
-	dir := makeSocket(t, "pulse-AbCd", "native")
-	clearEnv(t, "XDG_RUNTIME_DIR", "TMPDIR", "PREFIX", "PULSE_SERVER")
-	withEnv(t, map[string]string{"TMPDIR": dir})
-
-	sp := &termuxSpeaker{}
-	if err := sp.Init(44100, 4096); err != nil {
-		t.Skipf("Init failed (expected on fake socket): %v", err)
-	}
-
-	sp.started.Store(true)
-
-	sp.Clear()
-	if !sp.started.Load() {
-		t.Fatal("Clear must not reset started (precondition for Play to skip a new runStream)")
-	}
+// TestPlay_ClearThenPlay_UsesOneSession guards the Play -> Clear -> Play race
+// while startup is pending. Clear and Play must not create a second session
+// while the supervisor owns the first StartContext call.
+func TestPlay_ClearThenPlay_UsesOneSession(t *testing.T) {
+	sp, factory, first := newFakeTermuxSpeaker(t)
 
 	sp.Play()
-	if !sp.started.Load() {
-		t.Fatal("Play must not have spawned a competing runStream")
+	select {
+	case <-first.startEntered:
+	case <-time.After(time.Second):
+		t.Fatal("startup did not begin")
 	}
+	sp.Clear()
+	sp.Play()
+
+	if got := factory.count(); got != 1 {
+		t.Fatalf("session count after Play -> Clear -> Play = %d, want 1", got)
+	}
+	if got := first.startCalls.Load(); got != 1 {
+		t.Fatalf("start calls after Play → Clear → Play = %d, want 1", got)
+	}
+	first.releaseStart()
 }
 
 // TestPlay_NoGoroutineWhenStreamNil verifies that Play is safe to call
@@ -505,9 +566,118 @@ func TestPlay_NoGoroutineWhenStreamNil(t *testing.T) {
 
 	sp.Play()
 
-	if sp.started.Load() {
-		t.Errorf("started must remain false when stream is nil")
+	sp.lifecycleMu.Lock()
+	session := sp.session
+	sp.lifecycleMu.Unlock()
+	if session != nil {
+		t.Errorf("session must remain nil when Play is called before Init")
 	}
+}
+
+func TestTermuxSpeaker_ReconnectsBeforeStarted(t *testing.T) {
+	sp, factory, first := newFakeTermuxSpeaker(t)
+
+	sp.Play()
+	select {
+	case <-first.startEntered:
+	case <-time.After(time.Second):
+		t.Fatal("startup did not begin")
+	}
+	first.disconnect()
+
+	second := waitForFakeSession(t, factory.created)
+	select {
+	case <-second.startEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("replacement startup did not begin after pre-start disconnect")
+	}
+	if got := first.closeCalls.Load(); got == 0 {
+		t.Fatal("lost pre-start session was not closed")
+	}
+	second.releaseStart()
+}
+
+func TestTermuxSpeaker_ReconnectsAfterStarted(t *testing.T) {
+	sp, factory, first := newFakeTermuxSpeaker(t)
+
+	sp.Play()
+	select {
+	case <-first.startEntered:
+	case <-time.After(time.Second):
+		t.Fatal("startup did not begin")
+	}
+	first.releaseStart()
+	select {
+	case <-first.startReturned:
+	case <-time.After(time.Second):
+		t.Fatal("startup did not return")
+	}
+	first.disconnect()
+
+	second := waitForFakeSession(t, factory.created)
+	select {
+	case <-second.startEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("replacement startup did not begin after post-start disconnect")
+	}
+	if got := first.closeCalls.Load(); got == 0 {
+		t.Fatal("lost post-start session was not closed")
+	}
+	second.releaseStart()
+}
+
+func TestTermuxSpeaker_CloseCancelsPendingStart(t *testing.T) {
+	sp, _, first := newFakeTermuxSpeaker(t)
+	sp.Play()
+	select {
+	case <-first.startEntered:
+	case <-time.After(time.Second):
+		t.Fatal("startup did not begin")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		sp.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not cancel pending startup")
+	}
+}
+
+func TestTermuxSpeaker_CloseAllowsReinitialization(t *testing.T) {
+	sp, factory, first := newFakeTermuxSpeaker(t)
+
+	sp.Play()
+	select {
+	case <-first.startEntered:
+	case <-time.After(time.Second):
+		t.Fatal("initial startup did not begin")
+	}
+	first.releaseStart()
+	select {
+	case <-first.startReturned:
+	case <-time.After(time.Second):
+		t.Fatal("initial startup did not return")
+	}
+	sp.Close()
+
+	if err := sp.Init(44100, 4096); err != nil {
+		t.Fatalf("reinitialize after Close: %v", err)
+	}
+	second := waitForFakeSession(t, factory.created)
+	sp.Play()
+	select {
+	case <-second.startEntered:
+	case <-time.After(time.Second):
+		t.Fatal("replacement startup did not begin")
+	}
+	if got := factory.count(); got != 2 {
+		t.Fatalf("session count after Close -> Init = %d, want 2", got)
+	}
+	second.releaseStart()
 }
 
 // --- Retry deadline ---

--- a/player/speaker_termux_test.go
+++ b/player/speaker_termux_test.go
@@ -439,9 +439,12 @@ func TestClear_DoesNotTouchStream(t *testing.T) {
 	}
 }
 
-// TestClear_ResetsStartedAndErrored verifies the post-Clear state that
-// enables subsequent Play to re-establish a runStream goroutine.
-func TestClear_ResetsStartedAndErrored(t *testing.T) {
+// TestClear_DoesNotResetStarted verifies that Clear preserves the started
+// flag so a subsequent Play cannot launch a second runStream on the same
+// PulseAudio stream. The previous design reset started in Clear, which let
+// Play → Clear → Play deadlock on jfreymuth/pulse's unbuffered started
+// notification (only one is emitted per stream).
+func TestClear_DoesNotResetStarted(t *testing.T) {
 	dir := makeSocket(t, "pulse-AbCd", "native")
 	clearEnv(t, "XDG_RUNTIME_DIR", "TMPDIR", "PREFIX", "PULSE_SERVER")
 	withEnv(t, map[string]string{"TMPDIR": dir})
@@ -456,11 +459,41 @@ func TestClear_ResetsStartedAndErrored(t *testing.T) {
 
 	runClearWithTimeout(t, sp)
 
-	if sp.started.Load() {
-		t.Errorf("started must be false after Clear")
+	if !sp.started.Load() {
+		t.Errorf("Clear must not reset started (lets Play spawn a competing runStream)")
 	}
-	if sp.errored.Load() {
-		t.Errorf("errored must be false after Clear")
+	if !sp.errored.Load() {
+		t.Errorf("Clear must not reset errored (Suspend/Resume skip when errored)")
+	}
+}
+
+// TestPlay_ClearThenPlay_PreservesStarted is the regression guard for the
+// Play → Clear → Play deadlock: a prior Play schedules a runStream goroutine
+// that is still pending PlaybackStream.Start (blocking on the unbuffered
+// started channel). Clear must leave started set so the next Play's
+// CompareAndSwap fails and no second runStream is spawned — otherwise both
+// goroutines would race into Start and one would wait forever for a
+// "started" notification that jfreymuth/pulse only emits once per stream.
+func TestPlay_ClearThenPlay_PreservesStarted(t *testing.T) {
+	dir := makeSocket(t, "pulse-AbCd", "native")
+	clearEnv(t, "XDG_RUNTIME_DIR", "TMPDIR", "PREFIX", "PULSE_SERVER")
+	withEnv(t, map[string]string{"TMPDIR": dir})
+
+	sp := &termuxSpeaker{}
+	if err := sp.Init(44100, 4096); err != nil {
+		t.Skipf("Init failed (expected on fake socket): %v", err)
+	}
+
+	sp.started.Store(true)
+
+	sp.Clear()
+	if !sp.started.Load() {
+		t.Fatal("Clear must not reset started (precondition for Play to skip a new runStream)")
+	}
+
+	sp.Play()
+	if !sp.started.Load() {
+		t.Fatal("Play must not have spawned a competing runStream")
 	}
 }
 

--- a/site/index.html
+++ b/site/index.html
@@ -848,7 +848,7 @@ footer{padding:26px 0;border-top:1px solid var(--green);background:var(--ink)}
           <a href="#install" class="btn btn-go">Install</a>
           <a href="https://github.com/bjarneo/cliamp" class="btn btn-ghost">View source</a>
         </div>
-        <div class="hero-facts" aria-label="Project details"><span><b>MIT</b> licensed</span><span><b>Go</b> 1.26</span><span><b>Linux / macOS / Windows</b></span></div>
+        <div class="hero-facts" aria-label="Project details"><span><b>MIT</b> licensed</span><span><b>Go</b> 1.26</span><span><b>Linux / macOS / Windows / Termux</b></span></div>
       </div>
 
       <!-- CRT terminal — live radio player -->
@@ -988,7 +988,7 @@ footer{padding:26px 0;border-top:1px solid var(--green);background:var(--ink)}
       </button>
     </div>
     <div class="install-note reveal">
-      Build from source. <a href="https://github.com/bjarneo/cliamp">See the README.</a> Windows builds are in Releases. If <code>HOME</code> is not set, the config is in <code>%APPDATA%\cliamp</code>.
+      Build from source. <a href="https://github.com/bjarneo/cliamp">See the README.</a> Windows builds are in Releases. If <code>HOME</code> is not set, the config is in <code>%APPDATA%\cliamp</code>. On Termux (Android), build with <code>-tags=termux</code>; cliamp speaks PulseAudio directly, no ALSA bridge or <code>pactl</code> needed.
     </div>
     <div class="next-step reveal">
       <div class="next-step-label">Next: configure providers</div>


### PR DESCRIPTION
## Summary

This PR adds native Termux/Android audio support to cliamp through a PulseAudio backend.

The existing Linux audio backend remains unchanged. When built with `-tags=termux`, cliamp uses PulseAudio directly instead of the Linux/ALSA-based audio stack, allowing the ARM64 binary to run natively on Android/Bionic.

The Termux backend also discovers Termux's PulseAudio Unix socket and starts PulseAudio when necessary.

Closes #417

## Screenshots / video

<img width="720" height="1600" alt="imagen" src="https://github.com/user-attachments/assets/7b08c179-a43f-4699-a37d-40277846b3ca" />

## How to test

1. Install PulseAudio in Termux and make sure audio output is working.
2. Build cliamp natively in Termux:

   ```bash
   go build -tags=termux ./...
   ```
3. Run the resulting ARM64 binary and play a track.
4. Verify that audio is played through the Android audio output.
5. Verify the standard Linux build still works:

   ```bash
   go build ./...
   ```
6. Run the test suite:

   ```bash
   make check
   ```

## Checklist

* [x] `make check` passes
* [x] `docs/` and `site/index.html` updated for user-facing changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Termux (Android) support with native PulseAudio output.
  * Added automatic PulseAudio socket discovery and startup fallback on Termux.
  * Added optional PulseAudio diagnostics through `CLIAMP_DEBUG_PULSE`.
  * Improved playback resilience during PulseAudio connection interruptions and underflow events.

* **Documentation**
  * Updated the README and website with Termux support details and `-tags=termux` build instructions.
  * Clarified that Termux playback uses PulseAudio directly without an ALSA bridge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->