### PR TITLE
plex: prompt for library selection in setup wizard

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -164,15 +164,20 @@ func providers() []providerSpec {
 			fields: []fieldSpec{
 				{key: "url", label: "Server URL", help: "e.g. http://192.168.1.10:32400", required: true},
 				{key: "token", label: "X-Plex-Token", required: true, secret: true},
+				{key: "libraries", label: "Music libraries (optional)", help: "comma-separated names to include; blank loads every music library"},
 			},
 			validate: func(v map[string]string) error {
 				return plex.NewClient(v["url"], v["token"]).Ping()
 			},
 			body: func(v map[string]string) string {
-				return strings.Join([]string{
+				lines := []string{
 					fmt.Sprintf("url   = %q", v["url"]),
 					fmt.Sprintf("token = %q", v["token"]),
-				}, "\n")
+				}
+				if libraries := setupStringList(v["libraries"]); libraries != "" {
+					lines = append(lines, "libraries = "+libraries)
+				}
+				return strings.Join(lines, "\n")
 			},
 		},
 		{

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -354,6 +354,38 @@ func TestTidalSetupBody(t *testing.T) {
 	}
 }
 
+func TestPlexSetupBody(t *testing.T) {
+	var spec providerSpec
+	for _, p := range providers() {
+		if p.section == "plex" {
+			spec = p
+			break
+		}
+	}
+	if spec.section == "" {
+		t.Fatal("plex spec missing")
+	}
+
+	withLibraries := spec.body(map[string]string{
+		"url":       "http://192.168.1.10:32400",
+		"token":     "tok",
+		"libraries": "Music, Jazz",
+	})
+	for _, want := range []string{
+		`url   = "http://192.168.1.10:32400"`, `token = "tok"`,
+		`libraries = ["Music", "Jazz"]`,
+	} {
+		if !strings.Contains(withLibraries, want) {
+			t.Fatalf("body missing %q: %q", want, withLibraries)
+		}
+	}
+
+	noFilter := spec.body(map[string]string{"url": "http://x", "token": "tok"})
+	if strings.Contains(noFilter, "libraries") {
+		t.Fatalf("blank libraries field must not write a libraries key: %q", noFilter)
+	}
+}
+
 func TestMixcloudSetupBody(t *testing.T) {
 	var spec providerSpec
 	for _, p := range providers() {

--- a/docs/plex.md
+++ b/docs/plex.md
@@ -2,7 +2,7 @@
 
 Use cliamp to stream music from Plex Media Server, including any library served by PlexAmp. Streaming uses the Plex HTTP API. You do not need extra software.
 
-> **Quick start:** Run `cliamp setup`. Enter the server URL and `X-Plex-Token`. The TUI checks the token and writes the `[plex]` block. Manual steps follow.
+> **Quick start:** Run `cliamp setup`. Enter the server URL and `X-Plex-Token`, and optionally a comma-separated list of music libraries to include. The TUI checks the token and writes the `[plex]` block. Manual steps follow.
 
 ## Prerequisites
 

--- a/site/index.html
+++ b/site/index.html
@@ -993,7 +993,7 @@ footer{padding:26px 0;border-top:1px solid var(--green);background:var(--ink)}
     <div class="next-step reveal">
       <div class="next-step-label">Next: configure providers</div>
       <h3>Run setup</h3>
-      <p>Use the interactive TUI to configure Navidrome, Lyrion, Plex, Jellyfin, Emby, Spotify, Qobuz, Tidal, Mixcloud, NetEase, and YouTube Music. The TUI opens each provider credential page and writes the required block to the config file. The TUI tests supported server connections during setup. Mixcloud browser-session or OAuth credentials are optional and are tested when you use them.</p>
+      <p>Use the interactive TUI to configure Navidrome, Lyrion, Plex, Jellyfin, Emby, Spotify, Qobuz, Tidal, Mixcloud, NetEase, and YouTube Music. The TUI opens each provider credential page and writes the required block to the config file. The TUI tests supported server connections during setup. Mixcloud browser-session or OAuth credentials are optional and are tested when you use them. Plex setup can optionally restrict which music libraries load.</p>
       <button class="install-box" type="button" onclick="copyCmd(this,'cliamp setup')">
         <span class="install-platform">Setup</span>
         <code><span class="prompt">$ </span>cliamp setup</code>


### PR DESCRIPTION
## Summary

Addresses the remaining ask in #206 ("prompt for library selection during setup"). #211 already added a `libraries` key to the `[plex]` config block and made the provider merge albums across all matching libraries, but it required hand-editing `config.toml`. This adds an optional "Music libraries" field to the Plex step of `cliamp setup` so it can be set interactively, using the same comma-separated-list pattern the wizard already uses for Mixcloud's "styles" field. Leaving it blank preserves current behavior (all music libraries load).

## Screenshots / video

This is a TUI, so here's a terminal capture (`tmux capture-pane`) of the live wizard with the new field, filled in:

```
  cliamp setup
  configure remote providers

╭────────────────────────────────────────────────────────────────────────────╮
│                                                                            │
│  Plex Media Server                                                         │
│                                                                            │
│  Stream from your Plex server using an X-Plex-Token.                       │
│  Find a token: https://support.plex.tv/articles/204059436                  │
│                                                                            │
│    Server URL *                                                            │
│    http://192.168.1.10:32400                                               │
│                                                                            │
│    X-Plex-Token *                                                          │
│    •••••••••••••••••                                                       │
│                                                                            │
│  │ Music libraries (optional)                                              │
│  │ Music, Jazz▎                                                            │
│  │ comma-separated names to include; blank loads every music library       │
│                                                                            │
╰────────────────────────────────────────────────────────────────────────────╯
↑/↓ field   enter submit   esc back
```

Submitting this writes:

```toml
[plex]
url   = "http://192.168.1.10:32400"
token = "test-token-abc123"
libraries = ["Music", "Jazz"]
```

## How to test

1. `go test ./cmd/... -run TestPlexSetupBody -v` — covers both the filled-in and blank cases.
2. `cliamp setup` → select Plex Media Server → tab through URL, token, and the new "Music libraries" field → submit → confirm the `[plex]` block in `config.toml` gets a `libraries = [...]` line when the field is non-blank, and no `libraries` key at all when it's left empty.

## Checklist

- [x] `make check` passes
- [x] `docs/` updated (`docs/plex.md` quick-start note); `site/index.html` has no field-level setup content to update for this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Plex setup now optionally supports specifying a comma-separated list of music libraries.
  - Generated configuration includes the selected libraries when provided and omits the setting when left blank.

- **Documentation**
  - Updated Plex quick-start instructions and installation guidance to describe the optional music library setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->