### PR TITLE
setup: clear stale validation error after "save anyway"

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -1008,6 +1008,7 @@ func (m *setupModel) persistAndDone(warn bool) tea.Cmd {
 	}
 	m.stage = stageResult
 	m.awaitingSave = false
+	m.resultErr = nil
 	m.resultWarning = warn
 	m.resultText = fmt.Sprintf("Saved [%s] section.", spec.section)
 	return nil

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -246,6 +247,55 @@ func TestNetEaseSetupBody(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Fatalf("body missing %q: %q", want, body)
 		}
+	}
+}
+
+// TestSaveAnywayClearsStaleValidationError covers a regression where
+// choosing "Save anyway" after a failed validation probe saved the config
+// correctly but left the stale connection error in place, so the result
+// screen kept showing "Validation failed" / the raw error instead of the
+// intended "Saved without verification" message.
+func TestSaveAnywayClearsStaleValidationError(t *testing.T) {
+	t.Setenv("CLIAMP_CONFIG_DIR", filepath.Join(t.TempDir(), "config"))
+
+	m := newSetupModel()
+	m.pidx = -1
+	for i, p := range m.provs {
+		if p.section == "navidrome" {
+			m.pidx = i
+			break
+		}
+	}
+	if m.pidx < 0 {
+		t.Fatal("navidrome spec missing")
+	}
+	m.values = map[string]string{"url": "http://example.com", "user": "alice", "password": "secret"}
+
+	m.onValidateDone(errors.New("dial tcp: connection refused"))
+	if !m.awaitingSave || m.resultErr == nil {
+		t.Fatalf("onValidateDone(err) should prompt to save anyway; awaitingSave=%v resultErr=%v", m.awaitingSave, m.resultErr)
+	}
+
+	m.resultKey(keyPress('y', "y"))
+	if m.awaitingSave {
+		t.Fatal("pressing y should clear awaitingSave")
+	}
+	if m.saveFailed != nil {
+		t.Fatalf("saveFailed = %v, want nil", m.saveFailed)
+	}
+	if m.resultErr != nil {
+		t.Fatalf("resultErr = %v, want nil after a successful save-anyway", m.resultErr)
+	}
+	if !m.resultWarning {
+		t.Fatal("resultWarning should be true after save-anyway")
+	}
+
+	view := m.viewResult()
+	if strings.Contains(view, "connection refused") || strings.Contains(view, "Validation failed") {
+		t.Fatalf("view still shows the stale validation error: %q", view)
+	}
+	if !strings.Contains(view, "Saved without verification") {
+		t.Fatalf("view missing the save-anyway success message: %q", view)
 	}
 }
 


### PR DESCRIPTION
## Summary

Bug found while testing #430 (unrelated Plex feature), reproducible on any provider with a `validate` probe.

Repro: run `cliamp setup`, pick a provider (e.g. Navidrome or Plex), fill in the form with a server that will fail to connect, submit. The wizard shows "Validation failed … Save anyway? [y/N]". Press "y".

- **Expected:** the config section is written, and the result screen shows "⚠ Saved without verification".
- **Actual:** the config section *is* written correctly, but the result screen still shows the original connection-error text with "Press any key to return to the menu," which reads as if the save failed.

Root cause: `persistAndDone(warn bool)` sets `m.resultWarning`, `m.resultText`, and clears `m.awaitingSave` on a successful `saveSection`, but never clears `m.resultErr` (set earlier in `onValidateDone`). `viewResult()` checks `if m.resultErr != nil` before `if m.resultWarning`, so the stale error always wins whenever the user saves after a failed probe.

Fix: clear `m.resultErr = nil` in the success branch of `persistAndDone` (not the `m.saveFailed` branch, which is a genuine failure).

## Screenshots / video

Before (existing behavior — misleading):
```
✗ Validation failed

navidrome: ping.view: ... context deadline exceeded ...

Save anyway?  [y/N]
```
→ press `y` →
```
✗ navidrome: ping.view: ... context deadline exceeded ...

Press any key to return to the menu.
```
(despite the config having been saved)

After this fix, pressing `y` in the same flow instead shows:
```
  Navidrome / Subsonic

  ⚠ Saved without verification

  /tmp/.../config.toml

  Press any key to configure another provider, or q to quit.
```
verified live via `tmux` against an isolated `CLIAMP_CONFIG_DIR`, with the `[navidrome]` block confirmed written to disk in both cases (before and after this fix) — only the result screen was wrong.

## How to test

1. `go test ./cmd/... -run TestSaveAnywayClearsStaleValidationError -v` — new regression test; fails without the one-line fix, passes with it.
2. Manually: `CLIAMP_CONFIG_DIR=/tmp/x cliamp setup`, pick any provider with a validate probe, use an unreachable server, submit, press `y` on "Save anyway?". Confirm the result screen shows "Saved without verification" and `/tmp/x/config.toml` has the section.

## Checklist

- [x] `make check` passes
- [x] `docs/` and `site/index.html` — not applicable; this is an internal state-handling fix with no change to documented behavior or config keys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the setup wizard so stale validation errors no longer appear after successfully saving without verification.
  - The result screen now clearly confirms “Saved without verification” while removing outdated connection or validation failure messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->