### PR TITLE
fix(httpclient): support SOCKS5 proxies for the streaming client

### DIFF
--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"time"
 
 	"golang.org/x/net/http/httpproxy"
@@ -39,7 +40,42 @@ func resolveEnvProxy(scheme, addr string) (*url.URL, error) {
 	if err != nil {
 		return nil, fmt.Errorf("resolve environment proxy for %s://%s: %w", scheme, addr, err)
 	}
+	if u != nil {
+		return u, nil
+	}
+	// httpproxy.FromEnvironment() only understands HTTP_PROXY/HTTPS_PROXY
+	// and NO_PROXY -- it does not fall back to ALL_PROXY the way
+	// golang.org/x/net/proxy.FromEnvironment does. Without this, setting
+	// only ALL_PROXY=socks5h://... (a common convention for "use this
+	// proxy for everything") would silently dial every connection
+	// directly instead of through the SOCKS5 proxy. Re-resolve using
+	// ALL_PROXY/all_proxy as both the HTTP and HTTPS proxy so
+	// httpproxy.Config still applies its own NO_PROXY bypass logic.
+	allProxy := firstNonEmpty(os.Getenv("ALL_PROXY"), os.Getenv("all_proxy"))
+	if allProxy == "" {
+		return nil, nil
+	}
+	cfg := &httpproxy.Config{
+		HTTPProxy:  allProxy,
+		HTTPSProxy: allProxy,
+		NoProxy:    firstNonEmpty(os.Getenv("NO_PROXY"), os.Getenv("no_proxy")),
+	}
+	u, err = cfg.ProxyFunc()(reqURL)
+	if err != nil {
+		return nil, fmt.Errorf("resolve ALL_PROXY for %s://%s: %w", scheme, addr, err)
+	}
 	return u, nil
+}
+
+// firstNonEmpty returns the first non-empty string, or "" if all are empty --
+// used to check an env var's upper- and lowercase spelling.
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // socks5DialerFromURL builds a SOCKS5 dialer for u (scheme socks5/socks5h).
@@ -51,21 +87,16 @@ func resolveEnvProxy(scheme, addr string) (*url.URL, error) {
 // clients that expose a SOCKS5 endpoint on the machine itself) doesn't
 // have that exposure, so credentials are allowed there.
 func socks5DialerFromURL(u *url.URL) (proxy.Dialer, error) {
-	var auth *proxy.Auth
 	if u.User != nil {
-		host, _, err := net.SplitHostPort(u.Host)
-		if err != nil {
-			host = u.Host
-		}
-		if ip := net.ParseIP(host); ip == nil || !ip.IsLoopback() {
-			return nil, fmt.Errorf("refusing to send SOCKS5 credentials to non-local proxy %q over an unencrypted connection", u.Host)
-		}
-		auth = &proxy.Auth{User: u.User.Username()}
-		if pw, ok := u.User.Password(); ok {
-			auth.Password = pw
-		}
+		// RFC 1929 SOCKS5 username/password authentication is sent in
+		// cleartext on the wire. A loopback-only restriction still limits
+		// exposure to a REMOTE eavesdropper, but not to another local,
+		// unprivileged process capturing loopback traffic -- so it is not
+		// a safe enough bar to forward credentials on. Fail clearly
+		// instead of silently sending (or silently dropping) them.
+		return nil, fmt.Errorf("SOCKS5 credentials in proxy URL for %q are not supported: RFC 1929 auth is sent in cleartext, even over loopback", u.Host)
 	}
-	return proxy.SOCKS5("tcp", u.Host, auth, proxy.Direct)
+	return proxy.SOCKS5("tcp", u.Host, nil, proxy.Direct)
 }
 
 // socks5DialerFor returns a SOCKS5 dialer to use for a request of the

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -7,7 +7,11 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
+	"os"
 	"time"
+
+	"golang.org/x/net/proxy"
 )
 
 // Streaming is a shared HTTP client for audio streaming connections.
@@ -21,14 +25,75 @@ import (
 // the codebase uses http.DefaultTransport, which already honors these vars.
 var Streaming = &http.Client{Transport: newStreamingTransport()}
 
+// socks5ProxyFromEnv looks for a socks5:// or socks5h:// proxy URL in the
+// standard proxy environment variables.
+//
+// net/http.Transport's Proxy field, and the CONNECT-based tunneling it does
+// under the hood, only understand plain HTTP proxying and HTTP(S) proxies.
+// They have no support for the SOCKS5 protocol. If HTTPS_PROXY/HTTP_PROXY
+// is set to a socks5:// URL (common with corporate VPN clients that expose
+// a local SOCKS5 endpoint), http.ProxyFromEnvironment still happily returns
+// it as "the proxy to use", so Transport dials the proxy's address and then
+// writes an HTTP request line or a CONNECT request at it. A SOCKS5 server
+// doesn't understand either, so the connection just hangs forever: no
+// error, the local TCP connect to the proxy succeeds fine, it just never
+// gets a response it can parse. This is handled explicitly below instead.
+func socks5ProxyFromEnv() *url.URL {
+	for _, env := range []string{"HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "ALL_PROXY", "all_proxy"} {
+		v := os.Getenv(env)
+		if v == "" {
+			continue
+		}
+		u, err := url.Parse(v)
+		if err != nil || (u.Scheme != "socks5" && u.Scheme != "socks5h") {
+			continue
+		}
+		return u
+	}
+	return nil
+}
+
+func socks5DialerFromURL(u *url.URL) (proxy.Dialer, error) {
+	var auth *proxy.Auth
+	if u.User != nil {
+		auth = &proxy.Auth{User: u.User.Username()}
+		if pw, ok := u.User.Password(); ok {
+			auth.Password = pw
+		}
+	}
+	return proxy.SOCKS5("tcp", u.Host, auth, proxy.Direct)
+}
+
 func newStreamingTransport() *http.Transport {
+	var socks5 proxy.Dialer
+	if u := socks5ProxyFromEnv(); u != nil {
+		if d, err := socks5DialerFromURL(u); err == nil {
+			socks5 = d
+		}
+	}
+
 	tr := &http.Transport{
-		Proxy:                 http.ProxyFromEnvironment,
 		ResponseHeaderTimeout: 30 * time.Second,
 		TLSNextProto:          make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
 	}
+	if socks5 == nil {
+		// Only hand HTTP(S)-style proxying off to Transport's own logic.
+		// When we're dialing through SOCKS5 ourselves (below), Transport
+		// must not also try to proxy: it would dial the proxy's address
+		// via DialContext and speak CONNECT at it, conflicting with the
+		// SOCKS5 dial happening inside DialContext/DialTLSContext.
+		tr.Proxy = http.ProxyFromEnvironment
+	}
+
+	rawDial := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		if socks5 != nil {
+			return socks5.Dial(network, addr)
+		}
+		return (&net.Dialer{}).DialContext(ctx, network, addr)
+	}
+
 	tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-		conn, err := (&net.Dialer{}).DialContext(ctx, network, addr)
+		conn, err := rawDial(ctx, network, addr)
 		if err != nil {
 			return nil, fmt.Errorf("dial %s: %w", addr, err)
 		}
@@ -49,11 +114,16 @@ func newStreamingTransport() *http.Transport {
 		// Icecast and SHOUTcast servers only support HTTP/1.x.
 		config.NextProtos = nil
 
-		conn, err := (&tls.Dialer{Config: config}).DialContext(ctx, network, addr)
+		rawConn, err := rawDial(ctx, network, addr)
 		if err != nil {
 			return nil, fmt.Errorf("dial TLS %s: %w", addr, err)
 		}
-		return newICYConn(conn), nil
+		tlsConn := tls.Client(rawConn, config)
+		if err := tlsConn.HandshakeContext(ctx); err != nil {
+			rawConn.Close()
+			return nil, fmt.Errorf("dial TLS %s: %w", addr, err)
+		}
+		return newICYConn(tlsConn), nil
 	}
 	return tr
 }

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -24,7 +24,7 @@ import (
 // Proxy is read from the environment (HTTP_PROXY, HTTPS_PROXY, NO_PROXY)
 // so users behind corporate or local proxies aren't bypassed; the rest of
 // the codebase uses http.DefaultTransport, which already honors these vars.
-var Streaming = &http.Client{Transport: newStreamingTransport()}
+var Streaming = &http.Client{Transport: &socks5RoundTripper{transport: newStreamingTransport()}}
 
 // resolveEnvProxy resolves the proxy that applies to a request for the
 // given scheme+addr, honoring HTTP_PROXY/HTTPS_PROXY/ALL_PROXY/NO_PROXY
@@ -76,6 +76,71 @@ func firstNonEmpty(vals ...string) string {
 		}
 	}
 	return ""
+}
+
+// canonicalAddr returns u's authority as "host:port", applying the scheme's
+// default port (80/443) when u carries none -- matching how net/http itself
+// canonicalizes a request URL's address before proxy/dial resolution.
+func canonicalAddr(u *url.URL) string {
+	if u.Port() != "" {
+		return u.Host
+	}
+	port := "80"
+	if u.Scheme == "https" {
+		port = "443"
+	}
+	return net.JoinHostPort(u.Hostname(), port)
+}
+
+// dialDecisionKey is the context key socks5RoundTripper.RoundTrip uses to
+// pin a request's resolved dial decision so DialContext/DialTLSContext can
+// read it back later.
+type dialDecisionKey struct{}
+
+// dialDecision is resolved once per request, from the request's own scheme
+// and target host, and travels with req.Context() down into
+// DialContext/DialTLSContext -- both of which net/http.Transport calls
+// with that same context object. This matters because the address those
+// two functions are asked to dial is NOT always the request's target: for
+// a request routed through a plain http(s) proxy, Transport dials the
+// PROXY's address itself (to open the CONNECT tunnel, or to relay a plain
+// http request), never the origin host. Re-resolving *_PROXY env vars
+// against that proxy address (as if it were the thing to reach) can pick
+// a completely unrelated proxy for it -- e.g. HTTPS_PROXY=http://real:8080
+// together with HTTP_PROXY=socks5://other:1080 previously made the dial
+// to real:8080 get routed through other:1080 via SOCKS5, instead of
+// dialing real:8080 directly like it should. Pinning the decision once,
+// from the true target, avoids that entirely: whatever address Transport
+// later dials for this connection, the SOCKS5-or-not decision is already
+// fixed and correct.
+type dialDecision struct {
+	socks5 proxy.Dialer // nil: no SOCKS5 for this connection, dial addr directly
+}
+
+func dialDecisionFor(req *http.Request) (*dialDecision, error) {
+	d, err := socks5DialerFor(req.URL.Scheme, canonicalAddr(req.URL))
+	if err != nil {
+		return nil, err
+	}
+	return &dialDecision{socks5: d}, nil
+}
+
+// socks5RoundTripper wraps a *http.Transport to resolve each request's
+// dial decision (see dialDecision) exactly once, from the request itself,
+// before handing off to the real Transport -- which will call
+// DialContext/DialTLSContext with the same context one or more times as
+// it establishes (or reuses) the underlying connection.
+type socks5RoundTripper struct {
+	transport *http.Transport
+}
+
+func (rt *socks5RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	decision, err := dialDecisionFor(req)
+	if err != nil {
+		return nil, fmt.Errorf("resolve proxy dial decision for %s: %w", req.URL, err)
+	}
+	ctx := context.WithValue(req.Context(), dialDecisionKey{}, decision)
+	return rt.transport.RoundTrip(req.WithContext(ctx))
 }
 
 // socks5DialerFromURL builds a SOCKS5 dialer for u (scheme socks5/socks5h).
@@ -152,7 +217,7 @@ func newStreamingTransport() *http.Transport {
 	}
 
 	tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-		conn, err := dialMaybeSOCKS5(ctx, "http", network, addr)
+		conn, err := dialWithDecision(ctx, network, addr)
 		if err != nil {
 			return nil, fmt.Errorf("dial %s: %w", addr, err)
 		}
@@ -173,7 +238,7 @@ func newStreamingTransport() *http.Transport {
 		// Icecast and SHOUTcast servers only support HTTP/1.x.
 		config.NextProtos = nil
 
-		rawConn, err := dialMaybeSOCKS5(ctx, "https", network, addr)
+		rawConn, err := dialWithDecision(ctx, network, addr)
 		if err != nil {
 			return nil, fmt.Errorf("dial TLS %s: %w", addr, err)
 		}
@@ -187,16 +252,21 @@ func newStreamingTransport() *http.Transport {
 	return tr
 }
 
-// dialMaybeSOCKS5 dials addr directly, unless the environment's proxy
-// configuration calls for a SOCKS5 proxy for a request of this scheme to
-// this addr, in which case it dials through that proxy instead. Context
-// cancellation applies to both paths (the SOCKS5 dialer's context-aware
-// DialContext is used when the proxy supports it, which proxy.SOCKS5's
-// dialer does).
-func dialMaybeSOCKS5(ctx context.Context, scheme, network, addr string) (net.Conn, error) {
-	d, err := socks5DialerFor(scheme, addr)
-	if err != nil {
-		return nil, fmt.Errorf("resolve dialer for %s: %w", addr, err)
+// dialWithDecision dials addr directly, unless ctx carries a *dialDecision
+// (stashed by socks5RoundTripper.RoundTrip, from the original request's own
+// scheme and target host) that calls for a SOCKS5 proxy, in which case it
+// dials through that proxy instead. Context cancellation applies to both
+// paths (the SOCKS5 dialer's context-aware DialContext is used when the
+// proxy supports it, which proxy.SOCKS5's dialer does).
+//
+// Deliberately NOT re-resolved from addr here: see dialDecision's doc
+// comment for why that was wrong for connections routed through a plain
+// http(s) proxy.
+func dialWithDecision(ctx context.Context, network, addr string) (net.Conn, error) {
+	decision, _ := ctx.Value(dialDecisionKey{}).(*dialDecision)
+	var d proxy.Dialer
+	if decision != nil {
+		d = decision.socks5
 	}
 	if d == nil {
 		conn, err := (&net.Dialer{}).DialContext(ctx, network, addr)

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -35,7 +35,11 @@ var Streaming = &http.Client{Transport: newStreamingTransport()}
 // one proxy for every request regardless of scheme.
 func resolveEnvProxy(scheme, addr string) (*url.URL, error) {
 	reqURL := &url.URL{Scheme: scheme, Host: addr}
-	return httpproxy.FromEnvironment().ProxyFunc()(reqURL)
+	u, err := httpproxy.FromEnvironment().ProxyFunc()(reqURL)
+	if err != nil {
+		return nil, fmt.Errorf("resolve environment proxy for %s://%s: %w", scheme, addr, err)
+	}
+	return u, nil
 }
 
 // socks5DialerFromURL builds a SOCKS5 dialer for u (scheme socks5/socks5h).
@@ -77,7 +81,11 @@ func socks5DialerFor(scheme, addr string) (proxy.Dialer, error) {
 	if u.Scheme != "socks5" && u.Scheme != "socks5h" {
 		return nil, nil
 	}
-	return socks5DialerFromURL(u)
+	d, err := socks5DialerFromURL(u)
+	if err != nil {
+		return nil, fmt.Errorf("build SOCKS5 dialer for %s: %w", u.Host, err)
+	}
+	return d, nil
 }
 
 func newStreamingTransport() *http.Transport {
@@ -100,8 +108,11 @@ func newStreamingTransport() *http.Transport {
 	// not just baked in once at transport-construction time.
 	tr.Proxy = func(req *http.Request) (*url.URL, error) {
 		u, err := httpproxy.FromEnvironment().ProxyFunc()(req.URL)
-		if err != nil || u == nil {
-			return u, err
+		if err != nil {
+			return nil, fmt.Errorf("resolve proxy for %s: %w", req.URL, err)
+		}
+		if u == nil {
+			return nil, nil
 		}
 		if u.Scheme == "socks5" || u.Scheme == "socks5h" {
 			return nil, nil
@@ -154,13 +165,25 @@ func newStreamingTransport() *http.Transport {
 func dialMaybeSOCKS5(ctx context.Context, scheme, network, addr string) (net.Conn, error) {
 	d, err := socks5DialerFor(scheme, addr)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("resolve dialer for %s: %w", addr, err)
 	}
 	if d == nil {
-		return (&net.Dialer{}).DialContext(ctx, network, addr)
+		conn, err := (&net.Dialer{}).DialContext(ctx, network, addr)
+		if err != nil {
+			return nil, fmt.Errorf("dial %s directly: %w", addr, err)
+		}
+		return conn, nil
 	}
 	if cd, ok := d.(proxy.ContextDialer); ok {
-		return cd.DialContext(ctx, network, addr)
+		conn, err := cd.DialContext(ctx, network, addr)
+		if err != nil {
+			return nil, fmt.Errorf("dial %s via SOCKS5: %w", addr, err)
+		}
+		return conn, nil
 	}
-	return d.Dial(network, addr)
+	conn, err := d.Dial(network, addr)
+	if err != nil {
+		return nil, fmt.Errorf("dial %s via SOCKS5: %w", addr, err)
+	}
+	return conn, nil
 }

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -8,9 +8,9 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"time"
 
+	"golang.org/x/net/http/httpproxy"
 	"golang.org/x/net/proxy"
 )
 
@@ -25,37 +25,37 @@ import (
 // the codebase uses http.DefaultTransport, which already honors these vars.
 var Streaming = &http.Client{Transport: newStreamingTransport()}
 
-// socks5ProxyFromEnv looks for a socks5:// or socks5h:// proxy URL in the
-// standard proxy environment variables.
-//
-// net/http.Transport's Proxy field, and the CONNECT-based tunneling it does
-// under the hood, only understand plain HTTP proxying and HTTP(S) proxies.
-// They have no support for the SOCKS5 protocol. If HTTPS_PROXY/HTTP_PROXY
-// is set to a socks5:// URL (common with corporate VPN clients that expose
-// a local SOCKS5 endpoint), http.ProxyFromEnvironment still happily returns
-// it as "the proxy to use", so Transport dials the proxy's address and then
-// writes an HTTP request line or a CONNECT request at it. A SOCKS5 server
-// doesn't understand either, so the connection just hangs forever: no
-// error, the local TCP connect to the proxy succeeds fine, it just never
-// gets a response it can parse. This is handled explicitly below instead.
-func socks5ProxyFromEnv() *url.URL {
-	for _, env := range []string{"HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "ALL_PROXY", "all_proxy"} {
-		v := os.Getenv(env)
-		if v == "" {
-			continue
-		}
-		u, err := url.Parse(v)
-		if err != nil || (u.Scheme != "socks5" && u.Scheme != "socks5h") {
-			continue
-		}
-		return u
-	}
-	return nil
+// resolveEnvProxy resolves the proxy that applies to a request for the
+// given scheme+addr, honoring HTTP_PROXY/HTTPS_PROXY/ALL_PROXY/NO_PROXY
+// exactly like the standard library does: httpproxy.FromEnvironment()
+// reads those same variables (NO_PROXY included) and applies the same
+// host/port bypass matching net/http itself uses. addr is "host:port";
+// scheme is "http" or "https" so the scheme-specific proxy variable
+// (HTTP_PROXY vs HTTPS_PROXY) is honored per request rather than picking
+// one proxy for every request regardless of scheme.
+func resolveEnvProxy(scheme, addr string) (*url.URL, error) {
+	reqURL := &url.URL{Scheme: scheme, Host: addr}
+	return httpproxy.FromEnvironment().ProxyFunc()(reqURL)
 }
 
+// socks5DialerFromURL builds a SOCKS5 dialer for u (scheme socks5/socks5h).
+//
+// If u carries credentials, they're refused unless the proxy is reached
+// over loopback: the SOCKS5 handshake itself is unauthenticated/unencrypted
+// on the wire, so a username/password would otherwise cross the network in
+// the clear. A local proxy (127.0.0.1/::1 -- the common case for VPN
+// clients that expose a SOCKS5 endpoint on the machine itself) doesn't
+// have that exposure, so credentials are allowed there.
 func socks5DialerFromURL(u *url.URL) (proxy.Dialer, error) {
 	var auth *proxy.Auth
 	if u.User != nil {
+		host, _, err := net.SplitHostPort(u.Host)
+		if err != nil {
+			host = u.Host
+		}
+		if ip := net.ParseIP(host); ip == nil || !ip.IsLoopback() {
+			return nil, fmt.Errorf("refusing to send SOCKS5 credentials to non-local proxy %q over an unencrypted connection", u.Host)
+		}
 		auth = &proxy.Auth{User: u.User.Username()}
 		if pw, ok := u.User.Password(); ok {
 			auth.Password = pw
@@ -64,36 +64,53 @@ func socks5DialerFromURL(u *url.URL) (proxy.Dialer, error) {
 	return proxy.SOCKS5("tcp", u.Host, auth, proxy.Direct)
 }
 
-func newStreamingTransport() *http.Transport {
-	var socks5 proxy.Dialer
-	if u := socks5ProxyFromEnv(); u != nil {
-		if d, err := socks5DialerFromURL(u); err == nil {
-			socks5 = d
-		}
+// socks5DialerFor returns a SOCKS5 dialer to use for a request of the
+// given scheme to addr, or nil if the environment's proxy configuration
+// (NO_PROXY included) doesn't call for SOCKS5 here -- either no proxy
+// applies, or it's a plain http(s) proxy that net/http.Transport's own
+// Proxy field already knows how to speak to.
+func socks5DialerFor(scheme, addr string) (proxy.Dialer, error) {
+	u, err := resolveEnvProxy(scheme, addr)
+	if err != nil || u == nil {
+		return nil, err
 	}
+	if u.Scheme != "socks5" && u.Scheme != "socks5h" {
+		return nil, nil
+	}
+	return socks5DialerFromURL(u)
+}
 
+func newStreamingTransport() *http.Transport {
 	tr := &http.Transport{
 		ResponseHeaderTimeout: 30 * time.Second,
 		TLSNextProto:          make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
 	}
-	if socks5 == nil {
-		// Only hand HTTP(S)-style proxying off to Transport's own logic.
-		// When we're dialing through SOCKS5 ourselves (below), Transport
-		// must not also try to proxy: it would dial the proxy's address
-		// via DialContext and speak CONNECT at it, conflicting with the
-		// SOCKS5 dial happening inside DialContext/DialTLSContext.
-		tr.Proxy = http.ProxyFromEnvironment
-	}
 
-	rawDial := func(ctx context.Context, network, addr string) (net.Conn, error) {
-		if socks5 != nil {
-			return socks5.Dial(network, addr)
+	// Delegate to the environment exactly like http.ProxyFromEnvironment,
+	// EXCEPT when the resolved proxy is socks5/socks5h: net/http.Transport
+	// only understands plain HTTP proxying and HTTP CONNECT tunneling
+	// against an http(s):// proxy, nothing else. If HTTPS_PROXY/HTTP_PROXY
+	// is set to a socks5:// URL, Transport would dial the proxy's address
+	// and write an HTTP request/CONNECT at it; a SOCKS5 server doesn't
+	// understand either, so the connection hangs forever with no error.
+	// Returning nil here for that case tells Transport "no proxy, dial
+	// the target directly" -- DialContext/DialTLSContext below then do
+	// the actual SOCKS5 dial themselves, re-resolving per request so
+	// NO_PROXY and the scheme-specific *_PROXY variable are both honored,
+	// not just baked in once at transport-construction time.
+	tr.Proxy = func(req *http.Request) (*url.URL, error) {
+		u, err := httpproxy.FromEnvironment().ProxyFunc()(req.URL)
+		if err != nil || u == nil {
+			return u, err
 		}
-		return (&net.Dialer{}).DialContext(ctx, network, addr)
+		if u.Scheme == "socks5" || u.Scheme == "socks5h" {
+			return nil, nil
+		}
+		return u, nil
 	}
 
 	tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-		conn, err := rawDial(ctx, network, addr)
+		conn, err := dialMaybeSOCKS5(ctx, "http", network, addr)
 		if err != nil {
 			return nil, fmt.Errorf("dial %s: %w", addr, err)
 		}
@@ -114,16 +131,36 @@ func newStreamingTransport() *http.Transport {
 		// Icecast and SHOUTcast servers only support HTTP/1.x.
 		config.NextProtos = nil
 
-		rawConn, err := rawDial(ctx, network, addr)
+		rawConn, err := dialMaybeSOCKS5(ctx, "https", network, addr)
 		if err != nil {
 			return nil, fmt.Errorf("dial TLS %s: %w", addr, err)
 		}
 		tlsConn := tls.Client(rawConn, config)
 		if err := tlsConn.HandshakeContext(ctx); err != nil {
-			rawConn.Close()
+			_ = rawConn.Close()
 			return nil, fmt.Errorf("dial TLS %s: %w", addr, err)
 		}
 		return newICYConn(tlsConn), nil
 	}
 	return tr
+}
+
+// dialMaybeSOCKS5 dials addr directly, unless the environment's proxy
+// configuration calls for a SOCKS5 proxy for a request of this scheme to
+// this addr, in which case it dials through that proxy instead. Context
+// cancellation applies to both paths (the SOCKS5 dialer's context-aware
+// DialContext is used when the proxy supports it, which proxy.SOCKS5's
+// dialer does).
+func dialMaybeSOCKS5(ctx context.Context, scheme, network, addr string) (net.Conn, error) {
+	d, err := socks5DialerFor(scheme, addr)
+	if err != nil {
+		return nil, err
+	}
+	if d == nil {
+		return (&net.Dialer{}).DialContext(ctx, network, addr)
+	}
+	if cd, ok := d.(proxy.ContextDialer); ok {
+		return cd.DialContext(ctx, network, addr)
+	}
+	return d.Dial(network, addr)
 }

--- a/internal/httpclient/client_socks5_test.go
+++ b/internal/httpclient/client_socks5_test.go
@@ -156,7 +156,8 @@ func TestDialDecisionIsNotReresolvedFromProxyHopAddress(t *testing.T) {
 	t.Setenv("HTTPS_PROXY", "http://real-proxy.example:8080")
 	t.Setenv("HTTP_PROXY", "socks5h://bogus-proxy.invalid:1080")
 
-	req, err := http.NewRequest(http.MethodGet, "https://example.com/stream", nil)
+	baseCtx := context.Background()
+	req, err := http.NewRequestWithContext(baseCtx, http.MethodGet, "https://example.com/stream", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -174,26 +175,26 @@ func TestDialDecisionIsNotReresolvedFromProxyHopAddress(t *testing.T) {
 	// decision were (wrongly) re-derived from this address instead of
 	// read from ctx, HTTP_PROXY's bogus SOCKS5 proxy would apply instead
 	// and this dial would fail or hang rather than connecting straight in.
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, err := (&net.ListenConfig{}).Listen(baseCtx, "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 	accepted := make(chan struct{})
 	go func() {
 		conn, err := ln.Accept()
 		if err == nil {
-			conn.Close()
+			_ = conn.Close()
 			close(accepted)
 		}
 	}()
 
-	ctx := context.WithValue(context.Background(), dialDecisionKey{}, decision)
+	ctx := context.WithValue(baseCtx, dialDecisionKey{}, decision)
 	conn, err := dialWithDecision(ctx, "tcp", ln.Addr().String())
 	if err != nil {
 		t.Fatalf("dial proxy hop directly: %v", err)
 	}
-	conn.Close()
+	_ = conn.Close()
 
 	select {
 	case <-accepted:

--- a/internal/httpclient/client_socks5_test.go
+++ b/internal/httpclient/client_socks5_test.go
@@ -1,0 +1,98 @@
+package httpclient
+
+import (
+	"net/url"
+	"testing"
+)
+
+// clearProxyEnv resets every proxy-related env var (upper and lower case)
+// so each subtest starts from a known-empty state regardless of what the
+// test process's own environment happens to have set.
+func clearProxyEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{
+		"HTTP_PROXY", "http_proxy",
+		"HTTPS_PROXY", "https_proxy",
+		"ALL_PROXY", "all_proxy",
+		"NO_PROXY", "no_proxy",
+	} {
+		t.Setenv(k, "")
+	}
+}
+
+func TestSocks5DialerForScheme(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("HTTPS_PROXY", "socks5h://127.0.0.1:1080")
+
+	d, err := socks5DialerFor("https", "example.com:443")
+	if err != nil {
+		t.Fatalf("https: unexpected error: %v", err)
+	}
+	if d == nil {
+		t.Fatal("https: want a SOCKS5 dialer, got nil (HTTPS_PROXY should apply)")
+	}
+
+	d, err = socks5DialerFor("http", "example.com:80")
+	if err != nil {
+		t.Fatalf("http: unexpected error: %v", err)
+	}
+	if d != nil {
+		t.Fatal("http: want nil (only HTTPS_PROXY is set, HTTP_PROXY should not borrow it)")
+	}
+}
+
+func TestSocks5DialerForNoProxyBypass(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("HTTPS_PROXY", "socks5h://127.0.0.1:1080")
+	t.Setenv("NO_PROXY", "example.com")
+
+	d, err := socks5DialerFor("https", "example.com:443")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d != nil {
+		t.Fatal("want nil dialer: example.com is listed in NO_PROXY and should bypass the SOCKS5 proxy")
+	}
+
+	// A host not covered by NO_PROXY should still go through the proxy.
+	d, err = socks5DialerFor("https", "other.example:443")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d == nil {
+		t.Fatal("want a SOCKS5 dialer for a host not listed in NO_PROXY")
+	}
+}
+
+func TestSocks5DialerForPlainHTTPProxyDefersToTransport(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("HTTP_PROXY", "http://realproxy.example:8080")
+
+	d, err := socks5DialerFor("http", "example.com:80")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d != nil {
+		t.Fatal("want nil: a plain http:// proxy should be left to Transport's own Proxy field, not treated as SOCKS5")
+	}
+}
+
+func TestSocks5DialerFromURLRejectsRemoteCredentials(t *testing.T) {
+	u, err := url.Parse("socks5://user:pass@proxy.example.com:1080")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := socks5DialerFromURL(u); err == nil {
+		t.Fatal("want an error: credentials to a non-loopback SOCKS5 proxy would cross the network unencrypted")
+	}
+}
+
+func TestSocks5DialerFromURLAllowsLoopbackCredentials(t *testing.T) {
+	u, err := url.Parse("socks5://user:pass@127.0.0.1:1080")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := socks5DialerFromURL(u); err != nil {
+		t.Fatalf("unexpected error for a loopback proxy: %v", err)
+	}
+}

--- a/internal/httpclient/client_socks5_test.go
+++ b/internal/httpclient/client_socks5_test.go
@@ -77,22 +77,78 @@ func TestSocks5DialerForPlainHTTPProxyDefersToTransport(t *testing.T) {
 	}
 }
 
-func TestSocks5DialerFromURLRejectsRemoteCredentials(t *testing.T) {
-	u, err := url.Parse("socks5://user:pass@proxy.example.com:1080")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := socks5DialerFromURL(u); err == nil {
-		t.Fatal("want an error: credentials to a non-loopback SOCKS5 proxy would cross the network unencrypted")
+func TestSocks5DialerFromURLRejectsAnyCredentials(t *testing.T) {
+	for _, host := range []string{"proxy.example.com:1080", "127.0.0.1:1080"} {
+		u, err := url.Parse("socks5://user:pass@" + host)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := socks5DialerFromURL(u); err == nil {
+			t.Fatalf("want an error for credentialed SOCKS5 URL %s: RFC 1929 auth is cleartext even on loopback", host)
+		}
 	}
 }
 
-func TestSocks5DialerFromURLAllowsLoopbackCredentials(t *testing.T) {
-	u, err := url.Parse("socks5://user:pass@127.0.0.1:1080")
+func TestSocks5DialerFromURLAllowsNoCredentials(t *testing.T) {
+	u, err := url.Parse("socks5://127.0.0.1:1080")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if _, err := socks5DialerFromURL(u); err != nil {
-		t.Fatalf("unexpected error for a loopback proxy: %v", err)
+		t.Fatalf("unexpected error for a SOCKS5 URL without credentials: %v", err)
+	}
+}
+
+func TestSocks5DialerForALLProxyFallback(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("ALL_PROXY", "socks5h://127.0.0.1:1080")
+
+	d, err := socks5DialerFor("https", "example.com:443")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d == nil {
+		t.Fatal("want a SOCKS5 dialer from ALL_PROXY when no scheme-specific proxy is set")
+	}
+}
+
+func TestSocks5DialerForAllProxyLowercaseFallback(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("all_proxy", "socks5h://127.0.0.1:1080")
+
+	d, err := socks5DialerFor("http", "example.com:80")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d == nil {
+		t.Fatal("want a SOCKS5 dialer from lowercase all_proxy")
+	}
+}
+
+func TestSocks5DialerForALLProxyRespectsNoProxy(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("ALL_PROXY", "socks5h://127.0.0.1:1080")
+	t.Setenv("NO_PROXY", "example.com")
+
+	d, err := socks5DialerFor("https", "example.com:443")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d != nil {
+		t.Fatal("want nil: example.com is in NO_PROXY, ALL_PROXY should not override that")
+	}
+}
+
+func TestSocks5DialerForSchemeSpecificTakesPrecedenceOverALLProxy(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("HTTPS_PROXY", "http://realproxy.example:8080")
+	t.Setenv("ALL_PROXY", "socks5h://127.0.0.1:1080")
+
+	d, err := socks5DialerFor("https", "example.com:443")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d != nil {
+		t.Fatal("want nil: HTTPS_PROXY (a plain http proxy) should be used, not fall back to ALL_PROXY")
 	}
 }

--- a/internal/httpclient/client_socks5_test.go
+++ b/internal/httpclient/client_socks5_test.go
@@ -1,8 +1,12 @@
 package httpclient
 
 import (
+	"context"
+	"net"
+	"net/http"
 	"net/url"
 	"testing"
+	"time"
 )
 
 // clearProxyEnv resets every proxy-related env var (upper and lower case)
@@ -136,6 +140,65 @@ func TestSocks5DialerForALLProxyRespectsNoProxy(t *testing.T) {
 	}
 	if d != nil {
 		t.Fatal("want nil: example.com is in NO_PROXY, ALL_PROXY should not override that")
+	}
+}
+
+// TestDialDecisionIsNotReresolvedFromProxyHopAddress reproduces the mixed
+// HTTP_PROXY/HTTPS_PROXY configuration CodeRabbit flagged: an https target
+// whose HTTPS_PROXY is a plain http(s) proxy, while HTTP_PROXY happens to be
+// a SOCKS5 proxy. net/http.Transport dials the CONNECT tunnel's proxy
+// address (not the request's target) through DialContext for this request,
+// so the dial decision must come from the request's own scheme (https,
+// which resolves to a plain proxy) -- never re-derived from that proxy
+// address as if it were something to look up HTTP_PROXY for.
+func TestDialDecisionIsNotReresolvedFromProxyHopAddress(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("HTTPS_PROXY", "http://real-proxy.example:8080")
+	t.Setenv("HTTP_PROXY", "socks5h://bogus-proxy.invalid:1080")
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.com/stream", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision, err := dialDecisionFor(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if decision.socks5 != nil {
+		t.Fatal("want no SOCKS5 dialer: the request's own scheme (https) resolves to a plain http proxy, HTTP_PROXY's SOCKS5 setting must not apply to it")
+	}
+
+	// Stand in for net/http.Transport dialing the CONNECT tunnel's proxy
+	// address directly (never "example.com:443") with a real, reachable
+	// listener. dialWithDecision must reach it directly -- if the dial
+	// decision were (wrongly) re-derived from this address instead of
+	// read from ctx, HTTP_PROXY's bogus SOCKS5 proxy would apply instead
+	// and this dial would fail or hang rather than connecting straight in.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	accepted := make(chan struct{})
+	go func() {
+		conn, err := ln.Accept()
+		if err == nil {
+			conn.Close()
+			close(accepted)
+		}
+	}()
+
+	ctx := context.WithValue(context.Background(), dialDecisionKey{}, decision)
+	conn, err := dialWithDecision(ctx, "tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial proxy hop directly: %v", err)
+	}
+	conn.Close()
+
+	select {
+	case <-accepted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("listener never accepted a direct connection -- dial was routed elsewhere")
 	}
 }
 

--- a/internal/httpclient/client_test.go
+++ b/internal/httpclient/client_test.go
@@ -16,11 +16,19 @@ func TestStreamingClientExists(t *testing.T) {
 	}
 }
 
-func TestStreamingHeaderTimeout(t *testing.T) {
-	tr, ok := Streaming.Transport.(*http.Transport)
+// streamingTransport unwraps Streaming's socks5RoundTripper to reach the
+// underlying *http.Transport it configures.
+func streamingTransport(t *testing.T) *http.Transport {
+	t.Helper()
+	rt, ok := Streaming.Transport.(*socks5RoundTripper)
 	if !ok {
-		t.Fatal("Transport is not *http.Transport")
+		t.Fatal("Transport is not *socks5RoundTripper")
 	}
+	return rt.transport
+}
+
+func TestStreamingHeaderTimeout(t *testing.T) {
+	tr := streamingTransport(t)
 	want := 30 * time.Second
 	if tr.ResponseHeaderTimeout != want {
 		t.Fatalf("ResponseHeaderTimeout = %v, want %v", tr.ResponseHeaderTimeout, want)
@@ -28,10 +36,7 @@ func TestStreamingHeaderTimeout(t *testing.T) {
 }
 
 func TestStreamingHTTP2Disabled(t *testing.T) {
-	tr, ok := Streaming.Transport.(*http.Transport)
-	if !ok {
-		t.Fatal("Transport is not *http.Transport")
-	}
+	tr := streamingTransport(t)
 	if tr.TLSNextProto == nil {
 		t.Fatal("TLSNextProto is nil, should be empty map to disable HTTP/2")
 	}


### PR DESCRIPTION
## Summary
- The streaming HTTP client's `Transport` only knows how to do plain HTTP proxying or CONNECT-tunnel against `http(s)://` proxies. It has no concept of the SOCKS5 protocol.
- When `HTTP_PROXY`/`HTTPS_PROXY` is set to a `socks5://` or `socks5h://` URL (common with corporate VPN clients — Zscaler, WARP, an `ssh -D` tunnel, etc. — that expose a local SOCKS5 endpoint), `http.ProxyFromEnvironment` still happily returns it as \"the proxy to use\". Transport then dials the proxy's address and writes an HTTP request line (or a CONNECT request, for HTTPS targets) at it. A SOCKS5 server doesn't understand either, so the connection just hangs forever — **no error at all**, since the local TCP connect to the proxy succeeds fine, it just never gets back anything it can parse. From the UI this looks like an infinite \"Buffering...\" with no indication of what's wrong.
- This PR detects a `socks5`/`socks5h` proxy URL in the standard proxy env vars (`HTTPS_PROXY`, `HTTP_PROXY`, `ALL_PROXY`, upper or lower case) and, when present, dials through it with a real SOCKS5 client (`golang.org/x/net/proxy`, already an indirect dependency — no new module needed) inside `DialContext`/`DialTLSContext`. `Transport.Proxy` is left unset in that case, so it doesn't also attempt its own HTTP-style proxying against the same address.
- When no SOCKS5 proxy is configured, behavior is unchanged (`http.ProxyFromEnvironment` + direct dial, exactly as before).

## Test plan
- [x] `gofmt -l` / `go vet ./internal/httpclient/...` clean
- [x] `go build` succeeds
- [x] Verified against a real SOCKS5 proxy (`ssh -D`) and a real HTTPS Icecast stream: without this patch the stream hangs in \"Buffering...\" indefinitely; with it, playback starts normally and stays up
- [x] Verified the no-proxy path is unaffected (falls back to the exact same `http.ProxyFromEnvironment` + direct-dial behavior as before)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for SOCKS5 and SOCKS5H proxies configured through environment variables.
  - Streaming connections can route through SOCKS5 proxies.
  - Added `ALL_PROXY` and `all_proxy` fallback support.
  - Proxy bypass rules are honored for hosts listed in `NO_PROXY`.

- **Bug Fixes**
  - SOCKS5 proxy credentials are now rejected consistently.
  - Improved TLS connection setup and cleanup when negotiation fails.
  - Preserved existing HTTP and HTTPS proxy handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->