### PR TITLE
feat(navidrome): use transcoded files from navidrome by default

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -70,6 +70,7 @@ type NavidromeConfig struct {
 	URL              string // e.g. "https://music.example.com"
 	User             string
 	Password         string
+	Format           string
 	BrowseSort       string // album browse sort order, e.g. "alphabeticalByName"
 	ScrobbleDisabled bool   // true only when "scrobble = false" is explicitly set
 }
@@ -465,6 +466,8 @@ func Load() (Config, error) {
 				cfg.Navidrome.Password = parseString(val)
 			case "browse_sort":
 				cfg.Navidrome.BrowseSort = parseString(val)
+			case "format":
+				cfg.Navidrome.Format = parseString(val)
 			case "scrobble":
 				// Opt-out: only mark disabled when the value is explicitly "false".
 				cfg.Navidrome.ScrobbleDisabled = strings.ToLower(val) == "false"

--- a/docs/navidrome.md
+++ b/docs/navidrome.md
@@ -117,6 +117,10 @@ Bubbletea commands get playlists and tracks asynchronously. The UI remains respo
 
 To support another Subsonic-compatible server, such as Airsonic or Gonic, implement the same `Provider` interface for that server API.
 
+## Transcoding
+
+Cliamp will use transcoded files from Navidrome by default. The exact settings can be changed within Navidrome itself. If you want Navidrome to send raw music data (e.g. your flac files) instead of transcodes, add ``format = "raw"`` under ``[navidrome]`` section in ``config.toml``. A specific format (like mp3, aac, opus, etc.) can be set with the same configuration.
+
 ## Requirements
 
 You need only a running Navidrome instance. The client uses the Go standard `net/http` and `crypto/md5` packages. The Navidrome server must have the Subsonic API enabled. This is the default.

--- a/external/navidrome/client.go
+++ b/external/navidrome/client.go
@@ -509,10 +509,11 @@ func albumFromSubsonic(a subsonicAlbum) Album {
 // streamURL generates the authenticated streaming URL for a track ID.
 // format can be set in config.toml, see documentation
 func (c *NavidromeClient) streamURL(id string) string {
-	if c.format == "" {
-		return c.buildURL("stream", url.Values{"id": {id}})
+	urlValues := url.Values{"id": {id}}
+	if c.format != "" {
+		urlValues.Set("format", c.format)
 	}
-	return c.buildURL("stream", url.Values{"id": {id}, "format": {c.format}})
+	return c.buildURL("stream", urlValues)
 }
 
 func (c *NavidromeClient) CanReportPlayback(track playlist.Track) bool {

--- a/external/navidrome/client.go
+++ b/external/navidrome/client.go
@@ -88,6 +88,7 @@ type NavidromeClient struct {
 	user             string
 	password         string
 	browseSort       string
+	format           string
 	scrobbleDisabled bool
 	mu               sync.Mutex
 	playlistCache    []playlist.PlaylistInfo
@@ -125,6 +126,9 @@ func NewFromConfig(cfg config.NavidromeConfig) *NavidromeClient {
 	client := New(cfg.URL, cfg.User, cfg.Password)
 	if cfg.BrowseSort != "" {
 		client.browseSort = cfg.BrowseSort
+	}
+	if cfg.Format != "" {
+		client.format = cfg.Format
 	}
 	client.scrobbleDisabled = cfg.ScrobbleDisabled
 	return client
@@ -503,11 +507,12 @@ func albumFromSubsonic(a subsonicAlbum) Album {
 }
 
 // streamURL generates the authenticated streaming URL for a track ID.
-// format=raw (Subsonic API 1.9.0+) instructs the server to return the original
-// file without transcoding, giving a genuine Content-Length and preserving
-// audio quality (FLAC, OPUS, AAC, MP3 — whatever is stored).
+// format can be set in config.toml, see documentation
 func (c *NavidromeClient) streamURL(id string) string {
-	return c.buildURL("stream", url.Values{"id": {id}, "format": {"raw"}})
+	if c.format == "" {
+		return c.buildURL("stream", url.Values{"id": {id}})
+	}
+	return c.buildURL("stream", url.Values{"id": {id}, "format": {c.format}})
 }
 
 func (c *NavidromeClient) CanReportPlayback(track playlist.Track) bool {


### PR DESCRIPTION
## Summary

This makes cliamp use transcoded files from Navidrome.

## Screenshots / video

This is not a UI change.

## How to test

1. Load a large file into Navidrome, like something in FLAC.
2. Connect cliamp to Navidrome, and start cliamp with Navidrome provider.
3. Set transcoding for cliamp client in the Navidrome web UI.
4. Play the large file you uploaded. The filesize in the lower right will be substantially smaller.
5. Exit cliamp, and add ``format = "raw"`` under ``[navidrome]`` section in ``config.toml``.
6. Play same file you uploaded. The filesize in the lower right will be same size as the original large file.

## Checklist

- [x] `make check` passes
- [x] `docs/` and `site/index.html` updated for user-facing changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Navidrome audio streaming formats.
  * Users can choose raw audio or specify formats such as MP3, AAC, or Opus through configuration.
  * Navidrome streams now use the selected format when provided, with transcoded audio used by default.

* **Documentation**
  * Added guidance for configuring Navidrome transcoding and selecting raw or specific audio formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->