### PR TITLE
fix(ui): show Refresh provider in the Ctrl+K keymap

### DIFF
--- a/ui/model/command_registry.go
+++ b/ui/model/command_registry.go
@@ -154,7 +154,7 @@ var commandRegistry = []commandSpec{
 	{Mode: commandModeMain, Keys: []string{"?"}, KeyLabel: "?", Label: "Help", Keymap: true},
 	{Mode: commandModeAny, Keys: []string{"ctrl+c", "q"}, KeyLabel: "q", Label: "Quit", Keymap: true},
 	{Mode: commandModeAny, Keys: []string{"ctrl+z"}, KeyLabel: "Ctrl+Z", Label: "Undo latest playlist or queue mutation"},
-	{Mode: commandModeProvider, Keys: []string{"ctrl+r"}, KeyLabel: "Ctrl+R", Label: "Refresh provider"},
+	{Mode: commandModeProvider, Keys: []string{"ctrl+r"}, KeyLabel: "Ctrl+R", Label: "Refresh provider", Keymap: true, ContextHelp: true},
 
 	// Shared text editing is reserved even though these are intentionally absent
 	// from the global keymap, where they would be misleading outside a field.


### PR DESCRIPTION
## Summary

The Jellyfin/Emby/self-hosted provider refresh binding (`Ctrl+R`) works, but the **"Refresh provider"** command never appears in the `Ctrl+K` help overlay - even when the provider pane is focused.

In `ui/model/command_registry.go`, the "Refresh provider" command was registered without the `Keymap: true` (and `ContextHelp: true`) flags. The keymap builder (`ui/model/keymap.go`) filters both the context section and the global "player & library" section on those flags, so the entry was excluded in **every** focus state.

## Change

```diff
-{Mode: commandModeProvider, Keys: []string{"ctrl+r"}, KeyLabel: "Ctrl+R", Label: "Refresh provider"},
+{Mode: commandModeProvider, Keys: []string{"ctrl+r"}, KeyLabel: "Ctrl+R", Label: "Refresh provider", Keymap: true, ContextHelp: true},
```

`Keymap: true` surfaces it in the `Ctrl+K` overlay's "player & library" section; `ContextHelp: true` also shows it in the context hint bar while the provider pane has focus. It stays provider-pane-only (`Mode: commandModeProvider`), matching where the binding actually works.

`docs/keybindings.md` already documents `Ctrl+R` under "Provider playlist list"; `site/index.html` doesn't enumerate the provider playlist-list keymap, so no doc/site changes are needed.

## Verification

- Single data-field change; `go vet` / `go test ./...` via CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The “Refresh provider” command now appears in the global keymap and contextual help hints when browsing providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->