### PR TITLE
feat(spotify): load playlist tracks progressively

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ config.backup.toml
 .env
 .github/workflows/contextowl-changelog.yml
 /gui/
+coverage.out

--- a/external/spotify/provider.go
+++ b/external/spotify/provider.go
@@ -54,9 +54,10 @@ type playlistCache struct {
 // from two snapshots can splice together into a list that is short by one and
 // duplicated by one, which revalidation cannot detect.
 type pendingTracks struct {
-	tracks []playlist.Track
-	want   int
-	total  int
+	tracks   []playlist.Track
+	want     int
+	total    int
+	snapshot string // playlist snapshot_id the accumulation began under; "" for saved tracks
 }
 
 type SpotifyProvider struct {
@@ -519,6 +520,33 @@ func headMatches(accumulated, page []playlist.Track) bool {
 	return true
 }
 
+// snapshotIDLocked returns the snapshot_id last seen for playlistID, or "" if
+// none is known. p.mu must be held.
+func (p *SpotifyProvider) snapshotIDLocked(playlistID string) string {
+	if cached := p.trackCache[playlistID]; cached != nil {
+		return cached.snapshotID
+	}
+	return ""
+}
+
+// playlistSnapshot reads a playlist's current snapshot_id, Spotify's own version
+// token: it changes on every edit, so an unchanged one proves the playlist is
+// untouched -- which an unchanged total and head cannot, since an ordinary
+// playlist can be edited anywhere.
+func (p *SpotifyProvider) playlistSnapshot(ctx context.Context, playlistID string) (string, error) {
+	resp, err := p.webAPI(ctx, "GET", "/v1/playlists/"+playlistID, url.Values{"fields": {"snapshot_id"}})
+	if err != nil {
+		return "", err
+	}
+	var result struct {
+		SnapshotID string `json:"snapshot_id"`
+	}
+	if err := decodeBody(resp, &result); err != nil {
+		return "", err
+	}
+	return result.SnapshotID, nil
+}
+
 // cachedTracksLocked returns a copy of the committed list and its total, if
 // any. p.mu must be held.
 func (p *SpotifyProvider) cachedTracksLocked(playlistID string) (tracks []playlist.Track, total int, ok bool) {
@@ -601,22 +629,43 @@ func (p *SpotifyProvider) TracksPage(playlistID string, offset int) ([]playlist.
 	if next >= total {
 		next = 0
 	}
+
+	// Whether an abandoned accumulation can be resumed may need a request, so
+	// settle it before taking the lock the accumulation is guarded by.
+	resumable := false
+	if offset == 0 {
+		p.mu.Lock()
+		pend := p.pending[playlistID]
+		viable := pend != nil && pend.want > 0 && pend.total == total
+		head := viable && playlistID == savedTracksPlaylistID && headMatches(pend.tracks, page)
+		snapshot := ""
+		if viable && playlistID != savedTracksPlaylistID {
+			snapshot = pend.snapshot
+		}
+		p.mu.Unlock()
+
+		switch {
+		case head:
+			// Saved tracks cannot hide an edit: a like lands at position 0 and an
+			// unlike moves the total, so the head and total together are proof.
+			resumable = true
+		case snapshot != "":
+			current, err := p.playlistSnapshot(ctx, playlistID)
+			resumable = err == nil && current == snapshot
+		}
+	}
+
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	pend := p.pending[playlistID]
 	if offset == 0 {
 		// Re-entering a list abandoned mid-load resumes the earlier accumulation
-		// rather than refetching every page already paid for. Only saved tracks
-		// qualify: an unchanged total and an unchanged head prove nothing moved
-		// there, because a like lands at position 0 and an unlike changes the
-		// total. An ordinary playlist can be edited anywhere, so a same-total
-		// edit below the head but inside the fetched prefix would shift every
-		// later offset and stitch the two halves together a track short.
-		if playlistID == savedTracksPlaylistID && pend != nil && pend.want > 0 &&
-			pend.total == total && headMatches(pend.tracks, page) {
+		// rather than refetching every page already paid for, at the cost of one
+		// request to prove nothing moved in between.
+		if resumable && pend != nil {
 			return slices.Clone(pend.tracks), pend.want, nil
 		}
-		pend = &pendingTracks{total: total}
+		pend = &pendingTracks{total: total, snapshot: p.snapshotIDLocked(playlistID)}
 		p.pending[playlistID] = pend
 	}
 	// A page at an offset this accumulation is not waiting for belongs to a

--- a/external/spotify/provider.go
+++ b/external/spotify/provider.go
@@ -457,6 +457,13 @@ func (p *SpotifyProvider) Tracks(playlistID string) ([]playlist.Track, error) {
 	return slices.Clone(all), nil
 }
 
+// fetchTracksPage reads one page of a playlist's tracks and returns it with the
+// list's current total. Saved tracks and playlist items come from different
+// endpoints with different shapes, so this is the single place that difference
+// lives; both Tracks and TracksPage page through it so they cannot drift apart.
+// Items without an ID -- local files, unavailable tracks -- are skipped, so the
+// returned slice is usually shorter than the page size and the caller must
+// advance by the page size rather than by len(tracks).
 func (p *SpotifyProvider) fetchTracksPage(ctx context.Context, playlistID string, offset int) ([]playlist.Track, int, error) {
 	query := url.Values{
 		"limit":  {strconv.Itoa(spotifyTrackPageSize)},

--- a/external/spotify/provider.go
+++ b/external/spotify/provider.go
@@ -248,7 +248,7 @@ func (p *SpotifyProvider) Playlists() ([]playlist.PlaylistInfo, error) {
 	// For the moment, "Your Music" must sufficice without adding a localization
 	// map.
 	all = append(all, playlist.PlaylistInfo{
-		ID:         "YOUR MUSIC",
+		ID:         savedTracksPlaylistID,
 		Name:       "Your Music",
 		TrackCount: result.Total,
 		Section:    "Library",
@@ -470,7 +470,7 @@ func (p *SpotifyProvider) fetchTracksPage(ctx context.Context, playlistID string
 		"offset": {strconv.Itoa(offset)},
 	}
 	path := "/v1/me/tracks"
-	if playlistID != "YOUR MUSIC" {
+	if playlistID != savedTracksPlaylistID {
 		query.Set("fields", "items(item(id,name,type,uri,artists(name),album(name,release_date),show(name),release_date,duration_ms,track_number,is_playable,restrictions(reason))),total")
 		path = fmt.Sprintf("/v1/playlists/%s/items", playlistID)
 	}
@@ -570,6 +570,13 @@ func (p *SpotifyProvider) TracksPage(playlistID string, offset int) ([]playlist.
 	if err := p.ensureSession(); err != nil {
 		return nil, 0, err
 	}
+	// Saved albums are a separate endpoint and are small enough to arrive whole,
+	// so hand them back as one complete page. Tracks() routes them the same way;
+	// leaving them out here would build a playlist-items URL from an album ID.
+	if albumID, ok := isSavedAlbumID(playlistID); ok {
+		tracks, err := p.AlbumTracks(albumID)
+		return tracks, 0, err
+	}
 	p.mu.Lock()
 	var tracks []playlist.Track
 	var cachedTotal int
@@ -582,7 +589,7 @@ func (p *SpotifyProvider) TracksPage(playlistID string, offset int) ([]playlist.
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	if hit && (playlistID != "YOUR MUSIC" || p.savedTracksUnchanged(ctx, tracks, cachedTotal)) {
+	if hit && (playlistID != savedTracksPlaylistID || p.savedTracksUnchanged(ctx, tracks, cachedTotal)) {
 		return tracks, 0, nil
 	}
 	page, total, err := p.fetchTracksPage(ctx, playlistID, offset)
@@ -598,11 +605,15 @@ func (p *SpotifyProvider) TracksPage(playlistID string, offset int) ([]playlist.
 	defer p.mu.Unlock()
 	pend := p.pending[playlistID]
 	if offset == 0 {
-		// Re-entering a list that was abandoned mid-load resumes the earlier
-		// accumulation rather than refetching every page already paid for, but
-		// only when page 0 still reports the total it was started from -- a
-		// changed library would otherwise splice two snapshots.
-		if pend != nil && pend.want > 0 && pend.total == total && headMatches(pend.tracks, page) {
+		// Re-entering a list abandoned mid-load resumes the earlier accumulation
+		// rather than refetching every page already paid for. Only saved tracks
+		// qualify: an unchanged total and an unchanged head prove nothing moved
+		// there, because a like lands at position 0 and an unlike changes the
+		// total. An ordinary playlist can be edited anywhere, so a same-total
+		// edit below the head but inside the fetched prefix would shift every
+		// later offset and stitch the two halves together a track short.
+		if playlistID == savedTracksPlaylistID && pend != nil && pend.want > 0 &&
+			pend.total == total && headMatches(pend.tracks, page) {
 			return slices.Clone(pend.tracks), pend.want, nil
 		}
 		pend = &pendingTracks{total: total}

--- a/external/spotify/provider.go
+++ b/external/spotify/provider.go
@@ -536,13 +536,13 @@ func (p *SpotifyProvider) snapshotIDLocked(playlistID string) string {
 func (p *SpotifyProvider) playlistSnapshot(ctx context.Context, playlistID string) (string, error) {
 	resp, err := p.webAPI(ctx, "GET", "/v1/playlists/"+playlistID, url.Values{"fields": {"snapshot_id"}})
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("spotify: playlist snapshot %q: %w", playlistID, err)
 	}
 	var result struct {
 		SnapshotID string `json:"snapshot_id"`
 	}
 	if err := decodeBody(resp, &result); err != nil {
-		return "", err
+		return "", fmt.Errorf("spotify: parse playlist snapshot %q: %w", playlistID, err)
 	}
 	return result.SnapshotID, nil
 }

--- a/external/spotify/provider.go
+++ b/external/spotify/provider.go
@@ -601,8 +601,18 @@ func (p *SpotifyProvider) TracksPage(playlistID string, offset int) ([]playlist.
 		pend = &pendingTracks{total: total}
 		p.pending[playlistID] = pend
 	}
-	if pend == nil || pend.want != offset || pend.total != total {
+	// A page at an offset this accumulation is not waiting for belongs to a
+	// superseded chain: serve it to its caller, but do not accumulate it.
+	if pend == nil || pend.want != offset {
 		return page, next, nil
+	}
+	// The live chain's own page reporting a different total means the library
+	// moved under it. Every later page would mismatch the pinned snapshot too,
+	// so the load can never commit -- stop now rather than spending the rest of
+	// the pages on a result that is already discarded.
+	if pend.total != total {
+		delete(p.pending, playlistID)
+		return nil, 0, fmt.Errorf("spotify: list tracks: %q changed while loading", playlistID)
 	}
 	pend.tracks = append(pend.tracks, page...)
 	pend.want = next

--- a/external/spotify/provider.go
+++ b/external/spotify/provider.go
@@ -567,6 +567,13 @@ func (p *SpotifyProvider) TracksPage(playlistID string, offset int) ([]playlist.
 	defer p.mu.Unlock()
 	pend := p.pending[playlistID]
 	if offset == 0 {
+		// Re-entering a list that was abandoned mid-load resumes the earlier
+		// accumulation rather than refetching every page already paid for, but
+		// only when page 0 still reports the total it was started from -- a
+		// changed library would otherwise splice two snapshots.
+		if pend != nil && pend.want > 0 && pend.total == total {
+			return slices.Clone(pend.tracks), pend.want, nil
+		}
 		pend = &pendingTracks{total: total}
 		p.pending[playlistID] = pend
 	}

--- a/external/spotify/provider.go
+++ b/external/spotify/provider.go
@@ -42,6 +42,7 @@ var (
 type playlistCache struct {
 	snapshotID string
 	tracks     []playlist.Track
+	total      int
 }
 
 type SpotifyProvider struct {
@@ -52,7 +53,8 @@ type SpotifyProvider struct {
 	meFetched  bool   // /v1/me has been attempted this session; suppresses retry on failure
 	mu         sync.Mutex
 	trackCache map[string]*playlistCache // playlist ID → cache entry
-	authCancel context.CancelFunc        // cancels any in-progress OAuth flow
+	pending    map[string][]playlist.Track
+	authCancel context.CancelFunc // cancels any in-progress OAuth flow
 
 	// Playlist list cache to avoid redundant API calls on provider switch.
 	listCache   []playlist.PlaylistInfo
@@ -70,6 +72,7 @@ func New(session *Session, clientID string, bitrate int) *SpotifyProvider {
 		clientID:   clientID,
 		bitrate:    bitrate,
 		trackCache: make(map[string]*playlistCache),
+		pending:    make(map[string][]playlist.Track),
 	}
 }
 
@@ -407,55 +410,15 @@ func (p *SpotifyProvider) Tracks(playlistID string) ([]playlist.Track, error) {
 	offset := 0
 	limit := spotifyTrackPageSize
 
+	grand := 0
 	for {
-		var (
-			resp *http.Response
-			err  error
-		)
-
-		if playlistID == "YOUR MUSIC" {
-			query := url.Values{
-				"limit":  {fmt.Sprintf("%d", limit)},
-				"offset": {fmt.Sprintf("%d", offset)},
-			}
-			resp, err = p.webAPI(ctx, "GET", "/v1/me/tracks", query)
-		} else {
-			query := url.Values{
-				"limit":  {fmt.Sprintf("%d", limit)},
-				"offset": {fmt.Sprintf("%d", offset)},
-				"fields": {"items(item(id,name,type,uri,artists(name),album(name,release_date),show(name),release_date,duration_ms,track_number,is_playable,restrictions(reason))),total"},
-			}
-			path := fmt.Sprintf("/v1/playlists/%s/items", playlistID)
-			resp, err = p.webAPI(ctx, "GET", path, query)
-		}
-
+		page, total, err := p.fetchTracksPage(ctx, playlistID, offset)
 		if err != nil {
-			return nil, fmt.Errorf("spotify: list tracks: %w", err)
+			return nil, err
 		}
-
-		var result struct {
-			Items []struct {
-				Item  *spotifyItem `json:"item"`
-				Track *spotifyItem `json:"track"`
-			} `json:"items"`
-			Total int `json:"total"`
-		}
-		if err := decodeBody(resp, &result); err != nil {
-			return nil, fmt.Errorf("spotify: parse tracks: %w", err)
-		}
-
-		for _, item := range result.Items {
-			t := item.Item
-			if t == nil {
-				t = item.Track
-			}
-			if t == nil || t.ID == "" {
-				continue // skip local/unavailable tracks
-			}
-			all = append(all, trackFromItem(t))
-		}
-
-		if offset+limit >= result.Total {
+		all = append(all, page...)
+		grand = total
+		if offset+limit >= total {
 			break
 		}
 		offset += limit
@@ -465,12 +428,121 @@ func (p *SpotifyProvider) Tracks(playlistID string) ([]playlist.Track, error) {
 	p.mu.Lock()
 	if cached, ok := p.trackCache[playlistID]; ok {
 		cached.tracks = all
+		cached.total = grand
 	} else {
-		p.trackCache[playlistID] = &playlistCache{tracks: all}
+		p.trackCache[playlistID] = &playlistCache{tracks: all, total: grand}
 	}
 	p.mu.Unlock()
 
 	return slices.Clone(all), nil
+}
+
+func (p *SpotifyProvider) fetchTracksPage(ctx context.Context, playlistID string, offset int) ([]playlist.Track, int, error) {
+	query := url.Values{
+		"limit":  {fmt.Sprintf("%d", spotifyTrackPageSize)},
+		"offset": {fmt.Sprintf("%d", offset)},
+	}
+	path := "/v1/me/tracks"
+	if playlistID != "YOUR MUSIC" {
+		query.Set("fields", "items(item(id,name,type,uri,artists(name),album(name,release_date),show(name),release_date,duration_ms,track_number,is_playable,restrictions(reason))),total")
+		path = fmt.Sprintf("/v1/playlists/%s/items", playlistID)
+	}
+	resp, err := p.webAPI(ctx, "GET", path, query)
+	if err != nil {
+		return nil, 0, fmt.Errorf("spotify: list tracks: %w", err)
+	}
+	var result struct {
+		Items []struct {
+			Item  *spotifyItem `json:"item"`
+			Track *spotifyItem `json:"track"`
+		} `json:"items"`
+		Total int `json:"total"`
+	}
+	if err := decodeBody(resp, &result); err != nil {
+		return nil, 0, fmt.Errorf("spotify: parse tracks: %w", err)
+	}
+	var tracks []playlist.Track
+	for _, item := range result.Items {
+		t := item.Item
+		if t == nil {
+			t = item.Track
+		}
+		if t == nil || t.ID == "" {
+			continue
+		}
+		tracks = append(tracks, trackFromItem(t))
+	}
+	return tracks, result.Total, nil
+}
+
+// savedTracksUnchanged revalidates a cached Liked Songs list with a single
+// limit=1 request: /v1/me/tracks is sorted by added_at descending, so an
+// unchanged total plus an unchanged newest entry means no add or removal.
+func (p *SpotifyProvider) savedTracksUnchanged(ctx context.Context, tracks []playlist.Track, total int) bool {
+	resp, err := p.webAPI(ctx, "GET", "/v1/me/tracks", url.Values{"limit": {"1"}})
+	if err != nil {
+		return false
+	}
+	var result struct {
+		Items []struct {
+			Track *spotifyItem `json:"track"`
+		} `json:"items"`
+		Total int `json:"total"`
+	}
+	if err := decodeBody(resp, &result); err != nil || result.Total != total {
+		return false
+	}
+	if len(result.Items) == 0 || result.Items[0].Track == nil {
+		return len(tracks) == 0
+	}
+	return len(tracks) > 0 && trackFromItem(result.Items[0].Track).Path == tracks[0].Path
+}
+
+// TracksPage returns one page of playlistID's tracks plus the offset to request
+// next, or 0 when the playlist is fully loaded. Implements provider.TrackPager.
+func (p *SpotifyProvider) TracksPage(playlistID string, offset int) ([]playlist.Track, int, error) {
+	if err := p.ensureSession(); err != nil {
+		return nil, 0, err
+	}
+	p.mu.Lock()
+	cached, hit := p.trackCache[playlistID]
+	var tracks []playlist.Track
+	var cachedTotal int
+	if hit = hit && cached.tracks != nil && offset == 0; hit {
+		tracks = slices.Clone(cached.tracks)
+		cachedTotal = cached.total
+	}
+	p.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	if hit && (playlistID != "YOUR MUSIC" || p.savedTracksUnchanged(ctx, tracks, cachedTotal)) {
+		return tracks, 0, nil
+	}
+	page, total, err := p.fetchTracksPage(ctx, playlistID, offset)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	next := offset + spotifyTrackPageSize
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if offset == 0 {
+		p.pending[playlistID] = nil
+	}
+	p.pending[playlistID] = append(p.pending[playlistID], page...)
+	if next < total {
+		return page, next, nil
+	}
+	if cached, ok := p.trackCache[playlistID]; ok {
+		cached.tracks = p.pending[playlistID]
+		cached.total = total
+	} else {
+		p.trackCache[playlistID] = &playlistCache{tracks: p.pending[playlistID], total: total}
+	}
+	delete(p.pending, playlistID)
+	return page, 0, nil
 }
 
 // isAuthError returns true if the error is an authentication/session-related

--- a/external/spotify/provider.go
+++ b/external/spotify/provider.go
@@ -496,6 +496,23 @@ func (p *SpotifyProvider) fetchTracksPage(ctx context.Context, playlistID string
 	return tracks, result.Total, nil
 }
 
+// headMatches reports whether an abandoned accumulation still begins with the
+// freshly fetched page 0, meaning nothing entered or left the head of the list
+// while it was closed. Resuming stitches two separate loads together, so an
+// unchanged total is not enough on its own: a same-total swap below the head
+// would splice the old ordering onto the new suffix.
+func headMatches(accumulated, page []playlist.Track) bool {
+	if len(accumulated) < len(page) {
+		return false
+	}
+	for i, t := range page {
+		if accumulated[i].Path != t.Path {
+			return false
+		}
+	}
+	return true
+}
+
 // cacheTracksLocked stores a fully loaded track list. p.mu must be held.
 func (p *SpotifyProvider) cacheTracksLocked(playlistID string, tracks []playlist.Track, total int) {
 	if cached, ok := p.trackCache[playlistID]; ok {
@@ -571,7 +588,7 @@ func (p *SpotifyProvider) TracksPage(playlistID string, offset int) ([]playlist.
 		// accumulation rather than refetching every page already paid for, but
 		// only when page 0 still reports the total it was started from -- a
 		// changed library would otherwise splice two snapshots.
-		if pend != nil && pend.want > 0 && pend.total == total {
+		if pend != nil && pend.want > 0 && pend.total == total && headMatches(pend.tracks, page) {
 			return slices.Clone(pend.tracks), pend.want, nil
 		}
 		pend = &pendingTracks{total: total}

--- a/external/spotify/provider.go
+++ b/external/spotify/provider.go
@@ -612,7 +612,7 @@ func (p *SpotifyProvider) TracksPage(playlistID string, offset int) ([]playlist.
 	// the pages on a result that is already discarded.
 	if pend.total != total {
 		delete(p.pending, playlistID)
-		return nil, 0, fmt.Errorf("spotify: list tracks: %q changed while loading", playlistID)
+		return nil, 0, fmt.Errorf("spotify: list tracks %q: %w", playlistID, playlist.ErrListChanged)
 	}
 	pend.tracks = append(pend.tracks, page...)
 	pend.want = next

--- a/external/spotify/provider.go
+++ b/external/spotify/provider.go
@@ -47,11 +47,16 @@ type playlistCache struct {
 }
 
 // pendingTracks accumulates a progressive load. want is the offset the next
-// page must carry; a page arriving out of order belongs to a superseded chain
-// and is served to the caller but never accumulated.
+// page must carry and total is the list size the first page reported; a page
+// that is out of order, or that reports a different total and so was read from
+// a changed library, is served to the caller but never accumulated. Contiguity
+// alone is not enough: a mutation mid-load shifts every later offset, so pages
+// from two snapshots can splice together into a list that is short by one and
+// duplicated by one, which revalidation cannot detect.
 type pendingTracks struct {
 	tracks []playlist.Track
 	want   int
+	total  int
 }
 
 type SpotifyProvider struct {
@@ -550,10 +555,10 @@ func (p *SpotifyProvider) TracksPage(playlistID string, offset int) ([]playlist.
 	defer p.mu.Unlock()
 	pend := p.pending[playlistID]
 	if offset == 0 {
-		pend = &pendingTracks{}
+		pend = &pendingTracks{total: total}
 		p.pending[playlistID] = pend
 	}
-	if pend == nil || pend.want != offset {
+	if pend == nil || pend.want != offset || pend.total != total {
 		return page, next, nil
 	}
 	pend.tracks = append(pend.tracks, page...)

--- a/external/spotify/provider.go
+++ b/external/spotify/provider.go
@@ -32,6 +32,7 @@ var (
 	_ provider.PlaylistCreator = (*SpotifyProvider)(nil)
 	_ provider.CustomStreamer  = (*SpotifyProvider)(nil)
 	_ provider.Closer          = (*SpotifyProvider)(nil)
+	_ provider.TrackPager      = (*SpotifyProvider)(nil)
 )
 
 // maxResponseBody limits JSON API responses to 10 MB.
@@ -45,6 +46,14 @@ type playlistCache struct {
 	total      int
 }
 
+// pendingTracks accumulates a progressive load. want is the offset the next
+// page must carry; a page arriving out of order belongs to a superseded chain
+// and is served to the caller but never accumulated.
+type pendingTracks struct {
+	tracks []playlist.Track
+	want   int
+}
+
 type SpotifyProvider struct {
 	session    *Session
 	clientID   string
@@ -53,7 +62,7 @@ type SpotifyProvider struct {
 	meFetched  bool   // /v1/me has been attempted this session; suppresses retry on failure
 	mu         sync.Mutex
 	trackCache map[string]*playlistCache // playlist ID → cache entry
-	pending    map[string][]playlist.Track
+	pending    map[string]*pendingTracks
 	authCancel context.CancelFunc // cancels any in-progress OAuth flow
 
 	// Playlist list cache to avoid redundant API calls on provider switch.
@@ -72,7 +81,7 @@ func New(session *Session, clientID string, bitrate int) *SpotifyProvider {
 		clientID:   clientID,
 		bitrate:    bitrate,
 		trackCache: make(map[string]*playlistCache),
-		pending:    make(map[string][]playlist.Track),
+		pending:    make(map[string]*pendingTracks),
 	}
 }
 
@@ -426,12 +435,7 @@ func (p *SpotifyProvider) Tracks(playlistID string) ([]playlist.Track, error) {
 
 	// Cache the fetched tracks.
 	p.mu.Lock()
-	if cached, ok := p.trackCache[playlistID]; ok {
-		cached.tracks = all
-		cached.total = grand
-	} else {
-		p.trackCache[playlistID] = &playlistCache{tracks: all, total: grand}
-	}
+	p.cacheTracksLocked(playlistID, all, grand)
 	p.mu.Unlock()
 
 	return slices.Clone(all), nil
@@ -475,9 +479,21 @@ func (p *SpotifyProvider) fetchTracksPage(ctx context.Context, playlistID string
 	return tracks, result.Total, nil
 }
 
+// cacheTracksLocked stores a fully loaded track list. p.mu must be held.
+func (p *SpotifyProvider) cacheTracksLocked(playlistID string, tracks []playlist.Track, total int) {
+	if cached, ok := p.trackCache[playlistID]; ok {
+		cached.tracks = tracks
+		cached.total = total
+		return
+	}
+	p.trackCache[playlistID] = &playlistCache{tracks: tracks, total: total}
+}
+
 // savedTracksUnchanged revalidates a cached Liked Songs list with a single
-// limit=1 request: /v1/me/tracks is sorted by added_at descending, so an
-// unchanged total plus an unchanged newest entry means no add or removal.
+// limit=1 request. /v1/me/tracks ordering is undocumented but is empirically
+// added_at descending, so an unchanged total plus an unchanged newest entry
+// means no add or removal. If that ever stops holding the comparison simply
+// misses and we refetch, so the failure direction is stale-free.
 func (p *SpotifyProvider) savedTracksUnchanged(ctx context.Context, tracks []playlist.Track, total int) bool {
 	resp, err := p.webAPI(ctx, "GET", "/v1/me/tracks", url.Values{"limit": {"1"}})
 	if err != nil {
@@ -495,7 +511,7 @@ func (p *SpotifyProvider) savedTracksUnchanged(ctx context.Context, tracks []pla
 	if len(result.Items) == 0 || result.Items[0].Track == nil {
 		return len(tracks) == 0
 	}
-	return len(tracks) > 0 && trackFromItem(result.Items[0].Track).Path == tracks[0].Path
+	return len(tracks) > 0 && result.Items[0].Track.URI == tracks[0].Path
 }
 
 // TracksPage returns one page of playlistID's tracks plus the offset to request
@@ -505,10 +521,11 @@ func (p *SpotifyProvider) TracksPage(playlistID string, offset int) ([]playlist.
 		return nil, 0, err
 	}
 	p.mu.Lock()
-	cached, hit := p.trackCache[playlistID]
+	cached := p.trackCache[playlistID]
+	hit := offset == 0 && cached != nil && cached.tracks != nil
 	var tracks []playlist.Track
 	var cachedTotal int
-	if hit = hit && cached.tracks != nil && offset == 0; hit {
+	if hit {
 		tracks = slices.Clone(cached.tracks)
 		cachedTotal = cached.total
 	}
@@ -526,23 +543,26 @@ func (p *SpotifyProvider) TracksPage(playlistID string, offset int) ([]playlist.
 	}
 
 	next := offset + spotifyTrackPageSize
+	if next >= total {
+		next = 0
+	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	pend := p.pending[playlistID]
 	if offset == 0 {
-		p.pending[playlistID] = nil
+		pend = &pendingTracks{}
+		p.pending[playlistID] = pend
 	}
-	p.pending[playlistID] = append(p.pending[playlistID], page...)
-	if next < total {
+	if pend == nil || pend.want != offset {
 		return page, next, nil
 	}
-	if cached, ok := p.trackCache[playlistID]; ok {
-		cached.tracks = p.pending[playlistID]
-		cached.total = total
-	} else {
-		p.trackCache[playlistID] = &playlistCache{tracks: p.pending[playlistID], total: total}
+	pend.tracks = append(pend.tracks, page...)
+	pend.want = next
+	if next == 0 {
+		p.cacheTracksLocked(playlistID, pend.tracks, total)
+		delete(p.pending, playlistID)
 	}
-	delete(p.pending, playlistID)
-	return page, 0, nil
+	return page, next, nil
 }
 
 // isAuthError returns true if the error is an authentication/session-related

--- a/external/spotify/provider.go
+++ b/external/spotify/provider.go
@@ -410,8 +410,7 @@ func (p *SpotifyProvider) Tracks(playlistID string) ([]playlist.Track, error) {
 	}
 	// Check cache — if we have tracks and the snapshot_id hasn't changed, return cached.
 	p.mu.Lock()
-	if cached, ok := p.trackCache[playlistID]; ok && cached.tracks != nil {
-		tracks := slices.Clone(cached.tracks)
+	if tracks, _, ok := p.cachedTracksLocked(playlistID); ok {
 		p.mu.Unlock()
 		return tracks, nil
 	}
@@ -460,8 +459,8 @@ func (p *SpotifyProvider) Tracks(playlistID string) ([]playlist.Track, error) {
 
 func (p *SpotifyProvider) fetchTracksPage(ctx context.Context, playlistID string, offset int) ([]playlist.Track, int, error) {
 	query := url.Values{
-		"limit":  {fmt.Sprintf("%d", spotifyTrackPageSize)},
-		"offset": {fmt.Sprintf("%d", offset)},
+		"limit":  {strconv.Itoa(spotifyTrackPageSize)},
+		"offset": {strconv.Itoa(offset)},
 	}
 	path := "/v1/me/tracks"
 	if playlistID != "YOUR MUSIC" {
@@ -513,6 +512,16 @@ func headMatches(accumulated, page []playlist.Track) bool {
 	return true
 }
 
+// cachedTracksLocked returns a copy of the committed list and its total, if
+// any. p.mu must be held.
+func (p *SpotifyProvider) cachedTracksLocked(playlistID string) (tracks []playlist.Track, total int, ok bool) {
+	cached := p.trackCache[playlistID]
+	if cached == nil || cached.tracks == nil {
+		return nil, 0, false
+	}
+	return slices.Clone(cached.tracks), cached.total, true
+}
+
 // cacheTracksLocked stores a fully loaded track list. p.mu must be held.
 func (p *SpotifyProvider) cacheTracksLocked(playlistID string, tracks []playlist.Track, total int) {
 	if cached, ok := p.trackCache[playlistID]; ok {
@@ -555,13 +564,11 @@ func (p *SpotifyProvider) TracksPage(playlistID string, offset int) ([]playlist.
 		return nil, 0, err
 	}
 	p.mu.Lock()
-	cached := p.trackCache[playlistID]
-	hit := offset == 0 && cached != nil && cached.tracks != nil
 	var tracks []playlist.Track
 	var cachedTotal int
-	if hit {
-		tracks = slices.Clone(cached.tracks)
-		cachedTotal = cached.total
+	hit := false
+	if offset == 0 {
+		tracks, cachedTotal, hit = p.cachedTracksLocked(playlistID)
 	}
 	p.mu.Unlock()
 

--- a/external/spotify/provider.go
+++ b/external/spotify/provider.go
@@ -420,27 +420,39 @@ func (p *SpotifyProvider) Tracks(playlistID string) ([]playlist.Track, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
+	// A like or unlike mid-load shifts every later offset, so pages read either
+	// side of the change splice into a list short by one and duplicated by one.
+	// Restart against the new snapshot when the total moves, bounding restarts
+	// so a library being actively edited cannot loop forever.
+	const maxRestarts = 2
 	var all []playlist.Track
-	offset := 0
-	limit := spotifyTrackPageSize
-
-	grand := 0
+	total, offset, restarts := -1, 0, 0
 	for {
-		page, total, err := p.fetchTracksPage(ctx, playlistID, offset)
+		page, pageTotal, err := p.fetchTracksPage(ctx, playlistID, offset)
 		if err != nil {
 			return nil, err
 		}
+		if total < 0 {
+			total = pageTotal
+		}
+		if pageTotal != total {
+			if restarts == maxRestarts {
+				return nil, fmt.Errorf("spotify: list tracks: %q changed while loading", playlistID)
+			}
+			restarts++
+			all, total, offset = nil, -1, 0
+			continue
+		}
 		all = append(all, page...)
-		grand = total
-		if offset+limit >= total {
+		if offset+spotifyTrackPageSize >= total {
 			break
 		}
-		offset += limit
+		offset += spotifyTrackPageSize
 	}
 
 	// Cache the fetched tracks.
 	p.mu.Lock()
-	p.cacheTracksLocked(playlistID, all, grand)
+	p.cacheTracksLocked(playlistID, all, total)
 	p.mu.Unlock()
 
 	return slices.Clone(all), nil

--- a/external/spotify/provider_paging_test.go
+++ b/external/spotify/provider_paging_test.go
@@ -146,8 +146,9 @@ func TestTracksPageIgnoresNonContiguousPages(t *testing.T) {
 	}
 	// A page from a superseded chain lands at an offset the current
 	// accumulation is not waiting for; it must not be spliced in.
-	if _, _, err := p.TracksPage("YOUR MUSIC", 100); err != nil {
-		t.Fatal(err)
+	page, next, err := p.TracksPage("YOUR MUSIC", 100)
+	if err != nil || len(page) != 50 || next != 150 {
+		t.Fatalf("stale page not served to its caller: len=%d next=%d err=%v", len(page), next, err)
 	}
 	pend := p.pending["YOUR MUSIC"]
 	if pend == nil || len(pend.tracks) != 50 || pend.want != 50 {

--- a/external/spotify/provider_paging_test.go
+++ b/external/spotify/provider_paging_test.go
@@ -290,3 +290,80 @@ func TestTracksGivesUpOnAContinuouslyChangingLibrary(t *testing.T) {
 		t.Error("cached a list assembled from a library that never settled")
 	}
 }
+
+// Backing out of a still-loading list and re-entering must not refetch the
+// pages already paid for; the accumulation resumes where it stopped.
+func TestTracksPageResumesAnAbandonedLoad(t *testing.T) {
+	calls := 0
+	p := savedTracksProvider(t, 200, &calls)
+
+	if _, next, err := p.TracksPage("YOUR MUSIC", 0); err != nil || next != 50 {
+		t.Fatalf("page 0: next=%d err=%v", next, err)
+	}
+	if _, next, err := p.TracksPage("YOUR MUSIC", 50); err != nil || next != 100 {
+		t.Fatalf("page 50: next=%d err=%v", next, err)
+	}
+	calls = 0
+
+	page, next, err := p.TracksPage("YOUR MUSIC", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page) != 100 {
+		t.Errorf("resumed with %d tracks, want the 100 already loaded", len(page))
+	}
+	if next != 100 {
+		t.Errorf("resumed at offset %d, want 100", next)
+	}
+	if calls != 1 {
+		t.Errorf("made %d requests to resume, want 1 (page 0 only)", calls)
+	}
+
+	if got := drainFrom(t, p, next) + len(page); got != 200 {
+		t.Errorf("collected %d tracks in total, want 200", got)
+	}
+	if cached := p.trackCache["YOUR MUSIC"]; cached == nil || len(cached.tracks) != 200 {
+		t.Error("resumed load did not commit a complete cache")
+	}
+}
+
+// A library that changed while the user was away must discard the abandoned
+// accumulation rather than resuming onto a different snapshot.
+func TestTracksPageDiscardsAbandonedLoadWhenLibraryChanged(t *testing.T) {
+	calls := 0
+	p := mutatingSavedTracks(t, 200, 0, &calls)
+
+	if _, next, err := p.TracksPage("YOUR MUSIC", 0); err != nil || next != 50 {
+		t.Fatalf("page 0: next=%d err=%v", next, err)
+	}
+	if _, _, err := p.TracksPage("YOUR MUSIC", 50); err != nil {
+		t.Fatal(err)
+	}
+	// Someone likes a track while the list is closed.
+	p.pending["YOUR MUSIC"].total = 199
+
+	page, next, err := p.TracksPage("YOUR MUSIC", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page) != 50 || next != 50 {
+		t.Errorf("got %d tracks and next=%d, want a fresh page 0 of 50 and next=50", len(page), next)
+	}
+	if pend := p.pending["YOUR MUSIC"]; pend == nil || len(pend.tracks) != 50 || pend.total != 200 {
+		t.Error("stale accumulation survived a snapshot change")
+	}
+}
+
+func drainFrom(t *testing.T, p *SpotifyProvider, offset int) int {
+	t.Helper()
+	got := 0
+	for offset != 0 {
+		page, next, err := p.TracksPage("YOUR MUSIC", offset)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got += len(page)
+		offset = next
+	}
+	return got
+}

--- a/external/spotify/provider_paging_test.go
+++ b/external/spotify/provider_paging_test.go
@@ -264,6 +264,9 @@ func TestTracksRestartsWhenLibraryChangesMidLoad(t *testing.T) {
 	if len(tracks) != 121 {
 		t.Errorf("got %d tracks, want 121 from a single settled snapshot", len(tracks))
 	}
+	if len(tracks) > 0 && tracks[0].Path != "spotify:track:new0" {
+		t.Errorf("newest track is %s, want the settled snapshot's new0", tracks[0].Path)
+	}
 	seen := make(map[string]bool, len(tracks))
 	for _, tr := range tracks {
 		if seen[tr.Path] {

--- a/external/spotify/provider_paging_test.go
+++ b/external/spotify/provider_paging_test.go
@@ -206,3 +206,84 @@ func TestTracksPageAbandonsLoadWhenLibraryChangesMidLoad(t *testing.T) {
 		t.Errorf("committed a cache spanning two library snapshots (%d tracks)", len(cached.tracks))
 	}
 }
+
+// mutatingSavedTracks models a library that grows while it is being read. A
+// like prepends, so at snapshot k index i holds new{k-1-i} for the k newest
+// entries and t{i-k} below them -- meaning pages read either side of a change
+// overlap by one. bumps caps how many times the library moves.
+func mutatingSavedTracks(t *testing.T, start, bumps int, calls *int) *SpotifyProvider {
+	t.Helper()
+	total := start
+	done := 0
+	body := func(offset, limit, total, shift int) string {
+		var items []string
+		for i := offset; i < total && i < offset+limit; i++ {
+			id := fmt.Sprintf("t%d", i-shift)
+			if i < shift {
+				id = fmt.Sprintf("new%d", shift-1-i)
+			}
+			items = append(items, fmt.Sprintf(
+				`{"track":{"id":"%s","name":"%s","type":"track","uri":"spotify:track:%s"}}`, id, id, id))
+		}
+		return fmt.Sprintf(`{"items":[%s],"total":%d}`, strings.Join(items, ","), total)
+	}
+	originalTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/v1/me/tracks" {
+			return nil, fmt.Errorf("unexpected Spotify API path %q", req.URL.Path)
+		}
+		*calls++
+		offset, _ := strconv.Atoi(req.URL.Query().Get("offset"))
+		limit, _ := strconv.Atoi(req.URL.Query().Get("limit"))
+		out := body(offset, limit, total, done)
+		if offset == 0 && done < bumps {
+			total++
+			done++
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(out)),
+			Request:    req,
+		}, nil
+	})
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	sess := &Session{tokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "token"})}
+	return New(sess, "client", 320)
+}
+
+func TestTracksRestartsWhenLibraryChangesMidLoad(t *testing.T) {
+	calls := 0
+	p := mutatingSavedTracks(t, 120, 1, &calls)
+
+	tracks, err := p.Tracks("YOUR MUSIC")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tracks) != 121 {
+		t.Errorf("got %d tracks, want 121 from a single settled snapshot", len(tracks))
+	}
+	seen := make(map[string]bool, len(tracks))
+	for _, tr := range tracks {
+		if seen[tr.Path] {
+			t.Fatalf("duplicate %s: the list was spliced across two snapshots", tr.Path)
+		}
+		seen[tr.Path] = true
+	}
+	if cached := p.trackCache["YOUR MUSIC"]; cached == nil || cached.total != 121 {
+		t.Errorf("cached total = %v, want 121", cached)
+	}
+}
+
+func TestTracksGivesUpOnAContinuouslyChangingLibrary(t *testing.T) {
+	calls := 0
+	p := mutatingSavedTracks(t, 120, 99, &calls)
+
+	if _, err := p.Tracks("YOUR MUSIC"); err == nil {
+		t.Fatal("expected an error when the library never settles")
+	}
+	if _, ok := p.trackCache["YOUR MUSIC"]; ok {
+		t.Error("cached a list assembled from a library that never settled")
+	}
+}

--- a/external/spotify/provider_paging_test.go
+++ b/external/spotify/provider_paging_test.go
@@ -158,26 +158,6 @@ func TestTracksPageAbortedLoadDoesNotCache(t *testing.T) {
 	}
 }
 
-// A library that changes mid-load shifts every later offset, so pages from two
-// snapshots would splice into a list short by one and duplicated by one. The
-// revalidation probe cannot see that, so the accumulation must refuse to commit.
-func TestTracksPageAbandonsLoadWhenLibraryChangesMidLoad(t *testing.T) {
-	calls := 0
-	total := 120
-	p := stubSavedTracks(t, &calls, func(offset, limit int) string {
-		body := savedTracksBodyShift(offset, limit, total, 0)
-		if offset == 0 {
-			total++ // someone liked a track while page 1 was in flight
-		}
-		return body
-	})
-	drainSavedTracks(t, p)
-
-	if cached, ok := p.trackCache["YOUR MUSIC"]; ok && cached.tracks != nil {
-		t.Errorf("committed a cache spanning two library snapshots (%d tracks)", len(cached.tracks))
-	}
-}
-
 // savedTracksBodyShift renders a saved-tracks page for a library that has had
 // shift entries prepended: index i holds new{shift-1-i} for the newest ones and
 // t{i-shift} below them, which is how a like actually moves every later index.
@@ -209,6 +189,69 @@ func mutatingSavedTracks(t *testing.T, start, bumps int, calls *int) *SpotifyPro
 		}
 		return body
 	})
+}
+
+// A library that changes mid-load shifts every later offset, so pages from two
+// snapshots would splice into a list short by one and duplicated by one. The
+// revalidation probe cannot see that, so the load must refuse to commit -- and
+// must stop, since every later page would mismatch the pinned snapshot too.
+func TestTracksPageAbandonsLoadWhenLibraryChangesMidLoad(t *testing.T) {
+	calls := 0
+	total := 120
+	p := stubSavedTracks(t, &calls, func(offset, limit int) string {
+		body := savedTracksBodyShift(offset, limit, total, 0)
+		if offset == 0 {
+			total++ // someone liked a track while page 1 was in flight
+		}
+		return body
+	})
+
+	var err error
+	for offset := 0; ; {
+		var next int
+		if _, next, err = p.TracksPage("YOUR MUSIC", offset); err != nil || next == 0 {
+			break
+		}
+		offset = next
+	}
+
+	if err == nil {
+		t.Error("a load spanning two snapshots was allowed to run to completion")
+	}
+	if cached, ok := p.trackCache["YOUR MUSIC"]; ok && cached.tracks != nil {
+		t.Errorf("committed a cache spanning two library snapshots (%d tracks)", len(cached.tracks))
+	}
+	if _, ok := p.pending["YOUR MUSIC"]; ok {
+		t.Error("a doomed accumulation was left behind")
+	}
+}
+
+// Drift is detected on the page that carries the new total, and nothing after
+// it can ever be accumulated. Continuing would spend the rest of the library's
+// pages on a result already destined to be discarded.
+func TestTracksPageStopsSpendingRequestsAfterDrift(t *testing.T) {
+	calls := 0
+	total := 1000
+	p := stubSavedTracks(t, &calls, func(offset, limit int) string {
+		body := savedTracksBodyShift(offset, limit, total, 0)
+		if offset == 200 {
+			total-- // a track is removed while page 200 is in flight
+		}
+		return body
+	})
+
+	for offset := 0; ; {
+		_, next, err := p.TracksPage("YOUR MUSIC", offset)
+		if err != nil || next == 0 {
+			break
+		}
+		offset = next
+	}
+
+	// Pages 0..200 are five requests; the sixth carries the changed total.
+	if calls != 6 {
+		t.Errorf("made %d requests, want 6: the chain kept fetching past the drift", calls)
+	}
 }
 
 func TestTracksRestartsWhenLibraryChangesMidLoad(t *testing.T) {

--- a/external/spotify/provider_paging_test.go
+++ b/external/spotify/provider_paging_test.go
@@ -1,0 +1,132 @@
+package spotify
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	"golang.org/x/oauth2"
+)
+
+func savedTracksBody(offset, limit, total int) string {
+	var items []string
+	for i := offset; i < total && i < offset+limit; i++ {
+		items = append(items, fmt.Sprintf(
+			`{"track":{"id":"t%d","name":"Track %d","type":"track","uri":"spotify:track:t%d"}}`, i, i, i))
+	}
+	return fmt.Sprintf(`{"items":[%s],"total":%d}`, strings.Join(items, ","), total)
+}
+
+func savedTracksProvider(t *testing.T, total int, calls *int) *SpotifyProvider {
+	t.Helper()
+	originalTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/v1/me/tracks" {
+			return nil, fmt.Errorf("unexpected Spotify API path %q", req.URL.Path)
+		}
+		*calls++
+		offset, _ := strconv.Atoi(req.URL.Query().Get("offset"))
+		limit, _ := strconv.Atoi(req.URL.Query().Get("limit"))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(savedTracksBody(offset, limit, total))),
+			Request:    req,
+		}, nil
+	})
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	sess := &Session{tokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "token"})}
+	return New(sess, "client", 320)
+}
+
+func drainSavedTracks(t *testing.T, p *SpotifyProvider) int {
+	t.Helper()
+	got, offset := 0, 0
+	for {
+		page, next, err := p.TracksPage("YOUR MUSIC", offset)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got += len(page)
+		if next == 0 {
+			return got
+		}
+		offset = next
+	}
+}
+
+func TestTracksPagePagesThroughSavedTracks(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		total     int
+		wantPages int
+	}{
+		{name: "empty", total: 0, wantPages: 1},
+		{name: "single partial page", total: 20, wantPages: 1},
+		{name: "exact page boundary", total: 100, wantPages: 2},
+		{name: "multiple pages", total: 120, wantPages: 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			p := savedTracksProvider(t, tc.total, &calls)
+			if got := drainSavedTracks(t, p); got != tc.total {
+				t.Errorf("collected %d tracks, want %d", got, tc.total)
+			}
+			if calls != tc.wantPages {
+				t.Errorf("made %d requests, want %d", calls, tc.wantPages)
+			}
+		})
+	}
+}
+
+func TestTracksPageRevalidatesCachedSavedTracks(t *testing.T) {
+	calls := 0
+	p := savedTracksProvider(t, 120, &calls)
+	if got := drainSavedTracks(t, p); got != 120 {
+		t.Fatalf("first load collected %d tracks, want 120", got)
+	}
+	afterLoad := calls
+
+	if got := drainSavedTracks(t, p); got != 120 {
+		t.Fatalf("cached load collected %d tracks, want 120", got)
+	}
+	if calls != afterLoad+1 {
+		t.Errorf("cached load made %d requests, want 1 revalidation probe", calls-afterLoad)
+	}
+}
+
+func TestTracksPageRefetchesWhenSavedTracksChanged(t *testing.T) {
+	calls := 0
+	p := savedTracksProvider(t, 120, &calls)
+	if got := drainSavedTracks(t, p); got != 120 {
+		t.Fatalf("first load collected %d tracks, want 120", got)
+	}
+
+	calls = 0
+	p2 := savedTracksProvider(t, 140, &calls)
+	p2.trackCache = p.trackCache
+	if got := drainSavedTracks(t, p2); got != 140 {
+		t.Errorf("collected %d tracks, want 140 after change", got)
+	}
+	if calls < 4 {
+		t.Errorf("made %d requests, want a probe plus 3 pages", calls)
+	}
+}
+
+func TestTracksPageAbortedLoadDoesNotCache(t *testing.T) {
+	calls := 0
+	p := savedTracksProvider(t, 120, &calls)
+	if _, next, err := p.TracksPage("YOUR MUSIC", 0); err != nil || next != 50 {
+		t.Fatalf("first page: next=%d err=%v", next, err)
+	}
+	if cached, ok := p.trackCache["YOUR MUSIC"]; ok && cached.tracks != nil {
+		t.Error("partial load committed to cache")
+	}
+	if got := drainSavedTracks(t, p); got != 120 {
+		t.Errorf("restart collected %d tracks, want 120", got)
+	}
+}

--- a/external/spotify/provider_paging_test.go
+++ b/external/spotify/provider_paging_test.go
@@ -207,6 +207,22 @@ func TestTracksPageAbandonsLoadWhenLibraryChangesMidLoad(t *testing.T) {
 	}
 }
 
+// savedTracksBodyShift renders a saved-tracks page for a library that has had
+// shift entries prepended: index i holds new{shift-1-i} for the newest ones and
+// t{i-shift} below them, which is how a like actually moves every later index.
+func savedTracksBodyShift(offset, limit, total, shift int) string {
+	var items []string
+	for i := offset; i < total && i < offset+limit; i++ {
+		id := fmt.Sprintf("t%d", i-shift)
+		if i < shift {
+			id = fmt.Sprintf("new%d", shift-1-i)
+		}
+		items = append(items, fmt.Sprintf(
+			`{"track":{"id":"%s","name":"%s","type":"track","uri":"spotify:track:%s"}}`, id, id, id))
+	}
+	return fmt.Sprintf(`{"items":[%s],"total":%d}`, strings.Join(items, ","), total)
+}
+
 // mutatingSavedTracks models a library that grows while it is being read. A
 // like prepends, so at snapshot k index i holds new{k-1-i} for the k newest
 // entries and t{i-k} below them -- meaning pages read either side of a change
@@ -215,18 +231,6 @@ func mutatingSavedTracks(t *testing.T, start, bumps int, calls *int) *SpotifyPro
 	t.Helper()
 	total := start
 	done := 0
-	body := func(offset, limit, total, shift int) string {
-		var items []string
-		for i := offset; i < total && i < offset+limit; i++ {
-			id := fmt.Sprintf("t%d", i-shift)
-			if i < shift {
-				id = fmt.Sprintf("new%d", shift-1-i)
-			}
-			items = append(items, fmt.Sprintf(
-				`{"track":{"id":"%s","name":"%s","type":"track","uri":"spotify:track:%s"}}`, id, id, id))
-		}
-		return fmt.Sprintf(`{"items":[%s],"total":%d}`, strings.Join(items, ","), total)
-	}
 	originalTransport := http.DefaultTransport
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		if req.URL.Path != "/v1/me/tracks" {
@@ -235,7 +239,7 @@ func mutatingSavedTracks(t *testing.T, start, bumps int, calls *int) *SpotifyPro
 		*calls++
 		offset, _ := strconv.Atoi(req.URL.Query().Get("offset"))
 		limit, _ := strconv.Atoi(req.URL.Query().Get("limit"))
-		out := body(offset, limit, total, done)
+		out := savedTracksBodyShift(offset, limit, total, done)
 		if offset == 0 && done < bumps {
 			total++
 			done++
@@ -366,4 +370,57 @@ func drainFrom(t *testing.T, p *SpotifyProvider, offset int) int {
 		offset = next
 	}
 	return got
+}
+
+// A same-total swap while the list is closed -- one track unliked, another
+// liked -- leaves the total intact but moves the head. Resuming onto that
+// accumulation would splice the old ordering onto a new suffix, so the head
+// comparison must discard it even though the total still matches.
+func TestTracksPageDiscardsAbandonedLoadWhenHeadChangedAtSameTotal(t *testing.T) {
+	calls := 0
+	shift := 0
+	const total = 200
+	originalTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/v1/me/tracks" {
+			return nil, fmt.Errorf("unexpected Spotify API path %q", req.URL.Path)
+		}
+		calls++
+		offset, _ := strconv.Atoi(req.URL.Query().Get("offset"))
+		limit, _ := strconv.Atoi(req.URL.Query().Get("limit"))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(savedTracksBodyShift(offset, limit, total, shift))),
+			Request:    req,
+		}, nil
+	})
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	sess := &Session{tokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "token"})}
+	p := New(sess, "client", 320)
+
+	if _, next, err := p.TracksPage("YOUR MUSIC", 0); err != nil || next != 50 {
+		t.Fatalf("page 0: next=%d err=%v", next, err)
+	}
+	if _, _, err := p.TracksPage("YOUR MUSIC", 50); err != nil {
+		t.Fatal(err)
+	}
+	shift = 1 // one unliked, one liked: same total, different head
+
+	page, next, err := p.TracksPage("YOUR MUSIC", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page) != 50 || next != 50 {
+		t.Fatalf("got %d tracks and next=%d, want a fresh page 0 of 50 and next=50", len(page), next)
+	}
+	pend := p.pending["YOUR MUSIC"]
+	if pend == nil || len(pend.tracks) != 50 {
+		t.Fatalf("stale accumulation survived a same-total head change: %v", pend)
+	}
+	if pend.tracks[0].Path != "spotify:track:new0" {
+		t.Errorf("restarted accumulation begins with %s, want the new head", pend.tracks[0].Path)
+	}
 }

--- a/external/spotify/provider_paging_test.go
+++ b/external/spotify/provider_paging_test.go
@@ -108,12 +108,50 @@ func TestTracksPageRefetchesWhenSavedTracksChanged(t *testing.T) {
 
 	calls = 0
 	p2 := savedTracksProvider(t, 140, &calls)
-	p2.trackCache = p.trackCache
+	p2.trackCache["YOUR MUSIC"] = p.trackCache["YOUR MUSIC"]
 	if got := drainSavedTracks(t, p2); got != 140 {
 		t.Errorf("collected %d tracks, want 140 after change", got)
 	}
-	if calls < 4 {
-		t.Errorf("made %d requests, want a probe plus 3 pages", calls)
+	if calls != 4 {
+		t.Errorf("made %d requests, want 4 (probe plus 3 pages)", calls)
+	}
+}
+
+// A same-size library whose newest entry changed is the case the total check
+// alone cannot see; only the newest-URI comparison catches it.
+func TestTracksPageRefetchesWhenNewestSavedTrackChanged(t *testing.T) {
+	calls := 0
+	p := savedTracksProvider(t, 60, &calls)
+	if got := drainSavedTracks(t, p); got != 60 {
+		t.Fatalf("first load collected %d tracks, want 60", got)
+	}
+
+	cached := p.trackCache["YOUR MUSIC"]
+	cached.tracks[0].Path = "spotify:track:replaced"
+
+	calls = 0
+	if got := drainSavedTracks(t, p); got != 60 {
+		t.Errorf("collected %d tracks, want 60", got)
+	}
+	if calls != 3 {
+		t.Errorf("made %d requests, want 3 (probe plus 2 pages)", calls)
+	}
+}
+
+func TestTracksPageIgnoresNonContiguousPages(t *testing.T) {
+	calls := 0
+	p := savedTracksProvider(t, 200, &calls)
+	if _, next, err := p.TracksPage("YOUR MUSIC", 0); err != nil || next != 50 {
+		t.Fatalf("first page: next=%d err=%v", next, err)
+	}
+	// A page from a superseded chain lands at an offset the current
+	// accumulation is not waiting for; it must not be spliced in.
+	if _, _, err := p.TracksPage("YOUR MUSIC", 100); err != nil {
+		t.Fatal(err)
+	}
+	pend := p.pending["YOUR MUSIC"]
+	if pend == nil || len(pend.tracks) != 50 || pend.want != 50 {
+		t.Fatalf("non-contiguous page polluted accumulation: len=%d want=%d", len(pend.tracks), pend.want)
 	}
 }
 

--- a/external/spotify/provider_paging_test.go
+++ b/external/spotify/provider_paging_test.go
@@ -169,3 +169,40 @@ func TestTracksPageAbortedLoadDoesNotCache(t *testing.T) {
 		t.Errorf("restart collected %d tracks, want 120", got)
 	}
 }
+
+// A library that changes mid-load shifts every later offset, so pages from two
+// snapshots would splice into a list short by one and duplicated by one. The
+// revalidation probe cannot see that, so the accumulation must refuse to commit.
+func TestTracksPageAbandonsLoadWhenLibraryChangesMidLoad(t *testing.T) {
+	calls := 0
+	total := 120
+	originalTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/v1/me/tracks" {
+			return nil, fmt.Errorf("unexpected Spotify API path %q", req.URL.Path)
+		}
+		calls++
+		offset, _ := strconv.Atoi(req.URL.Query().Get("offset"))
+		limit, _ := strconv.Atoi(req.URL.Query().Get("limit"))
+		body := savedTracksBody(offset, limit, total)
+		if offset == 0 {
+			total++ // someone liked a track while page 1 was in flight
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	sess := &Session{tokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "token"})}
+	p := New(sess, "client", 320)
+	drainSavedTracks(t, p)
+
+	if cached, ok := p.trackCache["YOUR MUSIC"]; ok && cached.tracks != nil {
+		t.Errorf("committed a cache spanning two library snapshots (%d tracks)", len(cached.tracks))
+	}
+}

--- a/external/spotify/provider_paging_test.go
+++ b/external/spotify/provider_paging_test.go
@@ -406,16 +406,16 @@ func TestTracksPageDiscardsAbandonedLoadWhenHeadChangedAtSameTotal(t *testing.T)
 	}
 }
 
-// Accumulations are keyed by playlist, so several lists can each be abandoned
-// part-way and later resume from their own stopping point.
-func TestTracksPageResumesEachPlaylistIndependently(t *testing.T) {
-	totals := map[string]int{"alpha": 200, "beta": 150}
+// An ordinary playlist can be edited anywhere, so an unchanged total and head
+// prove nothing about the pages already read: a same-total edit below the head
+// would shift every later offset and stitch the halves together a track short.
+// Only saved tracks resume; everything else restarts from a clean page 0.
+func TestTracksPageDoesNotResumeOrdinaryPlaylists(t *testing.T) {
+	const total = 200
 	calls := 0
 	originalTransport := http.DefaultTransport
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		id := strings.TrimSuffix(strings.TrimPrefix(req.URL.Path, "/v1/playlists/"), "/items")
-		total, ok := totals[id]
-		if !ok {
+		if req.URL.Path != "/v1/playlists/alpha/items" {
 			return nil, fmt.Errorf("unexpected Spotify API path %q", req.URL.Path)
 		}
 		calls++
@@ -424,55 +424,77 @@ func TestTracksPageResumesEachPlaylistIndependently(t *testing.T) {
 		var items []string
 		for i := offset; i < total && i < offset+limit; i++ {
 			items = append(items, fmt.Sprintf(
-				`{"item":{"id":"%s%d","name":"n","type":"track","uri":"spotify:track:%s%d"}}`, id, i, id, i))
+				`{"item":{"id":"p%d","name":"n","type":"track","uri":"spotify:track:p%d"}}`, i, i))
 		}
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Status:     "200 OK",
-			Header:     make(http.Header),
+		return &http.Response{StatusCode: http.StatusOK, Status: "200 OK", Header: make(http.Header),
 			Body: io.NopCloser(strings.NewReader(
 				fmt.Sprintf(`{"items":[%s],"total":%d}`, strings.Join(items, ","), total))),
-			Request: req,
-		}, nil
+			Request: req}, nil
 	})
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
 
 	sess := &Session{tokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "token"})}
 	p := New(sess, "client", 320)
 
-	// Get two lists part-way, abandoning each.
-	for _, step := range []struct {
-		id     string
-		stopAt int
-	}{{"alpha", 100}, {"beta", 50}} {
-		offset := 0
-		for offset < step.stopAt {
-			_, next, err := p.TracksPage(step.id, offset)
-			if err != nil {
-				t.Fatal(err)
-			}
-			offset = next
-		}
-	}
-
-	for _, want := range []struct {
-		id     string
-		tracks int
-		next   int
-	}{{"alpha", 100, 100}, {"beta", 50, 50}} {
-		calls = 0
-		page, next, err := p.TracksPage(want.id, 0)
+	for offset := 0; offset < 100; {
+		_, next, err := p.TracksPage("alpha", offset)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if len(page) != want.tracks || next != want.next {
-			t.Errorf("%s resumed with %d tracks at %d, want %d at %d", want.id, len(page), next, want.tracks, want.next)
+		offset = next
+	}
+
+	page, next, err := p.TracksPage("alpha", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page) != 50 || next != 50 {
+		t.Errorf("got %d tracks and next=%d, want a fresh page 0 of 50 and next=50", len(page), next)
+	}
+	if page[0].Path != "spotify:track:p0" {
+		t.Errorf("restarted page 0 begins with %s, want the head of the playlist", page[0].Path)
+	}
+}
+
+// Saved albums come from /v1/albums/{id}/tracks, not the playlist-items
+// endpoint. Every Spotify list opens through TracksPage now, so without a guard
+// here an album ID would be spliced into a playlist URL.
+func TestTracksPageServesSavedAlbumsWholly(t *testing.T) {
+	var paths []string
+	originalTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		paths = append(paths, req.URL.Path)
+		var body string
+		switch {
+		case strings.HasPrefix(req.URL.Path, "/v1/albums/") && strings.HasSuffix(req.URL.Path, "/tracks"):
+			body = `{"items":[{"id":"a1","name":"One","type":"track","uri":"spotify:track:a1"},` +
+				`{"id":"a2","name":"Two","type":"track","uri":"spotify:track:a2"}],"total":2}`
+		case strings.HasPrefix(req.URL.Path, "/v1/albums/"):
+			body = `{"id":"alb","name":"Album","total_tracks":2,"artists":[{"name":"Artist"}]}`
+		default:
+			return nil, fmt.Errorf("unexpected Spotify API path %q", req.URL.Path)
 		}
-		if calls != 1 {
-			t.Errorf("%s took %d requests to resume, want 1", want.id, calls)
-		}
-		if page[0].Path != fmt.Sprintf("spotify:track:%s0", want.id) {
-			t.Errorf("%s resumed with another playlist's tracks: %s", want.id, page[0].Path)
+		return &http.Response{StatusCode: http.StatusOK, Status: "200 OK", Header: make(http.Header),
+			Body: io.NopCloser(strings.NewReader(body)), Request: req}, nil
+	})
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	sess := &Session{tokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "token"})}
+	p := New(sess, "client", 320)
+
+	tracks, next, err := p.TracksPage(savedAlbumIDPrefix+"alb", 0)
+	if err != nil {
+		t.Fatalf("saved album failed to load: %v", err)
+	}
+	if next != 0 {
+		t.Errorf("next = %d, want 0: an album arrives whole", next)
+	}
+	if len(tracks) != 2 {
+		t.Errorf("got %d tracks, want 2", len(tracks))
+	}
+	for _, path := range paths {
+		if strings.HasPrefix(path, "/v1/playlists/") {
+			t.Errorf("an album ID was routed to the playlist-items endpoint: %s", path)
 		}
 	}
 }

--- a/external/spotify/provider_paging_test.go
+++ b/external/spotify/provider_paging_test.go
@@ -424,3 +424,74 @@ func TestTracksPageDiscardsAbandonedLoadWhenHeadChangedAtSameTotal(t *testing.T)
 		t.Errorf("restarted accumulation begins with %s, want the new head", pend.tracks[0].Path)
 	}
 }
+
+// Accumulations are keyed by playlist, so several lists can each be abandoned
+// part-way and later resume from their own stopping point.
+func TestTracksPageResumesEachPlaylistIndependently(t *testing.T) {
+	totals := map[string]int{"alpha": 200, "beta": 150}
+	calls := 0
+	originalTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		id := strings.TrimSuffix(strings.TrimPrefix(req.URL.Path, "/v1/playlists/"), "/items")
+		total, ok := totals[id]
+		if !ok {
+			return nil, fmt.Errorf("unexpected Spotify API path %q", req.URL.Path)
+		}
+		calls++
+		offset, _ := strconv.Atoi(req.URL.Query().Get("offset"))
+		limit, _ := strconv.Atoi(req.URL.Query().Get("limit"))
+		var items []string
+		for i := offset; i < total && i < offset+limit; i++ {
+			items = append(items, fmt.Sprintf(
+				`{"item":{"id":"%s%d","name":"n","type":"track","uri":"spotify:track:%s%d"}}`, id, i, id, i))
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     make(http.Header),
+			Body: io.NopCloser(strings.NewReader(
+				fmt.Sprintf(`{"items":[%s],"total":%d}`, strings.Join(items, ","), total))),
+			Request: req,
+		}, nil
+	})
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	sess := &Session{tokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "token"})}
+	p := New(sess, "client", 320)
+
+	// Get two lists part-way, abandoning each.
+	for _, step := range []struct {
+		id     string
+		stopAt int
+	}{{"alpha", 100}, {"beta", 50}} {
+		offset := 0
+		for offset < step.stopAt {
+			_, next, err := p.TracksPage(step.id, offset)
+			if err != nil {
+				t.Fatal(err)
+			}
+			offset = next
+		}
+	}
+
+	for _, want := range []struct {
+		id     string
+		tracks int
+		next   int
+	}{{"alpha", 100, 100}, {"beta", 50, 50}} {
+		calls = 0
+		page, next, err := p.TracksPage(want.id, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(page) != want.tracks || next != want.next {
+			t.Errorf("%s resumed with %d tracks at %d, want %d at %d", want.id, len(page), next, want.tracks, want.next)
+		}
+		if calls != 1 {
+			t.Errorf("%s took %d requests to resume, want 1", want.id, calls)
+		}
+		if page[0].Path != fmt.Sprintf("spotify:track:%s0", want.id) {
+			t.Errorf("%s resumed with another playlist's tracks: %s", want.id, page[0].Path)
+		}
+	}
+}

--- a/external/spotify/provider_paging_test.go
+++ b/external/spotify/provider_paging_test.go
@@ -406,35 +406,76 @@ func TestTracksPageDiscardsAbandonedLoadWhenHeadChangedAtSameTotal(t *testing.T)
 	}
 }
 
-// An ordinary playlist can be edited anywhere, so an unchanged total and head
-// prove nothing about the pages already read: a same-total edit below the head
-// would shift every later offset and stitch the halves together a track short.
-// Only saved tracks resume; everything else restarts from a clean page 0.
-func TestTracksPageDoesNotResumeOrdinaryPlaylists(t *testing.T) {
-	const total = 200
-	calls := 0
+// playlistStub serves one playlist's items plus its snapshot_id, so a test can
+// move the playlist underneath a load without changing its length.
+func playlistStub(t *testing.T, id string, total int, snapshot, prefix *string, calls *int) *SpotifyProvider {
+	t.Helper()
 	originalTransport := http.DefaultTransport
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		if req.URL.Path != "/v1/playlists/alpha/items" {
-			return nil, fmt.Errorf("unexpected Spotify API path %q", req.URL.Path)
+		*calls++
+		switch req.URL.Path {
+		case "/v1/playlists/" + id:
+			return jsonResponse(req, fmt.Sprintf(`{"snapshot_id":%q}`, *snapshot))
+		case "/v1/playlists/" + id + "/items":
+			offset, _ := strconv.Atoi(req.URL.Query().Get("offset"))
+			limit, _ := strconv.Atoi(req.URL.Query().Get("limit"))
+			var items []string
+			for i := offset; i < total && i < offset+limit; i++ {
+				items = append(items, fmt.Sprintf(
+					`{"item":{"id":"%s%d","name":"n","type":"track","uri":"spotify:track:%s%d"}}`,
+					*prefix, i, *prefix, i))
+			}
+			return jsonResponse(req, fmt.Sprintf(`{"items":[%s],"total":%d}`, strings.Join(items, ","), total))
 		}
-		calls++
-		offset, _ := strconv.Atoi(req.URL.Query().Get("offset"))
-		limit, _ := strconv.Atoi(req.URL.Query().Get("limit"))
-		var items []string
-		for i := offset; i < total && i < offset+limit; i++ {
-			items = append(items, fmt.Sprintf(
-				`{"item":{"id":"p%d","name":"n","type":"track","uri":"spotify:track:p%d"}}`, i, i))
-		}
-		return &http.Response{StatusCode: http.StatusOK, Status: "200 OK", Header: make(http.Header),
-			Body: io.NopCloser(strings.NewReader(
-				fmt.Sprintf(`{"items":[%s],"total":%d}`, strings.Join(items, ","), total))),
-			Request: req}, nil
+		return nil, fmt.Errorf("unexpected Spotify API path %q", req.URL.Path)
 	})
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
-
 	sess := &Session{tokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "token"})}
 	p := New(sess, "client", 320)
+	p.trackCache[id] = &playlistCache{snapshotID: *snapshot}
+	return p
+}
+
+func jsonResponse(req *http.Request, body string) (*http.Response, error) {
+	return &http.Response{StatusCode: http.StatusOK, Status: "200 OK", Header: make(http.Header),
+		Body: io.NopCloser(strings.NewReader(body)), Request: req}, nil
+}
+
+// An unchanged snapshot_id is Spotify's own proof that a playlist has not been
+// touched, so the pages already read can be trusted and the load resumes.
+func TestTracksPageResumesPlaylistOnUnchangedSnapshot(t *testing.T) {
+	calls := 0
+	snapshot, prefix := "snap-1", "p"
+	p := playlistStub(t, "alpha", 200, &snapshot, &prefix, &calls)
+
+	for offset := 0; offset < 100; {
+		_, next, err := p.TracksPage("alpha", offset)
+		if err != nil {
+			t.Fatal(err)
+		}
+		offset = next
+	}
+	calls = 0
+
+	page, next, err := p.TracksPage("alpha", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page) != 100 || next != 100 {
+		t.Errorf("resumed with %d tracks at %d, want 100 at 100", len(page), next)
+	}
+	if calls != 2 {
+		t.Errorf("took %d requests to resume, want 2 (page 0 plus the snapshot probe)", calls)
+	}
+}
+
+// A changed snapshot_id means the playlist was edited, and an ordinary playlist
+// can be edited anywhere -- a same-total edit below the head would shift every
+// later offset and stitch the halves together a track short. Restart instead.
+func TestTracksPageRestartsPlaylistOnChangedSnapshot(t *testing.T) {
+	calls := 0
+	snapshot, prefix := "snap-1", "p"
+	p := playlistStub(t, "alpha", 200, &snapshot, &prefix, &calls)
 
 	for offset := 0; offset < 100; {
 		_, next, err := p.TracksPage("alpha", offset)
@@ -444,15 +485,17 @@ func TestTracksPageDoesNotResumeOrdinaryPlaylists(t *testing.T) {
 		offset = next
 	}
 
+	snapshot, prefix = "snap-2", "q" // edited: same length, different contents
+
 	page, next, err := p.TracksPage("alpha", 0)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(page) != 50 || next != 50 {
-		t.Errorf("got %d tracks and next=%d, want a fresh page 0 of 50 and next=50", len(page), next)
+		t.Fatalf("got %d tracks and next=%d, want a fresh page 0 of 50 and next=50", len(page), next)
 	}
-	if page[0].Path != "spotify:track:p0" {
-		t.Errorf("restarted page 0 begins with %s, want the head of the playlist", page[0].Path)
+	if page[0].Path != "spotify:track:q0" {
+		t.Errorf("restarted page 0 begins with %s, want the edited playlist's head", page[0].Path)
 	}
 }
 

--- a/external/spotify/provider_paging_test.go
+++ b/external/spotify/provider_paging_test.go
@@ -11,16 +11,8 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func savedTracksBody(offset, limit, total int) string {
-	var items []string
-	for i := offset; i < total && i < offset+limit; i++ {
-		items = append(items, fmt.Sprintf(
-			`{"track":{"id":"t%d","name":"Track %d","type":"track","uri":"spotify:track:t%d"}}`, i, i, i))
-	}
-	return fmt.Sprintf(`{"items":[%s],"total":%d}`, strings.Join(items, ","), total)
-}
-
-func savedTracksProvider(t *testing.T, total int, calls *int) *SpotifyProvider {
+// stubSavedTracks serves /v1/me/tracks pages rendered by body and counts requests.
+func stubSavedTracks(t *testing.T, calls *int, body func(offset, limit int) string) *SpotifyProvider {
 	t.Helper()
 	originalTransport := http.DefaultTransport
 	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -34,7 +26,7 @@ func savedTracksProvider(t *testing.T, total int, calls *int) *SpotifyProvider {
 			StatusCode: http.StatusOK,
 			Status:     "200 OK",
 			Header:     make(http.Header),
-			Body:       io.NopCloser(strings.NewReader(savedTracksBody(offset, limit, total))),
+			Body:       io.NopCloser(strings.NewReader(body(offset, limit))),
 			Request:    req,
 		}, nil
 	})
@@ -43,20 +35,16 @@ func savedTracksProvider(t *testing.T, total int, calls *int) *SpotifyProvider {
 	return New(sess, "client", 320)
 }
 
+func savedTracksProvider(t *testing.T, total int, calls *int) *SpotifyProvider {
+	t.Helper()
+	return stubSavedTracks(t, calls, func(offset, limit int) string {
+		return savedTracksBodyShift(offset, limit, total, 0)
+	})
+}
+
 func drainSavedTracks(t *testing.T, p *SpotifyProvider) int {
 	t.Helper()
-	got, offset := 0, 0
-	for {
-		page, next, err := p.TracksPage("YOUR MUSIC", offset)
-		if err != nil {
-			t.Fatal(err)
-		}
-		got += len(page)
-		if next == 0 {
-			return got
-		}
-		offset = next
-	}
+	return drainFrom(t, p, 0)
 }
 
 func TestTracksPagePagesThroughSavedTracks(t *testing.T) {
@@ -176,30 +164,13 @@ func TestTracksPageAbortedLoadDoesNotCache(t *testing.T) {
 func TestTracksPageAbandonsLoadWhenLibraryChangesMidLoad(t *testing.T) {
 	calls := 0
 	total := 120
-	originalTransport := http.DefaultTransport
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		if req.URL.Path != "/v1/me/tracks" {
-			return nil, fmt.Errorf("unexpected Spotify API path %q", req.URL.Path)
-		}
-		calls++
-		offset, _ := strconv.Atoi(req.URL.Query().Get("offset"))
-		limit, _ := strconv.Atoi(req.URL.Query().Get("limit"))
-		body := savedTracksBody(offset, limit, total)
+	p := stubSavedTracks(t, &calls, func(offset, limit int) string {
+		body := savedTracksBodyShift(offset, limit, total, 0)
 		if offset == 0 {
 			total++ // someone liked a track while page 1 was in flight
 		}
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Status:     "200 OK",
-			Header:     make(http.Header),
-			Body:       io.NopCloser(strings.NewReader(body)),
-			Request:    req,
-		}, nil
+		return body
 	})
-	t.Cleanup(func() { http.DefaultTransport = originalTransport })
-
-	sess := &Session{tokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "token"})}
-	p := New(sess, "client", 320)
 	drainSavedTracks(t, p)
 
 	if cached, ok := p.trackCache["YOUR MUSIC"]; ok && cached.tracks != nil {
@@ -229,32 +200,15 @@ func savedTracksBodyShift(offset, limit, total, shift int) string {
 // overlap by one. bumps caps how many times the library moves.
 func mutatingSavedTracks(t *testing.T, start, bumps int, calls *int) *SpotifyProvider {
 	t.Helper()
-	total := start
-	done := 0
-	originalTransport := http.DefaultTransport
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		if req.URL.Path != "/v1/me/tracks" {
-			return nil, fmt.Errorf("unexpected Spotify API path %q", req.URL.Path)
-		}
-		*calls++
-		offset, _ := strconv.Atoi(req.URL.Query().Get("offset"))
-		limit, _ := strconv.Atoi(req.URL.Query().Get("limit"))
-		out := savedTracksBodyShift(offset, limit, total, done)
+	total, done := start, 0
+	return stubSavedTracks(t, calls, func(offset, limit int) string {
+		body := savedTracksBodyShift(offset, limit, total, done)
 		if offset == 0 && done < bumps {
 			total++
 			done++
 		}
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Status:     "200 OK",
-			Header:     make(http.Header),
-			Body:       io.NopCloser(strings.NewReader(out)),
-			Request:    req,
-		}, nil
+		return body
 	})
-	t.Cleanup(func() { http.DefaultTransport = originalTransport })
-	sess := &Session{tokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "token"})}
-	return New(sess, "client", 320)
 }
 
 func TestTracksRestartsWhenLibraryChangesMidLoad(t *testing.T) {
@@ -335,7 +289,7 @@ func TestTracksPageResumesAnAbandonedLoad(t *testing.T) {
 // accumulation rather than resuming onto a different snapshot.
 func TestTracksPageDiscardsAbandonedLoadWhenLibraryChanged(t *testing.T) {
 	calls := 0
-	p := mutatingSavedTracks(t, 200, 0, &calls)
+	p := savedTracksProvider(t, 200, &calls)
 
 	if _, next, err := p.TracksPage("YOUR MUSIC", 0); err != nil || next != 50 {
 		t.Fatalf("page 0: next=%d err=%v", next, err)
@@ -361,15 +315,17 @@ func TestTracksPageDiscardsAbandonedLoadWhenLibraryChanged(t *testing.T) {
 func drainFrom(t *testing.T, p *SpotifyProvider, offset int) int {
 	t.Helper()
 	got := 0
-	for offset != 0 {
+	for {
 		page, next, err := p.TracksPage("YOUR MUSIC", offset)
 		if err != nil {
 			t.Fatal(err)
 		}
 		got += len(page)
+		if next == 0 {
+			return got
+		}
 		offset = next
 	}
-	return got
 }
 
 // A same-total swap while the list is closed -- one track unliked, another
@@ -379,27 +335,9 @@ func drainFrom(t *testing.T, p *SpotifyProvider, offset int) int {
 func TestTracksPageDiscardsAbandonedLoadWhenHeadChangedAtSameTotal(t *testing.T) {
 	calls := 0
 	shift := 0
-	const total = 200
-	originalTransport := http.DefaultTransport
-	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		if req.URL.Path != "/v1/me/tracks" {
-			return nil, fmt.Errorf("unexpected Spotify API path %q", req.URL.Path)
-		}
-		calls++
-		offset, _ := strconv.Atoi(req.URL.Query().Get("offset"))
-		limit, _ := strconv.Atoi(req.URL.Query().Get("limit"))
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Status:     "200 OK",
-			Header:     make(http.Header),
-			Body:       io.NopCloser(strings.NewReader(savedTracksBodyShift(offset, limit, total, shift))),
-			Request:    req,
-		}, nil
+	p := stubSavedTracks(t, &calls, func(offset, limit int) string {
+		return savedTracksBodyShift(offset, limit, 200, shift)
 	})
-	t.Cleanup(func() { http.DefaultTransport = originalTransport })
-
-	sess := &Session{tokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "token"})}
-	p := New(sess, "client", 320)
 
 	if _, next, err := p.TracksPage("YOUR MUSIC", 0); err != nil || next != 50 {
 		t.Fatalf("page 0: next=%d err=%v", next, err)

--- a/external/spotify/provider_shared.go
+++ b/external/spotify/provider_shared.go
@@ -27,6 +27,10 @@ const (
 // are bare base62, so the "spotify:album:" prefix never collides with one.
 const savedAlbumIDPrefix = "spotify:album:"
 
+// savedTracksPlaylistID is the synthetic list ID standing in for Liked Songs,
+// which Spotify does not expose through /v1/me/playlists.
+const savedTracksPlaylistID = "YOUR MUSIC"
+
 // savedAlbumSection is the UI section header for the user's saved albums.
 const savedAlbumSection = "Saved albums"
 

--- a/playlist/provider.go
+++ b/playlist/provider.go
@@ -6,6 +6,11 @@ import "errors"
 // before they can be used.
 var ErrNeedsAuth = errors.New("sign-in required")
 
+// ErrListChanged is returned when a list changed underneath a load that was
+// reading it in pages, so the pages already read can no longer be combined
+// into one coherent result. Reopening the list starts a clean load.
+var ErrListChanged = errors.New("list changed while loading")
+
 // PlaylistInfo describes a playlist with its name and track count.
 //
 // DurationSecs is optional: providers that can compute it cheaply should

--- a/provider/interfaces.go
+++ b/provider/interfaces.go
@@ -328,3 +328,9 @@ type FavoritesManager interface {
 	// FavoritesCount returns the number of favorited tracks.
 	FavoritesCount() int
 }
+
+// TrackPager is implemented by providers that can return a playlist's tracks
+// one page at a time so the UI can populate the queue progressively.
+type TrackPager interface {
+	TracksPage(playlistID string, offset int) (tracks []playlist.Track, next int, err error)
+}

--- a/provider/interfaces.go
+++ b/provider/interfaces.go
@@ -330,7 +330,11 @@ type FavoritesManager interface {
 }
 
 // TrackPager is implemented by providers that can return a playlist's tracks
-// one page at a time so the UI can populate the queue progressively.
+// one page at a time so the UI can populate the queue progressively. Pages are
+// requested sequentially: the caller feeds each returned next back in until it
+// is 0. Unlike the Tracks path, paged results are not run through PLS/M3U
+// wrapper resolution and skip the ResumeTarget probe, so only implement this
+// for providers returning direct, already-resolved track URIs.
 type TrackPager interface {
 	TracksPage(playlistID string, offset int) (tracks []playlist.Track, next int, err error)
 }

--- a/ui/model/commands.go
+++ b/ui/model/commands.go
@@ -50,6 +50,16 @@ type ShowStatusMsg struct {
 	Duration time.Duration
 }
 
+type tracksPageMsg struct {
+	tracks       []playlist.Track
+	playlistID   string
+	providerName string
+	offset       int
+	next         int
+	gen          uint64
+	err          error
+}
+
 type tracksLoadedMsg struct {
 	tracks        []playlist.Track
 	playlistID    string
@@ -318,6 +328,13 @@ func saveYTDLCmd(pageURL string, saveDir string) tea.Cmd {
 	return func() tea.Msg {
 		path, err := resolve.DownloadYTDL(pageURL, saveDir)
 		return ytdlSavedMsg{path: path, err: err}
+	}
+}
+
+func fetchTracksPageCmd(pager provider.TrackPager, name, playlistID string, offset int, gen uint64) tea.Cmd {
+	return func() tea.Msg {
+		tracks, next, err := pager.TracksPage(playlistID, offset)
+		return tracksPageMsg{tracks: tracks, playlistID: playlistID, providerName: name, offset: offset, next: next, gen: gen, err: err}
 	}
 }
 

--- a/ui/model/commands.go
+++ b/ui/model/commands.go
@@ -323,6 +323,11 @@ func saveYTDLCmd(pageURL string, saveDir string) tea.Cmd {
 	}
 }
 
+// fetchTracksPageCmd fetches one page of a paged provider's tracks. The chain is
+// driven from the message loop rather than from a goroutine: the handler for the
+// resulting message issues the command for the next offset, so pages stay
+// strictly sequential and a superseded load stops as soon as one of its messages
+// is dropped by the generation guard.
 func fetchTracksPageCmd(pager provider.TrackPager, name, playlistID string, offset int, gen uint64) tea.Cmd {
 	return func() tea.Msg {
 		tracks, next, err := pager.TracksPage(playlistID, offset)

--- a/ui/model/commands.go
+++ b/ui/model/commands.go
@@ -50,16 +50,6 @@ type ShowStatusMsg struct {
 	Duration time.Duration
 }
 
-type tracksPageMsg struct {
-	tracks       []playlist.Track
-	playlistID   string
-	providerName string
-	offset       int
-	next         int
-	gen          uint64
-	err          error
-}
-
 type tracksLoadedMsg struct {
 	tracks        []playlist.Track
 	playlistID    string
@@ -68,6 +58,8 @@ type tracksLoadedMsg struct {
 	gen           uint64
 	resumeIdx     int
 	resumeOffset  time.Duration
+	offset        int // TrackPager: offset this page was fetched at
+	next          int // TrackPager: next offset to fetch, 0 when fully loaded
 	err           error
 }
 
@@ -334,7 +326,7 @@ func saveYTDLCmd(pageURL string, saveDir string) tea.Cmd {
 func fetchTracksPageCmd(pager provider.TrackPager, name, playlistID string, offset int, gen uint64) tea.Cmd {
 	return func() tea.Msg {
 		tracks, next, err := pager.TracksPage(playlistID, offset)
-		return tracksPageMsg{tracks: tracks, playlistID: playlistID, providerName: name, offset: offset, next: next, gen: gen, err: err}
+		return tracksLoadedMsg{tracks: tracks, playlistID: playlistID, providerName: name, offset: offset, next: next, gen: gen, err: err}
 	}
 }
 

--- a/ui/model/ipc_extended.go
+++ b/ui/model/ipc_extended.go
@@ -528,6 +528,11 @@ func (m *Model) handleIPCProviderLoad(result ipcProviderLoadResult) tea.Cmd {
 		result.request.Reply <- ipc.Response{OK: false, Error: result.err.Error()}
 		return nil
 	}
+	// This replaces the queue wholesale, so retire any in-flight paged load:
+	// its later pages would otherwise still pass the generation guard and
+	// append onto the list loaded here.
+	nextRequest(&m.requests.tracks)
+	m.tracksPaging = false
 	m.replacePlaylist(result.tracks)
 	m.loadedPlaylist = result.loaded
 	m.setHeaderStateFromTracks(result.tracks)

--- a/ui/model/model.go
+++ b/ui/model/model.go
@@ -395,6 +395,10 @@ type Model struct {
 
 	showAlbumHeaders bool
 	headerManual     bool
+	// tracksPaging is true while a progressive track load still has pages in
+	// flight. Each page remixes the upcoming order, so preloading is held off
+	// until the order settles. A frontier-EOF deferral would use this too.
+	tracksPaging bool
 	// Running counters for the cohesion heuristic so Add can update header
 	// visibility in O(k) instead of walking the whole playlist on each call.
 	headerLastAlbum string

--- a/ui/model/playback_test.go
+++ b/ui/model/playback_test.go
@@ -35,6 +35,7 @@ type playbackFakeEngine struct {
 	stopCalls           int
 	playGeneration      uint64
 	preloadGeneration   uint64
+	hasPreload          bool
 	eqBands             [eqBandCount]float64
 }
 
@@ -108,7 +109,7 @@ func (f *playbackFakeEngine) CancelSeekYTDL()    { f.cancelSeekYTDLCalls++ }
 func (f *playbackFakeEngine) IsPlaying() bool    { return f.playing }
 func (f *playbackFakeEngine) IsPaused() bool     { return f.paused }
 func (f *playbackFakeEngine) Drained() bool      { return f.drained }
-func (f *playbackFakeEngine) HasPreload() bool   { return false }
+func (f *playbackFakeEngine) HasPreload() bool   { return f.hasPreload }
 func (f *playbackFakeEngine) Seekable() bool     { return f.seekable }
 func (f *playbackFakeEngine) IsStreamSeek() bool { return false }
 func (f *playbackFakeEngine) IsYTDLSeek() bool   { return f.ytdlSeek }

--- a/ui/model/progressive_tracks_test.go
+++ b/ui/model/progressive_tracks_test.go
@@ -167,3 +167,35 @@ func TestPagesDoNotUnpinTheAlbumHeader(t *testing.T) {
 		t.Errorf("album headers = %v after a later page, want %v", m.showAlbumHeaders, pinned)
 	}
 }
+
+// Add mixes a new page into the upcoming shuffle order, so a preload armed for
+// the old order is no longer the next track. Gapless swaps on the audio thread
+// and the model then names the track from playlist.Next(), so keeping a stale
+// preload would play one track while announcing another.
+func TestPageDropsAStalePreload(t *testing.T) {
+	prov := &pagerProv{name: "Pager", pages: [][]playlist.Track{
+		pageOf("a", "b"), pageOf("c", "d"),
+	}}
+	m := newPagingModel(prov)
+	engine := m.player.(*playbackFakeEngine)
+	engine.hasPreload = true
+
+	updated, _ := m.Update(tracksLoadedMsg{
+		tracks: prov.pages[0], playlistID: "list", providerName: "Pager", offset: 0, next: 1, gen: 1,
+	})
+	m = updated.(Model)
+	before := engine.clearPreloadCalls
+	m.preloading = true
+
+	updated, _ = m.Update(tracksLoadedMsg{
+		tracks: prov.pages[1], playlistID: "list", providerName: "Pager", offset: 1, next: 0, gen: 1,
+	})
+	m = updated.(Model)
+
+	if engine.clearPreloadCalls == before {
+		t.Error("appending a page left a stale preload armed")
+	}
+	if m.preloading {
+		t.Error("preloading flag still set; the tick loop will not re-arm")
+	}
+}

--- a/ui/model/progressive_tracks_test.go
+++ b/ui/model/progressive_tracks_test.go
@@ -1,10 +1,14 @@
 package model
 
 import (
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/bjarneo/cliamp/playlist"
 )
+
+var errStubLoad = errors.New("stub load failure")
 
 // pagerProv is a stub provider that serves tracks one page at a time.
 type pagerProv struct {
@@ -197,5 +201,77 @@ func TestPageDropsAStalePreload(t *testing.T) {
 	}
 	if m.preloading {
 		t.Error("preloading flag still set; the tick loop will not re-arm")
+	}
+}
+
+func TestPagingSuppressesPreloadUntilTheOrderSettles(t *testing.T) {
+	prov := &pagerProv{name: "Pager", pages: [][]playlist.Track{
+		pageOf("a", "b"), pageOf("c", "d"),
+	}}
+	m := newPagingModel(prov)
+
+	updated, _ := m.Update(tracksLoadedMsg{
+		tracks: prov.pages[0], playlistID: "list", providerName: "Pager", offset: 0, next: 1, gen: 1,
+	})
+	m = updated.(Model)
+	if !m.tracksPaging {
+		t.Error("tracksPaging not set while pages are still in flight")
+	}
+
+	updated, _ = m.Update(tracksLoadedMsg{
+		tracks: prov.pages[1], playlistID: "list", providerName: "Pager", offset: 1, next: 0, gen: 1,
+	})
+	if updated.(Model).tracksPaging {
+		t.Error("tracksPaging still set after the terminal page")
+	}
+}
+
+func TestPagingFlagClearsOnError(t *testing.T) {
+	prov := &pagerProv{name: "Pager", pages: [][]playlist.Track{pageOf("a")}}
+	m := newPagingModel(prov)
+	m.tracksPaging = true
+
+	updated, _ := m.Update(tracksLoadedMsg{
+		playlistID: "list", providerName: "Pager", offset: 1, gen: 1, err: errStubLoad,
+	})
+	if updated.(Model).tracksPaging {
+		t.Error("a failed page left preloading suppressed for the session")
+	}
+}
+
+// A superseded chain never delivers a terminal page, so the flag has to be
+// reset where the next request is dispatched, not only where pages arrive.
+func TestProviderNavResetClearsThePagingFlag(t *testing.T) {
+	prov := &pagerProv{name: "Pager", pages: [][]playlist.Track{pageOf("a")}}
+	m := newPagingModel(prov)
+	m.tracksPaging = true
+
+	m.resetProviderNav()
+
+	if m.tracksPaging {
+		t.Error("switching provider left preloading suppressed for the session")
+	}
+}
+
+// The tick loop is the main arming path, and it only fires into an empty slot.
+// While pages are landing the order keeps changing, so it must be held off;
+// preloadNext marks m.preloading before returning its command, which is the
+// observable side effect of the guard letting it through.
+func TestTickDoesNotArmPreloadWhilePaging(t *testing.T) {
+	prov := &pagerProv{name: "Pager", pages: [][]playlist.Track{pageOf("a", "b")}}
+	m := newPagingModel(prov)
+	m.playlist.Add(pageOf("a", "b")...)
+	m.player.(*playbackFakeEngine).playing = true
+
+	m.tracksPaging = true
+	updated, _ := m.Update(tickMsg(time.Now()))
+	if updated.(Model).preloading {
+		t.Error("a tick armed a preload while pages were still landing")
+	}
+
+	m.tracksPaging = false
+	updated, _ = m.Update(tickMsg(time.Now()))
+	if !updated.(Model).preloading {
+		t.Fatal("a tick did not arm a preload once paging finished; the test proves nothing")
 	}
 }

--- a/ui/model/progressive_tracks_test.go
+++ b/ui/model/progressive_tracks_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bjarneo/cliamp/ipc"
 	"github.com/bjarneo/cliamp/playlist"
 )
 
@@ -273,5 +274,43 @@ func TestTickDoesNotArmPreloadWhilePaging(t *testing.T) {
 	updated, _ = m.Update(tickMsg(time.Now()))
 	if !updated.(Model).preloading {
 		t.Fatal("a tick did not arm a preload once paging finished; the test proves nothing")
+	}
+}
+
+// An external provider.load replaces the queue wholesale. A paged load still in
+// flight would otherwise keep passing the generation guard and append its
+// remaining pages onto the list the IPC client just installed.
+func TestIPCProviderLoadRetiresAnInFlightPagedLoad(t *testing.T) {
+	prov := &pagerProv{name: "Pager", pages: [][]playlist.Track{
+		pageOf("a", "b"), pageOf("c", "d"),
+	}}
+	m := newPagingModel(prov)
+
+	updated, _ := m.Update(tracksLoadedMsg{
+		tracks: prov.pages[0], playlistID: "list", providerName: "Pager", offset: 0, next: 1, gen: 1,
+	})
+	m = updated.(Model)
+	if !m.tracksPaging {
+		t.Fatal("setup: expected a paged load in flight")
+	}
+
+	reply := make(chan ipc.Response, 1)
+	m.handleIPCProviderLoad(ipcProviderLoadResult{
+		request: ipc.LibraryRequestMsg{Reply: reply},
+		tracks:  pageOf("ipc-1", "ipc-2"),
+		loaded:  "other",
+	})
+
+	if m.tracksPaging {
+		t.Error("an IPC load left the paged load marked in flight")
+	}
+
+	updated, _ = m.Update(tracksLoadedMsg{
+		tracks: prov.pages[1], playlistID: "list", providerName: "Pager", offset: 1, next: 0, gen: 1,
+	})
+	m = updated.(Model)
+
+	if got := m.playlist.Len(); got != 2 {
+		t.Errorf("queue has %d tracks, want the 2 the IPC client loaded: a retired page appended", got)
 	}
 }

--- a/ui/model/progressive_tracks_test.go
+++ b/ui/model/progressive_tracks_test.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -312,5 +313,42 @@ func TestIPCProviderLoadRetiresAnInFlightPagedLoad(t *testing.T) {
 
 	if got := m.playlist.Len(); got != 2 {
 		t.Errorf("queue has %d tracks, want the 2 the IPC client loaded: a retired page appended", got)
+	}
+}
+
+// m.err has no expiry and renders ahead of the status line, so a list that
+// changed mid-load must not land there: the message would sit on screen for
+// the rest of the session and mask every later status.
+func TestListChangedReportsThroughTheStatusLine(t *testing.T) {
+	prov := &pagerProv{name: "Pager", pages: [][]playlist.Track{pageOf("a")}}
+	m := newPagingModel(prov)
+
+	updated, _ := m.Update(tracksLoadedMsg{
+		playlistID: "list", providerName: "Pager", offset: 1, gen: 1,
+		err: fmt.Errorf("spotify: list tracks %q: %w", "YOUR MUSIC", playlist.ErrListChanged),
+	})
+	m = updated.(Model)
+
+	if m.err != nil {
+		t.Errorf("a mid-load change set the permanent error slot: %v", m.err)
+	}
+	if m.status.text == "" {
+		t.Error("no status message shown for a list that changed mid-load")
+	}
+	if m.provLoading || m.tracksPaging {
+		t.Error("the load was not retired after the list changed")
+	}
+}
+
+// Genuine failures should still persist rather than expiring silently.
+func TestOtherLoadFailuresStillPersist(t *testing.T) {
+	prov := &pagerProv{name: "Pager", pages: [][]playlist.Track{pageOf("a")}}
+	m := newPagingModel(prov)
+
+	updated, _ := m.Update(tracksLoadedMsg{
+		playlistID: "list", providerName: "Pager", offset: 1, gen: 1, err: errStubLoad,
+	})
+	if updated.(Model).err == nil {
+		t.Error("a real load failure was downgraded to a transient status message")
 	}
 }

--- a/ui/model/progressive_tracks_test.go
+++ b/ui/model/progressive_tracks_test.go
@@ -108,3 +108,31 @@ func TestLaterPagesAppendWithoutReplacing(t *testing.T) {
 		t.Error("provLoading set after the terminal page")
 	}
 }
+
+// A superseded chain's straggler page must not append to the list the new chain
+// installed. phase0_test covers the offset == 0 shape; this guards the append.
+func TestStaleGenPageDoesNotAppend(t *testing.T) {
+	prov := &pagerProv{name: "Pager", pages: [][]playlist.Track{
+		pageOf("a", "b"),
+		pageOf("c", "d"),
+	}}
+	m := newPagingModel(prov)
+
+	updated, _ := m.Update(tracksLoadedMsg{
+		tracks: prov.pages[0], playlistID: "list", providerName: "Pager", offset: 0, next: 1, gen: 1,
+	})
+	m = updated.(Model)
+	m.requests.tracks = 2 // the user re-entered; chain 1 is now dead
+
+	updated, cmd := m.Update(tracksLoadedMsg{
+		tracks: prov.pages[1], playlistID: "list", providerName: "Pager", offset: 1, next: 0, gen: 1,
+	})
+	m = updated.(Model)
+
+	if got := m.playlist.Len(); got != 2 {
+		t.Errorf("playlist has %d tracks, want 2: a stale page appended", got)
+	}
+	if cmd != nil {
+		t.Error("a stale page dispatched a follow-up request")
+	}
+}

--- a/ui/model/progressive_tracks_test.go
+++ b/ui/model/progressive_tracks_test.go
@@ -1,0 +1,110 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/bjarneo/cliamp/playlist"
+)
+
+// pagerProv is a stub provider that serves tracks one page at a time.
+type pagerProv struct {
+	name  string
+	pages [][]playlist.Track
+}
+
+func (p *pagerProv) Name() string { return p.name }
+
+func (p *pagerProv) Playlists() ([]playlist.PlaylistInfo, error) {
+	return []playlist.PlaylistInfo{{ID: "list", Name: "List"}}, nil
+}
+
+func (p *pagerProv) Tracks(string) ([]playlist.Track, error) {
+	var all []playlist.Track
+	for _, page := range p.pages {
+		all = append(all, page...)
+	}
+	return all, nil
+}
+
+func (p *pagerProv) TracksPage(_ string, offset int) ([]playlist.Track, int, error) {
+	idx := offset
+	if idx >= len(p.pages) {
+		return nil, 0, nil
+	}
+	next := idx + 1
+	if next >= len(p.pages) {
+		next = 0
+	}
+	return p.pages[idx], next, nil
+}
+
+func pageOf(paths ...string) []playlist.Track {
+	tracks := make([]playlist.Track, 0, len(paths))
+	for _, path := range paths {
+		tracks = append(tracks, playlist.Track{Path: path})
+	}
+	return tracks
+}
+
+func newPagingModel(prov *pagerProv) Model {
+	m := Model{
+		player:        &playbackFakeEngine{},
+		playlist:      playlist.New(),
+		provider:      prov,
+		providerLists: []playlist.PlaylistInfo{{ID: "list", Name: "List"}},
+		provLoading:   true,
+	}
+	m.requests.tracks = 1
+	return m
+}
+
+// The provider pane gates Enter on !provLoading, so holding it across the whole
+// page chain locks the user out of re-entering a list that is still filling.
+func TestFirstPageClearsProvLoading(t *testing.T) {
+	prov := &pagerProv{name: "Pager", pages: [][]playlist.Track{
+		pageOf("a", "b"),
+		pageOf("c", "d"),
+	}}
+	m := newPagingModel(prov)
+
+	updated, cmd := m.Update(tracksLoadedMsg{
+		tracks: prov.pages[0], playlistID: "list", providerName: "Pager", offset: 0, next: 1, gen: 1,
+	})
+	m = updated.(Model)
+
+	if m.provLoading {
+		t.Error("provLoading still set after the first page; Enter stays blocked while loading")
+	}
+	if cmd == nil {
+		t.Fatal("no command returned for the next page; the chain stopped early")
+	}
+	if got := m.playlist.Len(); got != 2 {
+		t.Errorf("playlist has %d tracks after page 1, want 2", got)
+	}
+}
+
+func TestLaterPagesAppendWithoutReplacing(t *testing.T) {
+	prov := &pagerProv{name: "Pager", pages: [][]playlist.Track{
+		pageOf("a", "b"),
+		pageOf("c", "d"),
+	}}
+	m := newPagingModel(prov)
+
+	updated, _ := m.Update(tracksLoadedMsg{
+		tracks: prov.pages[0], playlistID: "list", providerName: "Pager", offset: 0, next: 1, gen: 1,
+	})
+	updated, cmd := updated.(Model).Update(tracksLoadedMsg{
+		tracks: prov.pages[1], playlistID: "list", providerName: "Pager", offset: 1, next: 0, gen: 1,
+	})
+	m = updated.(Model)
+
+	if cmd != nil {
+		t.Error("a command was returned after the terminal page; the chain should stop")
+	}
+	if got := m.playlist.Len(); got != 4 {
+		t.Errorf("playlist has %d tracks after both pages, want 4 (later pages must append)", got)
+	}
+	if m.provLoading {
+		t.Error("provLoading set after the terminal page")
+	}
+}

--- a/ui/model/progressive_tracks_test.go
+++ b/ui/model/progressive_tracks_test.go
@@ -136,3 +136,34 @@ func TestStaleGenPageDoesNotAppend(t *testing.T) {
 		t.Error("a stale page dispatched a follow-up request")
 	}
 }
+
+// toggleAlbumHeadersManual pins the user's choice so later Adds do not re-run
+// the cohesion heuristic over them. Rebuilding the header from the whole queue
+// on each page cleared that pin, silently undoing a mid-load toggle.
+func TestPagesDoNotUnpinTheAlbumHeader(t *testing.T) {
+	prov := &pagerProv{name: "Pager", pages: [][]playlist.Track{
+		pageOf("a", "b"),
+		pageOf("c", "d"),
+	}}
+	m := newPagingModel(prov)
+
+	updated, _ := m.Update(tracksLoadedMsg{
+		tracks: prov.pages[0], playlistID: "list", providerName: "Pager", offset: 0, next: 1, gen: 1,
+	})
+	m = updated.(Model)
+
+	m.toggleAlbumHeadersManual()
+	pinned := m.showAlbumHeaders
+
+	updated, _ = m.Update(tracksLoadedMsg{
+		tracks: prov.pages[1], playlistID: "list", providerName: "Pager", offset: 1, next: 0, gen: 1,
+	})
+	m = updated.(Model)
+
+	if !m.headerManual {
+		t.Error("a later page cleared the manual header pin")
+	}
+	if m.showAlbumHeaders != pinned {
+		t.Errorf("album headers = %v after a later page, want %v", m.showAlbumHeaders, pinned)
+	}
+}

--- a/ui/model/providers.go
+++ b/ui/model/providers.go
@@ -15,6 +15,7 @@ func (m *Model) resetProviderNav() {
 	nextRequest(&m.requests.tracks)
 	nextRequest(&m.requests.auth)
 	nextRequest(&m.requests.catalog)
+	m.tracksPaging = false
 	m.provCursor = 0
 	m.provScroll = 0
 	m.provLoading = true
@@ -78,7 +79,9 @@ func (m *Model) fetchProviderTracks(playlistID string) tea.Cmd {
 		return nil
 	}
 	gen := nextRequest(&m.requests.tracks)
-	if pager, ok := m.provider.(provider.TrackPager); ok {
+	pager, paged := m.provider.(provider.TrackPager)
+	m.tracksPaging = paged
+	if paged {
 		return fetchTracksPageCmd(pager, m.provider.Name(), playlistID, 0, gen)
 	}
 	return fetchTracksCmd(m.provider, playlistID, gen)

--- a/ui/model/providers.go
+++ b/ui/model/providers.go
@@ -77,7 +77,11 @@ func (m *Model) fetchProviderTracks(playlistID string) tea.Cmd {
 	if m.provider == nil {
 		return nil
 	}
-	return fetchTracksCmd(m.provider, playlistID, nextRequest(&m.requests.tracks))
+	gen := nextRequest(&m.requests.tracks)
+	if pager, ok := m.provider.(provider.TrackPager); ok {
+		return fetchTracksPageCmd(pager, m.provider.Name(), playlistID, 0, gen)
+	}
+	return fetchTracksCmd(m.provider, playlistID, gen)
 }
 
 // applyTracksResume positions the cursor on the in-progress track and arms the

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -426,6 +426,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.playlist.Add(msg.tracks...)
 			m.normalizeQueueOverlay()
 			m.addToHeaderState(msg.tracks)
+			// Add mixes the page into the upcoming shuffle order, so an armed
+			// preload may no longer be the next track. The gapless swap runs on
+			// the audio thread and the model then names the new track from
+			// playlist.Next(), so a stale preload would play one track while the
+			// UI, scrobble and now-playing announced another. Drop it and let the
+			// tick loop re-arm against the order this page produced.
+			if m.player.HasPreload() {
+				m.player.ClearPreload()
+				m.preloading = false
+			}
 		} else {
 			m.replacePlayerPlaylist(msg.tracks)
 			if msg.playlistExact && m.localProvider != nil && msg.providerName == m.localProvider.Name() && msg.playlistID != history.PlaylistName {

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -412,8 +412,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.gen != m.requests.tracks || !m.isActiveProvider(msg.providerName) {
 			return m, nil
 		}
+		m.provLoading = false
 		if msg.err != nil {
-			m.provLoading = false
 			if errors.Is(msg.err, playlist.ErrNeedsAuth) {
 				m.provSignIn = true
 				m.err = nil
@@ -439,7 +439,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, fetchTracksPageCmd(pager, msg.providerName, msg.playlistID, msg.next, msg.gen)
 			}
 		}
-		m.provLoading = false
 		if msg.offset > 0 {
 			msg.tracks = m.playlist.Tracks()
 		}

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -364,7 +364,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// the current stream has >streamPreloadLeadTime remaining. Poll every tick
 		// until we're within the window and the preload gets armed.
 		// Guard with !m.preloading so we don't fire a second concurrent HTTP
-		// connection while the first preloadStreamCmd goroutine is still running.
+		// connection while the first preloadStreamCmd goroutine is still running,
+		// and with !m.tracksPaging because each page of a paged load remixes the
+		// upcoming order, so anything armed now would be stale by the next one.
 		if m.player.IsPlaying() && !m.player.IsPaused() && !m.buffering && !m.preloading && !m.tracksPaging && !m.player.HasPreload() {
 			if cmd := m.preloadNext(); cmd != nil {
 				cmds = append(cmds, cmd)

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -427,7 +427,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// partial view of a list that no longer exists. Say so and let it
 				// expire: reopening starts a clean load, and a persistent error
 				// would sit in front of every later status message.
-				m.status.Warningf(statusTTLDefault, "Playlist changed while loading — reopen to reload")
+				m.status.Warningf(statusTTLDefault, "Playlist changed while loading — reopen current playlist to reload")
 				return m, nil
 			}
 			m.err = msg.err

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -408,7 +408,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
-	case tracksPageMsg:
+	case tracksLoadedMsg:
 		if msg.gen != m.requests.tracks || !m.isActiveProvider(msg.providerName) {
 			return m, nil
 		}
@@ -422,45 +422,26 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.err = msg.err
 			return m, nil
 		}
-		if msg.offset == 0 {
-			m.replacePlayerPlaylist(msg.tracks)
-		} else {
+		if msg.offset > 0 {
 			m.playlist.Add(msg.tracks...)
 			m.normalizeQueueOverlay()
 			m.setHeaderStateFromTracks(m.playlist.Tracks())
+		} else {
+			m.replacePlayerPlaylist(msg.tracks)
+			if msg.playlistExact && m.localProvider != nil && msg.providerName == m.localProvider.Name() && msg.playlistID != history.PlaylistName {
+				m.loadedPlaylist = msg.playlistID
+			}
 		}
 		if msg.next > 0 {
 			m.adjustScroll()
 			m.notifyAll()
-			pager, ok := m.provider.(provider.TrackPager)
-			if !ok {
-				return m, nil
+			if pager, ok := m.provider.(provider.TrackPager); ok {
+				return m, fetchTracksPageCmd(pager, msg.providerName, msg.playlistID, msg.next, msg.gen)
 			}
-			return m, fetchTracksPageCmd(pager, msg.providerName, msg.playlistID, msg.next, msg.gen)
 		}
 		m.provLoading = false
-		m.applyTracksResume(tracksLoadedMsg{tracks: m.playlist.Tracks(), playlistID: msg.playlistID, providerName: msg.providerName, gen: msg.gen})
-		m.adjustScroll()
-		m.notifyAll()
-		return m, nil
-
-	case tracksLoadedMsg:
-		if msg.gen != m.requests.tracks || !m.isActiveProvider(msg.providerName) {
-			return m, nil
-		}
-		m.provLoading = false
-		if msg.err != nil {
-			if errors.Is(msg.err, playlist.ErrNeedsAuth) {
-				m.provSignIn = true
-				m.err = nil
-				return m, nil
-			}
-			m.err = msg.err
-			return m, nil
-		}
-		m.replacePlayerPlaylist(msg.tracks)
-		if msg.playlistExact && m.localProvider != nil && msg.providerName == m.localProvider.Name() && msg.playlistID != history.PlaylistName {
-			m.loadedPlaylist = msg.playlistID
+		if msg.offset > 0 {
+			msg.tracks = m.playlist.Tracks()
 		}
 		m.applyTracksResume(msg)
 		m.adjustScroll()

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -425,7 +425,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.offset > 0 {
 			m.playlist.Add(msg.tracks...)
 			m.normalizeQueueOverlay()
-			m.setHeaderStateFromTracks(m.playlist.Tracks())
+			m.addToHeaderState(msg.tracks)
 		} else {
 			m.replacePlayerPlaylist(msg.tracks)
 			if msg.playlistExact && m.localProvider != nil && msg.providerName == m.localProvider.Name() && msg.playlistID != history.PlaylistName {

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -365,7 +365,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// until we're within the window and the preload gets armed.
 		// Guard with !m.preloading so we don't fire a second concurrent HTTP
 		// connection while the first preloadStreamCmd goroutine is still running.
-		if m.player.IsPlaying() && !m.player.IsPaused() && !m.buffering && !m.preloading && !m.player.HasPreload() {
+		if m.player.IsPlaying() && !m.player.IsPaused() && !m.buffering && !m.preloading && !m.tracksPaging && !m.player.HasPreload() {
 			if cmd := m.preloadNext(); cmd != nil {
 				cmds = append(cmds, cmd)
 			}
@@ -413,6 +413,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.provLoading = false
+		m.tracksPaging = msg.err == nil && msg.next > 0
 		if msg.err != nil {
 			if errors.Is(msg.err, playlist.ErrNeedsAuth) {
 				m.provSignIn = true
@@ -432,7 +433,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// playlist.Next(), so a stale preload would play one track while the
 			// UI, scrobble and now-playing announced another. Drop it and let the
 			// tick loop re-arm against the order this page produced.
-			if m.player.HasPreload() {
+			if m.player.HasPreload() || m.preloading {
 				m.player.ClearPreload()
 				m.preloading = false
 			}

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -422,6 +422,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.err = nil
 				return m, nil
 			}
+			if errors.Is(msg.err, playlist.ErrListChanged) {
+				// The list moved under a paged read, so what is on screen is a
+				// partial view of a list that no longer exists. Say so and let it
+				// expire: reopening starts a clean load, and a persistent error
+				// would sit in front of every later status message.
+				m.status.Warningf(statusTTLDefault, "Playlist changed while loading — reopen to reload")
+				return m, nil
+			}
 			m.err = msg.err
 			return m, nil
 		}

--- a/ui/model/update.go
+++ b/ui/model/update.go
@@ -408,6 +408,42 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case tracksPageMsg:
+		if msg.gen != m.requests.tracks || !m.isActiveProvider(msg.providerName) {
+			return m, nil
+		}
+		if msg.err != nil {
+			m.provLoading = false
+			if errors.Is(msg.err, playlist.ErrNeedsAuth) {
+				m.provSignIn = true
+				m.err = nil
+				return m, nil
+			}
+			m.err = msg.err
+			return m, nil
+		}
+		if msg.offset == 0 {
+			m.replacePlayerPlaylist(msg.tracks)
+		} else {
+			m.playlist.Add(msg.tracks...)
+			m.normalizeQueueOverlay()
+			m.setHeaderStateFromTracks(m.playlist.Tracks())
+		}
+		if msg.next > 0 {
+			m.adjustScroll()
+			m.notifyAll()
+			pager, ok := m.provider.(provider.TrackPager)
+			if !ok {
+				return m, nil
+			}
+			return m, fetchTracksPageCmd(pager, msg.providerName, msg.playlistID, msg.next, msg.gen)
+		}
+		m.provLoading = false
+		m.applyTracksResume(tracksLoadedMsg{tracks: m.playlist.Tracks(), playlistID: msg.playlistID, providerName: msg.providerName, gen: msg.gen})
+		m.adjustScroll()
+		m.notifyAll()
+		return m, nil
+
 	case tracksLoadedMsg:
 		if msg.gen != m.requests.tracks || !m.isActiveProvider(msg.providerName) {
 			return m, nil


### PR DESCRIPTION
## Summary

Opening a large Spotify playlist blocked until every page had been fetched. `Tracks()` paginated `/v1/me/tracks` 50 at a time and the UI waited for the full result, so a large "Liked Songs" library sat on a spinner for about a minute before anything appeared.

This pages tracks into the queue as they arrive. The first page installs the queue and playback is available immediately; each later page appends.

**Request count, spacing and density are unchanged** — paging is still strictly sequential, one page at a time. This adds no rate-limit pressure; the win is that results are visible immediately rather than after the last page.

Mechanically it is a new optional interface, `provider.TrackPager`, asserted at the call site the same way `ResumeTarget` and `CustomStreamer` already are. Only Spotify implements it; every other provider keeps the existing `Tracks()` path unchanged. Pages are driven by a self-chaining `tea.Cmd`, so there are no goroutines or channels and no `tea.Program` handle is needed in `ui/model`.

One related fix came with it. "Liked Songs" is a synthetic ID with no `snapshot_id`, so unlike real playlists it never invalidated its session cache — liking a song elsewhere was invisible until cliamp restarted. It is now revalidated with a single `limit=1` request: `/v1/me/tracks` is ordered `added_at` descending, so an unchanged total plus an unchanged newest entry means nothing was added or removed. Any mismatch, or any error, refetches — the failure direction is stale-free. Repeat visits drop from N requests to 1.

## Screenshots / video

https://github.com/user-attachments/assets/618fa05c-e756-4055-b965-a0603b6ddc89

## How to test

1. Configure a Spotify account with a large Liked Songs library (the effect scales with size; a few thousand tracks makes it obvious).
2. Open the Spotify provider and press Enter on **Your Music**.
3. The queue appears immediately and fills in pages of 50 rather than blocking on the full fetch.
4. Start playback while the list is still growing — the queue stays usable and shuffle mixes new pages into the unplayed tail.
5. Back out with Esc and press Enter again while it is still filling — the list reopens rather than ignoring the key.
6. Leave and re-enter **Your Music** once loaded: it returns from cache after a single revalidation request.
7. Back out mid-load, wait a moment, then re-enter: it picks up where it stopped rather than starting over.
8. Let a track play through to the next one while a large list is still filling: the track that plays is the one the header and MPRIS name.
9. Add or remove a liked song from another Spotify client while a list is loading: the load stops with a notice rather than quietly assembling a list from two different snapshots.
10. Like or unlike a track in another Spotify client, then re-enter **Your Music**: the change is picked up without restarting cliamp.

## Checklist

- [x] `make check` passes
- [ ] `docs/` and `site/index.html` updated for user-facing changes — see below

`make check` passes, and so does the full CI gate locally: `make fmt-check vet staticcheck security` and `go test -count=1 -race ./...`, on Go 1.26.6 to match `go.mod`.

No `docs/` or `site/index.html` change: nothing `docs/` covers has changed — no new keybinding, config key, provider or plugin API. The behaviour differences are the ones named below (a list fills in rather than appearing at once, and gapless is held off while it does), neither of which is documented today. Happy to write them up if you would rather they were.

## The cache invariant

The branch establishes one property worth stating explicitly, because it is what most of the commits are defending: **no writer to `trackCache` can commit a list assembled from more than one library snapshot.**

That matters because a like or unlike prepends, shifting every later offset by one. Pages read either side of such a change splice into a list that is short by one and duplicated by one — and the revalidation probe cannot detect it, since the total and the newest entry both still match. It would be sticky and silent until the next library change.

Both writers are now covered. `TracksPage` pins the total its accumulation started from and refuses any page reporting a different one, so a load that saw the library move never commits — and it stops rather than spending the rest of the library's pages on a result already destined to be discarded. `Tracks()` pins the same way and restarts from a fresh snapshot, bounded at two restarts so a library being actively edited returns an error rather than looping. `Tracks()` is still reachable in both daemon mode and TUI mode — `ui/model/ipc_extended.go` dispatches `provider.tracks` and `provider.load` straight to it — so leaving it unpinned would have left the shared cache poisonable from outside.

Re-entering a list abandoned mid-load resumes the earlier accumulation rather than refetching every page already paid for, which costs one request instead of dozens on a large library. That stitches two separate reads together, so it is only allowed where the pages already held can be proven still valid, and the proof differs by list.

Ordinary playlists use `snapshot_id`, Spotify's own version token, which changes on any edit. The accumulation records the snapshot it began under and one request checks it on re-entry; an unchanged token proves the playlist is untouched. Saved tracks have no snapshot, so they use an unchanged total together with an unchanged head — which is proof only there, because a like lands at position 0 and an unlike moves the total, so no edit can hide from both. An ordinary playlist can be edited anywhere, and a same-total edit below the head but inside the fetched prefix would shift every later offset and stitch the halves together one track short, which is why total and head alone are not enough for them. A missing or unreadable snapshot restarts, which is the safe direction.

Gapless preloading is held off while pages are landing. Each page remixes the upcoming order — and under repeat-all a sequential load wraps to the head at the frontier — so a preload armed mid-load can stop being the next track, and the player advances into a preloaded pipeline on its own thread rather than being told to. It arms again as soon as the order settles, so the cost is no gapless across a boundary falling inside the load window.

One deliberate semantic change: an external `provider.load` over IPC now supersedes an in-flight load rather than racing it. It replaces the queue wholesale, and a paged load would otherwise keep appending its remaining pages onto the list the client just installed.

One behaviour worth naming so it is not mistaken for a bug: opening list B while list A is still loading abandons A's chain silently. A keeps whatever it had, and returns to it for a single request whenever you go back. Backing out with Esc does not abandon a load — it runs to completion — so nothing downloads unless you are looking at it or just were. That is deliberate: a background queue would spend rate-limit budget on lists you may never open again.

One residual is accepted deliberately: unliking one track and liking another between two visits to Liked Songs leaves both the total and the newest entry unchanged, so the revalidation probe serves the cached list. The difference is bounded to that one entry and heals on the next library change.

Saved albums are served whole rather than paged. They come from their own endpoint and are small enough not to need it.

## Notes

Tests are table-driven in `external/spotify/provider_paging_test.go`, using the existing `roundTripFunc` stub. They cover pagination across empty / partial / exact-boundary / multi-page; the revalidation hit and both miss cases (changed total, changed newest entry); rejection of non-contiguous pages; an aborted load leaving nothing cached; the mid-load mutation case for both cache writers, including that a drifted load stops instead of spending the rest of its pages; and the resume path — resuming in a single request through to a complete commit, discarding when the total moved, discarding when the head moved at an unchanged total, resuming a playlist on an unchanged `snapshot_id` and restarting it on a changed one, and serving a saved album whole through its own endpoint rather than splicing an album ID into a playlist-items URL. `ui/model/progressive_tracks_test.go` covers the UI side: the pane unblocking on the first page so a still-filling list can be reopened, later pages appending rather than replacing, a superseded page neither appending nor dispatching, the album-header pin surviving later pages, an IPC load retiring an in-flight paged load, the changed-list notice expiring instead of occupying the permanent error slot while real failures still persist, and the preload guarantees — a stale preload dropped on append, arming suppressed while pages land, and the flag cleared on the terminal page, on error and on provider reset so it cannot strand preloading for the session. The tick test asserts both directions, so the guard cannot pass vacuously.

Two deliberate design points, in case they look odd in review:

- Track totals are stored explicitly rather than derived from `len(tracks)`, because pages skip items with no ID (local/unavailable tracks). Deriving the total would make any library containing local files look permanently changed.
- Partial loads accumulate in a `pending` map and are only promoted to `trackCache` on completion, so navigating away mid-load cannot leave a partial list posing as a complete one. Pages arriving out of order are served to their caller but not accumulated.

The `added_at` ordering that revalidation relies on is undocumented, though consistently observed. It is noted as such in the code, and the failure mode if it ever changes is an extra refetch, never stale data.

Also included, as a separate commit: `coverage.out` added to `.gitignore`. `make coverage` writes it to the repo root, so it shows up untracked after a local CI run. Happy to pull it into its own PR if you would rather keep this one to the provider change.

I have one follow-up queued for this provider — passing `market`, so `is_playable` is actually populated and region-locked tracks are skipped rather than failing at play time. Happy to fold it into this PR if you would prefer one bundle, or keep it separate.

Working on this also turned up a few pre-existing issues that are out of scope here and that I am happy to file separately: `webAPIWithBody` honours a 429 `Retry-After` verbatim, so a long backoff always outlives the caller's context and the retry loop can never complete; `ytdlBatchMsg` appends batches the same way this branch does and leaves a stale gapless preload behind, which is the same defect fixed here for the paged path; and `preloadStreamCmd` and `preloadLocalCmd` are byte-identical.

## Attribution

The code here was written by Claude Code (Opus 5). I directed the work and made the design decisions with it — what to build, what to leave out, and which trade-offs to accept — and a second model, Kimi K3, reviewed every commit. Several of the fixes in this branch exist only because that review caught something: the snapshot pin, the bounded restart in `Tracks()`, and the head comparison guarding resume were all raised there.

Being straight about the limits of that: I have not read the diff line by line myself. What I did do is build it and use it, repeatedly — the re-entry lockout and the full reload on re-entry were both found by hand-testing rather than by either model, and every fix here was re-tested against a real library before this PR, including playing through a track boundary mid-load and mutating the library while a list was still filling. Happy to walk through anything or make changes if a human review turns up something we missed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Spotify playlists and saved tracks now load progressively, displaying tracks sooner as additional pages are retrieved.
  - Interrupted page requests can resume, improving navigation through large libraries.

- **Bug Fixes**
  - Improved handling of playlists that change during loading, including stale-result protection and temporary warnings.
  - Prevented outdated loads from replacing newer queue contents or disrupting preloading.
  - Improved saved-track cache validation so library changes are detected more efficiently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

