### PR TITLE
fix(ui): stop showing add/remove favorite notifications in the footer

### DIFF
--- a/ui/model/dirs_screen_test.go
+++ b/ui/model/dirs_screen_test.go
@@ -392,9 +392,6 @@ func TestPlMgrNKeyRemovesRowFromFavoritesScreen(t *testing.T) {
 	if len(m.plManager.tracks) != 1 || m.plManager.tracks[0].Path != "/b.mp3" {
 		t.Fatalf("tracks = %+v, want only /b.mp3", m.plManager.tracks)
 	}
-	if !strings.HasPrefix(m.status.text, favRemovedMark) {
-		t.Fatalf("status = %q, want dimmed heart prefix %q", m.status.text, favRemovedMark)
-	}
 	if cmd == nil {
 		t.Fatal("expected a provider-playlist refresh command")
 	}
@@ -887,9 +884,6 @@ func TestNKeyTogglesFavorite(t *testing.T) {
 	if _, ok := m.favSet["/song.mp3"]; !ok {
 		t.Fatal("favSet should contain /song.mp3 after toggle")
 	}
-	if !strings.HasPrefix(m.status.text, favAddedMark) {
-		t.Fatalf("status = %q, want red heart prefix %q", m.status.text, favAddedMark)
-	}
 
 	// Toggle off.
 	m.handleKey(tea.KeyPressMsg{Text: "n"})
@@ -900,9 +894,6 @@ func TestNKeyTogglesFavorite(t *testing.T) {
 		if _, ok := m.favSet["/song.mp3"]; ok {
 			t.Fatal("favSet should not contain /song.mp3 after toggle off")
 		}
-	}
-	if !strings.HasPrefix(m.status.text, favRemovedMark) {
-		t.Fatalf("status = %q, want dimmed heart prefix %q", m.status.text, favRemovedMark)
 	}
 }
 

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -600,17 +600,11 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 			if !ok {
 				return nil
 			}
-			added, err := m.favMgr.ToggleFavorite(track)
-			if err != nil {
+			if _, err := m.favMgr.ToggleFavorite(track); err != nil {
 				m.status.Errorf(statusTTLDefault, "Favorite failed: %s", err)
 				return nil
 			}
 			m.refreshFavSet()
-			if added {
-				m.status.Showf(statusTTLDefault, favAddedMark+" %s", track.DisplayName())
-			} else {
-				m.status.Showf(statusTTLDefault, favRemovedMark+" %s", track.DisplayName())
-			}
 			// The provider pane renders Favorites counts from Playlists();
 			// re-pull so it reflects the toggle. The manager list refreshes
 			// itself on open.
@@ -2053,17 +2047,11 @@ func (m *Model) handlePlMgrTracksKey(msg tea.KeyPressMsg) tea.Cmd {
 			realIdx := m.plMgrTrackRealIndex(m.plManager.cursor)
 			if realIdx >= 0 && realIdx < len(m.plManager.tracks) {
 				track := m.plManager.tracks[realIdx]
-				added, err := m.favMgr.ToggleFavorite(track)
-				if err != nil {
+				if _, err := m.favMgr.ToggleFavorite(track); err != nil {
 					m.status.Errorf(statusTTLDefault, "Favorite failed: %s", err)
 					return nil
 				}
 				m.refreshFavSet()
-				if added {
-					m.status.Showf(statusTTLDefault, favAddedMark+" %s", track.DisplayName())
-				} else {
-					m.status.Showf(statusTTLDefault, favRemovedMark+" %s", track.DisplayName())
-				}
 				// Inside the Favorites screen a toggle re-reads the store so
 				// the rows mirror it: an unfavorite drops the row, a
 				// re-favorite restores it.

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -29,21 +29,11 @@ var (
 	// look. The glyph carries U+FE0E (text presentation) so terminals render
 	// it as a compact font glyph rather than a large color emoji.
 	favMarkerStyle = lipgloss.NewStyle().Foreground(ui.ColorError)
-	// favRemovedStyle mutes the same filled heart for unfavorite feedback:
-	// identical attractive glyph, faded to signal the removed state instead
-	// of switching to a thin outline glyph.
-	favRemovedStyle = lipgloss.NewStyle().Foreground(ui.ColorDim)
 )
 
 // favHeart is the small, text-presentation favorite heart used everywhere the
-// UI shows favorite state (track rows, header badge, status messages).
+// UI shows favorite state (track rows, header badge).
 const favHeart = "♥\uFE0E"
-
-// Pre-rendered toggle feedback marks for the status bar.
-var (
-	favAddedMark   = favMarkerStyle.Render(favHeart)
-	favRemovedMark = favRemovedStyle.Render(favHeart)
-)
 
 // providerEmptyStateHint, keyed by lowercase provider Name(), returns the
 // remediation hint shown under the generic "No playlists in X" message.


### PR DESCRIPTION
The add/remove favorite notification is a distraction and there's no need for it. It also caused a footer layout shift I fixed in a separate PR, but that PR was closed in favor of this simpler approach.

Removes the transient status-bar notification (footer row) shown when a track is added to or removed from favorites via `n`.

- Does not post `favAddedMark`/`favRemovedMark` messages from the playlist or playlist-manager handlers.
- Drops the now-unused `favRemovedStyle`, `favAddedMark`, and `favRemovedMark` definitions.
- Removes the corresponding status-text assertions from tests.