### PR TITLE
Remove theme name from player view #436

### DIFF
--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -12,7 +12,6 @@ import (
 	"github.com/bjarneo/cliamp/favorites"
 	"github.com/bjarneo/cliamp/playlist"
 	"github.com/bjarneo/cliamp/provider"
-	"github.com/bjarneo/cliamp/theme"
 	"github.com/bjarneo/cliamp/ui"
 )
 
@@ -714,11 +713,6 @@ func (m Model) renderPlaylistHeader() string {
 		favStr = " " + activeToggle.Render(fmt.Sprintf("[%s %d]", favHeart, count))
 	}
 
-	var themeStr string
-	if name := m.ThemeName(); name != theme.DefaultName {
-		themeStr = " " + activeToggle.Render("[Theme: "+name+"]")
-	}
-
 	var posStr string
 	if total := m.playlist.Len(); total > 0 {
 		posStr = " " + dimStyle.Render(fmt.Sprintf("[%d/%d]", m.playlist.Index()+1, total))
@@ -730,7 +724,7 @@ func (m Model) renderPlaylistHeader() string {
 		headerStyle = activeToggle
 		headerLabel = "▸─ Playlist ── "
 	}
-	return headerStyle.Render(headerLabel) + shuffle + queueStr + bookmarkStr + favStr + posStr + themeStr + " " + dimStyle.Render("──")
+	return headerStyle.Render(headerLabel) + shuffle + queueStr + bookmarkStr + favStr + posStr + " " + dimStyle.Render("──")
 }
 
 func (m Model) renderProviderList() string {


### PR DESCRIPTION
## Summary

Removes the label for the current selected theme. It is static data that isn't all that relevant for the main player view.

## Screenshots / video

<img width="1598" height="905" alt="CliampNoTheme" src="https://github.com/user-attachments/assets/f8d9f9c4-bfeb-42ba-accb-cdce27354015" />

## How to test

1. Set a theme.
2. It will not display on the main player view.

## Checklist

- [x] `make check` passes
- [x] (doesn't seem to apply) `docs/` and `site/index.html` updated for user-facing changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Changes**
  * Removed the playlist header’s active theme indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->