### PR TITLE
feat(ui): made theme name optional

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -34,7 +34,7 @@ func buildApp() *cli.Command {
 		&cli.BoolWithInverseFlag{Name: "auto-play", Usage: "start playback immediately"},
 		&cli.BoolWithInverseFlag{Name: "simplified", Usage: "simplified playback view (no visualizer or playlist)"},
 		&cli.BoolWithInverseFlag{Name: "help-bar", Usage: "show the key-binding hint bar (? still opens the full keymap)", Value: true},
-		&cli.BoolWithInverseFlag{Name: "show-theme", Usage: "show the currently selected theme next to the playback stats", Value: true},
+		&cli.BoolWithInverseFlag{Name: "print-theme", Usage: "show the currently selected theme next to the playback stats", Value: true},
 		&cli.StringFlag{Name: "provider", Usage: "default provider: radio, navidrome, lyrion, plex, jellyfin, emby, spotify, qobuz, tidal, soundcloud, mixcloud, netease, yandex, audiobookshelf, abs, yt, youtube, ytmusic"},
 		&cli.StringFlag{Name: "start-theme", Usage: "UI theme name"},
 		&cli.StringFlag{Name: "visualizer", Usage: "visualizer mode"},
@@ -158,8 +158,8 @@ func overridesFromFlags(c *cli.Command) (config.Overrides, error) {
 		v := !c.Bool("help-bar")
 		ov.HideHelpBar = &v
 	}
-	if c.IsSet("show-theme") {
-		v := !c.Bool("show-theme")
+	if c.IsSet("print-theme") {
+		v := !c.Bool("print-theme")
 		ov.HideTheme = &v
 	}
 	if c.IsSet("provider") {

--- a/commands.go
+++ b/commands.go
@@ -34,6 +34,7 @@ func buildApp() *cli.Command {
 		&cli.BoolWithInverseFlag{Name: "auto-play", Usage: "start playback immediately"},
 		&cli.BoolWithInverseFlag{Name: "simplified", Usage: "simplified playback view (no visualizer or playlist)"},
 		&cli.BoolWithInverseFlag{Name: "help-bar", Usage: "show the key-binding hint bar (? still opens the full keymap)", Value: true},
+		&cli.BoolWithInverseFlag{Name: "show-theme", Usage: "show the currently selected theme next to the playback stats", Value: true},
 		&cli.StringFlag{Name: "provider", Usage: "default provider: radio, navidrome, lyrion, plex, jellyfin, emby, spotify, qobuz, tidal, soundcloud, mixcloud, netease, yandex, audiobookshelf, abs, yt, youtube, ytmusic"},
 		&cli.StringFlag{Name: "start-theme", Usage: "UI theme name"},
 		&cli.StringFlag{Name: "visualizer", Usage: "visualizer mode"},
@@ -156,6 +157,10 @@ func overridesFromFlags(c *cli.Command) (config.Overrides, error) {
 	if c.IsSet("help-bar") {
 		v := !c.Bool("help-bar")
 		ov.HideHelpBar = &v
+	}
+	if c.IsSet("show-theme") {
+		v := !c.Bool("show-theme")
+		ov.HideTheme = &v
 	}
 	if c.IsSet("provider") {
 		v := strings.ToLower(c.String("provider"))

--- a/config/config.go
+++ b/config/config.go
@@ -356,6 +356,7 @@ type Config struct {
 	BitDepth         int                          // PCM bit depth for FFmpeg output: 16 or 32
 	Simplified       bool                         // simplified playback view: track summary and time strip
 	HideHelpBar      bool                         // hide the key-binding hint bar above the status line
+	HideTheme        bool                         // hide current cliamp theme in player view
 	PaddingH         int                          // horizontal padding for the UI frame (default 3)
 	PaddingV         int                          // vertical padding for the UI frame (default 1)
 	AudioDevice      string                       // preferred audio output device name (empty = system default)
@@ -723,6 +724,8 @@ func Load() (Config, error) {
 				cfg.Simplified = val == "true"
 			case "hide_help_bar":
 				cfg.HideHelpBar = val == "true"
+			case "hide_theme":
+				cfg.HideTheme = val == "true"
 			case "audio_device":
 				cfg.AudioDevice = parseString(val)
 			case "initial_directory":

--- a/config/flags.go
+++ b/config/flags.go
@@ -17,6 +17,7 @@ type Overrides struct {
 	Play            *bool
 	Simplified      *bool
 	HideHelpBar     *bool
+	HideTheme       *bool
 	AudioDevice     *string
 	Playlist        *string
 	LogLevel        *string
@@ -67,6 +68,9 @@ func (o Overrides) Apply(cfg *Config) {
 	}
 	if o.HideHelpBar != nil {
 		cfg.HideHelpBar = *o.HideHelpBar
+	}
+	if o.HideTheme != nil {
+		cfg.HideTheme = *o.HideTheme
 	}
 	if o.Play != nil {
 		cfg.AutoPlay = *o.Play

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -127,6 +127,7 @@ cliamp track.mp3 --repeat all --mono ~/Music
 | `--auto-play` / `--no-auto-play` | bool | false | |
 | `--simplified` / `--no-simplified` | bool | false | artist/title and time strip; no visualizer or playlist |
 | `--help-bar` / `--no-help-bar` | bool | true | show or hide the key-binding hint bar; `?` still opens the full keymap |
+| `--print-theme` / `--no-print-theme` | bool | true | prints the currently selected theme next to the playback stats |
 | `--visualizer-60fps` | bool | false | render a visible visualizer at about 60 FPS |
 | `--start-theme` | string | | theme name |
 | `--eq-preset` | string | | preset name |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,6 +92,9 @@ simplified = false
 # Hide the key-binding hint bar above the status line.
 hide_help_bar = false
 
+# Hide the currently selected theme (next to the playback stats)
+hide_theme = false
+
 # UI theme name (see available themes in ~/.config/cliamp/themes/)
 theme = "Tokyo Night"
 

--- a/main.go
+++ b/main.go
@@ -513,6 +513,9 @@ func run(overrides config.Overrides, positional []string, daemon, visualizer60FP
 	if cfg.HideHelpBar {
 		m.SetHideHelpBar(true)
 	}
+	if cfg.HideTheme {
+		m.SetHideTheme(true)
+	}
 
 	if rs := resume.Load(); rs.Path != "" && rs.PositionSec > 0 {
 		// Mixcloud is commonly opened from its provider browser rather than a

--- a/ui/model/init.go
+++ b/ui/model/init.go
@@ -132,6 +132,11 @@ func (m *Model) SetHideHelpBar(v bool) {
 	m.refreshChrome()
 }
 
+// SetHideTheme hides the currently selected theme (located next to the playback stats)
+func (m *Model) SetHideTheme(v bool) {
+	m.hideTheme = v
+}
+
 // SetInitialDirectory sets the initial directory for the file browser.
 func (m *Model) SetInitialDirectory(dir string) { m.initialDir = dir }
 

--- a/ui/model/model.go
+++ b/ui/model/model.go
@@ -413,6 +413,7 @@ type Model struct {
 	visualizer60FPS bool // render a visible visualizer at the animation cadence
 	simplified      bool // simplified playback view: track summary and time strip
 	hideHelpBar     bool // hide the key-binding hint bar above the status line
+	hideTheme       bool // hide the currently selected theme (located next to the playback stats)
 	heightExpanded  bool // tracks whether manual 'x' expansion is active
 
 	// Cached per-tick to avoid repeated speaker.Lock() calls in View().

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -715,7 +715,7 @@ func (m Model) renderPlaylistHeader() string {
 	}
 
 	var themeStr string
-	if name := m.ThemeName(); name != theme.DefaultName {
+	if name := m.ThemeName(); !m.hideTheme && name != theme.DefaultName {
 		themeStr = " " + activeToggle.Render("[Theme: "+name+"]")
 	}
 

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bjarneo/cliamp/favorites"
 	"github.com/bjarneo/cliamp/playlist"
 	"github.com/bjarneo/cliamp/provider"
+	"github.com/bjarneo/cliamp/theme"
 	"github.com/bjarneo/cliamp/ui"
 )
 


### PR DESCRIPTION
The theme name in the ui is now togglable option via the cli flag --print-theme / --no-print-theme , and the config option hide_theme

## Summary

Like i mentioned in PR#441, I think that making `themeStr` configurable would be useful for users who still want to see the active theme. And since the PR author told me I could build on his PR, I'm proposing these changes

## Screenshots / video

Flag enabled:
<img width="547" height="45" alt="image" src="https://github.com/user-attachments/assets/71b11386-a026-4672-9701-32a504d319e1" />
<img width="1206" height="527" alt="image" src="https://github.com/user-attachments/assets/a74a6b0f-45f6-4528-a3b0-2ade43465f47" />

Flag disabled:
<img width="656" height="42" alt="image" src="https://github.com/user-attachments/assets/2aa6c132-abd4-4168-8229-79082bd4a5d3" />
<img width="1212" height="527" alt="image" src="https://github.com/user-attachments/assets/72b569b5-6a31-433f-aca1-d29833bfdf6b" />


<!-- Drag-and-drop screenshots or a short screen recording for UI changes. -->

## How to test

1. Set the flag `hide_theme` to `false` or call cliamp with the flag --show-theme (or no flags)
2. The current theme is printed in the UI
3. Now, set the flag `hide_theme` to `true` or call cliamp with the flag --no-show-theme
4. The current theme is not printed in the UI

## Checklist

- [x] `make check` passes
- [x] `docs/` and `site/index.html` updated for user-facing changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added options to show or hide the currently selected theme next to playback statistics.
  * Added CLI controls for displaying the theme, enabled by default.
  * Added a configuration setting to hide the theme display.
  * Theme indicators are omitted when hidden or when the default theme is active.

* **Documentation**
  * Updated CLI and configuration references with the new theme display options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->