### PR TITLE
feat(radio): frequency dial widget for custom stations

### DIFF
--- a/external/radio/provider.go
+++ b/external/radio/provider.go
@@ -96,8 +96,9 @@ type Provider struct {
 }
 
 type station struct {
-	name string
-	url  string
+	name      string
+	url       string
+	frequency string // e.g. "88.3 FM", "1200 AM"; shown on the radio dial widget
 }
 
 // New creates a Provider with the built-in station plus any user-defined
@@ -256,9 +257,13 @@ func (p *Provider) Tracks(id string) ([]playlist.Track, error) {
 		if idx < 0 || idx >= len(p.stations) {
 			return nil, errors.New("invalid local station index")
 		}
-		return []playlist.Track{{
+		track := playlist.Track{
 			Path: p.stations[idx].url, Title: p.stations[idx].name, Stream: true, Realtime: true,
-		}}, nil
+		}
+		if freq := p.stations[idx].frequency; freq != "" {
+			track.ProviderMeta = map[string]string{"radio.frequency": freq}
+		}
+		return []playlist.Track{track}, nil
 	case "f":
 		favs := p.favorites.Stations()
 		if idx < 0 || idx >= len(favs) {
@@ -557,7 +562,7 @@ func loadStations(path string) ([]station, error) {
 
 	var stations []station
 	tomlutil.ParseSections(data, "station", func(f map[string]string) {
-		s := station{name: f["name"], url: f["url"]}
+		s := station{name: f["name"], url: f["url"], frequency: f["frequency"]}
 		if s.name != "" && s.url != "" {
 			stations = append(stations, s)
 		}

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -259,8 +259,11 @@ func (m Model) mainSections(playlist string, includeTransient, contentFirst bool
 			if !m.visualizerDisabled() {
 				sections = append(sections, m.renderSpectrum())
 			}
+			sections = append(sections, m.renderSeekBar())
+			if dial := m.renderRadioDial(); dial != "" {
+				sections = append(sections, dial)
+			}
 			sections = append(sections,
-				m.renderSeekBar(),
 				m.renderCompactControls(),
 				m.renderCompactSource(),
 				m.renderPlaylistHeader(),
@@ -283,6 +286,9 @@ func (m Model) mainSections(playlist string, includeTransient, contentFirst bool
 				sections = append(sections, m.renderSpectrum())
 			}
 			sections = append(sections, m.renderSeekBar())
+			if dial := m.renderRadioDial(); dial != "" {
+				sections = append(sections, dial)
+			}
 			switch {
 			case m.layout.twoColumn:
 				// EQ, volume, source, and speed move into the settings pane

--- a/ui/model/view_radio_dial.go
+++ b/ui/model/view_radio_dial.go
@@ -1,0 +1,16 @@
+package model
+
+import "github.com/bjarneo/cliamp/ui"
+
+// renderRadioDial returns the radio frequency dial for the currently playing
+// track, or "" when the track has no frequency metadata.
+func (m Model) renderRadioDial() string {
+	if !m.playingTrackActive {
+		return ""
+	}
+	freq := m.playingTrack.Meta("radio.frequency")
+	if freq == "" {
+		return ""
+	}
+	return ui.RenderRadioDial(freq, ui.PanelWidth)
+}

--- a/ui/radio_dial.go
+++ b/ui/radio_dial.go
@@ -58,9 +58,17 @@ func ParseFrequency(s string) (float64, string) {
 	return freq, band
 }
 
-// RenderRadioDial draws a retro frequency dial for the given frequency string.
-// width is the available character width. Returns empty string if the frequency
-// cannot be parsed.
+// dialRows is the height of the LED dot-matrix dial in terminal rows.
+const dialRows = 4
+
+// dialColor is a light blue reminiscent of classic Pioneer/Marantz receiver
+// tuner dials from the 1970s–80s.
+var dialColor = lipgloss.ANSIColor(14) // bright cyan
+
+// RenderRadioDial draws a retro LED dot-matrix frequency dial using Braille
+// characters in light blue. The band to the left of the needle is bright, the
+// right side is dim. A uniform-width needle line rises from bottom to top.
+// Tick marks punctuate at major frequencies.
 func RenderRadioDial(freqStr string, width int) string {
 	freq, band := ParseFrequency(freqStr)
 	if freq == 0 {
@@ -79,129 +87,192 @@ func RenderRadioDial(freqStr string, width int) string {
 		minF, maxF, ticks = fmMin, fmMax, dialTicksFM
 	}
 
-	// Clamp frequency to band range for positioning.
-	pos := freq
-	if pos < minF {
-		pos = minF
+	pos := clampF(freq, minF, maxF)
+
+	dotCols := width * 2
+	height := dialRows
+	dotRows := height * 4
+
+	// Needle position in dot-column space.
+	needleDot := int(math.Round(float64(dotCols-1) * (pos - minF) / (maxF - minF)))
+
+	// Grid stores brightness: 0=empty, 1=dim, 2=bright.
+	grid := make([]byte, dotRows*dotCols)
+
+	// --- Filled band: bottom 40% is a solid lit strip ---
+	// Left of needle = bright (2), right of needle = dim (1).
+	bandHeight := dotRows * 2 / 5
+	if bandHeight < 4 {
+		bandHeight = 4
 	}
-	if pos > maxF {
-		pos = maxF
+	for dr := 0; dr < bandHeight; dr++ {
+		row := dotRows - 1 - dr
+		for dc := range dotCols {
+			if dc <= needleDot {
+				grid[row*dotCols+dc] = 2
+			} else {
+				grid[row*dotCols+dc] = 1
+			}
+		}
 	}
 
-	// Build the dial scale line.
-	scaleWidth := width - 6 // reserve space for band label + borders
-	if scaleWidth < 20 {
-		scaleWidth = 20
-	}
-
-	// Position of needle on the scale (0-based column index).
-	needleCol := int(math.Round(float64(scaleWidth-1) * (pos - minF) / (maxF - minF)))
-
-	// --- Line 1: Band label and frequency display ---
-	freqDisplay := formatFreqDisplay(freq, band)
-	line1 := fmt.Sprintf("  %s  %s", band, freqDisplay)
-
-	// --- Line 2: Tick labels ---
-	tickLine := make([]byte, scaleWidth)
-	for i := range tickLine {
-		tickLine[i] = ' '
-	}
-	// Place tick labels on the scale.
-	type tickLabel struct {
-		col  int
-		text string
-	}
-	var labels []tickLabel
+	// --- Tick marks: short columns rising above the band ---
+	tickRise := 5 // dots above the band top
 	for _, t := range ticks {
-		col := int(math.Round(float64(scaleWidth-1) * (t - minF) / (maxF - minF)))
-		if col < 0 || col >= scaleWidth {
+		tc := int(math.Round(float64(dotCols-1) * (t - minF) / (maxF - minF)))
+		if tc < 0 || tc >= dotCols {
 			continue
 		}
-		text := formatTickLabel(t)
-		labels = append(labels, tickLabel{col: col, text: text})
+		topOfBand := dotRows - bandHeight
+		for dr := 0; dr < bandHeight+tickRise && dotRows-1-dr >= 0; dr++ {
+			row := dotRows - 1 - dr
+			brightness := byte(1)
+			if tc <= needleDot {
+				brightness = 2
+			}
+			if row >= topOfBand {
+				brightness = max(brightness, grid[row*dotCols+tc])
+			}
+			if grid[row*dotCols+tc] < brightness {
+				grid[row*dotCols+tc] = brightness
+			}
+		}
 	}
 
-	// Render tick labels, avoiding overlap.
-	labelLine := strings.Repeat(" ", scaleWidth)
-	labelRunes := []rune(labelLine)
-	for _, lbl := range labels {
-		text := []rune(lbl.text)
-		start := lbl.col - len(text)/2
+	// --- Needle: uniform 3-dot-wide line from bottom to top ---
+	for row := range dotRows {
+		// Center column: bright.
+		if needleDot >= 0 && needleDot < dotCols {
+			grid[row*dotCols+needleDot] = 2
+		}
+		// One dot on each side: bright.
+		if c := needleDot - 1; c >= 0 && c < dotCols {
+			if grid[row*dotCols+c] < 2 {
+				grid[row*dotCols+c] = 2
+			}
+		}
+		if c := needleDot + 1; c >= 0 && c < dotCols {
+			if grid[row*dotCols+c] < 2 {
+				grid[row*dotCols+c] = 2
+			}
+		}
+	}
+
+	// --- Render grid into Braille characters, all in light blue ---
+	dialBright := lipgloss.NewStyle().Foreground(dialColor)
+	dialDim := lipgloss.NewStyle().Foreground(dialColor).Faint(true)
+
+	lines := make([]string, height)
+	for row := range height {
+		var sb strings.Builder
+		for col := range width {
+			var braille rune = '\u2800'
+			maxBright := byte(0)
+			for dr := range 4 {
+				for dc := range 2 {
+					gr := row*4 + dr
+					gc := col*2 + dc
+					if gr < dotRows && gc < dotCols {
+						val := grid[gr*dotCols+gc]
+						if val > 0 {
+							braille |= brailleBit[dr][dc]
+						}
+						if val > maxBright {
+							maxBright = val
+						}
+					}
+				}
+			}
+
+			switch maxBright {
+			case 2:
+				sb.WriteString(dialBright.Render(string(braille)))
+			case 1:
+				sb.WriteString(dialDim.Render(string(braille)))
+			default:
+				sb.WriteRune(' ')
+			}
+		}
+		lines[row] = sb.String()
+	}
+
+	// --- Tick labels below the dial ---
+	labelLine := renderDialLabels(ticks, minF, maxF, width)
+
+	// --- Frequency readout centered above the dial ---
+	readout := formatDialReadout(freq, band)
+	readoutStyle := lipgloss.NewStyle().Foreground(dialColor).Bold(true)
+	bandStyle := lipgloss.NewStyle().Foreground(ColorDim)
+
+	readoutStr := bandStyle.Render(band+" ") + readoutStyle.Render(readout)
+	rawLen := len(band) + 1 + len(readout)
+	readoutPad := ""
+	if rawLen < width {
+		readoutPad = strings.Repeat(" ", (width-rawLen)/2)
+	}
+
+	result := []string{readoutPad + readoutStr}
+	result = append(result, lines...)
+	result = append(result, labelLine)
+
+	return strings.Join(result, "\n")
+}
+
+func clampF(v, lo, hi float64) float64 {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
+// formatDialReadout formats the large frequency display.
+func formatDialReadout(freq float64, band string) string {
+	if band == "AM" {
+		return fmt.Sprintf("%.0f kHz", freq)
+	}
+	return fmt.Sprintf("%.1f MHz", freq)
+}
+
+// renderDialLabels renders the tick frequency labels below the dial.
+func renderDialLabels(ticks []float64, minF, maxF float64, width int) string {
+	dimStyle := lipgloss.NewStyle().Foreground(ColorDim)
+
+	runes := make([]rune, width)
+	for i := range runes {
+		runes[i] = ' '
+	}
+
+	for _, t := range ticks {
+		col := int(math.Round(float64(width-1) * (t - minF) / (maxF - minF)))
+		label := formatTickLabel(t)
+		text := []rune(label)
+		start := col - len(text)/2
 		if start < 0 {
 			start = 0
 		}
-		if start+len(text) > scaleWidth {
-			start = scaleWidth - len(text)
+		if start+len(text) > width {
+			start = width - len(text)
 		}
-		// Check for overlap.
 		overlap := false
-		for j := start; j < start+len(text) && j < scaleWidth; j++ {
-			if labelRunes[j] != ' ' {
+		for j := start; j < start+len(text) && j < width; j++ {
+			if runes[j] != ' ' {
 				overlap = true
 				break
 			}
 		}
 		if !overlap {
 			for j, r := range text {
-				if start+j < scaleWidth {
-					labelRunes[start+j] = r
+				if start+j < width {
+					runes[start+j] = r
 				}
 			}
 		}
 	}
 
-	// --- Line 3: Scale with ticks ---
-	scale := make([]rune, scaleWidth)
-	for i := range scale {
-		scale[i] = '─'
-	}
-	// Mark tick positions.
-	for _, t := range ticks {
-		col := int(math.Round(float64(scaleWidth-1) * (t - minF) / (maxF - minF)))
-		if col >= 0 && col < scaleWidth {
-			scale[col] = '┼'
-		}
-	}
-
-	// --- Line 4: Needle indicator ---
-	needleLine := make([]rune, scaleWidth)
-	for i := range needleLine {
-		needleLine[i] = ' '
-	}
-	if needleCol >= 0 && needleCol < scaleWidth {
-		needleLine[needleCol] = '▲'
-	}
-
-	// Style everything.
-	dimStyle := lipgloss.NewStyle().Foreground(ColorDim)
-	accentStyle := lipgloss.NewStyle().Foreground(ColorAccent)
-	titleStyle := lipgloss.NewStyle().Foreground(ColorTitle).Bold(true)
-
-	// Pad each line with leading spaces for centering the scale portion.
-	pad := "  "
-
-	// Color the needle line — highlight just the needle.
-	needleStr := colorNeedleLine(needleLine, needleCol, accentStyle, dimStyle)
-
-	// Color the scale — highlight the filled portion up to the needle.
-	scaleStr := colorScale(scale, needleCol, accentStyle, dimStyle)
-
-	lines := []string{
-		titleStyle.Render(line1),
-		dimStyle.Render(pad + string(labelRunes)),
-		pad + scaleStr,
-		pad + needleStr,
-	}
-
-	return strings.Join(lines, "\n")
-}
-
-// formatFreqDisplay formats the main frequency readout.
-func formatFreqDisplay(freq float64, band string) string {
-	if band == "AM" {
-		return fmt.Sprintf("[ %4.0f kHz ]", freq)
-	}
-	return fmt.Sprintf("[ %5.1f MHz ]", freq)
+	return dimStyle.Render(string(runes))
 }
 
 // formatTickLabel formats a tick value for the scale.
@@ -209,39 +280,8 @@ func formatTickLabel(t float64) string {
 	if t >= 200 { // AM
 		return fmt.Sprintf("%4.0f", t)
 	}
-	// FM: show whole numbers without decimal.
 	if t == math.Trunc(t) {
 		return fmt.Sprintf("%3.0f", t)
 	}
 	return fmt.Sprintf("%5.1f", t)
-}
-
-// colorScale renders the scale runes with accent color up to and including the
-// needle position, and dim color for the rest.
-func colorScale(scale []rune, needleCol int, accent, dim lipgloss.Style) string {
-	if len(scale) == 0 {
-		return ""
-	}
-	var b strings.Builder
-	for i, r := range scale {
-		if i <= needleCol {
-			b.WriteString(accent.Render(string(r)))
-		} else {
-			b.WriteString(dim.Render(string(r)))
-		}
-	}
-	return b.String()
-}
-
-// colorNeedleLine renders the needle indicator line.
-func colorNeedleLine(line []rune, needleCol int, accent, dim lipgloss.Style) string {
-	var b strings.Builder
-	for i, r := range line {
-		if i == needleCol {
-			b.WriteString(accent.Render(string(r)))
-		} else {
-			b.WriteString(dim.Render(string(r)))
-		}
-	}
-	return b.String()
 }

--- a/ui/radio_dial.go
+++ b/ui/radio_dial.go
@@ -1,0 +1,247 @@
+package ui
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+)
+
+// FM and AM band boundaries.
+const (
+	fmMin = 87.5
+	fmMax = 108.0
+	amMin = 530.0
+	amMax = 1700.0
+)
+
+// dialTicksFM are the major tick marks on the FM dial.
+var dialTicksFM = []float64{88, 90, 92, 94, 96, 98, 100, 102, 104, 106, 108}
+
+// dialTicksAM are the major tick marks on the AM dial.
+var dialTicksAM = []float64{600, 800, 1000, 1200, 1400, 1600}
+
+// ParseFrequency extracts the numeric frequency and band ("FM" or "AM") from
+// a string like "88.3 FM" or "1200 AM". Returns 0, "" on parse failure.
+func ParseFrequency(s string) (float64, string) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, ""
+	}
+
+	band := "FM" // default
+	upper := strings.ToUpper(s)
+	if strings.HasSuffix(upper, " FM") {
+		s = strings.TrimSpace(s[:len(s)-3])
+	} else if strings.HasSuffix(upper, " AM") {
+		band = "AM"
+		s = strings.TrimSpace(s[:len(s)-3])
+	} else if strings.HasSuffix(upper, "FM") {
+		s = strings.TrimSpace(s[:len(s)-2])
+	} else if strings.HasSuffix(upper, "AM") {
+		band = "AM"
+		s = strings.TrimSpace(s[:len(s)-2])
+	}
+
+	freq, err := strconv.ParseFloat(s, 64)
+	if err != nil || freq <= 0 {
+		return 0, ""
+	}
+
+	// Auto-detect band from frequency range if not explicitly stated.
+	if freq > 200 {
+		band = "AM"
+	}
+
+	return freq, band
+}
+
+// RenderRadioDial draws a retro frequency dial for the given frequency string.
+// width is the available character width. Returns empty string if the frequency
+// cannot be parsed.
+func RenderRadioDial(freqStr string, width int) string {
+	freq, band := ParseFrequency(freqStr)
+	if freq == 0 {
+		return ""
+	}
+
+	if width < 30 {
+		width = 30
+	}
+
+	var minF, maxF float64
+	var ticks []float64
+	if band == "AM" {
+		minF, maxF, ticks = amMin, amMax, dialTicksAM
+	} else {
+		minF, maxF, ticks = fmMin, fmMax, dialTicksFM
+	}
+
+	// Clamp frequency to band range for positioning.
+	pos := freq
+	if pos < minF {
+		pos = minF
+	}
+	if pos > maxF {
+		pos = maxF
+	}
+
+	// Build the dial scale line.
+	scaleWidth := width - 6 // reserve space for band label + borders
+	if scaleWidth < 20 {
+		scaleWidth = 20
+	}
+
+	// Position of needle on the scale (0-based column index).
+	needleCol := int(math.Round(float64(scaleWidth-1) * (pos - minF) / (maxF - minF)))
+
+	// --- Line 1: Band label and frequency display ---
+	freqDisplay := formatFreqDisplay(freq, band)
+	line1 := fmt.Sprintf("  %s  %s", band, freqDisplay)
+
+	// --- Line 2: Tick labels ---
+	tickLine := make([]byte, scaleWidth)
+	for i := range tickLine {
+		tickLine[i] = ' '
+	}
+	// Place tick labels on the scale.
+	type tickLabel struct {
+		col  int
+		text string
+	}
+	var labels []tickLabel
+	for _, t := range ticks {
+		col := int(math.Round(float64(scaleWidth-1) * (t - minF) / (maxF - minF)))
+		if col < 0 || col >= scaleWidth {
+			continue
+		}
+		text := formatTickLabel(t)
+		labels = append(labels, tickLabel{col: col, text: text})
+	}
+
+	// Render tick labels, avoiding overlap.
+	labelLine := strings.Repeat(" ", scaleWidth)
+	labelRunes := []rune(labelLine)
+	for _, lbl := range labels {
+		text := []rune(lbl.text)
+		start := lbl.col - len(text)/2
+		if start < 0 {
+			start = 0
+		}
+		if start+len(text) > scaleWidth {
+			start = scaleWidth - len(text)
+		}
+		// Check for overlap.
+		overlap := false
+		for j := start; j < start+len(text) && j < scaleWidth; j++ {
+			if labelRunes[j] != ' ' {
+				overlap = true
+				break
+			}
+		}
+		if !overlap {
+			for j, r := range text {
+				if start+j < scaleWidth {
+					labelRunes[start+j] = r
+				}
+			}
+		}
+	}
+
+	// --- Line 3: Scale with ticks ---
+	scale := make([]rune, scaleWidth)
+	for i := range scale {
+		scale[i] = '─'
+	}
+	// Mark tick positions.
+	for _, t := range ticks {
+		col := int(math.Round(float64(scaleWidth-1) * (t - minF) / (maxF - minF)))
+		if col >= 0 && col < scaleWidth {
+			scale[col] = '┼'
+		}
+	}
+
+	// --- Line 4: Needle indicator ---
+	needleLine := make([]rune, scaleWidth)
+	for i := range needleLine {
+		needleLine[i] = ' '
+	}
+	if needleCol >= 0 && needleCol < scaleWidth {
+		needleLine[needleCol] = '▲'
+	}
+
+	// Style everything.
+	dimStyle := lipgloss.NewStyle().Foreground(ColorDim)
+	accentStyle := lipgloss.NewStyle().Foreground(ColorAccent)
+	titleStyle := lipgloss.NewStyle().Foreground(ColorTitle).Bold(true)
+
+	// Pad each line with leading spaces for centering the scale portion.
+	pad := "  "
+
+	// Color the needle line — highlight just the needle.
+	needleStr := colorNeedleLine(needleLine, needleCol, accentStyle, dimStyle)
+
+	// Color the scale — highlight the filled portion up to the needle.
+	scaleStr := colorScale(scale, needleCol, accentStyle, dimStyle)
+
+	lines := []string{
+		titleStyle.Render(line1),
+		dimStyle.Render(pad + string(labelRunes)),
+		pad + scaleStr,
+		pad + needleStr,
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// formatFreqDisplay formats the main frequency readout.
+func formatFreqDisplay(freq float64, band string) string {
+	if band == "AM" {
+		return fmt.Sprintf("[ %4.0f kHz ]", freq)
+	}
+	return fmt.Sprintf("[ %5.1f MHz ]", freq)
+}
+
+// formatTickLabel formats a tick value for the scale.
+func formatTickLabel(t float64) string {
+	if t >= 200 { // AM
+		return fmt.Sprintf("%4.0f", t)
+	}
+	// FM: show whole numbers without decimal.
+	if t == math.Trunc(t) {
+		return fmt.Sprintf("%3.0f", t)
+	}
+	return fmt.Sprintf("%5.1f", t)
+}
+
+// colorScale renders the scale runes with accent color up to and including the
+// needle position, and dim color for the rest.
+func colorScale(scale []rune, needleCol int, accent, dim lipgloss.Style) string {
+	if len(scale) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for i, r := range scale {
+		if i <= needleCol {
+			b.WriteString(accent.Render(string(r)))
+		} else {
+			b.WriteString(dim.Render(string(r)))
+		}
+	}
+	return b.String()
+}
+
+// colorNeedleLine renders the needle indicator line.
+func colorNeedleLine(line []rune, needleCol int, accent, dim lipgloss.Style) string {
+	var b strings.Builder
+	for i, r := range line {
+		if i == needleCol {
+			b.WriteString(accent.Render(string(r)))
+		} else {
+			b.WriteString(dim.Render(string(r)))
+		}
+	}
+	return b.String()
+}

--- a/ui/radio_dial.go
+++ b/ui/radio_dial.go
@@ -17,11 +17,29 @@ const (
 	amMax = 1700.0
 )
 
-// dialTicksFM are the major tick marks on the FM dial.
+// dialTicksFM are the major tick marks on the FM dial (labeled).
 var dialTicksFM = []float64{88, 90, 92, 94, 96, 98, 100, 102, 104, 106, 108}
 
-// dialTicksAM are the major tick marks on the AM dial.
+// dialMinorTicksFM are the minor subdivisions between major FM ticks.
+var dialMinorTicksFM = func() []float64 {
+	var t []float64
+	for f := 89.0; f < 108.0; f += 2.0 {
+		t = append(t, f)
+	}
+	return t
+}()
+
+// dialTicksAM are the major tick marks on the AM dial (labeled).
 var dialTicksAM = []float64{600, 800, 1000, 1200, 1400, 1600}
+
+// dialMinorTicksAM are minor subdivisions for AM.
+var dialMinorTicksAM = func() []float64 {
+	var t []float64
+	for f := 700.0; f < 1700.0; f += 200.0 {
+		t = append(t, f)
+	}
+	return t
+}()
 
 // ParseFrequency extracts the numeric frequency and band ("FM" or "AM") from
 // a string like "88.3 FM" or "1200 AM". Returns 0, "" on parse failure.
@@ -50,7 +68,6 @@ func ParseFrequency(s string) (float64, string) {
 		return 0, ""
 	}
 
-	// Auto-detect band from frequency range if not explicitly stated.
 	if freq > 200 {
 		band = "AM"
 	}
@@ -58,17 +75,28 @@ func ParseFrequency(s string) (float64, string) {
 	return freq, band
 }
 
-// dialRows is the height of the LED dot-matrix dial in terminal rows.
+// dialRows is the height of the Braille dial area in terminal rows.
 const dialRows = 4
 
-// dialColor is a light blue reminiscent of classic Pioneer/Marantz receiver
-// tuner dials from the 1970s–80s.
-var dialColor = lipgloss.ANSIColor(14) // bright cyan
+// Dial colors: green scale with a red needle, like a 1970s Sansui/Marantz.
+var (
+	dialGreen    = lipgloss.ANSIColor(2)  // dark green — warm backlit scale
+	dialGreenLit = lipgloss.ANSIColor(10) // bright green — lit numerals/ticks
+	dialRed      = lipgloss.ANSIColor(9)  // bright red — the needle/pointer
+)
 
-// RenderRadioDial draws a retro LED dot-matrix frequency dial using Braille
-// characters in light blue. The band to the left of the needle is bright, the
-// right side is dim. A uniform-width needle line rises from bottom to top.
-// Tick marks punctuate at major frequencies.
+// Grid cell types for the two-color render pass.
+const (
+	cellEmpty    = 0
+	cellGreenDim = 1 // dim green (untuned band fill)
+	cellGreen    = 2 // bright green (tuned band fill, ticks)
+	cellRed      = 3 // red needle
+)
+
+// RenderRadioDial draws a retro receiver-style frequency dial. Green backlit
+// scale with a thin red pointer line, inspired by 1970s Sansui and Marantz
+// stereo receivers. The band fills bright green left of the needle and dim
+// green right. Major and minor tick marks punctuate the scale.
 func RenderRadioDial(freqStr string, width int) string {
 	freq, band := ParseFrequency(freqStr)
 	if freq == 0 {
@@ -80,11 +108,13 @@ func RenderRadioDial(freqStr string, width int) string {
 	}
 
 	var minF, maxF float64
-	var ticks []float64
+	var majorTicks, minorTicks []float64
 	if band == "AM" {
-		minF, maxF, ticks = amMin, amMax, dialTicksAM
+		minF, maxF = amMin, amMax
+		majorTicks, minorTicks = dialTicksAM, dialMinorTicksAM
 	} else {
-		minF, maxF, ticks = fmMin, fmMax, dialTicksFM
+		minF, maxF = fmMin, fmMax
+		majorTicks, minorTicks = dialTicksFM, dialMinorTicksFM
 	}
 
 	pos := clampF(freq, minF, maxF)
@@ -93,14 +123,12 @@ func RenderRadioDial(freqStr string, width int) string {
 	height := dialRows
 	dotRows := height * 4
 
-	// Needle position in dot-column space.
 	needleDot := int(math.Round(float64(dotCols-1) * (pos - minF) / (maxF - minF)))
 
-	// Grid stores brightness: 0=empty, 1=dim, 2=bright.
 	grid := make([]byte, dotRows*dotCols)
 
-	// --- Filled band: bottom 40% is a solid lit strip ---
-	// Left of needle = bright (2), right of needle = dim (1).
+	// --- Filled band: bottom 40% solid green strip ---
+	// Left of needle = bright green, right = dim green.
 	bandHeight := dotRows * 2 / 5
 	if bandHeight < 4 {
 		bandHeight = 4
@@ -109,29 +137,25 @@ func RenderRadioDial(freqStr string, width int) string {
 		row := dotRows - 1 - dr
 		for dc := range dotCols {
 			if dc <= needleDot {
-				grid[row*dotCols+dc] = 2
+				grid[row*dotCols+dc] = cellGreen
 			} else {
-				grid[row*dotCols+dc] = 1
+				grid[row*dotCols+dc] = cellGreenDim
 			}
 		}
 	}
 
-	// --- Tick marks: short columns rising above the band ---
-	tickRise := 5 // dots above the band top
-	for _, t := range ticks {
+	// --- Major tick marks: tall columns through the band and above ---
+	majorTickHeight := bandHeight + 6
+	for _, t := range majorTicks {
 		tc := int(math.Round(float64(dotCols-1) * (t - minF) / (maxF - minF)))
 		if tc < 0 || tc >= dotCols {
 			continue
 		}
-		topOfBand := dotRows - bandHeight
-		for dr := 0; dr < bandHeight+tickRise && dotRows-1-dr >= 0; dr++ {
+		for dr := 0; dr < majorTickHeight && dotRows-1-dr >= 0; dr++ {
 			row := dotRows - 1 - dr
-			brightness := byte(1)
+			brightness := byte(cellGreenDim)
 			if tc <= needleDot {
-				brightness = 2
-			}
-			if row >= topOfBand {
-				brightness = max(brightness, grid[row*dotCols+tc])
+				brightness = cellGreen
 			}
 			if grid[row*dotCols+tc] < brightness {
 				grid[row*dotCols+tc] = brightness
@@ -139,35 +163,72 @@ func RenderRadioDial(freqStr string, width int) string {
 		}
 	}
 
-	// --- Needle: uniform 3-dot-wide line from bottom to top ---
-	for row := range dotRows {
-		// Center column: bright.
-		if needleDot >= 0 && needleDot < dotCols {
-			grid[row*dotCols+needleDot] = 2
+	// --- Minor tick marks: shorter columns, just above the band ---
+	minorTickHeight := bandHeight + 3
+	for _, t := range minorTicks {
+		tc := int(math.Round(float64(dotCols-1) * (t - minF) / (maxF - minF)))
+		if tc < 0 || tc >= dotCols {
+			continue
 		}
-		// One dot on each side: bright.
-		if c := needleDot - 1; c >= 0 && c < dotCols {
-			if grid[row*dotCols+c] < 2 {
-				grid[row*dotCols+c] = 2
+		for dr := 0; dr < minorTickHeight && dotRows-1-dr >= 0; dr++ {
+			row := dotRows - 1 - dr
+			brightness := byte(cellGreenDim)
+			if tc <= needleDot {
+				brightness = cellGreen
 			}
-		}
-		if c := needleDot + 1; c >= 0 && c < dotCols {
-			if grid[row*dotCols+c] < 2 {
-				grid[row*dotCols+c] = 2
+			if grid[row*dotCols+tc] < brightness {
+				grid[row*dotCols+tc] = brightness
 			}
 		}
 	}
 
-	// --- Render grid into Braille characters, all in light blue ---
-	dialBright := lipgloss.NewStyle().Foreground(dialColor)
-	dialDim := lipgloss.NewStyle().Foreground(dialColor).Faint(true)
+	// --- Red needle: exactly 2-dot-wide line from bottom to top ---
+	// We paint two adjacent dot-columns as red. To prevent the needle from
+	// appearing wider in the filled band, clear any green dots in the same
+	// Braille cells as the needle so the cell only contains red dots.
+	needleDots := [2]int{needleDot, needleDot + 1}
+	for row := range dotRows {
+		for _, nd := range needleDots {
+			if nd >= 0 && nd < dotCols {
+				grid[row*dotCols+nd] = cellRed
+			}
+		}
+		// Clear the other dot-column in each Braille cell that contains a
+		// needle dot, so the cell doesn't mix red and green.
+		for _, nd := range needleDots {
+			if nd < 0 || nd >= dotCols {
+				continue
+			}
+			// Braille cells are 2 dot-columns wide. Find the partner column.
+			partner := nd ^ 1 // if nd is even, partner is nd+1; if odd, nd-1
+			if partner < 0 || partner >= dotCols {
+				continue
+			}
+			// If the partner is not also a needle dot, clear it.
+			isNeedle := false
+			for _, nd2 := range needleDots {
+				if partner == nd2 {
+					isNeedle = true
+					break
+				}
+			}
+			if !isNeedle && grid[row*dotCols+partner] != cellEmpty {
+				grid[row*dotCols+partner] = cellEmpty
+			}
+		}
+	}
+
+	// --- Render grid into Braille characters ---
+	greenBright := lipgloss.NewStyle().Foreground(dialGreenLit)
+	greenDim := lipgloss.NewStyle().Foreground(dialGreen)
+	redStyle := lipgloss.NewStyle().Foreground(dialRed)
 
 	lines := make([]string, height)
 	for row := range height {
 		var sb strings.Builder
 		for col := range width {
 			var braille rune = '\u2800'
-			maxBright := byte(0)
+			maxType := byte(0)
 			for dr := range 4 {
 				for dc := range 2 {
 					gr := row*4 + dr
@@ -177,18 +238,20 @@ func RenderRadioDial(freqStr string, width int) string {
 						if val > 0 {
 							braille |= brailleBit[dr][dc]
 						}
-						if val > maxBright {
-							maxBright = val
+						if val > maxType {
+							maxType = val
 						}
 					}
 				}
 			}
 
-			switch maxBright {
-			case 2:
-				sb.WriteString(dialBright.Render(string(braille)))
-			case 1:
-				sb.WriteString(dialDim.Render(string(braille)))
+			switch maxType {
+			case cellRed:
+				sb.WriteString(redStyle.Render(string(braille)))
+			case cellGreen:
+				sb.WriteString(greenBright.Render(string(braille)))
+			case cellGreenDim:
+				sb.WriteString(greenDim.Render(string(braille)))
 			default:
 				sb.WriteRune(' ')
 			}
@@ -196,13 +259,13 @@ func RenderRadioDial(freqStr string, width int) string {
 		lines[row] = sb.String()
 	}
 
-	// --- Tick labels below the dial ---
-	labelLine := renderDialLabels(ticks, minF, maxF, width)
+	// --- Tick labels below the dial in green ---
+	labelLine := renderDialLabels(majorTicks, minF, maxF, width, dialGreenLit)
 
 	// --- Frequency readout centered above the dial ---
 	readout := formatDialReadout(freq, band)
-	readoutStyle := lipgloss.NewStyle().Foreground(dialColor).Bold(true)
-	bandStyle := lipgloss.NewStyle().Foreground(ColorDim)
+	readoutStyle := lipgloss.NewStyle().Foreground(dialRed).Bold(true)
+	bandStyle := lipgloss.NewStyle().Foreground(dialGreen)
 
 	readoutStr := bandStyle.Render(band+" ") + readoutStyle.Render(readout)
 	rawLen := len(band) + 1 + len(readout)
@@ -237,8 +300,8 @@ func formatDialReadout(freq float64, band string) string {
 }
 
 // renderDialLabels renders the tick frequency labels below the dial.
-func renderDialLabels(ticks []float64, minF, maxF float64, width int) string {
-	dimStyle := lipgloss.NewStyle().Foreground(ColorDim)
+func renderDialLabels(ticks []float64, minF, maxF float64, width int, labelColor lipgloss.ANSIColor) string {
+	style := lipgloss.NewStyle().Foreground(labelColor)
 
 	runes := make([]rune, width)
 	for i := range runes {
@@ -272,7 +335,7 @@ func renderDialLabels(ticks []float64, minF, maxF float64, width int) string {
 		}
 	}
 
-	return dimStyle.Render(string(runes))
+	return style.Render(string(runes))
 }
 
 // formatTickLabel formats a tick value for the scale.

--- a/ui/radio_dial_test.go
+++ b/ui/radio_dial_test.go
@@ -1,0 +1,52 @@
+package ui
+
+import "testing"
+
+func TestParseFrequency(t *testing.T) {
+	tests := []struct {
+		input    string
+		wantFreq float64
+		wantBand string
+	}{
+		{"88.3 FM", 88.3, "FM"},
+		{"91.7FM", 91.7, "FM"},
+		{"90.3", 90.3, "FM"},
+		{"1200 AM", 1200, "AM"},
+		{"880AM", 880, "AM"},
+		{"660", 660, "AM"},
+		{"", 0, ""},
+		{"not a number", 0, ""},
+	}
+	for _, tt := range tests {
+		freq, band := ParseFrequency(tt.input)
+		if freq != tt.wantFreq || band != tt.wantBand {
+			t.Errorf("ParseFrequency(%q) = (%v, %q), want (%v, %q)",
+				tt.input, freq, band, tt.wantFreq, tt.wantBand)
+		}
+	}
+}
+
+func TestRenderRadioDialNonEmpty(t *testing.T) {
+	out := RenderRadioDial("91.7 FM", 60)
+	if out == "" {
+		t.Fatal("expected non-empty dial output for valid frequency")
+	}
+}
+
+func TestRenderRadioDialEmpty(t *testing.T) {
+	out := RenderRadioDial("", 60)
+	if out != "" {
+		t.Fatalf("expected empty output for empty frequency, got %q", out)
+	}
+	out = RenderRadioDial("bad", 60)
+	if out != "" {
+		t.Fatalf("expected empty output for unparseable frequency, got %q", out)
+	}
+}
+
+func TestRenderRadioDialAM(t *testing.T) {
+	out := RenderRadioDial("1200 AM", 60)
+	if out == "" {
+		t.Fatal("expected non-empty dial output for AM frequency")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds an optional `frequency` field to `radios.toml` custom stations (e.g. `frequency = "91.7 FM"`)
- Renders a retro FM/AM frequency dial in the radio playback view, inspired by 1970s Sansui/Marantz stereo
  receivers
- Green backlit scale with a thin red pointer needle, major + minor tick marks, and a "tuned" fill effect (bright
   left of needle, dim right)
- Uses Braille dot-matrix rendering to match the existing visualizer aesthetic
- Dial appears between the seek bar and controls when a station with a frequency is playing
- Supports both FM (87.5–108 MHz) and AM (530–1700 kHz) bands

## Screenshots / video

<img width="972" height="588" alt="▶_KVRX_91_7_Austin___cliamp_and_✳_Claude_Code_and_reporting_table_p1_p2_recomme…_priviledged_-_Google_Sheets" src="https://github.com/user-attachments/assets/c688b5f8-5f8a-41df-9527-3b68ce5dd537" />


## How to test

1. Add a station with a frequency to `~/.config/cliamp/radios.toml`:
     ```toml
     [[station]]
     name = "KVRX 91.7 Austin"
     url = "https://streams.kut.org/5020_192.mp3"
     frequency = "91.7 FM"
  2. make build && ./cliamp
  3. Navigate to Radio > Stations > play the station
  4. The dial should appear below the seek bar with a green scale and red needle
  5. Stations without a frequency field should show no dial

## Checklist

- [ ] `make check` passes
- [ ] `docs/` and `site/index.html` updated for user-facing changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a retro-style radio frequency dial to the playback interface.
  * Displays station frequencies for local radio stations, including FM and AM bands.
  * Shows frequency readouts, tuning scales, tick marks, and a visual indicator for the current station.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->