### PR TITLE
feat(ui): add RedSector visualizer mode

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,7 +65,7 @@ eq = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 # keeps it available, and both values are restored after restart.
 
 # Visualizer mode (leave empty for default Bars)
-# Options: Bars, BarsDot, Rain, BarsOutline, Bricks, Columns, ClassicPeak, Wave, Scatter, Flame, Retro, Pulse, Matrix, Binary, Sakura, Firework, Bubbles, Logo, Terrain, Scope, Heartbeat, Butterfly, Ascii, Firefly, Mosaic, Sand, Geyser, ClassicLED, Stereo, Mirror, Omarchy, None
+# Options: Bars, BarsDot, Rain, BarsOutline, Bricks, Columns, ClassicPeak, Wave, Scatter, Flame, Retro, Pulse, Matrix, Binary, Sakura, Firework, Bubbles, Logo, Terrain, Scope, Heartbeat, Butterfly, Ascii, Firefly, Mosaic, Sand, Geyser, ClassicLED, Stereo, Mirror, Omarchy, RedSector, None
 # Mirror draws tapered Braille bars around a persistent horizontal center axis.
 visualizer = "Bars"
 

--- a/ui/new_vis_smoke_test.go
+++ b/ui/new_vis_smoke_test.go
@@ -17,6 +17,7 @@ func TestCharmVisualizersRender(t *testing.T) {
 		"Sand",
 		"ClassicLED",
 		"Omarchy",
+		"RedSector",
 	}
 
 	signal := make([]float64, 2048)

--- a/ui/vis_red_sector.go
+++ b/ui/vis_red_sector.go
@@ -1,0 +1,515 @@
+package ui
+
+import (
+	"fmt"
+	"image/color"
+	"math"
+	"strings"
+	"time"
+
+	"charm.land/lipgloss/v2"
+)
+
+// A wireframe equalizer after the vector part of the Red Sector Inc. RSI
+// Megademo (Amiga, 1989). Five hollow bars stand on a common ground line, each
+// driven by two spectrum bands, and the whole group tumbles as a rigid body
+// while a starfield drifts behind it. Hidden edges are removed with per-face
+// backface culling, so a bar shows its front, one flank and its cap, the way
+// the original vector objects do.
+//
+// A cell keeps the highest tag drawn into it, which is what puts every bar in
+// front of every star: the four star tags sit below the three bar tags. That
+// ordering is why this mode rasterises into a grid of its own rather than the
+// shared brailleGrid, whose three tiers leave no room below the bars.
+
+const (
+	redSectorBars      = 5
+	redSectorHalfWidth = 0.26
+	redSectorHalfDepth = 0.26
+	// Centre-to-centre distance between neighbouring bars.
+	redSectorPitch = 0.78
+	// The common base line all bars stand on.
+	redSectorGroundY   = -1.05
+	redSectorMinHeight = 0.40
+	redSectorMaxHeight = 2.30
+	redSectorFocal     = 3.2
+	redSectorCameraZ   = 6.0
+	// How far the object drifts towards the viewer and back.
+	redSectorZoomAmplitude = 1.5
+	// How far the picture may be widened past its own height.
+	redSectorMaxStretch = 2.0
+	// Dot rows at which no widening is needed any more.
+	redSectorComfortDotRows = 40
+
+	// Rotation in radians per frame. The demo tumbles the object around two
+	// axes at unrelated rates, so it never repeats a pose for long.
+	redSectorSpinY    = 0.105
+	redSectorSpinX    = 0.073
+	redSectorZoomRate = 0.011
+
+	// Per frame, how fast a band's ceiling and floor close in on each other.
+	redSectorEnvelopeRelax = 0.001
+	// The narrowest span that still counts as movement.
+	redSectorMinEnvelope = 0.06
+
+	// Cell tags, low to high. The four star tags sit below the three bar tags,
+	// so a bar always wins the cell it shares with a star.
+	redSectorStarTags = 4
+	redSectorTagLow   = 5
+	redSectorTagMid   = 6
+	redSectorTagHigh  = 7
+	redSectorTagCount = redSectorTagHigh
+
+	// How much of a spectrum colour a star keeps. Only themes without an ANSI
+	// twin are scaled; see redSectorDim.
+	redSectorStarDim = 0.6
+
+	// Dot cells per star, and the bounds the count is held inside.
+	redSectorDotsPerStar = 130
+	redSectorMinStars    = 6
+	redSectorMaxStars    = 90
+)
+
+// The eight corners of a bar, as signs on its base centre. Height is filled in
+// per frame, so only the signs live here.
+var (
+	redSectorCornerX   = [8]float64{-1, 1, 1, -1, -1, 1, 1, -1}
+	redSectorCornerZ   = [8]float64{-1, -1, -1, -1, 1, 1, 1, 1}
+	redSectorCornerTop = [8]bool{false, false, true, true, false, false, true, true}
+)
+
+// Faces wound so the cross product of the first two edges points inwards. A
+// face is then visible when that normal points away from the viewer.
+var redSectorFaces = [6][4]int{
+	{0, 1, 2, 3}, // front
+	{5, 4, 7, 6}, // back
+	{0, 3, 7, 4}, // left
+	{1, 5, 6, 2}, // right
+	{3, 2, 6, 7}, // top
+	{0, 4, 5, 1}, // bottom
+}
+
+// redSectorDriver keeps the per-band envelope and the eased bar heights across
+// frames. Both outlive a single render, which is why this mode carries a
+// driver of its own rather than a plain render function.
+type redSectorDriver struct {
+	grid    redSectorGrid
+	ceiling [redSectorBars]float64
+	floor   [redSectorBars]float64
+	heights [redSectorBars]float64
+}
+
+func newRedSectorDriver() visModeDriver {
+	d := &redSectorDriver{}
+	d.reset()
+	return d
+}
+
+func (d *redSectorDriver) reset() {
+	for i := range d.ceiling {
+		// Start wide open, so the first frames pull both ends onto the real range.
+		d.ceiling[i] = 0
+		d.floor[i] = 1
+		d.heights[i] = redSectorMinHeight
+	}
+	d.grid = redSectorGrid{}
+}
+
+func (*redSectorDriver) AnalysisSpec(*Visualizer) VisAnalysisSpec {
+	return spectrumAnalysisSpec(DefaultSpectrumBands)
+}
+
+func (d *redSectorDriver) Tick(v *Visualizer, ctx VisTickContext) {
+	defaultDriverTick(v, ctx, d.AnalysisSpec(v))
+	if ctx.OverlayActive {
+		return
+	}
+	d.advance(v.SmoothedBands())
+}
+
+func (*redSectorDriver) TickInterval(_ *Visualizer, ctx VisTickContext) time.Duration {
+	return defaultDriverTickInterval(ctx)
+}
+
+func (d *redSectorDriver) OnEnter(*Visualizer) { d.reset() }
+
+func (*redSectorDriver) OnLeave(*Visualizer) {}
+
+// advance reads each bar's pair of bands and eases its height.
+//
+// Every band sits at its own resting level and moves only a little around it:
+// in a measured stream the bass band hovers near the top while the treble
+// bands stay low, and every one of them swings by about a tenth. Read as
+// absolute heights that draws the fixed shape of the mix, not the beat. So
+// every bar tracks its own ceiling and floor and shows where the level sits
+// between them. The ceiling sinks and the floor climbs slowly, which lets the
+// pair follow a change of track without flattening a steady passage.
+func (d *redSectorDriver) advance(bands []float64) {
+	for i := range redSectorBars {
+		// Two bands per bar, taking the louder of the pair. Averaging would let
+		// a silent band halve its partner, and the top band is empty on most
+		// material because the encoder cuts everything above 16 kHz.
+		level := max(redSectorBand(bands, i*2), redSectorBand(bands, i*2+1))
+
+		if level > d.ceiling[i] {
+			d.ceiling[i] = level
+		} else {
+			d.ceiling[i] -= redSectorEnvelopeRelax
+		}
+		if level < d.floor[i] {
+			d.floor[i] = level
+		} else {
+			d.floor[i] += redSectorEnvelopeRelax
+		}
+		if d.ceiling[i] < d.floor[i]+redSectorMinEnvelope {
+			d.ceiling[i] = d.floor[i] + redSectorMinEnvelope
+		}
+
+		norm := min(1, max(0, (level-d.floor[i])/(d.ceiling[i]-d.floor[i])))
+		target := redSectorMinHeight + norm*(redSectorMaxHeight-redSectorMinHeight)
+		// Rising fast and falling slow keeps a transient visible long enough
+		// to read as a hit rather than a flicker.
+		rate := 0.28
+		if target > d.heights[i] {
+			rate = 0.75
+		}
+		d.heights[i] += (target - d.heights[i]) * rate
+	}
+}
+
+func redSectorBand(bands []float64, i int) float64 {
+	if i >= len(bands) {
+		return 0
+	}
+	return min(1, max(0, bands[i]))
+}
+
+func (d *redSectorDriver) Render(v *Visualizer) string {
+	dotRows, dotCols := v.Rows*4, PanelWidth*2
+	if dotRows < 4 || dotCols < 16 {
+		return strings.Repeat("\n", max(0, v.Rows-1))
+	}
+	d.grid.ensure(dotRows, dotCols)
+
+	frame := float64(v.Frame())
+	d.drawStars(dotRows, dotCols, frame)
+	d.drawBars(dotRows, dotCols, frame)
+
+	return d.grid.render(v.Rows)
+}
+
+// Deterministic pseudo-random value in [0, 1) for star index i, one slot per
+// coordinate. The index is mixed rather than scaled: a value merely scaled by
+// a constant stays a straight line in i, which puts every star on one of a few
+// diagonals and leaves neighbouring stars a fixed step apart. The avalanche
+// below is splitmix64's finaliser, which carries a one-bit change through the
+// whole word and breaks that structure.
+func redSectorStarHash(i, slot int) float64 {
+	x := uint64(i)*0x9E3779B97F4A7C15 + uint64(slot+1)*0xD1B54A32D192ED03
+	x ^= x >> 30
+	x *= 0xBF58476D1CE4E5B9
+	x ^= x >> 27
+	x *= 0x94D049BB133111EB
+	x ^= x >> 31
+	// The top 53 bits are the ones a float64 can hold without rounding.
+	return float64(x>>11) / float64(uint64(1)<<53)
+}
+
+func (d *redSectorDriver) drawStars(dotRows, dotCols int, frame float64) {
+	count := min(redSectorMaxStars, max(redSectorMinStars, dotRows*dotCols/redSectorDotsPerStar))
+	for i := 1; i <= count; i++ {
+		// Three speed lanes give the field a shallow sense of depth.
+		speed := 0.10 + float64(i%3)*0.09
+		x := math.Mod(redSectorStarHash(i, 0)*float64(dotCols)-frame*speed, float64(dotCols))
+		if x < 0 {
+			x += float64(dotCols)
+		}
+		y := int(redSectorStarHash(i, 1) * float64(dotRows))
+		// Colour is drawn once per star index, so a star keeps its hue while it
+		// drifts instead of flickering from frame to frame.
+		hue := min(redSectorStarTags, 1+int(redSectorStarHash(i, 2)*redSectorStarTags))
+		d.grid.set(int(x), y, int8(hue))
+	}
+}
+
+// redSectorPlace rotates a model point around Y then X and projects it. It
+// returns the rotated point plus its projected position in world units, before
+// any panel scaling.
+func redSectorPlace(x, y, z, cosX, sinX, cosY, sinY, camZ float64) (rx, ry, rz, px, py float64) {
+	x1 := x*cosY + z*sinY
+	z1 := -x*sinY + z*cosY
+	y1 := y*cosX - z1*sinX
+	z2 := y*sinX + z1*cosX
+	depth := max(0.35, z2+camZ)
+	f := redSectorFocal / depth
+	return x1, y1, z2, x1 * f, y1 * f
+}
+
+func (d *redSectorDriver) drawBars(dotRows, dotCols int, frame float64) {
+	cosY, sinY := math.Cos(frame*redSectorSpinY), math.Sin(frame*redSectorSpinY)
+	cosX, sinX := math.Cos(frame*redSectorSpinX), math.Sin(frame*redSectorSpinX)
+	camZ := redSectorCameraZ + math.Sin(frame*redSectorZoomRate)*redSectorZoomAmplitude
+
+	fitX, fitY, centreX, centreY := redSectorFit(dotRows, dotCols, frame, cosX, sinX, cosY, sinY, camZ)
+
+	var rx, ry, rz, px, py [8]float64
+	for bar := range redSectorBars {
+		baseX := (float64(bar) - float64(redSectorBars-1)/2) * redSectorPitch
+		topY := redSectorGroundY + d.heights[bar]
+		tag := redSectorBarTag(d.heights[bar])
+
+		for c := range 8 {
+			y := redSectorGroundY
+			if redSectorCornerTop[c] {
+				y = topY
+			}
+			x1, y1, z2, sx, sy := redSectorPlace(
+				baseX+redSectorCornerX[c]*redSectorHalfWidth, y,
+				redSectorCornerZ[c]*redSectorHalfDepth,
+				cosX, sinX, cosY, sinY, camZ)
+			rx[c], ry[c], rz[c] = x1, y1, z2
+			px[c] = centreX + sx*fitX
+			py[c] = centreY - sy*fitY
+		}
+
+		for _, face := range redSectorFaces {
+			i1, i2, i3 := face[0], face[1], face[2]
+			visible := redSectorFaceVisible(
+				[3]float64{rx[i1], ry[i1], rz[i1]},
+				[3]float64{rx[i2], ry[i2], rz[i2]},
+				[3]float64{rx[i3], ry[i3], rz[i3]}, camZ)
+			if !visible {
+				continue
+			}
+			for e := range 4 {
+				from, to := face[e], face[(e+1)%4]
+				d.drawLine(dotRows, dotCols, px[from], py[from], px[to], py[to], tag)
+			}
+		}
+	}
+}
+
+// redSectorFaceVisible reports whether a face is turned towards the viewer.
+// The faces are wound so the cross product of the first two edges points into
+// the bar, which makes a face visible exactly when that normal points away
+// from the camera.
+func redSectorFaceVisible(p1, p2, p3 [3]float64, camZ float64) bool {
+	ux, uy, uz := p2[0]-p1[0], p2[1]-p1[1], p2[2]-p1[2]
+	vx, vy, vz := p3[0]-p2[0], p3[1]-p2[1], p3[2]-p2[2]
+	nx := uy*vz - uz*vy
+	ny := uz*vx - ux*vz
+	nz := ux*vy - uy*vx
+	// The view vector runs from the camera to the first corner of the face.
+	return nx*p1[0]+ny*p1[1]+nz*(p1[2]+camZ) > 0
+}
+
+// redSectorBarTag reads a bar's colour off its height, using the thresholds of
+// cliamp's own spectrum.
+func redSectorBarTag(height float64) int8 {
+	shown := (height - redSectorMinHeight) / (redSectorMaxHeight - redSectorMinHeight)
+	switch {
+	case shown >= 0.6:
+		return redSectorTagHigh
+	case shown >= 0.3:
+		return redSectorTagMid
+	default:
+		return redSectorTagLow
+	}
+}
+
+// redSectorFit scales the picture against a hull the object can never exceed,
+// not against the bars as they stand this frame. Fitting the live shape would
+// blow a quiet picture up to full height and leave the bars looking motionless.
+func redSectorFit(dotRows, dotCols int, frame, cosX, sinX, cosY, sinY, camZ float64) (fitX, fitY, centreX, centreY float64) {
+	hullX := float64(redSectorBars-1)/2*redSectorPitch + redSectorHalfWidth
+	minX, maxX := math.Inf(1), math.Inf(-1)
+	minY, maxY := math.Inf(1), math.Inf(-1)
+	for _, sx := range [2]float64{-1, 1} {
+		for _, y := range [2]float64{redSectorGroundY, redSectorGroundY + redSectorMaxHeight} {
+			for _, sz := range [2]float64{-1, 1} {
+				_, _, _, hx, hy := redSectorPlace(sx*hullX, y, sz*redSectorHalfDepth,
+					cosX, sinX, cosY, sinY, camZ)
+				minX, maxX = min(minX, hx), max(maxX, hx)
+				minY, maxY = min(minY, hy), max(maxY, hy)
+			}
+		}
+	}
+
+	spanX := max(maxX-minX, 0.001)
+	spanY := max(maxY-minY, 0.001)
+
+	// Breathe in and out, the way the demo pulls the object towards the viewer
+	// and back. The upper bound leaves a margin at full size.
+	zoom := 0.55 + 0.30*(0.5+0.5*math.Sin(frame*redSectorZoomRate))
+	fitY = float64(dotRows-1) / spanY * zoom
+
+	// A short panel starves the object of height, so the bars are widened to
+	// stay apart. Once the panel is tall enough the picture keeps the object's
+	// own proportions.
+	stretch := min(redSectorMaxStretch, max(1, redSectorComfortDotRows/float64(dotRows)))
+	fitX = min(fitY*stretch, float64(dotCols-1)/spanX)
+
+	centreX = float64(dotCols)/2 - (minX+maxX)/2*fitX
+	centreY = float64(dotRows)/2 + (minY+maxY)/2*fitY
+	return fitX, fitY, centreX, centreY
+}
+
+// redSectorMaxLineSteps caps a single edge, so a degenerate projection cannot
+// turn one line into an unbounded loop.
+const redSectorMaxLineSteps = 512
+
+func (d *redSectorDriver) drawLine(dotRows, dotCols int, x0, y0, x1, y1 float64, tag int8) {
+	dx, dy := x1-x0, y1-y0
+	span := max(math.Abs(dx), math.Abs(dy))
+	if math.IsNaN(span) || math.IsInf(span, 0) {
+		return
+	}
+	steps := min(redSectorMaxLineSteps, int(span)+1)
+	for s := 0; s <= steps; s++ {
+		t := float64(s) / float64(steps)
+		x := int(math.Floor(x0 + dx*t + 0.5))
+		y := int(math.Floor(y0 + dy*t + 0.5))
+		if x < 0 || x >= dotCols || y < 0 || y >= dotRows {
+			continue
+		}
+		d.grid.set(x, y, tag)
+	}
+}
+
+// redSectorGrid is a 4x2 dot-per-cell rasteriser with a tag per dot. It is the
+// shared brailleGrid with a wider palette: seven tags instead of three, so the
+// stars have somewhere to sit below the bars. A cell wears the highest tag any
+// of its eight dots carries.
+type redSectorGrid struct {
+	cells   []int8
+	dotRows int
+	dotCols int
+}
+
+func (g *redSectorGrid) ensure(rows, cols int) {
+	if rows == g.dotRows && cols == g.dotCols && len(g.cells) == rows*cols {
+		for i := range g.cells {
+			g.cells[i] = 0
+		}
+		return
+	}
+	g.cells = make([]int8, rows*cols)
+	g.dotRows = rows
+	g.dotCols = cols
+}
+
+func (g *redSectorGrid) set(x, y int, tag int8) {
+	if x < 0 || x >= g.dotCols || y < 0 || y >= g.dotRows {
+		return
+	}
+	if tag > g.cells[y*g.dotCols+x] {
+		g.cells[y*g.dotCols+x] = tag
+	}
+}
+
+// render flattens the dot grid to len(rows) lines, packing 4x2 dot blocks into
+// Braille glyphs and emitting tag-coloured runs. An empty cell keeps whatever
+// colour is running: a blank Braille glyph paints nothing, so breaking the run
+// there would only add ANSI noise.
+func (g *redSectorGrid) render(rows int) string {
+	if g.dotRows < rows*4 || g.dotCols < PanelWidth*2 {
+		return strings.Repeat("\n", max(0, rows-1))
+	}
+	lines := make([]string, rows)
+	for row := range rows {
+		var sb, run strings.Builder
+		tag := 0
+		for col := range PanelWidth {
+			var braille rune = '⠀'
+			cellTag := 0
+			for dr := range 4 {
+				for dc := range 2 {
+					t := g.cells[(row*4+dr)*g.dotCols+col*2+dc]
+					if t == 0 {
+						continue
+					}
+					braille |= brailleBit[dr][dc]
+					cellTag = max(cellTag, int(t))
+				}
+			}
+			if cellTag != 0 && cellTag != tag {
+				flushRedSectorRun(&sb, &run, tag)
+				tag = cellTag
+			}
+			run.WriteRune(braille)
+		}
+		flushRedSectorRun(&sb, &run, tag)
+		lines[row] = sb.String()
+	}
+	return strings.Join(lines, "\n")
+}
+
+func flushRedSectorRun(sb *strings.Builder, run *strings.Builder, tag int) {
+	if run.Len() == 0 {
+		return
+	}
+	var prefix, suffix string
+	if tag >= 1 && tag <= redSectorTagCount {
+		prefix, suffix = redSectorPrefix[tag-1], redSectorSuffix[tag-1]
+	}
+	if prefix != "" {
+		sb.WriteString(prefix)
+	}
+	// run.String() aliases the builder's backing array (no allocation) and we
+	// copy those bytes into sb before run.Reset() releases the slice.
+	sb.WriteString(run.String())
+	if suffix != "" {
+		sb.WriteString(suffix)
+	}
+	run.Reset()
+}
+
+// Raw ANSI wrappers for the seven tags, cached the way the spectrum styles are
+// and rebuilt from refreshSpecANSI when the theme changes.
+var (
+	redSectorPrefix [redSectorTagCount]string
+	redSectorSuffix [redSectorTagCount]string
+)
+
+func refreshRedSectorANSI() {
+	// Four star colours below three bar colours: the field carries the quiet
+	// twins of the spectrum plus the dim foreground, the bars the spectrum
+	// itself. That is the contrast the Amiga original draws between its
+	// starfield and its vector object.
+	tags := [redSectorTagCount]color.Color{
+		ColorDim,
+		redSectorDim(SpectrumLow),
+		redSectorDim(SpectrumMid),
+		redSectorDim(SpectrumHigh),
+		SpectrumLow,
+		SpectrumMid,
+		SpectrumHigh,
+	}
+	for i, c := range tags {
+		redSectorPrefix[i], redSectorSuffix[i] = splitStyleAroundProbe(
+			lipgloss.NewStyle().Foreground(c))
+	}
+}
+
+// redSectorDim returns the quieter twin of a colour. The sixteen ANSI colours
+// come in pairs, 8 to 15 being the bright half of 0 to 7, so a default-theme
+// spectrum colour has an exact twin to fall back on. A theme colour is a hex
+// value with no such pair and is scaled down instead.
+func redSectorDim(c color.Color) color.Color {
+	if c == nil {
+		return c
+	}
+	if ansi, ok := c.(lipgloss.ANSIColor); ok {
+		if ansi >= 8 && ansi <= 15 {
+			return lipgloss.ANSIColor(ansi - 8)
+		}
+		// Already the plain half of a pair, or a colour from the 256-colour
+		// cube whose value carries no brightness the terminal would honour.
+		return c
+	}
+	r, g, b, _ := c.RGBA()
+	scale := func(channel uint32) int {
+		return int(math.Round(float64(channel>>8) * redSectorStarDim))
+	}
+	return lipgloss.Color(fmt.Sprintf("#%02x%02x%02x", scale(r), scale(g), scale(b)))
+}

--- a/ui/vis_red_sector_test.go
+++ b/ui/vis_red_sector_test.go
@@ -1,0 +1,362 @@
+package ui
+
+import (
+	"image/color"
+	"math"
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+)
+
+// Backface culling is where a silent mistake would live: a face wound the
+// wrong way still draws, it just draws the edges that should be hidden, and
+// nothing else in the package would notice. A bar seen head-on shows its
+// front, never its back.
+func TestRedSectorFaceVisibility(t *testing.T) {
+	// The unrotated bar, standing on the ground line with a full-height cap.
+	corner := func(i int) [3]float64 {
+		y := redSectorGroundY
+		if redSectorCornerTop[i] {
+			y = redSectorGroundY + redSectorMaxHeight
+		}
+		return [3]float64{
+			redSectorCornerX[i] * redSectorHalfWidth,
+			y,
+			redSectorCornerZ[i] * redSectorHalfDepth,
+		}
+	}
+	visible := func(face [4]int) bool {
+		return redSectorFaceVisible(corner(face[0]), corner(face[1]), corner(face[2]), redSectorCameraZ)
+	}
+
+	front, back := redSectorFaces[0], redSectorFaces[1]
+	if !visible(front) {
+		t.Error("the front face should be visible to a camera in front of the bar")
+	}
+	if visible(back) {
+		t.Error("the back face should be culled")
+	}
+
+	// Every face is either visible or culled, and a closed box never shows all
+	// six at once. Four is the most a box can turn towards a viewer.
+	count := 0
+	for _, face := range redSectorFaces {
+		if visible(face) {
+			count++
+		}
+	}
+	if count == 0 || count > 3 {
+		t.Errorf("%d of six faces visible head-on, want between one and three", count)
+	}
+}
+
+// The bars read their level against a range they track themselves, so a quiet
+// band and a loud one both use the full height of the picture. Reading the
+// level absolutely would leave the treble bars flat on nearly every track.
+func TestRedSectorEnvelopeTracksBandRange(t *testing.T) {
+	d := &redSectorDriver{}
+	d.reset()
+
+	// Bar 0 swings between 0.7 and 0.9, bar 1 between 0.1 and 0.3. Same span,
+	// very different levels.
+	bands := make([]float64, DefaultSpectrumBands)
+	var peak0, peak1 float64
+	for frame := range 400 {
+		swing := 0.0
+		if frame%2 == 0 {
+			swing = 0.2
+		}
+		bands[0], bands[1] = 0.7+swing, 0.7+swing
+		bands[2], bands[3] = 0.1+swing, 0.1+swing
+		d.advance(bands)
+		if frame > 200 {
+			peak0 = max(peak0, d.heights[0])
+			peak1 = max(peak1, d.heights[1])
+		}
+	}
+
+	// Both reach up into the picture, and neither is pinned to an end stop.
+	for i, peak := range [2]float64{peak0, peak1} {
+		if peak <= redSectorMinHeight+0.1 {
+			t.Errorf("bar %d peaks at %.3f, barely above the floor of %.2f",
+				i, peak, redSectorMinHeight)
+		}
+	}
+	if diff := math.Abs(peak0 - peak1); diff > 0.3 {
+		t.Errorf("a loud bar peaks at %.3f and a quiet one at %.3f; the envelope "+
+			"should bring them close", peak0, peak1)
+	}
+
+	// The envelope never closes past its own floor, whatever the material.
+	for i := range 2 {
+		if span := d.ceiling[i] - d.floor[i]; span < redSectorMinEnvelope-1e-9 {
+			t.Errorf("bar %d envelope = %.4f, want at least %.2f", i, span, redSectorMinEnvelope)
+		}
+	}
+}
+
+// A band held at one level is not movement, and the bar it drives sinks to
+// rest. This is what keeps a steady passage from standing at full height.
+func TestRedSectorConstantBandSettlesToRest(t *testing.T) {
+	d := &redSectorDriver{}
+	d.reset()
+
+	bands := make([]float64, DefaultSpectrumBands)
+	bands[0], bands[1] = 0.8, 0.8
+	for range 400 {
+		d.advance(bands)
+	}
+	if d.heights[0] > redSectorMinHeight+1e-6 {
+		t.Errorf("a constant band leaves the bar at %.4f, want it back at %.2f",
+			d.heights[0], redSectorMinHeight)
+	}
+}
+
+// A silent band must not divide out its partner: the pair takes the louder of
+// the two, which is what keeps a bar alive on material cut above 16 kHz.
+func TestRedSectorBarTakesLouderBand(t *testing.T) {
+	loud := &redSectorDriver{}
+	loud.reset()
+	both := &redSectorDriver{}
+	both.reset()
+
+	oneSided := make([]float64, DefaultSpectrumBands)
+	oneSided[0] = 0.9
+	balanced := make([]float64, DefaultSpectrumBands)
+	balanced[0], balanced[1] = 0.9, 0.9
+
+	for range 100 {
+		loud.advance(oneSided)
+		both.advance(balanced)
+	}
+	if math.Abs(loud.heights[0]-both.heights[0]) > 1e-9 {
+		t.Errorf("one loud band gives height %.4f, two give %.4f; they should agree",
+			loud.heights[0], both.heights[0])
+	}
+}
+
+func TestRedSectorBarTagThresholds(t *testing.T) {
+	span := redSectorMaxHeight - redSectorMinHeight
+	at := func(fraction float64) int8 {
+		return redSectorBarTag(redSectorMinHeight + fraction*span)
+	}
+	cases := []struct {
+		fraction float64
+		want     int8
+	}{
+		{0.0, redSectorTagLow},
+		{0.29, redSectorTagLow},
+		{0.30, redSectorTagMid},
+		{0.59, redSectorTagMid},
+		{0.60, redSectorTagHigh},
+		{1.0, redSectorTagHigh},
+	}
+	for _, tc := range cases {
+		if got := at(tc.fraction); got != tc.want {
+			t.Errorf("tag at %.2f of the range = %d, want %d", tc.fraction, got, tc.want)
+		}
+	}
+}
+
+// The whole point of the seven-tag order: a bar is drawn in front of a star
+// whatever colour either of them wears. If a star tag ever outranked a bar tag,
+// the field would punch holes through the object and nothing would catch it but
+// the eye.
+func TestRedSectorBarsOutrankStars(t *testing.T) {
+	span := redSectorMaxHeight - redSectorMinHeight
+	for _, fraction := range []float64{0, 0.3, 0.6, 1} {
+		barTag := redSectorBarTag(redSectorMinHeight + fraction*span)
+		if int(barTag) <= redSectorStarTags {
+			t.Errorf("bar tag %d at %.1f of the range does not outrank the %d star tags",
+				barTag, fraction, redSectorStarTags)
+		}
+		if int(barTag) > redSectorTagCount {
+			t.Errorf("bar tag %d is outside the palette of %d", barTag, redSectorTagCount)
+		}
+	}
+
+	// A star drawn into a cell a bar already owns leaves it alone.
+	var g redSectorGrid
+	g.ensure(4, 4)
+	g.set(0, 0, redSectorTagLow)
+	g.set(0, 0, redSectorStarTags)
+	if got := g.cells[0]; got != redSectorTagLow {
+		t.Errorf("cell holds tag %d after a star was drawn over a bar, want %d",
+			got, redSectorTagLow)
+	}
+}
+
+// Stars wear the quiet twin of a spectrum colour. On the default theme that
+// twin is exact: the bright ANSI colours are 8 above their plain counterparts.
+func TestRedSectorDimFindsANSITwin(t *testing.T) {
+	cases := []struct {
+		in   color.Color
+		want color.Color
+	}{
+		{lipgloss.ANSIColor(10), lipgloss.ANSIColor(2)}, // bright green -> green
+		{lipgloss.ANSIColor(11), lipgloss.ANSIColor(3)}, // bright yellow -> yellow
+		{lipgloss.ANSIColor(9), lipgloss.ANSIColor(1)},  // bright red -> red
+		{lipgloss.ANSIColor(7), lipgloss.ANSIColor(7)},  // already plain, left alone
+	}
+	for _, tc := range cases {
+		if got := redSectorDim(tc.in); got != tc.want {
+			t.Errorf("dim(%v) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+
+	// A theme colour has no twin, so each channel is scaled instead.
+	r, g, b, _ := redSectorDim(lipgloss.Color("#64c864")).RGBA()
+	channels := [3]uint32{r >> 8, g >> 8, b >> 8}
+	want := [3]uint32{0x3c, 0x78, 0x3c} // six tenths of 0x64, 0xc8, 0x64
+	if channels != want {
+		t.Errorf("dim(#64c864) = %v, want %v", channels, want)
+	}
+}
+
+// The picture is fitted to a hull the object can never exceed, so a full-height
+// object still lands inside the panel.
+func TestRedSectorFitKeepsHullInsidePanel(t *testing.T) {
+	const dotRows, dotCols = 28, 152
+
+	for _, frame := range []float64{0, 7, 31, 250} {
+		cosY, sinY := math.Cos(frame*redSectorSpinY), math.Sin(frame*redSectorSpinY)
+		cosX, sinX := math.Cos(frame*redSectorSpinX), math.Sin(frame*redSectorSpinX)
+		camZ := redSectorCameraZ + math.Sin(frame*redSectorZoomRate)*redSectorZoomAmplitude
+		fitX, fitY, centreX, centreY := redSectorFit(dotRows, dotCols, frame, cosX, sinX, cosY, sinY, camZ)
+
+		hullX := float64(redSectorBars-1)/2*redSectorPitch + redSectorHalfWidth
+		for _, sx := range [2]float64{-1, 1} {
+			for _, y := range [2]float64{redSectorGroundY, redSectorGroundY + redSectorMaxHeight} {
+				for _, sz := range [2]float64{-1, 1} {
+					_, _, _, hx, hy := redSectorPlace(sx*hullX, y, sz*redSectorHalfDepth,
+						cosX, sinX, cosY, sinY, camZ)
+					px := centreX + hx*fitX
+					py := centreY - hy*fitY
+					if px < 0 || px > float64(dotCols-1) || py < 0 || py > float64(dotRows-1) {
+						t.Errorf("frame %.0f: hull corner lands at (%.1f, %.1f), outside %dx%d",
+							frame, px, py, dotCols, dotRows)
+					}
+				}
+			}
+		}
+	}
+}
+
+// Stars keep their place from frame to frame and drift left, which is what
+// separates a starfield from per-frame noise.
+func TestRedSectorStarsDriftLeft(t *testing.T) {
+	const dotRows, dotCols = 20, 100
+
+	first := &redSectorDriver{}
+	first.grid.ensure(dotRows, dotCols)
+	first.drawStars(dotRows, dotCols, 0)
+
+	again := &redSectorDriver{}
+	again.grid.ensure(dotRows, dotCols)
+	again.drawStars(dotRows, dotCols, 0)
+
+	if !equalGrids(first.grid, again.grid) {
+		t.Error("the same frame drew a different field; the star hash is not deterministic")
+	}
+
+	later := &redSectorDriver{}
+	later.grid.ensure(dotRows, dotCols)
+	later.drawStars(dotRows, dotCols, 40)
+	if equalGrids(first.grid, later.grid) {
+		t.Error("the field did not move over forty frames")
+	}
+
+	lit := 0
+	for _, cell := range later.grid.cells {
+		if cell != 0 {
+			lit++
+		}
+		if cell != 0 && (cell < 1 || int(cell) > redSectorStarTags) {
+			t.Fatalf("star drawn on tag %d, want one of the %d star tags",
+				cell, redSectorStarTags)
+		}
+	}
+	if lit == 0 {
+		t.Error("no stars drawn")
+	}
+}
+
+// A field whose coordinates are a straight line in the star index puts every
+// star on one of a few diagonals, and short ruled chains of stars are what a
+// viewer actually notices. The exact step between neighbours is not the tell,
+// because wrapping breaks it up; the direction of that step is, since a lattice
+// only ever walks along its own gradient. Measured on the field this mode draws,
+// the linear hash the plugin used offered sixteen directions across eighty-eight
+// steps, an avalanche hash eighty-six.
+func TestRedSectorStarsAreNotOnALattice(t *testing.T) {
+	const dotRows, dotCols = 28, 174
+
+	type direction struct{ dx, dy int }
+	directions := map[direction]int{}
+	previous := [2]int{}
+	for i := 1; i <= redSectorMaxStars; i++ {
+		x := int(redSectorStarHash(i, 0) * dotCols)
+		y := int(redSectorStarHash(i, 1) * dotRows)
+		if i > 1 {
+			dx, dy := x-previous[0], y-previous[1]
+			step := greatestCommonDivisor(dx, dy)
+			directions[direction{dx / step, dy / step}]++
+		}
+		previous = [2]int{x, y}
+	}
+
+	steps := redSectorMaxStars - 1
+	if want := steps / 2; len(directions) < want {
+		t.Errorf("%d distinct directions across %d steps, want at least %d; "+
+			"the field is walking a lattice", len(directions), steps, want)
+	}
+}
+
+// greatestCommonDivisor reduces a step to its direction. It returns 1 for the
+// zero step, which has no direction to speak of.
+func greatestCommonDivisor(a, b int) int {
+	a, b = abs(a), abs(b)
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a == 0 {
+		return 1
+	}
+	return a
+}
+
+func abs(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}
+
+func equalGrids(a, b redSectorGrid) bool {
+	if len(a.cells) != len(b.cells) {
+		return false
+	}
+	for i := range a.cells {
+		if a.cells[i] != b.cells[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// A panel too narrow to draw into still has to return the exact number of
+// lines the layout reserved, or the frame below it shifts.
+func TestRedSectorNarrowPanelKeepsRowCount(t *testing.T) {
+	defer WithPanelWidth(4)()
+
+	v := NewVisualizer(44100)
+	v.Rows = 5
+	v.Mode = VisRedSector
+
+	d := newRedSectorDriver()
+	lines := strings.Split(d.Render(v), "\n")
+	if len(lines) != v.Rows {
+		t.Errorf("%d lines at a four-column panel, want %d", len(lines), v.Rows)
+	}
+}

--- a/ui/visualizer.go
+++ b/ui/visualizer.go
@@ -73,6 +73,7 @@ const (
 	VisStereo                     // stereo L/R horizontal LED peak meters
 	VisMirror                     // Braille spectrum bars mirrored about a horizontal axis
 	VisOmarchy                    // dithered pixel field with the Omarchy mark (omarchy.org style)
+	VisRedSector                  // tumbling wireframe equalizer over a drifting starfield
 	VisNone                       // hidden — no visualizer
 	VisCount                      // sentinel for cycling
 )
@@ -223,6 +224,7 @@ func refreshSpecANSI() {
 	specLowPrefix, specLowSuffix = splitStyleAroundProbe(specLowStyle)
 	specMidPrefix, specMidSuffix = splitStyleAroundProbe(specMidStyle)
 	specHighPrefix, specHighSuffix = splitStyleAroundProbe(specHighStyle)
+	refreshRedSectorANSI()
 }
 
 // splitStyleAroundProbe renders a rare marker through the style and splits the
@@ -490,6 +492,7 @@ var visModes = [VisCount]visEntry{
 	VisStereo:      {"Stereo", newStereoDriver},
 	VisMirror:      {"Mirror", newFastRenderOnlyDriver(spectrumAnalysisSpec(DefaultSpectrumBands), TickAnim, (*Visualizer).renderMirror)},
 	VisOmarchy:     {"Omarchy", newFastRenderOnlyDriver(spectrumAnalysisSpec(DefaultSpectrumBands), TickAnim, (*Visualizer).renderOmarchy)},
+	VisRedSector:   {"RedSector", newRedSectorDriver},
 	VisNone:        {"None", newNoOpDriver},
 }
 


### PR DESCRIPTION
A wireframe equalizer after the vector part of the Red Sector Inc. RSI Megademo (Amiga, 1989). Five hollow bars stand on a common ground line, each driven by two spectrum bands, and the whole group tumbles as a rigid body while a starfield drifts behind it. Per-face backface culling leaves a bar showing its front, one flank and its cap, the way the original vector objects do.

The mode rasterises into a grid of its own rather than the shared brailleGrid. A cell keeps the highest tag drawn into it, and that ordering is what puts every bar in front of every star. It needs seven tags, four for the field and three for the object. brailleGrid carries three tiers in total and leaves nothing below the bars.

Stars wear the quiet twin of a spectrum colour instead of a hard-coded ANSI escape, so the field follows the theme. On the default theme that twin is exact: the bright ANSI colours sit eight above their plain counterparts. A theme colour has no such pair and is scaled down instead.

A star takes its place from a hash of its index, so it keeps that place while it drifts. The index runs through splitmix64's finaliser, whose avalanche carries a one-bit change across the whole word. That is what scatters the field rather than ruling it: measured on the field this mode draws, 86 of the 89 steps between neighbouring stars go their own direction.

Bars read their level against a range each band tracks for itself. Read absolutely, a band hovers near its own resting level and swings by about a tenth, which draws the fixed shape of the mix rather than the music. One consequence is deliberate: a band held at one level is not movement, and the bar it drives sinks back to rest.

## Summary

Adds the RedSector Visualizer as suggested by @bjarneo on X.

## Screenshots / video

https://github.com/user-attachments/assets/bc13da96-34a6-406e-bac4-b885ea48c697

## How to test

1. Open cliamp
2. Start playing
3. Hit v until RedSector Visualizer is active

## Checklist

- [x] `make check` passes
- [x] `docs/` and `site/index.html` updated for user-facing changes (not required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the RedSector visualizer mode, featuring a wireframe equalizer, animated bars, and a drifting starfield.
  * Added the exported RedSector visualizer option for selection.
* **Documentation**
  * Documented RedSector among the available visualizer modes.
* **Tests**
  * Added coverage for RedSector rendering, animation, color behavior, layout, and deterministic star movement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->