### PR TITLE
fix(ui): unify inactive visualizer decay and refine ClassicPeak timing

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -1090,8 +1090,7 @@ func (d *daemon) bandsResponse() ipc.Response {
 	}
 	d.vis.Tick(ui.VisTickContext{
 		Now:     time.Now(),
-		Playing: d.player.IsPlaying(),
-		Paused:  d.player.IsPaused(),
+		Playing: d.player.IsPlaying() && !d.player.IsPaused(),
 		Analyze: func(spec ui.VisAnalysisSpec) []float64 {
 			samples := d.vis.SampleBuf()
 			n := d.player.SamplesInto(samples)

--- a/daemon_v2_test.go
+++ b/daemon_v2_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"math"
+	"slices"
 	"testing"
 	"time"
 
@@ -10,6 +12,7 @@ import (
 	"github.com/bjarneo/cliamp/ipc"
 	"github.com/bjarneo/cliamp/player"
 	"github.com/bjarneo/cliamp/playlist"
+	"github.com/bjarneo/cliamp/ui"
 )
 
 type daemonV2Engine struct {
@@ -24,6 +27,19 @@ type daemonV2Engine struct {
 	speed    float64
 	mono     bool
 	eq       [10]float64
+}
+
+type daemonSpectrumEngine struct {
+	*daemonV2Engine
+	sampleCalls int
+}
+
+func (e *daemonSpectrumEngine) SamplesInto(dst []float64) int {
+	e.sampleCalls++
+	for i := range dst {
+		dst[i] = 0.8 * math.Sin(2*math.Pi*1000*float64(i)/44100)
+	}
+	return len(dst)
 }
 
 func (e *daemonV2Engine) Play(string, time.Duration) error {
@@ -106,6 +122,28 @@ func TestDaemonV2StateSnapshot(t *testing.T) {
 	}
 	if snapshot.Track == nil || snapshot.LogicalTrack == nil || snapshot.Track.Path != "https://example.com/one" || snapshot.LogicalTrack.Path != "https://example.com/one" {
 		t.Fatalf("tracks = %#v/%#v", snapshot.Track, snapshot.LogicalTrack)
+	}
+}
+
+func TestDaemonInactiveSpectrumDecaysWithoutSampling(t *testing.T) {
+	engine := &daemonSpectrumEngine{daemonV2Engine: &daemonV2Engine{playing: true}}
+	d := &daemon{player: engine, vis: ui.NewVisualizer(44100)}
+
+	active := d.bandsResponse()
+	if engine.sampleCalls != 1 {
+		t.Fatalf("SamplesInto calls while playing = %d, want 1", engine.sampleCalls)
+	}
+	if slices.Max(active.Bands) == 0 {
+		t.Fatal("playing spectrum was silent; test setup did not charge a band")
+	}
+
+	engine.paused = true
+	paused := d.bandsResponse()
+	if engine.sampleCalls != 1 {
+		t.Fatalf("SamplesInto calls while paused = %d, want retained samples ignored", engine.sampleCalls)
+	}
+	if got, was := slices.Max(paused.Bands), slices.Max(active.Bands); got >= was {
+		t.Fatalf("paused IPC peak = %v, want decay below playing level %v", got, was)
 	}
 }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -31,7 +31,7 @@ cliamp --eq-preset "Bass Boost" ~/Music
 cliamp --visualizer-60fps ~/Music            # smoother visualizer animation (higher CPU use)
 ```
 
-`--visualizer-60fps` renders a visible visualizer at about 60 FPS during playback. `Wave`, `Scope`, and `Heartbeat` already use this rate because they draw from audio samples. The flag does not affect overlays or low-power mode.
+`--visualizer-60fps` renders a visible visualizer at about 60 FPS during playback. `Wave`, `Scope`, and `Heartbeat` already use this rate because they draw from audio samples. Without the flag, `ClassicPeak` adapts between approximately 48 and 60 FPS based on panel height, and `ClassicLED` runs at 30 FPS. The flag does not affect overlays or low-power mode.
 
 ## Diagnostics
 

--- a/site/index.html
+++ b/site/index.html
@@ -440,7 +440,7 @@ footer a{color:var(--fg-2)}
       </div>
       <div class="feat">
         <div class="feat-k">VISUALIZERS</div>
-        <p>31 built-in modes rendered in the terminal from live FFT data: spectrum bars, scope, wave, matrix, flame, and a true-stereo LED peak meter. <kbd>v</kbd> cycles, <kbd>V</kbd> goes full screen.</p>
+        <p>31 built-in modes rendered in the terminal from live FFT data: spectrum bars, scope, wave, matrix, flame, and a true-stereo LED peak meter. Without <code>--visualizer-60fps</code>, ClassicPeak adapts between approximately 48 and 60 FPS, and ClassicLED runs at 30 FPS. Use the flag for smoother animation in other modes. <kbd>v</kbd> cycles, <kbd>V</kbd> goes full screen.</p>
       </div>
       <div class="feat">
         <div class="feat-k">SYNCED LYRICS</div>

--- a/ui/model/tick.go
+++ b/ui/model/tick.go
@@ -39,23 +39,12 @@ func (m *Model) visualizerPlaying() bool {
 		!m.isOverlayActive() && m.player.IsPlaying() && !m.player.IsPaused()
 }
 
-func (m *Model) visualizerPaused() bool {
-	return m.player != nil && m.visualizerVisible() &&
-		!m.isOverlayActive() && m.player.IsPlaying() && m.player.IsPaused()
-}
-
-// visualizerSettlingPaused reports whether playback is paused and the
-// visualizer still has spectrum content easing to zero. While true the tick
-// stays above the idle cadence so the bars fall; once settled the model can
-// return to the fully-idle cadence.
-func (m *Model) visualizerSettlingPaused() bool {
-	if m.player == nil || !m.player.IsPaused() || m.isOverlayActive() {
-		return false
-	}
-	if !m.visualizerVisible() {
-		return false
-	}
-	return m.vis.PausedDecayPending(m.visualizerTickContext(time.Time{}))
+// visualizerSettling reports whether paused or stopped playback still has
+// visualizer content easing to zero. While true the tick stays above the idle
+// cadence so the animation can finish.
+func (m *Model) visualizerSettling() bool {
+	return m.player != nil && m.visualizerVisible() && !m.isOverlayActive() &&
+		!m.visualizerPlaying() && m.vis.DecayPending()
 }
 
 func (m *Model) visualizerTickContext(now time.Time) ui.VisTickContext {
@@ -67,7 +56,6 @@ func (m *Model) visualizerTickContext(now time.Time) ui.VisTickContext {
 	return ui.VisTickContext{
 		Now:           now,
 		Playing:       m.visualizerPlaying(),
-		Paused:        m.visualizerPaused(),
 		OverlayActive: m.isOverlayActive(),
 		StereoSamplesInto: func(dst [][2]float64) int {
 			if m.player == nil || m.vis == nil || m.vis.Mode == ui.VisNone {
@@ -95,14 +83,6 @@ func (m *Model) visualizerTickContext(now time.Time) ui.VisTickContext {
 				return nil
 			}
 			if bands, ok := cache[spec]; ok {
-				return bands
-			}
-			if m.player.IsPaused() {
-				// Paused playback yields no new samples; feed silence so
-				// spectrum content eases down to rest instead of freezing on
-				// the last played frame held in the audio tap.
-				bands := m.vis.Analyze(nil, spec)
-				cache[spec] = bands
 				return bands
 			}
 			buf := m.vis.EnsureSampleBuf(spec.FFTSize)
@@ -176,6 +156,13 @@ func (m *Model) tickInterval() time.Duration {
 	if m.visualizerVisible() {
 		d = m.vis.TickInterval(m.visualizerTickContext(time.Time{}))
 	}
+	// Classic meters animate at their own cadence between TickAnim and
+	// TickFast; other modes stay at TickFast without the 60 FPS flag.
+	fast := ui.TickFast
+	if m.visualizerVisible() &&
+		(m.vis.Mode == ui.VisClassicPeak || m.vis.Mode == ui.VisClassicLED) {
+		fast = min(d, ui.TickFast)
+	}
 	// Keep the seek bar / time counter smooth while audio is playing, even
 	// when the visualizer driver wants a slow cadence (VisNone, classic peak
 	// idle, etc.). Overlays, paused, and stopped playback keep the slower
@@ -188,16 +175,15 @@ func (m *Model) tickInterval() time.Duration {
 		if m.visualizerVisible() && (m.visualizer60FPS || m.vis.UsesRawSamples()) {
 			return ui.TickAnim
 		}
-		return ui.TickFast
+		return fast
 	}
-	// Paused visualizer content still easing to rest: run at the fast cadence
-	// so the bars fall smoothly instead of in ~5 fps steps, then drop to idle
-	// once the content has settled.
-	if m.visualizerSettlingPaused() {
+	// Inactive visualizer content still easing to rest: keep a fast cadence
+	// until the content has settled, then drop to idle.
+	if m.visualizerSettling() {
 		if m.visualizer60FPS {
 			return ui.TickAnim
 		}
-		return ui.TickFast
+		return fast
 	}
 	return max(d, ui.TickFast)
 }
@@ -212,7 +198,7 @@ func (m *Model) isFullyIdle() bool {
 	if m.player.IsPlaying() && !m.player.IsPaused() {
 		return false
 	}
-	if m.visualizerSettlingPaused() {
+	if m.visualizerSettling() {
 		return false
 	}
 	if m.isOverlayActive() || m.buffering || m.termTitle.introActive {

--- a/ui/model/tick_test.go
+++ b/ui/model/tick_test.go
@@ -166,6 +166,31 @@ func TestTickIntervalClampsFastVisualizerCadence(t *testing.T) {
 	}
 }
 
+func TestTickIntervalClassicMetersUseDriverCadence(t *testing.T) {
+	for _, mode := range []string{"ClassicPeak", "ClassicLED"} {
+		t.Run(mode, func(t *testing.T) {
+			p := &playbackFakeEngine{playing: true}
+			m := Model{
+				player:   p,
+				vis:      ui.NewVisualizer(float64(p.SampleRate())),
+				playlist: playlist.New(),
+				width:    80,
+				height:   24,
+			}
+			m.recomputeLayout()
+			m.SetVisualizer(mode)
+
+			want := m.vis.TickInterval(m.visualizerTickContext(time.Time{}))
+			if want >= ui.TickFast {
+				t.Fatalf("visualizer interval = %v, want faster than %v for test setup", want, ui.TickFast)
+			}
+			if got := m.tickInterval(); got != want {
+				t.Fatalf("tickInterval() = %v, want driver cadence %v", got, want)
+			}
+		})
+	}
+}
+
 func TestTickIntervalVisualizer60FPS(t *testing.T) {
 	p := &playbackFakeEngine{playing: true}
 	m := Model{
@@ -231,6 +256,31 @@ func TestRawSampleVisualizerUsesWaveformTap(t *testing.T) {
 	}
 }
 
+func TestStoppedModeSwitchDropsStaleWaveformAndIdles(t *testing.T) {
+	p := &samplingFakeEngine{playbackFakeEngine: &playbackFakeEngine{playing: true}}
+	m := Model{
+		player:   p,
+		vis:      ui.NewVisualizer(float64(p.SampleRate())),
+		playlist: playlist.New(),
+		width:    80,
+		height:   24,
+	}
+	m.recomputeLayout()
+
+	now := time.Unix(1, 0)
+	m.SetVisualizer("Wave")
+	m.tickVisualizer(now)
+	m.SetVisualizer("Stereo")
+	p.playing = false
+
+	if m.visualizerSettling() {
+		t.Fatal("visualizerSettling() = true after a stopped mode switch, want stale waveform dropped")
+	}
+	if got := m.tickInterval(); got != ui.TickIdle {
+		t.Fatalf("tickInterval() = %v, want %v after stopped Stereo settled", got, ui.TickIdle)
+	}
+}
+
 func TestTickIntervalLowPowerPlayingUsesLowPowerCadence(t *testing.T) {
 	p := &playbackFakeEngine{playing: true}
 	m := Model{
@@ -245,7 +295,7 @@ func TestTickIntervalLowPowerPlayingUsesLowPowerCadence(t *testing.T) {
 	}
 }
 
-func chargedPausedModel(t *testing.T) (Model, *samplingFakeEngine) {
+func chargedBarsModel(t *testing.T) (Model, *samplingFakeEngine) {
 	t.Helper()
 	p := &samplingFakeEngine{playbackFakeEngine: &playbackFakeEngine{playing: true}}
 	m := Model{
@@ -258,12 +308,17 @@ func chargedPausedModel(t *testing.T) (Model, *samplingFakeEngine) {
 	m.recomputeLayout()
 	m.vis.Mode = ui.VisBars
 
-	// Charge the bars through the normal tick path so v.bands is populated,
-	// then pause to leave non-empty spectrum content behind.
+	// Charge the bars through the normal tick path so v.bands is populated.
 	base := time.Unix(1, 0)
 	for i := range 3 {
 		m.tickVisualizer(base.Add(time.Duration(i+1) * ui.TickFast))
 	}
+	return m, p
+}
+
+func chargedPausedModel(t *testing.T) (Model, *samplingFakeEngine) {
+	t.Helper()
+	m, p := chargedBarsModel(t)
 	p.paused = true
 	return m, p
 }
@@ -275,8 +330,8 @@ func chargedPausedModel(t *testing.T) (Model, *samplingFakeEngine) {
 func TestTickIntervalPausedSettlingVisualizerUsesFast(t *testing.T) {
 	m, _ := chargedPausedModel(t)
 
-	if !m.isOverlayActive() && !m.visualizerSettlingPaused() {
-		t.Fatal("visualizerSettlingPaused() = false with charged paused bars, want true")
+	if !m.visualizerSettling() {
+		t.Fatal("visualizerSettling() = false with charged paused bars, want true")
 	}
 	if m.isFullyIdle() {
 		t.Fatal("isFullyIdle() = true while paused bars settle, want false")
@@ -292,11 +347,11 @@ func TestTickIntervalPausedSettledVisualizerUsesIdle(t *testing.T) {
 	base := time.Unix(1, 0)
 	for i := range 120 {
 		m.tickVisualizer(base.Add(time.Duration(i+1) * ui.TickSlow))
-		if !m.visualizerSettlingPaused() {
+		if !m.visualizerSettling() {
 			break
 		}
 	}
-	if m.visualizerSettlingPaused() {
+	if m.visualizerSettling() {
 		t.Fatal("visualizer still settling after decay ticks")
 	}
 	if !m.isFullyIdle() {
@@ -304,6 +359,85 @@ func TestTickIntervalPausedSettledVisualizerUsesIdle(t *testing.T) {
 	}
 	if got := m.tickInterval(); got != ui.TickIdle {
 		t.Fatalf("tickInterval() = %v, want %v after paused bars settle", got, ui.TickIdle)
+	}
+}
+
+func TestStoppedSpectrumUsesSilence(t *testing.T) {
+	m, p := chargedBarsModel(t)
+	before := append([]float64(nil), m.vis.Bands()...)
+	sampleCalls := p.sampleCalls
+	p.playing = false
+
+	if !m.visualizerSettling() {
+		t.Fatal("visualizerSettling() = false with charged stopped bars, want true")
+	}
+	m.tickVisualizer(time.Unix(2, 0))
+
+	if p.sampleCalls != sampleCalls {
+		t.Fatalf("SamplesInto calls while stopped = %d, want 0", p.sampleCalls-sampleCalls)
+	}
+	decreased := false
+	for i, got := range m.vis.Bands() {
+		if got > before[i] {
+			t.Fatalf("stopped band[%d] increased from %v to %v", i, before[i], got)
+		}
+		decreased = decreased || got < before[i]
+	}
+	if !decreased {
+		t.Fatal("stopped bands did not decay toward silence")
+	}
+}
+
+func TestTickIntervalStoppedClassicMetersSettleBeforeIdle(t *testing.T) {
+	for _, mode := range []string{"ClassicPeak", "ClassicLED"} {
+		t.Run(mode, func(t *testing.T) {
+			p := &samplingFakeEngine{playbackFakeEngine: &playbackFakeEngine{playing: true}}
+			m := Model{
+				player:   p,
+				vis:      ui.NewVisualizer(float64(p.SampleRate())),
+				playlist: playlist.New(),
+				width:    80,
+				height:   24,
+			}
+			m.recomputeLayout()
+			m.SetVisualizer(mode)
+
+			now := time.Unix(1, 0)
+			for range 4 {
+				now = now.Add(ui.TickFast)
+				m.tickVisualizer(now)
+			}
+			if p.sampleCalls == 0 {
+				t.Fatal("visualizer did not sample audio before stop")
+			}
+
+			p.playing = false
+			if !m.visualizerSettling() {
+				t.Fatal("visualizerSettling() = false with charged stopped meter, want true")
+			}
+			want := m.vis.TickInterval(m.visualizerTickContext(time.Time{}))
+			if got := m.tickInterval(); got != want {
+				t.Fatalf("tickInterval() = %v, want driver cadence %v", got, want)
+			}
+
+			sampleCalls := p.sampleCalls
+			for range 240 {
+				now = now.Add(m.tickInterval())
+				m.tickVisualizer(now)
+				if !m.visualizerSettling() {
+					break
+				}
+			}
+			if m.visualizerSettling() {
+				t.Fatal("stopped meter did not settle")
+			}
+			if p.sampleCalls != sampleCalls {
+				t.Fatalf("SamplesInto calls while stopped = %d, want 0", p.sampleCalls-sampleCalls)
+			}
+			if got := m.tickInterval(); got != ui.TickIdle {
+				t.Fatalf("tickInterval() = %v, want %v after stopped meter settled", got, ui.TickIdle)
+			}
+		})
 	}
 }
 
@@ -441,6 +575,7 @@ func TestVisualizerTickContextProcessesStereoOutput(t *testing.T) {
 
 func TestRefreshVisualizerIfPendingConsumesOneShotRequest(t *testing.T) {
 	m := Model{
+		player: &playbackFakeEngine{playing: true},
 		vis:    ui.NewVisualizer(44100),
 		width:  80,
 		height: 24,
@@ -465,6 +600,7 @@ func TestRefreshVisualizerIfPendingConsumesOneShotRequest(t *testing.T) {
 
 func TestLyricsScreenKeepsVisualizerLive(t *testing.T) {
 	m := Model{
+		player: &playbackFakeEngine{playing: true},
 		vis:    ui.NewVisualizer(44100),
 		width:  80,
 		height: 24,

--- a/ui/model/view_state_test.go
+++ b/ui/model/view_state_test.go
@@ -142,15 +142,13 @@ func TestRenderPlaylistKeepsCursorVisibleWhenFooterShrinksBudget(t *testing.T) {
 }
 
 func TestViewConsumesInitialVisualizerRefresh(t *testing.T) {
-	if sharedPlayer == nil {
-		t.Skip("audio hardware unavailable")
-	}
 	withFrameWidth(t, 80)
 
+	player := &playbackFakeEngine{playing: true}
 	m := Model{
-		player:   sharedPlayer,
+		player:   player,
 		playlist: playlist.New(),
-		vis:      ui.NewVisualizer(float64(sharedPlayer.SampleRate())),
+		vis:      ui.NewVisualizer(float64(player.SampleRate())),
 		width:    80,
 		height:   24,
 	}

--- a/ui/tick_vis_test.go
+++ b/ui/tick_vis_test.go
@@ -50,6 +50,107 @@ func TestClassicPeakAnalysisIntervalUsesFFTOverlapLimit(t *testing.T) {
 	}
 }
 
+func TestClassicPeakAnalysisCadenceKeepsItsPhase(t *testing.T) {
+	withPanelWidth(t, 80)
+
+	v := NewVisualizer(44100)
+	activateMode(t, v, VisClassicPeak)
+	driver := classicPeakDriverFor(t, v)
+	frame := driver.frameInterval(v)
+	analysis := driver.analysisInterval(v)
+	start := time.Unix(1, 0)
+	calls := 0
+	var elapsed time.Duration
+
+	for elapsed = 0; elapsed <= time.Second; elapsed += frame {
+		driver.Tick(v, VisTickContext{
+			Now:     start.Add(elapsed),
+			Playing: true,
+			Analyze: func(VisAnalysisSpec) []float64 {
+				calls++
+				return uniformBandsN(classicPeakSpectrumBands, 0.2)
+			},
+		})
+	}
+
+	lastTick := elapsed - frame
+	want := 1 + int(lastTick/analysis)
+	if calls != want {
+		t.Fatalf("Analyze() calls over %v = %d, want %d", lastTick, calls, want)
+	}
+}
+
+func TestClassicPeakAnalysisCadenceKeepsSampleFloor(t *testing.T) {
+	withPanelWidth(t, 80)
+
+	v := NewVisualizer(96000)
+	v.Rows = 24
+	activateMode(t, v, VisClassicPeak)
+	driver := classicPeakDriverFor(t, v)
+	frame := driver.frameInterval(v)
+	start := time.Unix(1, 0)
+	var analyzedAt []time.Time
+
+	for elapsed := time.Duration(0); elapsed <= time.Second; elapsed += frame {
+		now := start.Add(elapsed)
+		driver.Tick(v, VisTickContext{
+			Now:     now,
+			Playing: true,
+			Analyze: func(VisAnalysisSpec) []float64 {
+				analyzedAt = append(analyzedAt, now)
+				return uniformBandsN(classicPeakSpectrumBands, 0.2)
+			},
+		})
+	}
+
+	if len(analyzedAt) < 2 {
+		t.Fatalf("Analyze() calls = %d, want at least 2", len(analyzedAt))
+	}
+	for i := 1; i < len(analyzedAt); i++ {
+		if gap := analyzedAt[i].Sub(analyzedAt[i-1]); gap < classicPeakSampleFloor {
+			t.Fatalf("analysis gap = %v, want at least %v", gap, classicPeakSampleFloor)
+		}
+	}
+}
+
+func TestClassicPeakAnalysisFloorSurvivesIntervalChange(t *testing.T) {
+	withPanelWidth(t, 80)
+
+	v := NewVisualizer(192000)
+	activateMode(t, v, VisClassicPeak)
+	v.Rows = 5
+	driver := classicPeakDriverFor(t, v)
+	var analyzedAt []time.Time
+	tick := func(now time.Time) {
+		driver.Tick(v, VisTickContext{
+			Now:     now,
+			Playing: true,
+			Analyze: func(VisAnalysisSpec) []float64 {
+				analyzedAt = append(analyzedAt, now)
+				return uniformBandsN(classicPeakSpectrumBands, 0.2)
+			},
+		})
+	}
+
+	// A late tick leaves the hop phase behind the real analysis time; growing
+	// the panel then shortens the analysis interval before the next hop.
+	start := time.Unix(1, 0)
+	tick(start)
+	tick(start.Add(40 * time.Millisecond))
+	v.Rows = 10
+	tick(start.Add(52 * time.Millisecond))
+	tick(start.Add(60 * time.Millisecond))
+
+	if len(analyzedAt) != 3 {
+		t.Fatalf("Analyze() calls = %d, want 3", len(analyzedAt))
+	}
+	for i := 1; i < len(analyzedAt); i++ {
+		if gap := analyzedAt[i].Sub(analyzedAt[i-1]); gap < classicPeakSampleFloor {
+			t.Fatalf("analysis gap = %v after interval change, want at least %v", gap, classicPeakSampleFloor)
+		}
+	}
+}
+
 func TestTickClassicPeakStoppedDecayKeepsAnimatingTowardSilence(t *testing.T) {
 	v := NewVisualizer(44100)
 	activateMode(t, v, VisClassicPeak)
@@ -67,7 +168,7 @@ func TestTickClassicPeakStoppedDecayKeepsAnimatingTowardSilence(t *testing.T) {
 
 	calls := 0
 	driver.Tick(v, VisTickContext{
-		Now: time.Now(),
+		Now: time.Unix(1, 0),
 		Analyze: func(VisAnalysisSpec) []float64 {
 			calls++
 			return uniformBands(1)

--- a/ui/vis_classic_peak.go
+++ b/ui/vis_classic_peak.go
@@ -51,12 +51,13 @@ var classicPeakGlyphs = [4]rune{
 }
 
 type classicPeakDriver struct {
-	barPos   []float64
-	peakPos  []float64
-	peakVel  []float64
-	peakHold []float64
-	lastTick time.Time
-	bandsAt  time.Time
+	barPos     []float64
+	peakPos    []float64
+	peakVel    []float64
+	peakHold   []float64
+	lastTick   time.Time
+	bandsAt    time.Time // nominal hop boundary of the last analysis
+	analyzedAt time.Time // wall clock of the last analysis
 }
 
 func newClassicPeakDriver() visModeDriver {
@@ -111,11 +112,23 @@ func (d *classicPeakDriver) Tick(v *Visualizer, ctx VisTickContext) {
 		return
 	}
 	if ctx.Playing {
-		if d.bandsAt.IsZero() || ctx.Now.Sub(d.bandsAt) >= d.analysisInterval(v) {
+		interval := d.analysisInterval(v)
+		hopDue := d.bandsAt.IsZero() || ctx.Now.Sub(d.bandsAt) >= interval
+		floorDue := d.analyzedAt.IsZero() || ctx.Now.Sub(d.analyzedAt) >= classicPeakSampleFloor
+		if hopDue && floorDue {
 			if ctx.Analyze != nil {
 				v.bands = ctx.Analyze(d.AnalysisSpec(v))
 			}
-			d.bandsAt = ctx.Now
+			d.analyzedAt = ctx.Now
+			// Keep the nominal hop phase so redraw quantization does not lower
+			// the average analysis rate. The floor above is measured from the
+			// real analysis time so it survives interval changes.
+			if d.bandsAt.IsZero() {
+				d.bandsAt = ctx.Now
+			} else {
+				elapsed := ctx.Now.Sub(d.bandsAt)
+				d.bandsAt = d.bandsAt.Add(elapsed - elapsed%interval)
+			}
 		}
 	} else {
 		d.bandsAt = time.Time{}
@@ -124,6 +137,9 @@ func (d *classicPeakDriver) Tick(v *Visualizer, ctx VisTickContext) {
 	d.sync(v)
 	if d.animating(v) {
 		d.advance(v, ctx.Now)
+	} else {
+		// Fresh motion starts with one nominal frame after resting.
+		d.lastTick = time.Time{}
 	}
 }
 
@@ -195,8 +211,12 @@ func classicPeakGlyph(level float64, height int) (row int, glyph rune) {
 }
 
 func classicPeakDetached(level, peak float64, height int) bool {
-	minGap := max(classicPeakVisibleEpsilon, 0.5/float64(max(1, height*4)))
-	return peak > level+minGap
+	return peak > level+classicPeakVisibleGap(height)
+}
+
+func classicPeakVisibleGap(height int) float64 {
+	// Half a cap subcell filters motion that cannot be rendered reliably.
+	return max(classicPeakVisibleEpsilon, 0.5/float64(max(1, height*4)))
 }
 
 func classicPeakColsForWidth(width int) int {
@@ -248,8 +268,9 @@ func (d *classicPeakDriver) sync(v *Visualizer) {
 		d.reset(levels, time.Time{})
 		return
 	}
+	gap := classicPeakVisibleGap(v.Rows)
 	for i, level := range levels {
-		if d.landed(i) && level > d.peakPos[i] {
+		if d.landed(i) && level > d.peakPos[i]+gap {
 			delta := level - d.peakPos[i]
 			d.peakPos[i] = level
 			d.peakVel[i] = min(classicPeakLaunchMax, classicPeakLaunchBase+classicPeakLaunchGain*delta)
@@ -269,8 +290,7 @@ func (d *classicPeakDriver) advance(v *Visualizer, now time.Time) {
 	if !now.IsZero() && !d.lastTick.IsZero() {
 		dtSeconds = now.Sub(d.lastTick).Seconds()
 	}
-	// Clamp dt so long gaps (pause, sleep, stalled frame) step like one frame
-	// instead of integrating physics over a huge interval.
+	// Long gaps are suspension, not animation time. Resume with one frame.
 	if dtSeconds <= 0 || dtSeconds > 10*tickClassicPeak.Seconds() {
 		dtSeconds = tickClassicPeak.Seconds()
 	}
@@ -279,26 +299,30 @@ func (d *classicPeakDriver) advance(v *Visualizer, now time.Time) {
 	for i, level := range levels {
 		d.barPos[i] = classicPeakStep(d.barPos[i], level, dtSeconds)
 
-		if d.peakHold[i] > 0 {
-			d.peakHold[i] = max(0, d.peakHold[i]-dtSeconds)
-			if d.peakHold[i] > 0 {
-				continue
+		remaining := dtSeconds
+		if d.peakVel[i] > 0 {
+			// Apex within this frame: land there, start the hold, and spend
+			// the rest of the frame on the hold and the fall.
+			apexAt := d.peakVel[i] / classicPeakGravity
+			if apexAt <= remaining {
+				d.peakPos[i] = min(classicPeakMaxHeight, d.peakPos[i]+0.5*d.peakVel[i]*apexAt)
+				d.peakVel[i] = 0
+				remaining -= apexAt
+				d.peakHold[i] = classicPeakApexHold
 			}
 		}
-
-		prevVel := d.peakVel[i]
-		d.peakPos[i] += d.peakVel[i] * dtSeconds
-		d.peakVel[i] -= classicPeakGravity * dtSeconds
-
-		if d.peakPos[i] > classicPeakMaxHeight {
-			d.peakPos[i] = classicPeakMaxHeight
+		if d.peakHold[i] > 0 {
+			if remaining <= d.peakHold[i] {
+				d.peakHold[i] -= remaining
+				continue
+			}
+			remaining -= d.peakHold[i]
+			d.peakHold[i] = 0
 		}
-		if prevVel > 0 && d.peakVel[i] <= 0 && d.peakPos[i] > d.barPos[i]+classicPeakVisibleEpsilon {
-			d.peakVel[i] = 0
-			d.peakHold[i] = classicPeakApexHold
-			continue
-		}
-		if d.peakPos[i] <= d.barPos[i] {
+
+		d.peakPos[i] = min(classicPeakMaxHeight, d.peakPos[i]+d.peakVel[i]*remaining-0.5*classicPeakGravity*remaining*remaining)
+		d.peakVel[i] -= classicPeakGravity * remaining
+		if d.peakPos[i] <= d.barPos[i]+classicPeakVisibleEpsilon {
 			d.peakPos[i] = d.barPos[i]
 			d.peakVel[i] = 0
 			d.peakHold[i] = 0

--- a/ui/vis_classic_peak_test.go
+++ b/ui/vis_classic_peak_test.go
@@ -97,7 +97,7 @@ func TestVisualizerFrameAdvancesOnTickNotRender(t *testing.T) {
 		t.Fatalf("Render() advanced frame to %d, want 0 before tick", v.frame)
 	}
 
-	v.Tick(VisTickContext{})
+	v.Tick(VisTickContext{Playing: true})
 	if v.frame != 1 {
 		t.Fatalf("Tick() advanced frame to %d, want 1", v.frame)
 	}
@@ -286,6 +286,160 @@ func TestClassicPeakDoesNotRelaunchWhileAirborne(t *testing.T) {
 	}
 }
 
+func TestClassicPeakIgnoresSubcellLaunchJitter(t *testing.T) {
+	withPanelWidth(t, 8)
+
+	v := NewVisualizer(44100)
+	activateMode(t, v, VisClassicPeak)
+	driver := classicPeakDriverFor(t, v)
+	v.bands = uniformBands(0.2)
+	driver.sync(v)
+
+	gap := classicPeakVisibleGap(v.Rows)
+	v.bands = uniformBands(0.2 + gap/2)
+	driver.sync(v)
+	for i, vel := range driver.peakVel {
+		if vel != 0 {
+			t.Fatalf("subcell jitter launched cap[%d] with velocity %v", i, vel)
+		}
+	}
+
+	v.bands = uniformBands(0.2 + 2*gap)
+	driver.sync(v)
+	for i, vel := range driver.peakVel {
+		if vel <= 0 {
+			t.Fatalf("visible rise did not launch cap[%d]: velocity %v", i, vel)
+		}
+	}
+}
+
+func TestClassicPeakPhysicsIsConsistentAcrossTickCadences(t *testing.T) {
+	withPanelWidth(t, 1)
+
+	newDriver := func() (*Visualizer, *classicPeakDriver) {
+		v := NewVisualizer(44100)
+		activateMode(t, v, VisClassicPeak)
+		v.bands = uniformBands(0.2)
+		driver := classicPeakDriverFor(t, v)
+		driver.barPos = []float64{0.2}
+		driver.peakPos = []float64{0.6}
+		driver.peakVel = []float64{1.2}
+		driver.peakHold = []float64{0}
+		driver.lastTick = time.Unix(1, 0)
+		return v, driver
+	}
+
+	fineV, fine := newDriver()
+	coarseV, coarse := newDriver()
+	start := time.Unix(1, 0)
+	const elapsed = 400 * time.Millisecond
+	advanceFor := func(v *Visualizer, driver *classicPeakDriver, frame time.Duration) {
+		now := start
+		for remaining := elapsed; remaining > 0; {
+			step := min(remaining, frame)
+			now = now.Add(step)
+			driver.advance(v, now)
+			remaining -= step
+		}
+	}
+	advanceFor(fineV, fine, TickAnim)
+	advanceFor(coarseV, coarse, time.Second/time.Duration(classicPeakMinFPS))
+
+	if math.Abs(fine.barPos[0]-coarse.barPos[0]) > classicPeakTestEpsilon {
+		t.Fatalf("bar position differs by cadence: fine=%v coarse=%v", fine.barPos[0], coarse.barPos[0])
+	}
+	if math.Abs(fine.peakPos[0]-coarse.peakPos[0]) > classicPeakTestEpsilon {
+		t.Fatalf("peak position differs by cadence: fine=%v coarse=%v", fine.peakPos[0], coarse.peakPos[0])
+	}
+	if math.Abs(fine.peakVel[0]-coarse.peakVel[0]) > classicPeakTestEpsilon {
+		t.Fatalf("peak velocity differs by cadence: fine=%v coarse=%v", fine.peakVel[0], coarse.peakVel[0])
+	}
+	if math.Abs(fine.peakHold[0]-coarse.peakHold[0]) > classicPeakTestEpsilon {
+		t.Fatalf("peak hold differs by cadence: fine=%v coarse=%v", fine.peakHold[0], coarse.peakHold[0])
+	}
+}
+
+func TestClassicPeakAdvanceUsesFullRedrawInterval(t *testing.T) {
+	withPanelWidth(t, 1)
+
+	v := NewVisualizer(44100)
+	activateMode(t, v, VisClassicPeak)
+	v.bands = uniformBands(0.2)
+	driver := classicPeakDriverFor(t, v)
+	driver.barPos = []float64{0.2}
+	driver.peakPos = []float64{0.8}
+	driver.peakVel = []float64{-0.5}
+	driver.peakHold = []float64{0}
+
+	t0 := time.Unix(1, 0)
+	driver.lastTick = t0
+	dt := driver.frameInterval(v)
+	driver.advance(v, t0.Add(dt))
+
+	dtSeconds := dt.Seconds()
+	wantPos := 0.8 - 0.5*dtSeconds - 0.5*classicPeakGravity*dtSeconds*dtSeconds
+	wantVel := -0.5 - classicPeakGravity*dtSeconds
+	if math.Abs(driver.peakPos[0]-wantPos) > classicPeakTestEpsilon ||
+		math.Abs(driver.peakVel[0]-wantVel) > classicPeakTestEpsilon {
+		t.Fatalf("peak after %v = pos %v vel %v, want pos %v vel %v", dt, driver.peakPos[0], driver.peakVel[0], wantPos, wantVel)
+	}
+}
+
+func TestClassicPeakQuietPeriodDoesNotAgeNextTransient(t *testing.T) {
+	withPanelWidth(t, 1)
+
+	v := NewVisualizer(44100)
+	activateMode(t, v, VisClassicPeak)
+	v.Rows = DefaultVisRows
+	v.bands = uniformBands(0.2)
+	driver := classicPeakDriverFor(t, v)
+	driver.barPos = []float64{0.2}
+	driver.peakPos = []float64{0.2}
+	driver.peakVel = []float64{0}
+	driver.peakHold = []float64{0}
+
+	t0 := time.Unix(1, 0)
+	driver.lastTick = t0
+	quietAt := t0.Add(5 * tickClassicPeak)
+	driver.Tick(v, VisTickContext{Now: quietAt, Playing: true})
+	if !driver.lastTick.IsZero() {
+		t.Errorf("lastTick at rest = %v, want zero", driver.lastTick)
+	}
+
+	v.bands = uniformBands(0.95)
+	// The adaptive redraw interval is longer than the nominal first step.
+	driver.Tick(v, VisTickContext{Now: quietAt.Add(driver.frameInterval(v)), Playing: true})
+	want := classicPeakLaunchMax - classicPeakGravity*tickClassicPeak.Seconds()
+	if got := driver.peakVel[0]; math.Abs(got-want) > classicPeakTestEpsilon {
+		t.Fatalf("new peak velocity = %v after quiet period, want %v", got, want)
+	}
+}
+
+func TestClassicPeakCapStopsAtCeiling(t *testing.T) {
+	withPanelWidth(t, 1)
+
+	v := NewVisualizer(44100)
+	activateMode(t, v, VisClassicPeak)
+	v.bands = uniformBands(0.2)
+	driver := classicPeakDriverFor(t, v)
+	driver.barPos = []float64{0.2}
+	driver.peakPos = []float64{0.99}
+	driver.peakVel = []float64{classicPeakLaunchMax}
+	driver.peakHold = []float64{0}
+
+	t0 := time.Unix(1, 0)
+	driver.lastTick = t0
+	for i := 1; i <= 60 && driver.peakVel[0] > 0; i++ {
+		driver.advance(v, t0.Add(time.Duration(i)*tickClassicPeak))
+		if driver.peakPos[0] > classicPeakMaxHeight {
+			t.Fatalf("frame %d peak = %v, want at most %v", i, driver.peakPos[0], classicPeakMaxHeight)
+		}
+	}
+	if driver.peakVel[0] != 0 || driver.peakPos[0] != classicPeakMaxHeight || driver.peakHold[0] <= 0 {
+		t.Fatalf("apex = pos %v vel %v hold %v, want held at %v", driver.peakPos[0], driver.peakVel[0], driver.peakHold[0], classicPeakMaxHeight)
+	}
+}
+
 func TestClassicPeakResetsOnModeSwitchAndWidthChange(t *testing.T) {
 	withPanelWidth(t, 6)
 	cols6 := classicPeakColsForWidth(PanelWidth)
@@ -302,6 +456,7 @@ func TestClassicPeakResetsOnModeSwitchAndWidthChange(t *testing.T) {
 
 	activateMode(t, v, VisBars)
 	activateMode(t, v, VisClassicPeak)
+	v.bands = uniformBands(0.4)
 	driver.sync(v)
 	if len(driver.barPos) != cols6 {
 		t.Fatalf("reset bar len = %d, want %d", len(driver.barPos), cols6)
@@ -443,7 +598,7 @@ func TestClassicPeakRenderShowsAttachedCapWhileSettling(t *testing.T) {
 	}
 }
 
-func TestClassicPeakPausedDecaysBarsAndCapsToRest(t *testing.T) {
+func TestClassicPeakInactiveDecaysBarsAndCapsToRest(t *testing.T) {
 	withPanelWidth(t, 8)
 
 	v := NewVisualizer(44100)
@@ -460,40 +615,77 @@ func TestClassicPeakPausedDecaysBarsAndCapsToRest(t *testing.T) {
 
 	t0 := time.Unix(1, 0)
 	driver.lastTick = t0
-	// Paused ticks empty the bars instead of freezing them at launch height.
+	// Inactive ticks empty the bars instead of freezing them at launch height.
 	for i := range 2 {
-		v.Tick(VisTickContext{Now: t0.Add(time.Duration(i+1) * TickSlow), Paused: true})
+		v.Tick(VisTickContext{Now: t0.Add(time.Duration(i+1) * TickSlow)})
 	}
 	for i, got := range driver.barPos {
 		if got >= snapshotBar[i] {
-			t.Fatalf("paused bar[%d] = %v after decay, want below %v", i, got, snapshotBar[i])
+			t.Fatalf("inactive bar[%d] = %v after decay, want below %v", i, got, snapshotBar[i])
 		}
 	}
 
 	// Keep ticking until the airborne caps have fallen and the driver settles.
 	settled := false
 	for i := 2; i < 240; i++ {
-		v.Tick(VisTickContext{Now: t0.Add(time.Duration(i+1) * TickSlow), Paused: true})
-		if !v.PausedDecayPending(VisTickContext{Paused: true}) {
+		v.Tick(VisTickContext{Now: t0.Add(time.Duration(i+1) * TickSlow)})
+		if !v.DecayPending() {
 			settled = true
 			break
 		}
 	}
 	if !settled {
-		t.Fatal("classic peak never settled to rest while paused")
+		t.Fatal("classic peak never settled to rest while inactive")
 	}
 	for i, got := range driver.barPos {
-		if got >= pausedDecayEpsilon {
-			t.Fatalf("settled bar[%d] = %v, want below %v", i, got, pausedDecayEpsilon)
+		if got >= decaySettledEpsilon {
+			t.Fatalf("settled bar[%d] = %v, want below %v", i, got, decaySettledEpsilon)
 		}
 	}
 	for i, got := range driver.peakPos {
-		if got >= pausedDecayEpsilon {
-			t.Fatalf("settled cap[%d] = %v, want below %v", i, got, pausedDecayEpsilon)
+		if got >= decaySettledEpsilon {
+			t.Fatalf("settled cap[%d] = %v, want below %v", i, got, decaySettledEpsilon)
 		}
 	}
-	if got := v.TickInterval(VisTickContext{Paused: true}); got != TickSlow {
-		t.Fatalf("TickInterval(paused) = %v, want %v", got, TickSlow)
+	if got := v.TickInterval(VisTickContext{}); got != TickSlow {
+		t.Fatalf("TickInterval(inactive) = %v, want %v", got, TickSlow)
+	}
+}
+
+func TestClassicPeakStoppedDecaySuspendsBeforeResume(t *testing.T) {
+	withPanelWidth(t, 8)
+
+	v := NewVisualizer(44100)
+	activateMode(t, v, VisClassicPeak)
+	v.Rows = 5
+	v.bands = uniformBands(0.6)
+	driver := classicPeakDriverFor(t, v)
+	driver.barPos = repeatedClassicPeakSlice(PanelWidth, 0.6)
+	driver.peakPos = repeatedClassicPeakSlice(PanelWidth, 0.82)
+	driver.peakVel = repeatedClassicPeakSlice(PanelWidth, 1.1)
+	driver.peakHold = repeatedClassicPeakSlice(PanelWidth, classicPeakApexHold)
+
+	t0 := time.Unix(1, 0)
+	driver.lastTick = t0
+	var settledAt time.Time
+	for i := 0; i < 240; i++ {
+		settledAt = t0.Add(time.Duration(i+1) * TickSlow)
+		v.Tick(VisTickContext{Now: settledAt})
+		if !v.DecayPending() {
+			break
+		}
+	}
+	if v.DecayPending() {
+		t.Fatal("classic peak never settled to rest while stopped")
+	}
+	if !driver.lastTick.IsZero() {
+		t.Fatalf("lastTick after stopped decay = %v, want suspended clock", driver.lastTick)
+	}
+
+	v.bands = uniformBands(0.95)
+	v.Tick(VisTickContext{Now: settledAt.Add(10 * time.Second), Playing: true})
+	if got := driver.peakVel[0]; got <= 0 {
+		t.Fatalf("resumed peak velocity = %v, want cap still rising", got)
 	}
 }
 

--- a/ui/vis_flame.go
+++ b/ui/vis_flame.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+const flameVisibleHeat = 0.10
+
 // flameDriver renders a fire effect using the classic doom-fire propagation:
 // a heat field is fed at the bottom row from the spectrum, then each frame
 // every cell inherits its neighbour-below's heat with a small lateral wind
@@ -55,7 +57,9 @@ func (d *flameDriver) Tick(v *Visualizer, ctx VisTickContext) {
 
 	// Source (bottom) row: per-column heat seeded from a smooth spectrum sample
 	// plus a small per-column sparkle so the base shimmers even on quiet input.
-	if bandCount > 0 {
+	if !ctx.Playing {
+		clear(d.heat[:dotCols])
+	} else if bandCount > 0 {
 		last := float64(bandCount - 1)
 		for x := 0; x < dotCols; x++ {
 			pos := float64(x) / float64(max(1, dotCols-1)) * last
@@ -127,6 +131,15 @@ func (d *flameDriver) OnEnter(v *Visualizer) {
 
 func (*flameDriver) OnLeave(*Visualizer) {}
 
+func (d *flameDriver) decaySettled() bool {
+	for _, heat := range d.heat {
+		if heat >= flameVisibleHeat {
+			return false
+		}
+	}
+	return true
+}
+
 func (d *flameDriver) Render(v *Visualizer) string {
 	height := v.Rows
 	dotRows := height * 4
@@ -156,7 +169,7 @@ func (d *flameDriver) Render(v *Visualizer) string {
 					// Wispy tips: at low heat, only stochastically light the dot
 					// so the upper edge of the flame has a soft, broken silhouette
 					// instead of a hard cutoff.
-					if h < 0.10 {
+					if h < flameVisibleHeat {
 						continue
 					}
 					if h < 0.25 && scatterHash(0, y, x, d.frame) > h*4 {

--- a/ui/vis_geyser.go
+++ b/ui/vis_geyser.go
@@ -117,7 +117,7 @@ func (d *geyserDriver) spawn(x, y, spread int, vy float64, bass, mid, high *floa
 func (*geyserDriver) TickInterval(_ *Visualizer, ctx VisTickContext) time.Duration {
 	return defaultDriverTickInterval(ctx)
 }
-func (d *geyserDriver) pauseSettled() bool { return len(d.particles) == 0 }
+func (d *geyserDriver) decaySettled() bool { return len(d.particles) == 0 }
 func (d *geyserDriver) OnEnter(*Visualizer) {
 	d.grid = brailleGrid{}
 	d.particles = nil

--- a/ui/vis_mosaic.go
+++ b/ui/vis_mosaic.go
@@ -211,6 +211,15 @@ func (*mosaicDriver) TickInterval(_ *Visualizer, ctx VisTickContext) time.Durati
 	return defaultDriverTickInterval(ctx)
 }
 
+func (d *mosaicDriver) decaySettled() bool {
+	for _, cell := range d.cells {
+		if mosaicLevelFor(cell.value).tier >= 0 {
+			return false
+		}
+	}
+	return true
+}
+
 func (d *mosaicDriver) OnEnter(*Visualizer) {
 	// Force the grid to be regenerated on next Render/Tick so each visit
 	// reshuffles thresholds and band assignments — keeps the visualizer fresh.

--- a/ui/vis_sand.go
+++ b/ui/vis_sand.go
@@ -23,6 +23,7 @@ type sandDriver struct {
 	// each tick so the existing renderer needs no changes.
 	particles    []sandParticle
 	explosionTTL int
+	falling      bool
 }
 
 // sandParticle is one grain in mid-flight during the explosion sequence. Sub-
@@ -68,6 +69,7 @@ func (d *sandDriver) Tick(v *Visualizer, ctx VisTickContext) {
 		return
 	}
 	d.ensure(dotRows, dotCols)
+	d.falling = false
 
 	bands := v.SmoothedBands()
 	bass := bandAvg(bands, 0, max(1, len(bands)/3))
@@ -251,6 +253,18 @@ func (d *sandDriver) Tick(v *Visualizer, ctx VisTickContext) {
 		}
 	}
 
+	// Floor: grains in the very bottom row drift off-screen at a slow rate so
+	// the grid doesn't fill up over time. Without this, a long-running session
+	// gradually packs every cell. Runs before the falling pass so a grain left
+	// unsupported drops this same tick and d.falling reflects it.
+	if ctx.Playing {
+		for x := 0; x < dotCols; x++ {
+			if d.grid[(dotRows-1)*dotCols+x] != 0 && d.rand01() < 0.04 {
+				d.grid[(dotRows-1)*dotCols+x] = 0
+			}
+		}
+	}
+
 	// Falling pass: bottom-up so a grain we just moved into y+1 isn't moved
 	// twice this frame. Grains at the bottom row leave the grid.
 	for y := dotRows - 2; y >= 0; y-- {
@@ -270,6 +284,7 @@ func (d *sandDriver) Tick(v *Visualizer, ctx VisTickContext) {
 			if d.grid[(y+1)*dotCols+x] == 0 {
 				d.grid[(y+1)*dotCols+x] = g
 				d.grid[y*dotCols+x] = 0
+				d.falling = true
 				continue
 			}
 			// Diagonal: pick left or right first based on parity for symmetry.
@@ -285,18 +300,10 @@ func (d *sandDriver) Tick(v *Visualizer, ctx VisTickContext) {
 				if d.grid[(y+1)*dotCols+nx] == 0 {
 					d.grid[(y+1)*dotCols+nx] = g
 					d.grid[y*dotCols+x] = 0
+					d.falling = true
 					break
 				}
 			}
-		}
-	}
-
-	// Floor: grains in the very bottom row drift off-screen at a slow rate so
-	// the grid doesn't fill up over time. Without this, a long-running session
-	// gradually packs every cell.
-	for x := 0; x < dotCols; x++ {
-		if d.grid[(dotRows-1)*dotCols+x] != 0 && d.rand01() < 0.04 {
-			d.grid[(dotRows-1)*dotCols+x] = 0
 		}
 	}
 }
@@ -305,8 +312,8 @@ func (*sandDriver) TickInterval(_ *Visualizer, ctx VisTickContext) time.Duration
 	return defaultDriverTickInterval(ctx)
 }
 
-func (d *sandDriver) pauseSettled() bool {
-	return d.explosionTTL == 0 && len(d.particles) == 0
+func (d *sandDriver) decaySettled() bool {
+	return d.explosionTTL == 0 && len(d.particles) == 0 && !d.falling
 }
 
 func (d *sandDriver) OnEnter(*Visualizer) {
@@ -316,6 +323,7 @@ func (d *sandDriver) OnEnter(*Visualizer) {
 	d.prevBass = 0
 	d.particles = nil
 	d.explosionTTL = 0
+	d.falling = false
 }
 
 func (*sandDriver) OnLeave(*Visualizer) {}

--- a/ui/vis_stereo.go
+++ b/ui/vis_stereo.go
@@ -87,6 +87,12 @@ func (d *stereoDriver) Tick(_ *Visualizer, ctx VisTickContext) {
 		d.samplesAt = time.Time{}
 	}
 	d.advance(ctx.Now)
+	if !d.animating() {
+		// At rest the meters still hold a sub-epsilon residual and the
+		// renderer marks any peak above zero. Zero them so the panel goes dark.
+		d.level = [2]float64{}
+		d.peak = [2]float64{}
+	}
 }
 
 func (d *stereoDriver) TickInterval(_ *Visualizer, ctx VisTickContext) time.Duration {

--- a/ui/vis_stereo_test.go
+++ b/ui/vis_stereo_test.go
@@ -95,7 +95,45 @@ func TestStereoDriverReadsAndRendersStereoSamples(t *testing.T) {
 	}
 }
 
-func TestStereoPausedDecaysMetersToRest(t *testing.T) {
+func TestStereoSilentPlaybackClearsPeaksBeforeStopping(t *testing.T) {
+	v := NewVisualizer(44100)
+	v.Cols = 48
+	v.Rows = 5
+	v.Mode = VisStereo
+	now := time.Unix(1, 0)
+	samples := [][2]float64{{0.9, 0.9}, {-0.9, -0.9}}
+	for i := range 360 {
+		if i == 60 {
+			clear(samples)
+		}
+		now = now.Add(TickAnim)
+		v.Tick(VisTickContext{
+			Now:     now,
+			Playing: true,
+			StereoSamplesInto: func(dst [][2]float64) int {
+				return copy(dst, samples)
+			},
+		})
+		if i == 59 && !strings.Contains(v.Render(), "■") {
+			t.Fatal("loud playback did not produce peak markers")
+		}
+	}
+	if v.DecayPending() {
+		t.Fatal("stereo meters did not settle during silent playback")
+	}
+	if strings.Contains(v.Render(), "■") {
+		t.Error("silent playback left peak markers visible")
+	}
+	for range 300 {
+		now = now.Add(TickSlow)
+		v.Tick(VisTickContext{Now: now})
+	}
+	if strings.Contains(v.Render(), "■") {
+		t.Error("stopping after silent playback left peak markers visible")
+	}
+}
+
+func TestStereoInactiveDecaysMetersToRest(t *testing.T) {
 	v := NewVisualizer(44100)
 	v.Cols = 48
 	v.Rows = 5
@@ -120,30 +158,33 @@ func TestStereoPausedDecaysMetersToRest(t *testing.T) {
 		}
 	}
 
-	// Paused ticks empty both needles and peaks instead of freezing them.
+	// Inactive ticks empty both needles and peaks instead of freezing them.
 	settled := false
 	prevLevel := driver.level
 	prevPeak := driver.peak
 	for i := 0; i < 240; i++ {
-		v.Tick(VisTickContext{Now: t0.Add(time.Duration(i+1) * TickSlow), Paused: true})
+		v.Tick(VisTickContext{Now: t0.Add(time.Duration(i+1) * TickSlow)})
 		for c := range 2 {
 			if driver.level[c] > prevLevel[c]+1e-9 || driver.peak[c] > prevPeak[c]+1e-9 {
-				t.Fatalf("paused tick %d channel %d level %v->%v or peak %v->%v, want monotonic decay",
+				t.Fatalf("inactive tick %d channel %d level %v->%v or peak %v->%v, want monotonic decay",
 					i, c, prevLevel[c], driver.level[c], prevPeak[c], driver.peak[c])
 			}
 		}
 		prevLevel, prevPeak = driver.level, driver.peak
-		if !v.PausedDecayPending(VisTickContext{Paused: true}) {
+		if !v.DecayPending() {
 			settled = true
 			break
 		}
 	}
 	if !settled {
-		t.Fatal("stereo meters never settled to rest while paused")
+		t.Fatal("stereo meters never settled to rest while inactive")
 	}
 	for c := range 2 {
-		if driver.level[c] > stereoEpsilon || driver.peak[c] > stereoEpsilon {
-			t.Fatalf("settled channel %d level=%v peak=%v, want <= %v", c, driver.level[c], driver.peak[c], stereoEpsilon)
+		if driver.level[c] != 0 || driver.peak[c] != 0 {
+			t.Fatalf("settled channel %d level=%v peak=%v, want 0", c, driver.level[c], driver.peak[c])
 		}
+	}
+	if out := ansi.Strip(v.Render()); strings.Contains(out, "■") {
+		t.Fatalf("settled stereo render still shows peak markers:\n%s", out)
 	}
 }

--- a/ui/vis_terrain.go
+++ b/ui/vis_terrain.go
@@ -83,18 +83,22 @@ func (d *terrainDriver) Tick(v *Visualizer, ctx VisTickContext) {
 	// Scroll left by 2 dot columns per frame for visible movement.
 	copy(d.buf, d.buf[2:])
 
-	// Compute new rightmost height from average smoothed spectrum energy
-	// so successive scrolled columns glide instead of stepping at the FFT rate.
-	bands := v.SmoothedBands()
-	var totalEnergy float64
-	for _, e := range bands {
-		totalEnergy += e
-	}
-	avg := totalEnergy / float64(max(1, len(bands)))
+	if ctx.Playing {
+		// Compute new rightmost height from average smoothed spectrum energy
+		// so successive scrolled columns glide instead of stepping at the FFT rate.
+		bands := v.SmoothedBands()
+		var totalEnergy float64
+		for _, e := range bands {
+			totalEnergy += e
+		}
+		avg := totalEnergy / float64(max(1, len(bands)))
 
-	// Two new columns with slight noise for organic ridge edges.
-	d.buf[dotCols-2] = min(1.0, avg+scatterHash(0, 0, 0, v.frame)*0.12)
-	d.buf[dotCols-1] = min(1.0, avg+scatterHash(0, 0, 1, v.frame)*0.12)
+		// Two new columns with slight noise for organic ridge edges.
+		d.buf[dotCols-2] = min(1.0, avg+scatterHash(0, 0, 0, v.frame)*0.12)
+		d.buf[dotCols-1] = min(1.0, avg+scatterHash(0, 0, 1, v.frame)*0.12)
+	} else {
+		clear(d.buf[dotCols-2:])
+	}
 }
 
 func (*terrainDriver) TickInterval(_ *Visualizer, ctx VisTickContext) time.Duration {
@@ -104,3 +108,12 @@ func (*terrainDriver) TickInterval(_ *Visualizer, ctx VisTickContext) time.Durat
 func (*terrainDriver) OnEnter(*Visualizer) {}
 
 func (*terrainDriver) OnLeave(*Visualizer) {}
+
+func (d *terrainDriver) decaySettled() bool {
+	for _, height := range d.buf {
+		if height != 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/ui/visualizer.go
+++ b/ui/visualizer.go
@@ -19,9 +19,9 @@ const (
 	// frame) step like ~1 frame instead of integrating over a huge interval.
 	maxSmoothDtFrames        = 10
 	maxAnimationCatchUpSteps = 4
-	// Band level below which paused spectrum content is treated as fully
+	// Band level below which inactive spectrum content is treated as fully
 	// decayed to rest, letting the model drop the visualizer to the idle tick.
-	pausedDecayEpsilon = 0.01
+	decaySettledEpsilon = 0.01
 )
 
 var legacySpectrumEdges = [DefaultSpectrumBands + 1]float64{
@@ -244,7 +244,6 @@ func splitStyleAroundProbe(s lipgloss.Style) (prefix, suffix string) {
 type VisTickContext struct {
 	Now               time.Time
 	Playing           bool
-	Paused            bool
 	OverlayActive     bool
 	Analyze           func(VisAnalysisSpec) []float64
 	StereoSamplesInto func([][2]float64) int
@@ -281,8 +280,8 @@ type visModeDriver interface {
 	OnLeave(*Visualizer)
 }
 
-type visPauseSettler interface {
-	pauseSettled() bool
+type visDecaySettler interface {
+	decaySettled() bool
 }
 
 // visEntry pairs a display name with a factory for that mode's visModeDriver.
@@ -359,7 +358,12 @@ func defaultDriverTick(v *Visualizer, ctx VisTickContext, spec VisAnalysisSpec) 
 		return
 	}
 	spec = NormalizeAnalysisSpec(spec)
-	if ctx.Analyze != nil {
+	if !ctx.Playing {
+		v.lastAnalyzeAt = time.Time{}
+		if spec.BandCount > 0 {
+			v.bands = v.Analyze(nil, spec)
+		}
+	} else if ctx.Analyze != nil {
 		// Decouple FFT cadence from animation cadence. Raw-sample modes have no
 		// FFT work, so refresh their waveform on every render tick.
 		due := spec.BandCount == 0 || v.lastAnalyzeAt.IsZero() || ctx.Now.IsZero() ||
@@ -421,6 +425,7 @@ type Visualizer struct {
 	sampleBuf       []float64 // reusable buffer for reading audio tap samples
 	drivers         [VisCount]visModeDriver
 	activeMode      VisMode
+	activeSpec      VisAnalysisSpec // spec v.bands currently belongs to
 	activeModeSet   bool
 	refreshPending  bool
 	luaVisNames     []string
@@ -865,9 +870,6 @@ func (v *Visualizer) TickInterval(ctx VisTickContext) time.Duration {
 	if driver == nil {
 		return TickSlow
 	}
-	if ctx.Paused {
-		return TickSlow
-	}
 	return driver.TickInterval(v, ctx)
 }
 
@@ -892,30 +894,30 @@ func (v *Visualizer) Tick(ctx VisTickContext) {
 		return
 	}
 	v.refreshPending = false
-	if ctx.Paused {
-		if spec := NormalizeAnalysisSpec(driver.AnalysisSpec(v)); spec.BandCount == 0 {
-			v.waveBuf = v.waveBuf[:0]
-		}
-		// Keep easing the visual down to rest instead of freezing mid-frame.
-		// Drivers already know how to decay when not playing (silent band
-		// analysis, target-zero physics); we just keep ticking until settled.
-		if v.pausedSettled(driver, ctx) {
-			v.Suspend()
-		} else {
+	if ctx.OverlayActive {
+		v.resetFrameTiming()
+		driver.Tick(v, ctx)
+		return
+	}
+	if !ctx.Playing {
+		v.waveBuf = v.waveBuf[:0]
+		if !v.decaySettled(driver) {
 			driver.Tick(v, ctx)
+		}
+		if v.decaySettled(driver) {
+			v.clearSpectrum(driver)
+			v.Suspend()
 		}
 		return
 	}
-	if ctx.OverlayActive {
-		v.resetFrameTiming()
-	} else if v.Mode != VisNone {
+	if v.Mode != VisNone {
 		v.frame += v.animationSteps(ctx.Now, driver.TickInterval(v, ctx))
 	}
 	driver.Tick(v, ctx)
 }
 
 // Suspend resets elapsed-time accounting and the active driver's wall clock so
-// resuming after a hidden or paused interval advances by one frame, not the gap.
+// resuming after a hidden or inactive interval advances by one frame, not the gap.
 func (v *Visualizer) Suspend() {
 	if v == nil {
 		return
@@ -933,13 +935,13 @@ func (v *Visualizer) resetFrameTiming() {
 	v.frameInterval = 0
 }
 
-// pausedSettled reports whether a paused visualizer has no content left to
+// decaySettled reports whether an inactive visualizer has no content left to
 // ease down, so it can freeze at rest. Band-driven modes must empty both the
 // raw and smoothed bands, raw-sample modes must clear their waveform, and
 // stateful drivers must finish their own animation. Classic meters signal
-// animation through their tick interval; particle modes implement
-// visPauseSettler.
-func (v *Visualizer) pausedSettled(driver visModeDriver, ctx VisTickContext) bool {
+// animation through their tick interval; other stateful modes implement
+// visDecaySettler.
+func (v *Visualizer) decaySettled(driver visModeDriver) bool {
 	if v == nil || driver == nil {
 		return true
 	}
@@ -949,32 +951,42 @@ func (v *Visualizer) pausedSettled(driver visModeDriver, ctx VisTickContext) boo
 	}
 	if spec.BandCount > 0 {
 		for _, b := range v.bands {
-			if b >= pausedDecayEpsilon {
+			if b >= decaySettledEpsilon {
 				return false
 			}
 		}
 		for _, b := range v.smoothedBands {
-			if b >= pausedDecayEpsilon {
+			if b >= decaySettledEpsilon {
 				return false
 			}
 		}
 	}
-	if settler, ok := driver.(visPauseSettler); ok && !settler.pauseSettled() {
+	if settler, ok := driver.(visDecaySettler); ok && !settler.decaySettled() {
 		return false
 	}
-	ctx.Playing = false
-	return driver.TickInterval(v, ctx) >= TickSlow
+	return driver.TickInterval(v, VisTickContext{}) >= TickSlow
 }
 
-// PausedDecayPending reports whether a paused visualizer still needs ticks to
+// clearSpectrum drops the sub-epsilon residual left by inactive decay.
+// Eased renderers already show it as blank, but dot, brick, and outline
+// renderers light any level above zero and IPC consumers would read it.
+func (v *Visualizer) clearSpectrum(driver visModeDriver) {
+	clear(v.bands)
+	clear(v.smoothedBands)
+	if spec := NormalizeAnalysisSpec(driver.AnalysisSpec(v)); spec.BandCount > 0 {
+		clear(v.prevBands(spec))
+	}
+}
+
+// DecayPending reports whether an inactive visualizer still needs ticks to
 // settle its content to rest. The model uses it to keep an active tick cadence
 // instead of dropping to fully idle while content eases down.
-func (v *Visualizer) PausedDecayPending(ctx VisTickContext) bool {
+func (v *Visualizer) DecayPending() bool {
 	driver := v.syncDriverMode()
 	if driver == nil {
 		return false
 	}
-	return !v.pausedSettled(driver, ctx)
+	return !v.decaySettled(driver)
 }
 
 func (v *Visualizer) animationSteps(now time.Time, interval time.Duration) uint64 {
@@ -1125,36 +1137,42 @@ func (v *Visualizer) syncDriverMode() visModeDriver {
 		return nil
 	}
 	driver := v.driverFor(v.Mode)
+	spec := VisAnalysisSpec{}
+	if driver != nil {
+		spec = NormalizeAnalysisSpec(driver.AnalysisSpec(v))
+	}
 	if !v.activeModeSet {
 		if driver != nil {
 			driver.OnEnter(v)
 		}
 		v.activeMode = v.Mode
+		v.activeSpec = spec
 		v.activeModeSet = true
 		return driver
 	}
-	if v.activeMode != v.Mode {
-		prev := v.driverFor(v.activeMode)
-		prevSpec := VisAnalysisSpec{}
-		if prev != nil {
-			prevSpec = NormalizeAnalysisSpec(prev.AnalysisSpec(v))
-		}
-		nextSpec := VisAnalysisSpec{}
-		if driver != nil {
-			nextSpec = NormalizeAnalysisSpec(driver.AnalysisSpec(v))
-		}
-		if (prevSpec.BandCount == 0) != (nextSpec.BandCount == 0) {
-			v.resetSpectrumHistory()
-		}
-		v.smoothedBands = v.smoothedBands[:0]
-		v.lastSmoothTick = time.Time{}
-		if prev != nil {
+	modeChanged := v.activeMode != v.Mode
+	if modeChanged {
+		if prev := v.driverFor(v.activeMode); prev != nil {
 			prev.OnLeave(v)
 		}
 		if driver != nil {
 			driver.OnEnter(v)
 		}
 		v.activeMode = v.Mode
+	}
+	// The spec can also change without a mode change: ClassicLED's band
+	// count follows the panel width.
+	if modeChanged || spec != v.activeSpec {
+		if (v.activeSpec.BandCount == 0) != (spec.BandCount == 0) {
+			v.resetSpectrumHistory()
+		}
+		v.smoothedBands = v.smoothedBands[:0]
+		v.lastSmoothTick = time.Time{}
+		// Start from the incoming spec's own history so an inactive visualizer
+		// keeps decaying it instead of judging readiness by the old spec's
+		// bands and resuming with stale levels.
+		v.bands = v.Analyze(nil, spec)
+		v.activeSpec = spec
 	}
 	return driver
 }

--- a/ui/visualizer_driver_test.go
+++ b/ui/visualizer_driver_test.go
@@ -3,8 +3,12 @@ package ui
 import (
 	"math"
 	"reflect"
+	"slices"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/charmbracelet/x/ansi"
 )
 
 func TestAnalyzeSupportsArbitraryBandCounts(t *testing.T) {
@@ -143,15 +147,15 @@ func TestFastFrameDriverBoundsCatchUp(t *testing.T) {
 	}
 }
 
-func TestFastFrameDriverDoesNotCatchUpPausedOrHiddenTime(t *testing.T) {
+func TestFastFrameDriverDoesNotCatchUpInactiveOrHiddenTime(t *testing.T) {
 	tests := []struct {
 		name    string
 		suspend func(*Visualizer, time.Time)
 	}{
 		{
-			name: "paused",
+			name: "inactive",
 			suspend: func(v *Visualizer, now time.Time) {
-				v.Tick(VisTickContext{Now: now, Playing: true, Paused: true})
+				v.Tick(VisTickContext{Now: now})
 			},
 		},
 		{name: "hidden", suspend: func(v *Visualizer, _ time.Time) { v.Suspend() }},
@@ -218,7 +222,7 @@ func TestAdvanceSmoothingResizesOnBandCountChange(t *testing.T) {
 	}
 }
 
-func TestPausedBarsDecayToRestThenSuspend(t *testing.T) {
+func TestInactiveBarsDecayToRestThenSuspend(t *testing.T) {
 	withPanelWidth(t, 16)
 
 	v := NewVisualizer(44100)
@@ -226,66 +230,174 @@ func TestPausedBarsDecayToRestThenSuspend(t *testing.T) {
 	v.bands = uniformBands(0.8)
 	v.smoothedBands = append([]float64(nil), v.bands...)
 
-	analyze := func(spec VisAnalysisSpec) []float64 {
-		return v.Analyze(nil, spec)
-	}
-	ctxAt := func(now time.Time) VisTickContext {
-		return VisTickContext{Now: now, Paused: true, Analyze: analyze}
-	}
-
 	prev := append([]float64(nil), v.SmoothedBands()...)
 	settled := false
 	now := time.Unix(1, 0)
 	for i := 0; i < 240; i++ {
-		v.Tick(ctxAt(now.Add(time.Duration(i+1) * TickSlow)))
+		v.Tick(VisTickContext{Now: now.Add(time.Duration(i+1) * TickSlow)})
 		cur := v.SmoothedBands()
 		for b := range len(cur) {
 			if cur[b] > prev[b]+1e-9 {
-				t.Fatalf("paused tick %d band %d rose %v -> %v, want monotonic decay", i, b, prev[b], cur[b])
+				t.Fatalf("inactive tick %d band %d rose %v -> %v, want monotonic decay", i, b, prev[b], cur[b])
 			}
 		}
 		prev = append(prev[:0], cur...)
-		if !v.PausedDecayPending(ctxAt(now.Add(time.Duration(i+2) * TickSlow))) {
+		if !v.DecayPending() {
 			settled = true
 			break
 		}
 	}
 	if !settled {
-		t.Fatal("paused bars never settled to rest")
+		t.Fatal("inactive bars never settled to rest")
 	}
 	for i, got := range prev {
-		if got >= pausedDecayEpsilon {
-			t.Fatalf("band %d = %v after decay, want below %v", i, got, pausedDecayEpsilon)
+		if got >= decaySettledEpsilon {
+			t.Fatalf("band %d = %v after decay, want below %v", i, got, decaySettledEpsilon)
 		}
 	}
 
-	// Once settled, further paused ticks suspend and leave the frame alone.
+	// Once settled, further inactive ticks suspend and leave the frame alone.
 	frameBefore := v.Frame()
-	v.Tick(ctxAt(now.Add(10 * time.Second)))
+	v.Tick(VisTickContext{Now: now.Add(10 * time.Second)})
 	if got := v.Frame(); got != frameBefore {
-		t.Fatalf("settled paused tick advanced frame %d -> %d", frameBefore, got)
+		t.Fatalf("settled inactive tick advanced frame %d -> %d", frameBefore, got)
 	}
 	for i, got := range v.SmoothedBands() {
 		if math.Abs(got-prev[i]) > 1e-9 {
-			t.Fatalf("settled paused tick changed band %d %v -> %v", i, prev[i], got)
+			t.Fatalf("settled inactive tick changed band %d %v -> %v", i, prev[i], got)
 		}
 	}
 }
 
-func TestPausedRawSampleModeClearsWaveform(t *testing.T) {
+// sineSamples returns n samples of a loud 1 kHz tone at 44.1 kHz.
+func sineSamples(n int) []float64 {
+	s := make([]float64, n)
+	for i := range s {
+		s[i] = 0.8 * math.Sin(2*math.Pi*1000*float64(i)/44100)
+	}
+	return s
+}
+
+func TestInactiveWidthChangeDecaysReturnedSpecHistory(t *testing.T) {
+	withPanelWidth(t, 30)
+	v := NewVisualizer(44100)
+	v.Rows = 5
+	v.Mode = VisClassicLED
+	sine := sineSamples(classicLEDFFTSize)
+	loud := func(spec VisAnalysisSpec) []float64 { return v.Analyze(sine, spec) }
+	now := time.Unix(1, 0)
+	for _, width := range []int{30, 60} {
+		PanelWidth = width
+		for range 20 {
+			now = now.Add(TickFast)
+			v.Tick(VisTickContext{Now: now, Playing: true, Analyze: loud})
+		}
+	}
+
+	// Stop and settle at width 60, then shrink back to 30 while stopped.
+	for i := 0; i < 240 && v.DecayPending(); i++ {
+		now = now.Add(TickFast)
+		v.Tick(VisTickContext{Now: now})
+	}
+	PanelWidth = 30
+	if !v.DecayPending() {
+		t.Fatal("ClassicLED reported settled after a width change with its charged history")
+	}
+	for i := 0; i < 240 && v.DecayPending(); i++ {
+		now = now.Add(TickFast)
+		v.Tick(VisTickContext{Now: now})
+	}
+	if v.DecayPending() {
+		t.Fatal("ClassicLED never settled after the width change")
+	}
+
+	silent := func(spec VisAnalysisSpec) []float64 { return v.Analyze(nil, spec) }
+	v.Tick(VisTickContext{Now: now.Add(time.Second), Playing: true, Analyze: silent})
+	if got := slices.Max(v.Bands()); got >= decaySettledEpsilon {
+		t.Fatalf("resumed into silence with band level %v, want stale history decayed below %v", got, decaySettledEpsilon)
+	}
+}
+
+func TestInactiveModeSwitchDecaysReturnedSpecHistory(t *testing.T) {
+	withPanelWidth(t, 16)
+	v := NewVisualizer(44100)
+	v.Rows = 5
+	v.Mode = VisClassicPeak
+	sine := sineSamples(classicPeakFFTSize)
+	loud := func(spec VisAnalysisSpec) []float64 { return v.Analyze(sine, spec) }
+	now := time.Unix(1, 0)
+	for range 20 {
+		now = now.Add(TickFast)
+		v.Tick(VisTickContext{Now: now, Playing: true, Analyze: loud})
+	}
+
+	// Stop, let Bars settle, then return to ClassicPeak while still stopped.
+	v.Mode = VisBars
+	for i := 0; i < 240 && v.DecayPending(); i++ {
+		now = now.Add(TickFast)
+		v.Tick(VisTickContext{Now: now})
+	}
+	v.Mode = VisClassicPeak
+	if !v.DecayPending() {
+		t.Fatal("ClassicPeak reported settled on re-entry with its charged history")
+	}
+	for i := 0; i < 240 && v.DecayPending(); i++ {
+		now = now.Add(TickFast)
+		v.Tick(VisTickContext{Now: now})
+	}
+	if v.DecayPending() {
+		t.Fatal("ClassicPeak never settled after re-entry")
+	}
+
+	silent := func(spec VisAnalysisSpec) []float64 { return v.Analyze(nil, spec) }
+	v.Tick(VisTickContext{Now: now.Add(time.Second), Playing: true, Analyze: silent})
+	if got := slices.Max(v.Bands()); got >= decaySettledEpsilon {
+		t.Fatalf("resumed into silence with band level %v, want stale history decayed below %v", got, decaySettledEpsilon)
+	}
+}
+
+func TestSettledInactiveSpectrumReadsZero(t *testing.T) {
+	withPanelWidth(t, 16)
+	v := NewVisualizer(44100)
+	v.Rows = 5
+	v.Mode = VisBricks
+	sine := sineSamples(defaultFFTSize)
+	loud := func(spec VisAnalysisSpec) []float64 { return v.Analyze(sine, spec) }
+	now := time.Unix(1, 0)
+	for range 20 {
+		now = now.Add(TickFast)
+		v.Tick(VisTickContext{Now: now, Playing: true, Analyze: loud})
+	}
+	for i := 0; i < 240 && v.DecayPending(); i++ {
+		now = now.Add(TickFast)
+		v.Tick(VisTickContext{Now: now})
+	}
+	if v.DecayPending() {
+		t.Fatal("bricks never settled while inactive")
+	}
+	if got := slices.Max(v.SmoothedBands()); got != 0 {
+		t.Fatalf("settled smoothed band level = %v, want 0", got)
+	}
+	lines := strings.Split(v.Render(), "\n")
+	if bottom := strings.TrimSpace(ansi.Strip(lines[len(lines)-1])); bottom != "" {
+		t.Fatalf("settled bricks bottom row = %q, want blank", bottom)
+	}
+}
+
+func TestInactiveRawSampleModeClearsWaveform(t *testing.T) {
 	v := NewVisualizer(44100)
 	activateMode(t, v, VisWave)
 	v.waveBuf = []float64{-0.5, 0.5}
-	ctx := VisTickContext{Paused: true}
+	ctx := VisTickContext{}
 
-	if !v.PausedDecayPending(ctx) {
+	if !v.DecayPending() {
 		t.Fatal("raw waveform was considered settled before being cleared")
 	}
 	v.Tick(ctx)
 	if len(v.waveBuf) != 0 {
 		t.Fatalf("waveBuf len = %d after pause, want 0", len(v.waveBuf))
 	}
-	if v.PausedDecayPending(ctx) {
+	if v.DecayPending() {
 		t.Fatal("raw waveform still settling after pause clear")
 	}
 }
@@ -301,7 +413,7 @@ func TestModeSwitchClearsSmoothedBands(t *testing.T) {
 	}
 }
 
-func TestPausedGeyserWaitsForParticles(t *testing.T) {
+func TestInactiveGeyserWaitsForParticles(t *testing.T) {
 	withPanelWidth(t, 16)
 	v := NewVisualizer(44100)
 	v.Rows = 5
@@ -310,21 +422,21 @@ func TestPausedGeyserWaitsForParticles(t *testing.T) {
 	driver.particles = []geyserParticle{{x: 1, y: float64(v.Rows * 4), tier: 1}}
 	v.bands = uniformBands(0)
 	v.smoothedBands = uniformBands(0)
-	ctx := VisTickContext{Paused: true}
+	ctx := VisTickContext{}
 
-	if !v.PausedDecayPending(ctx) {
+	if !v.DecayPending() {
 		t.Fatal("geyser was considered settled with a live particle")
 	}
 	v.Tick(ctx)
 	if len(driver.particles) != 0 {
 		t.Fatalf("geyser particles = %d after off-screen decay, want 0", len(driver.particles))
 	}
-	if v.PausedDecayPending(ctx) {
+	if v.DecayPending() {
 		t.Fatal("geyser still settling after particles expired")
 	}
 }
 
-func TestPausedSandWaitsForExplosion(t *testing.T) {
+func TestInactiveSandWaitsForExplosion(t *testing.T) {
 	withPanelWidth(t, 16)
 	v := NewVisualizer(44100)
 	v.Rows = 5
@@ -335,17 +447,145 @@ func TestPausedSandWaitsForExplosion(t *testing.T) {
 	driver.explosionTTL = 1
 	v.bands = uniformBands(0)
 	v.smoothedBands = uniformBands(0)
-	ctx := VisTickContext{Paused: true}
+	ctx := VisTickContext{}
 
-	if !v.PausedDecayPending(ctx) {
+	if !v.DecayPending() {
 		t.Fatal("sand was considered settled during an explosion")
 	}
 	v.Tick(ctx)
 	if len(driver.particles) != 0 || driver.explosionTTL != 0 {
 		t.Fatalf("sand explosion state after decay = particles %d, ttl %d", len(driver.particles), driver.explosionTTL)
 	}
-	if v.PausedDecayPending(ctx) {
+	if v.DecayPending() {
 		t.Fatal("sand still settling after explosion expired")
+	}
+}
+
+func TestInactiveSandWaitsForFallingGrains(t *testing.T) {
+	withPanelWidth(t, 4)
+	v := NewVisualizer(44100)
+	v.Rows = 10
+	activateMode(t, v, VisSand)
+	driver := v.driverFor(VisSand).(*sandDriver)
+	driver.ensure(v.Rows*4, PanelWidth*2)
+	x := PanelWidth
+	driver.grid[x] = 1
+	v.bands = uniformBands(0)
+	v.smoothedBands = uniformBands(0)
+
+	now := time.Unix(1, 0)
+	v.Tick(VisTickContext{Now: now, Playing: true})
+	if !v.DecayPending() {
+		t.Fatal("sand was considered settled with a falling grain")
+	}
+	for i := 1; i <= driver.dotRows && v.DecayPending(); i++ {
+		v.Tick(VisTickContext{Now: now.Add(time.Duration(i) * TickFast)})
+	}
+	if v.DecayPending() {
+		t.Fatal("sand remained active after its falling grain landed")
+	}
+	if got := driver.grid[(driver.dotRows-1)*driver.dotCols+x]; got != 1 {
+		t.Fatalf("landed grain = %d, want 1", got)
+	}
+}
+
+func TestSandFloorErosionNeverSettlesOverAHole(t *testing.T) {
+	withPanelWidth(t, 4)
+	v := NewVisualizer(44100)
+	v.Rows = 5
+	activateMode(t, v, VisSand)
+	driver := v.driverFor(VisSand).(*sandDriver)
+	dotRows, dotCols := v.Rows*4, PanelWidth*2
+	driver.ensure(dotRows, dotCols)
+	for i := (dotRows - 2) * dotCols; i < len(driver.grid); i++ {
+		driver.grid[i] = 1
+	}
+	v.bands = uniformBands(0)
+	v.smoothedBands = uniformBands(0)
+
+	// Silent playback only erodes the floor. Run until the first erosion and
+	// check the grains it left unsupported keep the visualizer pending.
+	now := time.Unix(1, 0)
+	eroded := false
+	for i := 0; i < 2000 && !eroded; i++ {
+		before := slices.Clone(driver.grid)
+		now = now.Add(TickFast)
+		v.Tick(VisTickContext{Now: now, Playing: true})
+		eroded = !slices.Equal(before, driver.grid)
+	}
+	if !eroded {
+		t.Fatal("floor erosion never removed a grain")
+	}
+	if !v.DecayPending() {
+		t.Fatal("sand reported settled right after eroding a support")
+	}
+
+	for i := 0; i < dotRows && v.DecayPending(); i++ {
+		now = now.Add(TickFast)
+		v.Tick(VisTickContext{Now: now})
+	}
+	if v.DecayPending() {
+		t.Fatal("sand did not settle after erosion")
+	}
+	for y := 0; y < dotRows-1; y++ {
+		for x := range dotCols {
+			if driver.grid[y*dotCols+x] != 0 && driver.grid[(y+1)*dotCols+x] == 0 {
+				t.Fatalf("settled grain at column %d row %d floats over a hole", x, y)
+			}
+		}
+	}
+}
+
+func TestInactiveMosaicWaitsForVisibleCells(t *testing.T) {
+	withPanelWidth(t, 8)
+	v := NewVisualizer(44100)
+	v.Rows = 2
+	activateMode(t, v, VisMosaic)
+	driver := v.driverFor(VisMosaic).(*mosaicDriver)
+	driver.ensureGrid(v.Rows, mosaicTileCount(PanelWidth), DefaultSpectrumBands)
+	driver.cells[0].value = 0.06
+	v.bands = uniformBands(0)
+	v.smoothedBands = uniformBands(0)
+
+	if !v.DecayPending() {
+		t.Fatal("mosaic was considered settled with a visible cell")
+	}
+	v.Tick(VisTickContext{})
+	if !v.DecayPending() {
+		t.Fatal("mosaic settled while its fading cell was still visible")
+	}
+	v.Tick(VisTickContext{})
+	if v.DecayPending() {
+		t.Fatal("mosaic remained active after its cells became invisible")
+	}
+}
+
+func TestInactiveFlameWaitsForVisibleHeat(t *testing.T) {
+	withPanelWidth(t, 4)
+	v := NewVisualizer(44100)
+	v.Rows = 10
+	activateMode(t, v, VisFlame)
+	driver := v.driverFor(VisFlame).(*flameDriver)
+	for i := range driver.heat {
+		driver.heat[i] = 1
+	}
+	v.bands = uniformBands(0)
+	v.smoothedBands = uniformBands(0)
+
+	if !v.DecayPending() {
+		t.Fatal("flame was considered settled with visible heat")
+	}
+	v.Tick(VisTickContext{})
+	for x := range driver.dotCols {
+		if driver.heat[x] != 0 {
+			t.Fatalf("inactive flame source %d = %v, want 0", x, driver.heat[x])
+		}
+	}
+	for i := 1; i < 2*driver.dotRows && v.DecayPending(); i++ {
+		v.Tick(VisTickContext{})
+	}
+	if v.DecayPending() {
+		t.Fatal("flame remained active after its heat became invisible")
 	}
 }
 
@@ -398,6 +638,7 @@ func TestRenderOnlyDriverRequestsConfiguredBandCount(t *testing.T) {
 
 	var requested VisAnalysisSpec
 	v.Tick(VisTickContext{
+		Playing: true,
 		Analyze: func(spec VisAnalysisSpec) []float64 {
 			requested = spec
 			return uniformBandsN(spec.BandCount, 0.6)
@@ -514,7 +755,7 @@ func TestTerrainPreservesStateAcrossModeSwitch(t *testing.T) {
 	bands := uniformBands(0.6)
 	v.bands = bands
 
-	v.Tick(VisTickContext{})
+	v.Tick(VisTickContext{Playing: true})
 	snapshot := append([]float64(nil), driver.buf...)
 	if len(snapshot) != PanelWidth*2 {
 		t.Fatalf("terrain buffer len = %d, want %d", len(snapshot), PanelWidth*2)
@@ -541,7 +782,7 @@ func TestTerrainRenderDoesNotAdvanceWithoutTick(t *testing.T) {
 	driver := terrainDriverFor(t, v)
 	v.bands = uniformBands(0.6)
 
-	v.Tick(VisTickContext{})
+	v.Tick(VisTickContext{Playing: true})
 	snapshot := append([]float64(nil), driver.buf...)
 
 	v.Render()
@@ -549,6 +790,32 @@ func TestTerrainRenderDoesNotAdvanceWithoutTick(t *testing.T) {
 
 	if !reflect.DeepEqual(driver.buf, snapshot) {
 		t.Fatalf("terrain buffer changed across redraws without tick: got %v want %v", driver.buf, snapshot)
+	}
+}
+
+func TestInactiveTerrainScrollsHistoryToRest(t *testing.T) {
+	withPanelWidth(t, 8)
+
+	v := NewVisualizer(44100)
+	activateMode(t, v, VisTerrain)
+	driver := terrainDriverFor(t, v)
+	driver.buf = uniformBandsN(PanelWidth*2, 0.6)
+	v.bands = uniformBands(0)
+	v.smoothedBands = uniformBands(0)
+
+	if !v.DecayPending() {
+		t.Fatal("terrain was considered settled with visible history")
+	}
+	for range len(driver.buf) / 2 {
+		v.Tick(VisTickContext{})
+	}
+	if v.DecayPending() {
+		t.Fatal("terrain remained active after its history scrolled out")
+	}
+	for i, height := range driver.buf {
+		if height != 0 {
+			t.Fatalf("terrain column %d = %v after inactive decay, want 0", i, height)
+		}
 	}
 }
 

--- a/ui/visualizer_layout_test.go
+++ b/ui/visualizer_layout_test.go
@@ -15,7 +15,7 @@ func TestVisualizerFitsTinyRectangles(t *testing.T) {
 				v.Mode = mode
 				v.Cols = rect.cols
 				v.Rows = rect.rows
-				v.Tick(VisTickContext{})
+				v.Tick(VisTickContext{Playing: true})
 				got := v.Render()
 				if rect.cols == 0 || rect.rows == 0 || mode == VisNone {
 					if got != "" {


### PR DESCRIPTION
## Summary

Paused and stopped visualizers now share a decay-to-rest path: finish pending animation, clear residual spectrum values, then return to idle updates. This also prevents stale levels after mode or width changes and avoids resampling paused audio in daemon IPC responses.

ClassicPeak gets more consistent cap physics, analysis hop timing, jitter filtering, and a fresh clock after resting. The UI honors ClassicPeak's adaptive cadence and ClassicLED's 30 FPS. Regression tests and CLI/site documentation are included.

## Screenshots / video

No recording captured; live visual review remains pending.

## How to test

1. Run `make check` (passes on the rebased branch).
2. Play audio with ClassicPeak and ClassicLED, then pause, stop, and resume. Check cap motion and settling at normal and full-screen heights, with and without `--visualizer-60fps`.
3. Switch modes and resize while inactive. Check that old spectrum levels do not return; check that Stereo peak markers clear after loud audio transitions to silence.
4. Check Flame, Mosaic, Terrain, Geyser, and Sand finish their pending animation before idling; Sand retains its settled pile.

## Checklist

- [x] `make check` passes
- [x] `docs/` and `site/index.html` updated for user-facing changes
