### PR TITLE
fix(nix): refresh vendorHash so the flake builds again

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -38,7 +38,7 @@ buildGoModule {
   inherit version;
 
   src = lib.cleanSource ../.;
-  vendorHash = "sha256-rtwUWbft5XGEbuBCn0OMCn4TS5Ul+UXJNIqNOzXfU+M=";
+  vendorHash = "sha256-d/ENFm9b1DkIir1lz50VVX1pvuQpwPUVlA5XOC7Jj5o=";
 
   nativeBuildInputs = [
     makeWrapper


### PR DESCRIPTION
## Problem

`nix build github:bjarneo/cliamp` currently fails on `main` (93a4ac6) at the `go-modules` fixed-output derivation:

```
error: hash mismatch in fixed-output derivation '...-cliamp-<rev>-go-modules.drv':
         specified: sha256-rtwUWbft5XGEbuBCn0OMCn4TS5Ul+UXJNIqNOzXfU+M=
            got:    sha256-d/ENFm9b1DkIir1lz50VVX1pvuQpwPUVlA5XOC7Jj5o=
```

The `vendorHash` committed in #414 no longer matches the module set the current `go.mod`/`go.sum` produces. Since CI has no Nix job, this went unnoticed — same class of breakage as #142 and #413.

## Fix

Refresh `vendorHash` to the value Nix computes from the actual dependency closure (one line).

## Verification

Built on `x86_64-linux`:

- with this repo's own `flake.lock` nixpkgs pin: ✅
- against current `nixos-unstable` (d6524aa, via `inputs.nixpkgs.follows`): ✅ — both produce the same `go-modules` hash, so the value is stable across the two nixpkgs revisions.

## Follow-up suggestion

A minimal CI job running `nix build .#cliamp` (one runner, `ubuntu-latest` + install Nix) would catch stale `vendorHash` at PR time instead of after users hit it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package build metadata to match the current set of vendored Go dependencies.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->