### PR TITLE
spotify: bind OAuth callback to loopback

### DIFF
--- a/docs/spotify.md
+++ b/docs/spotify.md
@@ -84,7 +84,7 @@ Podcast episodes work as tracks. Press `Ctrl+F` to search Spotify. Matching epis
 
 ## Troubleshooting
 
-- **"OAuth failed"**: Ensure the Spotify dashboard redirect URI is exactly `http://127.0.0.1:19872/login`, without a trailing slash.
+- **"OAuth failed"**: Ensure the Spotify dashboard redirect URI is exactly `http://127.0.0.1:19872/login`, without a trailing slash. The temporary callback server listens only on this local address and does not accept connections from the network.
 - **Two authorization steps**: This is expected with your own `client_id`. After you approve Web API access, the same browser tab redirects to create a playback credential with the required Spotify built-in identity.
 - **Playlist not showing**: Save or follow the playlist in Spotify. The provider lists only library playlists.
 - **Playback issues**: Spotify integration needs a Premium account. Free accounts cannot stream.

--- a/external/spotify/session.go
+++ b/external/spotify/session.go
@@ -36,9 +36,17 @@ type storedCreds struct {
 	RefreshToken string `json:"refresh_token,omitempty"` // OAuth2 refresh token for silent re-auth
 }
 
-// CallbackPort is the fixed port for the OAuth2 callback server.
-// Must match the redirect URI registered in the Spotify Developer app.
-const CallbackPort = 19872
+const (
+	callbackHost = "127.0.0.1"
+
+	// CallbackPort is the fixed port for the OAuth2 callback server.
+	// Must match the redirect URI registered in the Spotify Developer app.
+	CallbackPort = 19872
+)
+
+func callbackAddress() string {
+	return net.JoinHostPort(callbackHost, fmt.Sprint(CallbackPort))
+}
 
 // authURLObserver is invoked with the OAuth URL when interactive auth begins.
 // Set via SetAuthURLObserver. Used by the TUI to show the URL when the
@@ -435,7 +443,7 @@ func performOAuth2PKCEFlows(ctx context.Context, flows []oauthFlow) ([]*oauth2.T
 		return nil, fmt.Errorf("no OAuth flows configured")
 	}
 
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", CallbackPort))
+	lis, err := net.Listen("tcp", callbackAddress())
 	if err != nil {
 		return nil, fmt.Errorf("listen on port %d: %w", CallbackPort, err)
 	}

--- a/external/spotify/session.go
+++ b/external/spotify/session.go
@@ -279,7 +279,7 @@ var playbackOAuthScopes = []string{"streaming"}
 func spotifyOAuthConfig(clientID string, scopes []string) *oauth2.Config {
 	return &oauth2.Config{
 		ClientID:    clientID,
-		RedirectURL: fmt.Sprintf("http://127.0.0.1:%d/login", CallbackPort),
+		RedirectURL: fmt.Sprintf("http://%s/login", callbackAddress()),
 		Scopes:      scopes,
 		Endpoint:    spotifyoauth2.Endpoint,
 	}

--- a/external/spotify/session_test.go
+++ b/external/spotify/session_test.go
@@ -22,6 +22,12 @@ type tokenSourceFunc func() (*oauth2.Token, error)
 
 func (f tokenSourceFunc) Token() (*oauth2.Token, error) { return f() }
 
+func TestCallbackAddressUsesIPv4Loopback(t *testing.T) {
+	if got, want := callbackAddress(), "127.0.0.1:19872"; got != want {
+		t.Fatalf("callbackAddress() = %q, want %q", got, want)
+	}
+}
+
 func TestAwaitSpotifyStreamTimeoutCancelsTransportAndReleasesReadLock(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		const timeout = 10 * time.Millisecond


### PR DESCRIPTION
## Summary

- bind the temporary Spotify OAuth callback listener to `127.0.0.1`
- keep the listener aligned with the registered loopback redirect URI
- add regression coverage for the callback address
- document that the callback does not accept network connections

Previously, the redirect URI used `127.0.0.1` while the listener bound to
`:19872`, which listens on non-loopback interfaces as well. Restricting it to
IPv4 loopback reduces the exposed surface and avoids unnecessary inbound-network
handling, particularly on Windows.

## Tests

- `go test ./external/spotify`
- `go vet ./external/spotify`
- `go test ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - OAuth callbacks now listen only on the local device at `127.0.0.1:19872`, preventing connections from other devices on the network.
  - Spotify sign-in now uses a loopback-only callback address for improved local request isolation.

- **Documentation**
  - Updated Spotify troubleshooting guidance to clarify that the callback server is accessible only from the local device.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->