### PR TITLE
Fix Jellyfin API compatibility

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -1035,7 +1035,9 @@ func (m *setupModel) resultKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 
 	switch msg.String() {
-	case "enter", "esc", "q", " ":
+	case "q":
+		return m, tea.Quit
+	case "enter", "esc", " ":
 		m.stage = stageMenu
 		return m, nil
 	}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -1246,7 +1246,7 @@ func (m *setupModel) viewResult() string {
 		b.WriteString("\n\n")
 		b.WriteString(hintStyle.Render("The config will still load on next launch — useful when the server is offline now."))
 		b.WriteString("\n\n")
-		b.WriteString(accentStyle.Render("Save anyway?  ") + "[y/N]")
+		b.WriteString(accentStyle.Render("Save anyway?  ") + "[y/N]  q quit")
 		return m.card(b.String())
 	}
 
@@ -1283,7 +1283,7 @@ func (m *setupModel) viewFooter() string {
 		keys = "ctrl+c cancel"
 	case stageResult:
 		if m.awaitingSave {
-			keys = "y save anyway   n cancel"
+			keys = "y save anyway   n cancel  q quit"
 		} else {
 			keys = "any key continue   q quit"
 		}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -1022,6 +1022,8 @@ func (m *setupModel) persistAndDone(warn bool) tea.Cmd {
 func (m *setupModel) resultKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if m.awaitingSave {
 		switch strings.ToLower(msg.String()) {
+		case "q":
+			return m, tea.Quit
 		case "y":
 			m.persistAndDone(true)
 			return m, nil

--- a/internal/embyapi/client.go
+++ b/internal/embyapi/client.go
@@ -224,8 +224,12 @@ func (c *Client) MusicLibraries() ([]Library, error) {
 	}
 
 	var resp itemsResponseDTO
-	if err := c.get("/Users/"+url.PathEscape(userID)+"/Views", nil, &resp); err != nil {
-		return nil, err
+	if err := c.get(
+			c.dialect.musicLibrariesPath(userID),
+			nil,
+			&resp,
+	); err != nil {
+			return nil, err
 	}
 
 	var libs []Library

--- a/internal/embyapi/client_test.go
+++ b/internal/embyapi/client_test.go
@@ -56,12 +56,12 @@ func TestEmbyPingUsesSystemInfo(t *testing.T) {
 	}
 }
 
-func TestJellyfinPingUsesUsersMe(t *testing.T) {
+func TestJellyfinPingUsesSystemInfo(t *testing.T) {
 	c := mock(NewJellyfinClient("https://jf.example.com", "tok", "user-1", "", ""), func(req *http.Request) (*http.Response, error) {
-		if req.URL.Path != "/Users/Me" {
-			t.Fatalf("Ping path = %s, want /Users/Me", req.URL.Path)
+		if req.URL.Path != "/System/Info" {
+			t.Fatalf("Ping path = %s, want /System/Info", req.URL.Path)
 		}
-		return jsonResponse(`{"Id":"user-1","Name":"Nomad"}`), nil
+		return jsonResponse(`{"ServerName":"My Jellyfin","Version":"10.11.0"}`), nil
 	})
 	if err := c.Ping(); err != nil {
 		t.Fatalf("Ping() error: %v", err)
@@ -124,21 +124,13 @@ func TestEmbyAuthHeaderScheme(t *testing.T) {
 
 func TestJellyfinAuthHeaderScheme(t *testing.T) {
 	c := mock(NewJellyfinClient("https://jf.example.com", "tok", "", "", ""), func(req *http.Request) (*http.Response, error) {
-		switch req.URL.Path {
-		case "/Users/Me":
-			return jsonResponse(`{"Id":"user-1","Name":"Nomad"}`), nil
-		case "/Users/user-1/Views":
-			if got := req.Header.Get("X-Emby-Token"); got != "tok" {
-				t.Fatalf("X-Emby-Token = %q, want tok", got)
-			}
-			if got := req.Header.Get("X-Emby-Authorization"); !strings.HasPrefix(got, "MediaBrowser ") {
-				t.Fatalf("X-Emby-Authorization = %q, want MediaBrowser scheme", got)
-			}
-			return jsonResponse(`{"Items":[{"Id":"music-1","Name":"Music","CollectionType":"music"}]}`), nil
-		default:
-			t.Fatalf("unexpected path %s", req.URL.Path)
-			return nil, nil
+		if req.URL.Path != "/Library/MediaFolders" {
+			t.Fatalf("path = %s, want /Library/MediaFolders", req.URL.Path)
 		}
+		if got := req.Header.Get("Authorization"); !strings.HasPrefix(got, "MediaBrowser ") {
+			t.Fatalf("Authorization = %q, want MediaBrowser scheme", got)
+		}
+		return jsonResponse(`{"Items":[{"Id":"music-1","Name":"Music","CollectionType":"music"}]}`), nil
 	})
 	if _, err := c.MusicLibraries(); err != nil {
 		t.Fatalf("MusicLibraries() error: %v", err)
@@ -180,13 +172,13 @@ func TestJellyfinAuthenticatesWithPassword(t *testing.T) {
 	c := mock(NewJellyfinClient("https://jf.example.com", "", "", "finamp", "1qazxsw2"), func(req *http.Request) (*http.Response, error) {
 		switch req.URL.Path {
 		case "/Users/AuthenticateByName":
-			if got := req.Header.Get("X-Emby-Authorization"); !strings.HasPrefix(got, "MediaBrowser ") {
-				t.Fatalf("auth request X-Emby-Authorization = %q, want MediaBrowser scheme", got)
+			if got := req.Header.Get("Authorization"); !strings.HasPrefix(got, "MediaBrowser ") {
+				t.Fatalf("auth request Authorization = %q, want MediaBrowser scheme", got)
 			}
 			return jsonResponse(`{"User":{"Id":"user-1"},"AccessToken":"tok-1"}`), nil
-		case "/Users/user-1/Views":
-			if got := req.Header.Get("X-Emby-Token"); got != "tok-1" {
-				t.Fatalf("X-Emby-Token = %q, want tok-1", got)
+		case "/Library/MediaFolders":
+			if got := req.Header.Get("Authorization"); !strings.HasPrefix(got, "MediaBrowser ") || !strings.Contains(got, `Token="tok-1"`) {
+				t.Fatalf("Authorization = %q, want MediaBrowser scheme with token", got)
 			}
 			return jsonResponse(`{"Items":[{"Id":"music-1","Name":"Music","CollectionType":"music"}]}`), nil
 		default:
@@ -271,8 +263,8 @@ func TestJellyfinReportNowPlaying(t *testing.T) {
 		if req.URL.Path != "/Sessions/Playing" {
 			t.Fatalf("path = %s, want /Sessions/Playing", req.URL.Path)
 		}
-		if got := req.Header.Get("X-Emby-Token"); got != "tok" {
-			t.Fatalf("X-Emby-Token = %q, want tok", got)
+		if got := req.Header.Get("Authorization"); !strings.HasPrefix(got, "MediaBrowser ") || !strings.Contains(got, `Token="tok"`) {
+			t.Fatalf("Authorization = %q, want MediaBrowser scheme with token", got)
 		}
 		var payload playbackInfo
 		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
@@ -516,3 +508,4 @@ func TestIsStreamURL(t *testing.T) {
 		t.Fatal("non-download URL should not be a stream URL")
 	}
 }
+

--- a/internal/embyapi/client_test.go
+++ b/internal/embyapi/client_test.go
@@ -127,9 +127,9 @@ func TestJellyfinAuthHeaderScheme(t *testing.T) {
 		if req.URL.Path != "/Library/MediaFolders" {
 			t.Fatalf("path = %s, want /Library/MediaFolders", req.URL.Path)
 		}
-		if got := req.Header.Get("Authorization"); !strings.HasPrefix(got, "MediaBrowser ") {
-			t.Fatalf("Authorization = %q, want MediaBrowser scheme", got)
-		}
+		if got := req.Header.Get("Authorization"); !strings.HasPrefix(got, "MediaBrowser ") || !strings.Contains(got, `Token="tok"`) {
+			t.Fatalf("Authorization = %q, want MediaBrowser scheme with token", got)
+ 		}
 		return jsonResponse(`{"Items":[{"Id":"music-1","Name":"Music","CollectionType":"music"}]}`), nil
 	})
 	if _, err := c.MusicLibraries(); err != nil {

--- a/internal/embyapi/dialect.go
+++ b/internal/embyapi/dialect.go
@@ -3,6 +3,7 @@ package embyapi
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/bjarneo/cliamp/internal/appmeta"
@@ -17,6 +18,7 @@ type dialect interface {
 	metaKey() string                                             // playlist.Track ProviderMeta key
 	applyAuth(req *http.Request, token, userID, deviceID string) // set auth headers
 	discoverUserID(c *Client) (string, error)                    // user-id discovery strategy
+  musicLibrariesPath(userID string) string
 }
 
 // embyDialect speaks Emby's `Authorization: Emby ...` scheme and discovers the
@@ -66,6 +68,10 @@ func (embyDialect) discoverUserID(c *Client) (string, error) {
 	return "", fmt.Errorf("emby: could not discover user id — set user_id in config")
 }
 
+func (embyDialect) musicLibrariesPath(userID string) string {
+  return "/Users/" + url.PathEscape(userID) + "/Views"
+}
+
 // unauthHeader / authHeader build Emby's Authorization header values.
 func embyUnauthHeader(deviceID string) string {
 	return fmt.Sprintf(`Emby Client="%s", Device="%s", DeviceId="%s", Version="%s"`,
@@ -81,31 +87,25 @@ func embyAuthHeader(userID, token, deviceID string) string {
 		appmeta.ClientName(), appmeta.DeviceName(), deviceID, appmeta.Version(), token)
 }
 
-// jellyfinDialect speaks Jellyfin's `X-Emby-Authorization: MediaBrowser ...`
+// jellyfinDialect speaks Jellyfin's `Authorization: MediaBrowser ... Token="..."`
 // scheme and discovers the user id from /Users/Me only.
 type jellyfinDialect struct{}
 
 func (jellyfinDialect) name() string     { return "jellyfin" }
-func (jellyfinDialect) pingPath() string { return "/Users/Me" }
+func (jellyfinDialect) pingPath() string { return "/System/Info" }
 func (jellyfinDialect) metaKey() string  { return provider.MetaJellyfinID }
 
 func (jellyfinDialect) applyAuth(req *http.Request, token, _, deviceID string) {
-	if token != "" {
-		req.Header.Set("X-Emby-Token", token)
-	}
-	req.Header.Set("X-Emby-Authorization",
-		fmt.Sprintf(`MediaBrowser Client="%s", Device="%s", DeviceId="%s", Version="%s"`,
-			appmeta.ClientName(), appmeta.DeviceName(), deviceID, appmeta.Version()))
+	req.Header.Set("Authorization",
+		fmt.Sprintf(`MediaBrowser Client="%s", Device="%s", DeviceId="%s", Version="%s", Token="%s"`,
+			appmeta.ClientName(), appmeta.DeviceName(), deviceID, appmeta.Version(), token))
 }
 
 func (jellyfinDialect) discoverUserID(c *Client) (string, error) {
-	var u userDTO
-	if err := c.get("/Users/Me", nil, &u); err != nil {
-		return "", err
-	}
-	if u.ID == "" {
-		return "", fmt.Errorf("jellyfin: current user response missing id")
-	}
-	c.setUserID(u.ID)
-	return u.ID, nil
+	// jellyfin does not require a userId
+	return "", nil
+}
+
+func (jellyfinDialect) musicLibrariesPath(string) string {
+  return "/Library/MediaFolders"
 }


### PR DESCRIPTION
## Summary

* Fix Jellyfin API compatibility for library discovery and authentication.
* Use Jellyfin's `/Library/MediaFolders` endpoint instead of the Emby `/Users/{id}/Views` endpoint.
* Update Jellyfin authentication to use the `Authorization: MediaBrowser ...` header format and avoid requiring a Jellyfin user ID.
* Add dialect-specific library path handling while keeping the common client logic shared with Emby.
* Fix `q` handling in the setup result screen so it properly quits instead of returning to the setup menu.

## Testing

* Verified Jellyfin authentication and library access against Jellyfin 10.10.7.
* Verified album and track retrieval through the Jellyfin API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved Jellyfin compatibility for sign-in, server detection, and music library browsing.
  - Added support for Jellyfin’s library paths and authorization requirements.
  - Library loading now works consistently across supported media servers.

- **Bug Fixes**
  - The setup wizard now exits when you press `q` on the result screen, including after validation failures.
  - Pressing Enter, Escape, or Space returns to the provider selection menu as expected.
  - Updated prompts clearly indicate the available quit option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->