### PR TITLE
fix(jellyfin): restore auth and streaming on Jellyfin 12

### DIFF
--- a/external/jellyfin/provider_test.go
+++ b/external/jellyfin/provider_test.go
@@ -188,7 +188,7 @@ func TestProviderRestoreTrackDefersAuthenticationUntilSourceResolution(t *testin
 	if err != nil {
 		t.Fatalf("ResolveSource() error: %v", err)
 	}
-	if want := "https://jf.example.com/Items/track-1/Download?api_key=new-token"; source != want {
+	if want := "https://jf.example.com/Items/track-1/Download?ApiKey=new-token&api_key=new-token"; source != want {
 		t.Fatalf("ResolveSource() = %q, want %q", source, want)
 	}
 	if got.Path != oldURL || got.Title != "Song" || got.Meta(provider.MetaJellyfinID) != "track-1" || !got.Stream {

--- a/external/jellyfin/provider_test.go
+++ b/external/jellyfin/provider_test.go
@@ -164,6 +164,8 @@ func TestProviderRestoreTrack(t *testing.T) {
 	}
 }
 
+// TestProviderRestoreTrackDefersAuthenticationUntilSourceResolution verifies that
+// restoring a track from history defers authentication until source resolution.
 func TestProviderRestoreTrackDefersAuthenticationUntilSourceResolution(t *testing.T) {
 	p := newProvider(NewClient("https://jf.example.com", "", "", "user", "password"))
 	p.client.SetHTTPClient(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {

--- a/internal/embyapi/client.go
+++ b/internal/embyapi/client.go
@@ -193,7 +193,15 @@ type playbackStopInfo struct {
 // Ping checks that the server is reachable and the token is accepted.
 func (c *Client) Ping() error {
 	var raw json.RawMessage
-	return c.get(c.dialect.pingPath(), nil, &raw)
+	if err := c.get(c.dialect.pingPath(), nil, &raw); err == nil {
+		return nil
+	} else if c.user == "" && c.password == "" {
+		// API keys aren't owned by a user, so /Users/Me returns 400.
+		// Fall back to listing /Users to prove the key is valid.
+		return c.get("/Users", nil, &raw)
+	} else {
+		return err
+	}
 }
 
 // UserID returns the active user id, discovering it lazily when needed.
@@ -529,7 +537,14 @@ func (c *Client) StreamURL(itemID string) string {
 }
 
 func (c *Client) streamURL(itemID, token string) string {
-	v := url.Values{"api_key": {token}}
+	// ApiKey is the auth query param Jellyfin reads on every version (including
+	// 10.12+/12 which disable legacy auth); api_key is the legacy alias that
+	// older servers still accept. Send both so buffered stream requests that
+	// carry no headers work on any server.
+	v := url.Values{
+		"ApiKey":  {token},
+		"api_key": {token},
+	}
 
 	// Use the direct item download route rather than the Audio controller.
 	// On the live servers used for validation, the Audio endpoints returned

--- a/internal/embyapi/client.go
+++ b/internal/embyapi/client.go
@@ -536,6 +536,7 @@ func (c *Client) StreamURL(itemID string) string {
 	return c.streamURL(itemID, c.authToken())
 }
 
+// streamURL constructs a direct-download stream URL for the specified item and auth token.
 func (c *Client) streamURL(itemID, token string) string {
 	// ApiKey is the auth query param Jellyfin reads on every version (including
 	// 10.12+/12 which disable legacy auth); api_key is the legacy alias that

--- a/internal/embyapi/client.go
+++ b/internal/embyapi/client.go
@@ -7,6 +7,7 @@ package embyapi
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -195,11 +196,15 @@ func (c *Client) Ping() error {
 	var raw json.RawMessage
 	if err := c.get(c.dialect.pingPath(), nil, &raw); err == nil {
 		return nil
-	} else if c.dialect.name() == "jellyfin" && c.user == "" && c.password == "" &&
-		strings.Contains(err.Error(), "Token is not owned by a user") {
-		// API keys aren't owned by a user, so /Users/Me returns 400.
-		// Fall back to listing /Users to prove the key is valid.
-		return c.get("/Users", nil, &raw)
+	} else if c.dialect.name() == "jellyfin" && c.user == "" && c.password == "" {
+		var httpErr *httpError
+		if errors.As(err, &httpErr) && httpErr.statusCode == http.StatusBadRequest &&
+			strings.Contains(httpErr.body, "Token is not owned by a user") {
+			// API keys aren't owned by a user, so /Users/Me returns 400.
+			// Fall back to listing /Users to prove the key is valid.
+			return c.get("/Users", nil, &raw)
+		}
+		return err
 	} else {
 		return err
 	}
@@ -589,6 +594,21 @@ func (c *Client) ReportScrobble(track playlist.Track, elapsed time.Duration, can
 	})
 }
 
+// httpError records an HTTP error response from an Emby or Jellyfin server.
+type httpError struct {
+	dialect    string
+	path       string
+	statusCode int
+	status     string
+	body       string
+}
+
+// Error returns the formatted error string without raw response bodies.
+func (e *httpError) Error() string {
+	return fmt.Sprintf("%s: %s: http status %s", e.dialect, e.path, e.status)
+}
+
+// get executes a GET request against the endpoint, unmarshaling JSON into out on success.
 func (c *Client) get(p string, params url.Values, out any) error {
 	if err := c.ensureAuth(); err != nil {
 		return err
@@ -608,13 +628,18 @@ func (c *Client) get(p string, params url.Values, out any) error {
 	switch resp.StatusCode {
 	case http.StatusOK:
 	default:
+		var bodyStr string
 		if resp.Body != nil {
 			body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-			if msg := strings.TrimSpace(string(body)); msg != "" {
-				return fmt.Errorf("%s: %s: http status %s: %s", c.dialect.name(), p, resp.Status, msg)
-			}
+			bodyStr = strings.TrimSpace(string(body))
 		}
-		return fmt.Errorf("%s: %s: http status %s", c.dialect.name(), p, resp.Status)
+		return &httpError{
+			dialect:    c.dialect.name(),
+			path:       p,
+			statusCode: resp.StatusCode,
+			status:     resp.Status,
+			body:       bodyStr,
+		}
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBody))

--- a/internal/embyapi/client.go
+++ b/internal/embyapi/client.go
@@ -195,7 +195,8 @@ func (c *Client) Ping() error {
 	var raw json.RawMessage
 	if err := c.get(c.dialect.pingPath(), nil, &raw); err == nil {
 		return nil
-	} else if c.user == "" && c.password == "" {
+	} else if c.dialect.name() == "jellyfin" && c.user == "" && c.password == "" &&
+		strings.Contains(err.Error(), "Token is not owned by a user") {
 		// API keys aren't owned by a user, so /Users/Me returns 400.
 		// Fall back to listing /Users to prove the key is valid.
 		return c.get("/Users", nil, &raw)
@@ -607,6 +608,12 @@ func (c *Client) get(p string, params url.Values, out any) error {
 	switch resp.StatusCode {
 	case http.StatusOK:
 	default:
+		if resp.Body != nil {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+			if msg := strings.TrimSpace(string(body)); msg != "" {
+				return fmt.Errorf("%s: %s: http status %s: %s", c.dialect.name(), p, resp.Status, msg)
+			}
+		}
 		return fmt.Errorf("%s: %s: http status %s", c.dialect.name(), p, resp.Status)
 	}
 

--- a/internal/embyapi/client_test.go
+++ b/internal/embyapi/client_test.go
@@ -95,7 +95,7 @@ func TestJellyfinPingAPIKeyBadTokenFails(t *testing.T) {
 	c := mock(NewJellyfinClient("https://jf.example.com", "bad-tok", "", "", ""), func(req *http.Request) (*http.Response, error) {
 		switch req.URL.Path {
 		case "/Users/Me":
-			return &http.Response{StatusCode: 400, Status: "400 Bad Request", Body: io.NopCloser(bytes.NewBuffer(nil))}, nil
+			return &http.Response{StatusCode: 400, Status: "400 Bad Request", Body: io.NopCloser(bytes.NewBuffer([]byte("Token is not owned by a user.")))}, nil
 		case "/Users":
 			return &http.Response{StatusCode: 401, Status: "401 Unauthorized", Body: io.NopCloser(bytes.NewBuffer(nil))}, nil
 		default:
@@ -105,6 +105,46 @@ func TestJellyfinPingAPIKeyBadTokenFails(t *testing.T) {
 	})
 	if err := c.Ping(); err == nil {
 		t.Fatal("Ping() with invalid API key succeeded, want error")
+	}
+}
+
+// TestJellyfinPingUnrelatedErrorDoesNotFallBackToUsers verifies that Ping does not fall back
+// to /Users when /Users/Me fails with an error other than "Token is not owned by a user".
+func TestJellyfinPingUnrelatedErrorDoesNotFallBackToUsers(t *testing.T) {
+	c := mock(NewJellyfinClient("https://jf.example.com", "tok", "", "", ""), func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/Users/Me":
+			return &http.Response{StatusCode: 500, Status: "500 Internal Server Error", Body: io.NopCloser(bytes.NewBuffer([]byte("server error")))}, nil
+		case "/Users":
+			t.Fatal("unexpected fallback to /Users on server error")
+			return jsonResponse(`[{"Id":"user-1","Name":"Alice"}]`), nil
+		default:
+			t.Fatalf("unexpected path %s", req.URL.Path)
+			return nil, nil
+		}
+	})
+	if err := c.Ping(); err == nil {
+		t.Fatal("Ping() succeeded on 500 error, want error")
+	}
+}
+
+// TestEmbyPingFailureDoesNotFallBackToUsers verifies that Emby ping failures do not
+// fall back to /Users even when username and password are empty.
+func TestEmbyPingFailureDoesNotFallBackToUsers(t *testing.T) {
+	c := mock(NewEmbyClient("https://emby.example.com", "tok", "", "", ""), func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/System/Info":
+			return &http.Response{StatusCode: 401, Status: "401 Unauthorized", Body: io.NopCloser(bytes.NewBuffer(nil))}, nil
+		case "/Users":
+			t.Fatal("unexpected fallback to /Users on Emby ping failure")
+			return jsonResponse(`[{"Id":"user-1","Name":"Alice"}]`), nil
+		default:
+			t.Fatalf("unexpected path %s", req.URL.Path)
+			return nil, nil
+		}
+	})
+	if err := c.Ping(); err == nil {
+		t.Fatal("Ping() succeeded on Emby 401 error, want error")
 	}
 }
 

--- a/internal/embyapi/client_test.go
+++ b/internal/embyapi/client_test.go
@@ -73,7 +73,9 @@ func TestJellyfinPingUsesUsersMe(t *testing.T) {
 func TestJellyfinPingAPIKeyFallsBackToUsers(t *testing.T) {
 	// API keys aren't owned by a user, so /Users/Me returns 400; /Users must
 	// succeed to prove the key is valid.
+	var requested []string
 	c := mock(NewJellyfinClient("https://jf.example.com", "tok", "", "", ""), func(req *http.Request) (*http.Response, error) {
+		requested = append(requested, req.URL.Path)
 		switch req.URL.Path {
 		case "/Users/Me":
 			return &http.Response{StatusCode: 400, Status: "400 Bad Request", Body: io.NopCloser(bytes.NewBuffer([]byte("Token is not owned by a user.")))}, nil
@@ -87,12 +89,17 @@ func TestJellyfinPingAPIKeyFallsBackToUsers(t *testing.T) {
 	if err := c.Ping(); err != nil {
 		t.Fatalf("Ping() with API key error: %v", err)
 	}
+	if len(requested) != 2 || requested[0] != "/Users/Me" || requested[1] != "/Users" {
+		t.Fatalf("requested paths = %v, want [/Users/Me, /Users]", requested)
+	}
 }
 
 // TestJellyfinPingAPIKeyBadTokenFails verifies that Ping fails when an invalid API key
 // is rejected by both /Users/Me and /Users.
 func TestJellyfinPingAPIKeyBadTokenFails(t *testing.T) {
+	var requested []string
 	c := mock(NewJellyfinClient("https://jf.example.com", "bad-tok", "", "", ""), func(req *http.Request) (*http.Response, error) {
+		requested = append(requested, req.URL.Path)
 		switch req.URL.Path {
 		case "/Users/Me":
 			return &http.Response{StatusCode: 400, Status: "400 Bad Request", Body: io.NopCloser(bytes.NewBuffer([]byte("Token is not owned by a user.")))}, nil
@@ -105,6 +112,9 @@ func TestJellyfinPingAPIKeyBadTokenFails(t *testing.T) {
 	})
 	if err := c.Ping(); err == nil {
 		t.Fatal("Ping() with invalid API key succeeded, want error")
+	}
+	if len(requested) != 2 || requested[0] != "/Users/Me" || requested[1] != "/Users" {
+		t.Fatalf("requested paths = %v, want [/Users/Me, /Users]", requested)
 	}
 }
 
@@ -125,6 +135,27 @@ func TestJellyfinPingUnrelatedErrorDoesNotFallBackToUsers(t *testing.T) {
 	})
 	if err := c.Ping(); err == nil {
 		t.Fatal("Ping() succeeded on 500 error, want error")
+	}
+}
+
+// TestJellyfinPingNon400WithTokenMessageDoesNotFallBackToUsers verifies that Ping does
+// not fall back to /Users when /Users/Me returns a non-400 status even if the body mentions
+// "Token is not owned by a user".
+func TestJellyfinPingNon400WithTokenMessageDoesNotFallBackToUsers(t *testing.T) {
+	c := mock(NewJellyfinClient("https://jf.example.com", "tok", "", "", ""), func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/Users/Me":
+			return &http.Response{StatusCode: 401, Status: "401 Unauthorized", Body: io.NopCloser(bytes.NewBuffer([]byte("Token is not owned by a user.")))}, nil
+		case "/Users":
+			t.Fatal("unexpected fallback to /Users on non-400 response")
+			return jsonResponse(`[{"Id":"user-1","Name":"Alice"}]`), nil
+		default:
+			t.Fatalf("unexpected path %s", req.URL.Path)
+			return nil, nil
+		}
+	})
+	if err := c.Ping(); err == nil {
+		t.Fatal("Ping() succeeded on 401 error, want error")
 	}
 }
 

--- a/internal/embyapi/client_test.go
+++ b/internal/embyapi/client_test.go
@@ -68,6 +68,8 @@ func TestJellyfinPingUsesUsersMe(t *testing.T) {
 	}
 }
 
+// TestJellyfinPingAPIKeyFallsBackToUsers checks that Ping falls back to /Users when
+// /Users/Me returns 400 for server-level API keys.
 func TestJellyfinPingAPIKeyFallsBackToUsers(t *testing.T) {
 	// API keys aren't owned by a user, so /Users/Me returns 400; /Users must
 	// succeed to prove the key is valid.
@@ -87,6 +89,8 @@ func TestJellyfinPingAPIKeyFallsBackToUsers(t *testing.T) {
 	}
 }
 
+// TestJellyfinPingAPIKeyBadTokenFails verifies that Ping fails when an invalid API key
+// is rejected by both /Users/Me and /Users.
 func TestJellyfinPingAPIKeyBadTokenFails(t *testing.T) {
 	c := mock(NewJellyfinClient("https://jf.example.com", "bad-tok", "", "", ""), func(req *http.Request) (*http.Response, error) {
 		switch req.URL.Path {
@@ -104,6 +108,8 @@ func TestJellyfinPingAPIKeyBadTokenFails(t *testing.T) {
 	}
 }
 
+// TestJellyfinUserIDAPIKeyFallback verifies that UserID falls back to /Users and picks the
+// first user when authenticated with an API key.
 func TestJellyfinUserIDAPIKeyFallback(t *testing.T) {
 	// /Users/Me returns 400 for API keys; fall back to /Users and pick the
 	// first user.
@@ -396,6 +402,8 @@ func TestTracksParsing(t *testing.T) {
 	}
 }
 
+// TestStreamURL verifies that StreamURL builds the download URL with both
+// legacy api_key and modern ApiKey query parameters.
 func TestStreamURL(t *testing.T) {
 	c := NewEmbyClient("https://emby.example.com", "tok", "user-1", "", "")
 	u := c.StreamURL("track-1")
@@ -445,6 +453,8 @@ func TestStreamItemID(t *testing.T) {
 	}
 }
 
+// TestResolveSourceAuthenticatesWithPassword verifies that source resolution
+// authenticates via password when no token is present and appends auth params.
 func TestResolveSourceAuthenticatesWithPassword(t *testing.T) {
 	for _, baseURL := range []string{"https://jf.example.com/media", "http://jf.lan:8096/media"} {
 		t.Run(baseURL, func(t *testing.T) {
@@ -497,6 +507,8 @@ func TestResolveSourceAuthenticationFailure(t *testing.T) {
 	}
 }
 
+// TestResolveSourceWithTokenDoesNotRequest ensures that resolving a source URL
+// when an auth token already exists does not send an extra authentication request.
 func TestResolveSourceWithTokenDoesNotRequest(t *testing.T) {
 	c := mock(NewJellyfinClient("https://jf.example.com/media", "new-token", "", "", ""), func(req *http.Request) (*http.Response, error) {
 		t.Fatalf("unexpected request with configured token: %s", req.URL)

--- a/internal/embyapi/client_test.go
+++ b/internal/embyapi/client_test.go
@@ -68,6 +68,70 @@ func TestJellyfinPingUsesUsersMe(t *testing.T) {
 	}
 }
 
+func TestJellyfinPingAPIKeyFallsBackToUsers(t *testing.T) {
+	// API keys aren't owned by a user, so /Users/Me returns 400; /Users must
+	// succeed to prove the key is valid.
+	c := mock(NewJellyfinClient("https://jf.example.com", "tok", "", "", ""), func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/Users/Me":
+			return &http.Response{StatusCode: 400, Status: "400 Bad Request", Body: io.NopCloser(bytes.NewBuffer([]byte("Token is not owned by a user.")))}, nil
+		case "/Users":
+			return jsonResponse(`[{"Id":"user-1","Name":"Alice"}]`), nil
+		default:
+			t.Fatalf("unexpected path %s", req.URL.Path)
+			return nil, nil
+		}
+	})
+	if err := c.Ping(); err != nil {
+		t.Fatalf("Ping() with API key error: %v", err)
+	}
+}
+
+func TestJellyfinPingAPIKeyBadTokenFails(t *testing.T) {
+	c := mock(NewJellyfinClient("https://jf.example.com", "bad-tok", "", "", ""), func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/Users/Me":
+			return &http.Response{StatusCode: 400, Status: "400 Bad Request", Body: io.NopCloser(bytes.NewBuffer(nil))}, nil
+		case "/Users":
+			return &http.Response{StatusCode: 401, Status: "401 Unauthorized", Body: io.NopCloser(bytes.NewBuffer(nil))}, nil
+		default:
+			t.Fatalf("unexpected path %s", req.URL.Path)
+			return nil, nil
+		}
+	})
+	if err := c.Ping(); err == nil {
+		t.Fatal("Ping() with invalid API key succeeded, want error")
+	}
+}
+
+func TestJellyfinUserIDAPIKeyFallback(t *testing.T) {
+	// /Users/Me returns 400 for API keys; fall back to /Users and pick the
+	// first user.
+	c := mock(NewJellyfinClient("https://jf.example.com", "tok", "", "", ""), func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/Users/Me":
+			return &http.Response{StatusCode: 400, Status: "400 Bad Request", Body: io.NopCloser(bytes.NewBuffer(nil))}, nil
+		case "/Users":
+			return jsonResponse(`[{"Id":"user-1","Name":"Alice"}]`), nil
+		case "/Users/user-1/Views":
+			return jsonResponse(`{"Items":[{"Id":"lib-1","Name":"Music","CollectionType":"music"}]}`), nil
+		default:
+			t.Fatalf("unexpected path %s", req.URL.Path)
+			return nil, nil
+		}
+	})
+	libs, err := c.MusicLibraries()
+	if err != nil {
+		t.Fatalf("MusicLibraries() error: %v", err)
+	}
+	if c.userID != "user-1" {
+		t.Fatalf("userID = %q after API key fallback, want user-1", c.userID)
+	}
+	if len(libs) != 1 || libs[0].ID != "lib-1" {
+		t.Fatalf("libraries = %+v", libs)
+	}
+}
+
 // --- Dialect-specific: Emby API-key user-id fallback ---
 
 func TestEmbyUserIDAPIKeyFallback(t *testing.T) {
@@ -341,6 +405,9 @@ func TestStreamURL(t *testing.T) {
 	if !strings.Contains(u, "api_key=tok") {
 		t.Fatalf("URL missing api_key: %q", u)
 	}
+	if !strings.Contains(u, "ApiKey=tok") {
+		t.Fatalf("URL missing ApiKey: %q", u)
+	}
 }
 
 func TestStreamURLFromCurrentAuth(t *testing.T) {
@@ -402,7 +469,7 @@ func TestResolveSourceAuthenticatesWithPassword(t *testing.T) {
 				if err != nil {
 					t.Fatalf("ResolveSource() error: %v", err)
 				}
-				if want := baseURL + "/Items/" + itemID + "/Download?api_key=new-token"; got != want {
+				if want := baseURL + "/Items/" + itemID + "/Download?ApiKey=new-token&api_key=new-token"; got != want {
 					t.Fatalf("ResolveSource() = %q, want %q", got, want)
 				}
 			}
@@ -439,7 +506,7 @@ func TestResolveSourceWithTokenDoesNotRequest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolveSource() error: %v", err)
 	}
-	if want := "https://jf.example.com/media/Items/track-1/Download?api_key=new-token"; got != want {
+	if want := "https://jf.example.com/media/Items/track-1/Download?ApiKey=new-token&api_key=new-token"; got != want {
 		t.Fatalf("ResolveSource() = %q, want %q", got, want)
 	}
 }

--- a/internal/embyapi/dialect.go
+++ b/internal/embyapi/dialect.go
@@ -91,6 +91,8 @@ func (jellyfinDialect) name() string     { return "jellyfin" }
 func (jellyfinDialect) pingPath() string { return "/Users/Me" }
 func (jellyfinDialect) metaKey() string  { return provider.MetaJellyfinID }
 
+// applyAuth sets Jellyfin authorization headers on req using both Authorization
+// and legacy X-Emby-Authorization for compatibility across server versions.
 func (jellyfinDialect) applyAuth(req *http.Request, token, _, deviceID string) {
 	auth := fmt.Sprintf(`MediaBrowser Client="%s", Device="%s", DeviceId="%s", Version="%s"`,
 		appmeta.ClientName(), appmeta.DeviceName(), deviceID, appmeta.Version())
@@ -102,6 +104,8 @@ func (jellyfinDialect) applyAuth(req *http.Request, token, _, deviceID string) {
 	req.Header.Set("X-Emby-Authorization", auth)
 }
 
+// discoverUserID retrieves the user ID for Jellyfin, trying /Users/Me first
+// and falling back to /Users when using server-level API keys.
 func (jellyfinDialect) discoverUserID(c *Client) (string, error) {
 	// Try /Users/Me first (works for session tokens from password auth).
 	var me userDTO

--- a/internal/embyapi/dialect.go
+++ b/internal/embyapi/dialect.go
@@ -81,8 +81,10 @@ func embyAuthHeader(userID, token, deviceID string) string {
 		appmeta.ClientName(), appmeta.DeviceName(), deviceID, appmeta.Version(), token)
 }
 
-// jellyfinDialect speaks Jellyfin's `X-Emby-Authorization: MediaBrowser ...`
-// scheme and discovers the user id from /Users/Me only.
+// jellyfinDialect speaks Jellyfin's `MediaBrowser ...` auth scheme. Newer
+// servers (10.11.2+, 10.12) read the client from the standard Authorization
+// header on /Users/AuthenticateByName; older servers read X-Emby-Authorization.
+// We send both.
 type jellyfinDialect struct{}
 
 func (jellyfinDialect) name() string     { return "jellyfin" }
@@ -90,22 +92,43 @@ func (jellyfinDialect) pingPath() string { return "/Users/Me" }
 func (jellyfinDialect) metaKey() string  { return provider.MetaJellyfinID }
 
 func (jellyfinDialect) applyAuth(req *http.Request, token, _, deviceID string) {
+	auth := fmt.Sprintf(`MediaBrowser Client="%s", Device="%s", DeviceId="%s", Version="%s"`,
+		appmeta.ClientName(), appmeta.DeviceName(), deviceID, appmeta.Version())
 	if token != "" {
+		auth += fmt.Sprintf(`, Token="%s"`, token)
 		req.Header.Set("X-Emby-Token", token)
 	}
-	req.Header.Set("X-Emby-Authorization",
-		fmt.Sprintf(`MediaBrowser Client="%s", Device="%s", DeviceId="%s", Version="%s"`,
-			appmeta.ClientName(), appmeta.DeviceName(), deviceID, appmeta.Version()))
+	req.Header.Set("Authorization", auth)
+	req.Header.Set("X-Emby-Authorization", auth)
 }
 
 func (jellyfinDialect) discoverUserID(c *Client) (string, error) {
-	var u userDTO
-	if err := c.get("/Users/Me", nil, &u); err != nil {
-		return "", err
+	// Try /Users/Me first (works for session tokens from password auth).
+	var me userDTO
+	if err := c.get("/Users/Me", nil, &me); err == nil && me.ID != "" {
+		c.setUserID(me.ID)
+		return me.ID, nil
 	}
-	if u.ID == "" {
-		return "", fmt.Errorf("jellyfin: current user response missing id")
+
+	// Fall back to /Users for API key auth (a key isn't owned by a user, so
+	// /Users/Me returns 400).
+	var users []userDTO
+	if err := c.get("/Users", nil, &users); err != nil {
+		return "", fmt.Errorf("jellyfin: could not discover user id (set user_id in config): %w", err)
 	}
-	c.setUserID(u.ID)
-	return u.ID, nil
+	// Prefer user matching the configured username; otherwise take first entry.
+	for _, user := range users {
+		if strings.EqualFold(user.Name, c.user) {
+			c.setUserID(user.ID)
+			return user.ID, nil
+		}
+	}
+	if c.user != "" {
+		return "", fmt.Errorf("jellyfin: user %q not found — check the user name in config", c.user)
+	}
+	if len(users) > 0 && users[0].ID != "" {
+		c.setUserID(users[0].ID)
+		return users[0].ID, nil
+	}
+	return "", fmt.Errorf("jellyfin: could not discover user id — set user_id in config")
 }


### PR DESCRIPTION
## Jellyfin 12 compatibility fix

Fixes cliamp against Jellyfin 10.11.2+/12, which dropped legacy auth and reads auth differently than older servers. Covers three regressions:

### Auth header (`internal/embyapi/dialect.go`)
Jellyfin 12 parses client identity for `/Users/AuthenticateByName` from the standard `Authorization` header; cliamp only sent `X-Emby-Authorization`, so login failed with `ArgumentNullException (request.App)`. `jellyfinDialect.applyAuth` now sends a `MediaBrowser ...` `Authorization` header (with `Token="..."` when present) alongside legacy `X-Emby-Authorization`/`X-Emby-Token`, so both new and old servers work.

### Streaming auth (`internal/embyapi/client.go`)
Buffered stream requests carry auth only via query params. Jellyfin 12 reads `ApiKey` unconditionally but honors the legacy `api_key` alias only when `EnableLegacyAuthorization` is on, causing `401 Unauthorized` from the buffer. `streamURL` now emits both `ApiKey=` and `api_key=`.

### API-key auth
Server-level API keys are not owned by a user:
- `GET /Users/Me` returns `400 "Token is not owned by a user"`, so token-only setup could never validate and user-id discovery failed.
- `Ping()` now falls back to `GET /Users` for token-only auth.
- `jellyfinDialect.discoverUserID` mirrors the Emby dialect's `/Users` fallback (prefers the configured username, else first user).

### Tests
- `internal/embyapi`: updated stream-URL assertions; added API-key ping-fallback, bad-token, and user-id-fallback tests.
- `external/jellyfin`: updated restore stream-URL assertion.

Verified against Jellyfin 12.0.0: password login, album enumeration, streaming (200 on the direct download URL), and the full API-key flow using a temporary key (created, tested, revoked via `/Auth/Keys`). `go test ./...` passes. Emby dialect behavior is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Jellyfin authentication compatibility with standard authorization headers and legacy token handling.
  * Added fallback options for identifying users when the primary user endpoint is unavailable.
  * API-key-only connections can recover from eligible ping failures while still reporting invalid credentials correctly.
  * Generated streaming URLs now include both current and legacy API-key parameters for broader compatibility.
  * Error messages for unsuccessful server responses now include relevant response details when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->