### PR TITLE
fix(ui): rebuild favorite heart styles on theme change

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -47,7 +47,7 @@ Press `t` to show the theme in the list immediately.
 | `fg`        | Muted text, help bar, inactive elements     |
 | `green`     | Playing, success, volume, spectrum low      |
 | `yellow`    | Warnings and spectrum middle               |
-| `red`       | Errors and spectrum top                    |
+| `red`       | Errors, favorite heart, and spectrum top    |
 
 All values are six-digit hex strings, for example `"#ff5733"`. Help-key pill
 text switches between black and white for readable contrast.

--- a/ui/model/dirs_screen_test.go
+++ b/ui/model/dirs_screen_test.go
@@ -392,8 +392,8 @@ func TestPlMgrNKeyRemovesRowFromFavoritesScreen(t *testing.T) {
 	if len(m.plManager.tracks) != 1 || m.plManager.tracks[0].Path != "/b.mp3" {
 		t.Fatalf("tracks = %+v, want only /b.mp3", m.plManager.tracks)
 	}
-	if !strings.HasPrefix(m.status.text, favRemovedMark) {
-		t.Fatalf("status = %q, want dimmed heart prefix %q", m.status.text, favRemovedMark)
+	if !strings.HasPrefix(m.status.text, favRemovedMark()) {
+		t.Fatalf("status = %q, want dimmed heart prefix %q", m.status.text, favRemovedMark())
 	}
 	if cmd == nil {
 		t.Fatal("expected a provider-playlist refresh command")
@@ -887,8 +887,8 @@ func TestNKeyTogglesFavorite(t *testing.T) {
 	if _, ok := m.favSet["/song.mp3"]; !ok {
 		t.Fatal("favSet should contain /song.mp3 after toggle")
 	}
-	if !strings.HasPrefix(m.status.text, favAddedMark) {
-		t.Fatalf("status = %q, want red heart prefix %q", m.status.text, favAddedMark)
+	if !strings.HasPrefix(m.status.text, favAddedMark()) {
+		t.Fatalf("status = %q, want red heart prefix %q", m.status.text, favAddedMark())
 	}
 
 	// Toggle off.
@@ -901,8 +901,8 @@ func TestNKeyTogglesFavorite(t *testing.T) {
 			t.Fatal("favSet should not contain /song.mp3 after toggle off")
 		}
 	}
-	if !strings.HasPrefix(m.status.text, favRemovedMark) {
-		t.Fatalf("status = %q, want dimmed heart prefix %q", m.status.text, favRemovedMark)
+	if !strings.HasPrefix(m.status.text, favRemovedMark()) {
+		t.Fatalf("status = %q, want dimmed heart prefix %q", m.status.text, favRemovedMark())
 	}
 }
 

--- a/ui/model/keys.go
+++ b/ui/model/keys.go
@@ -697,9 +697,9 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 			}
 			m.refreshFavSet()
 			if added {
-				m.status.Showf(statusTTLDefault, favAddedMark+" %s", track.DisplayName())
+				m.status.Showf(statusTTLDefault, favAddedMark()+" %s", track.DisplayName())
 			} else {
-				m.status.Showf(statusTTLDefault, favRemovedMark+" %s", track.DisplayName())
+				m.status.Showf(statusTTLDefault, favRemovedMark()+" %s", track.DisplayName())
 			}
 			// The provider pane renders Favorites counts from Playlists();
 			// re-pull so it reflects the toggle. The manager list refreshes
@@ -2153,9 +2153,9 @@ func (m *Model) handlePlMgrTracksKey(msg tea.KeyPressMsg) tea.Cmd {
 				}
 				m.refreshFavSet()
 				if added {
-					m.status.Showf(statusTTLDefault, favAddedMark+" %s", track.DisplayName())
+					m.status.Showf(statusTTLDefault, favAddedMark()+" %s", track.DisplayName())
 				} else {
-					m.status.Showf(statusTTLDefault, favRemovedMark+" %s", track.DisplayName())
+					m.status.Showf(statusTTLDefault, favRemovedMark()+" %s", track.DisplayName())
 				}
 				// Inside the Favorites screen a toggle re-reads the store so
 				// the rows mirror it: an unfavorite drops the row, a

--- a/ui/model/styles.go
+++ b/ui/model/styles.go
@@ -98,4 +98,6 @@ func rebuildModelStyles() {
 	seekDimStyle = lipgloss.NewStyle().Foreground(ui.ColorDim)
 	volBarStyle = lipgloss.NewStyle().Foreground(ui.ColorVolume)
 	activeToggle = lipgloss.NewStyle().Foreground(ui.ColorAccent).Bold(true)
+	favMarkerStyle = lipgloss.NewStyle().Foreground(ui.ColorError)
+	favRemovedStyle = lipgloss.NewStyle().Foreground(ui.ColorDim)
 }

--- a/ui/model/styles_test.go
+++ b/ui/model/styles_test.go
@@ -1,0 +1,92 @@
+package model
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/bjarneo/cliamp/theme"
+)
+
+var truecolorFG = regexp.MustCompile(`\x1b\[38;2;(\d+);(\d+);(\d+)m`)
+
+// renderedFG returns the foreground color lipgloss actually emitted for a
+// rendered string, as lowercase CSS hex, so a test can compare it with the
+// theme value it came from instead of with a style object.
+func renderedFG(t *testing.T, rendered string) string {
+	t.Helper()
+	match := truecolorFG.FindStringSubmatch(rendered)
+	if match == nil {
+		t.Fatalf("rendered %q carries no truecolor foreground", rendered)
+	}
+	rgb := make([]int, 3)
+	for i := range rgb {
+		value, err := strconv.Atoi(match[i+1])
+		if err != nil {
+			t.Fatalf("parse color component %d of %q: %v", i, rendered, err)
+		}
+		rgb[i] = value
+	}
+	return fmt.Sprintf("#%02x%02x%02x", rgb[0], rgb[1], rgb[2])
+}
+
+// TestFavoriteMarksFollowThemeChange covers the favorite markers shown in the
+// status bar after a toggle. Switching themes goes through SetTheme, which is
+// where the IPC `theme` op and the theme picker both land, so the markers have
+// to come out in the new theme's colors without a restart.
+func TestFavoriteMarksFollowThemeChange(t *testing.T) {
+	before := theme.Theme{
+		Name:     "marker-before",
+		Accent:   "#88aacc",
+		BrightFG: "#ffffff",
+		FG:       "#445566",
+		Green:    "#88cc88",
+		Yellow:   "#ddcc77",
+		Red:      "#ee1122",
+	}
+	after := theme.Theme{
+		Name:     "marker-after",
+		Accent:   "#aa88cc",
+		BrightFG: "#eeeeee",
+		FG:       "#cc99aa",
+		Green:    "#66bb66",
+		Yellow:   "#ccbb66",
+		Red:      "#3344ff",
+	}
+
+	tests := []struct {
+		name       string
+		mark       func() string
+		wantBefore string
+		wantAfter  string
+	}{
+		{name: "favorited", mark: favAddedMark, wantBefore: before.Red, wantAfter: after.Red},
+		{name: "unfavorited", mark: favRemovedMark, wantBefore: before.FG, wantAfter: after.FG},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := Model{themes: []theme.Theme{before, after}}
+			t.Cleanup(func() { applyThemeAll(theme.Default()) })
+
+			if !m.SetTheme(before.Name) {
+				t.Fatalf("SetTheme(%q) = false, want the theme to be found", before.Name)
+			}
+			if got := renderedFG(t, tc.mark()); got != tc.wantBefore {
+				t.Fatalf("marker = %s under %s, want %s", got, before.Name, tc.wantBefore)
+			}
+
+			if !m.SetTheme(after.Name) {
+				t.Fatalf("SetTheme(%q) = false, want the theme to be found", after.Name)
+			}
+			got := renderedFG(t, tc.mark())
+			if got == tc.wantBefore {
+				t.Fatalf("marker still %s from %s after switching to %s", got, before.Name, after.Name)
+			}
+			if got != tc.wantAfter {
+				t.Fatalf("marker = %s under %s, want %s", got, after.Name, tc.wantAfter)
+			}
+		})
+	}
+}

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -56,11 +56,13 @@ const (
 	seekEmptyGlyph = "─"
 )
 
-// Pre-rendered toggle feedback marks for the status bar.
-var (
-	favAddedMark   = favMarkerStyle.Render(favHeart)
-	favRemovedMark = favRemovedStyle.Render(favHeart)
-)
+// Toggle feedback marks for the status bar. Rendered per call, not stored, so
+// they pick up favMarkerStyle/favRemovedStyle as rebuildModelStyles leaves
+// them after a theme change. Both call sites are key handlers, not the render
+// loop.
+func favAddedMark() string { return favMarkerStyle.Render(favHeart) }
+
+func favRemovedMark() string { return favRemovedStyle.Render(favHeart) }
 
 // providerEmptyStateHint, keyed by lowercase provider Name(), returns the
 // remediation hint shown under the generic "No playlists in X" message.


### PR DESCRIPTION
## Summary

Favorite hearts never take the theme's colors. Pick any theme with a custom
`red` — say dracula's `#ff5555` — favorite a track, and the `♥` on the playlist
row and in the "♥ Track name" status message still comes out in the terminal's
own bright red rather than dracula's. Switching themes with `t` or
`cliamp theme <name>` does not change it either. The heart is the one element on
screen that ignores the theme for the whole life of the process.

Root cause is in `ui/model/styles.go`. `rebuildModelStyles()` is where every
theme change lands (`SetTheme` → `applyThemeAll` → here), and it reconstructs
each model style from the freshly applied `ui.Color*` values. It rebuilt 22 of
them. `favMarkerStyle` and `favRemovedStyle`, declared next to
`seekFillStyle`/`seekDimStyle`/`volBarStyle`/`activeToggle` in `ui/model/view.go`,
were the only two it missed, so both kept the `lipgloss.ANSIColor` values they
were given at package init. That is also why the startup theme is wrong, not
just the theme you switch to.

There is a second, independent copy of the same staleness: `favAddedMark` and
`favRemovedMark` were package-level `var`s rendered once at init, so the status
message would have stayed frozen even after the styles were fixed.

The fix is both halves:

- `ui/model/styles.go`: rebuild `favMarkerStyle` and `favRemovedStyle` in
  `rebuildModelStyles()`, in the same block as the other four styles that live
  in `view.go`. That block is the precedent I followed — `seekFillStyle`,
  `seekDimStyle`, `volBarStyle` and `activeToggle` are all declared in `view.go`
  and rebuilt here; the two heart styles were simply never added to the list.
- `ui/model/view.go`: turn `favAddedMark`/`favRemovedMark` into two one-line
  functions, so the marks are rendered from the current style instead of stored.
  Rendering at call time is what every other themed string in the package
  already does, including the playlist-row heart (`favMarkerStyle.Render(mark)`
  in `renderPlaylist`); these two were the only pre-rendered themed strings in
  the repo. Both call sites are key handlers, not the render loop, so nothing is
  re-rendered per frame.

Measured on the favorited heart, comparing the emitted SGR foreground with
theme A `red = #ee1122` and theme B `red = #3344ff`:

| | at startup | after switching to A | after switching to B |
|---|---|---|---|
| before | `38;5;9` | `38;5;9` | `38;5;9` |
| after | `38;5;9` | `38;2;238;17;34` | `38;2;51;68;255` |

`38;5;9` is the ANSI fallback. Before the change the heart never leaves it; with
the change it tracks the active theme. The startup column is the package-init
value read before any theme has been applied, so it is expected to match. The
unfavorite heart behaves the same way against `fg`.

Not addressed here, to keep the diff narrow:

- The bookmark star `★` and the `[★ n]` / `[♥ n]` header badges render through
  `activeToggle`, which `rebuildModelStyles()` was already rebuilding, so they
  follow the theme today and are untouched. Same for the seek bar and volume
  bar.
- `docs/themes.md` lists the stable text markers `>`, `Q`, `★`, `!`, `WARN:` and
  `ERR:` but not `♥`. That looks like an omission, but it is a separate
  documentation question that this fix does not change.
- `favMarkerStyle`/`favRemovedStyle` stay declared in `view.go` alongside the
  other per-render styles rather than moving into `styles.go`. Moving them would
  be a larger diff for no behavioural gain.

Docs: `docs/themes.md` gained "favorite heart" in the `red` row of the color
reference, since that key now genuinely drives the heart. `site/index.html` does
not enumerate the theme color keys and does not mention the favorite marker — it
carries its own page CSS — so it needs no change.

## Screenshots / video

No capture is attached. This is a color change to a single glyph, and a still
frame cannot show the before/after transition convincingly, so the emitted
escape sequences in the table above are the evidence instead.

To see it live, watch the heart in two places at once:

1. the `♥` prefix in the status line right after you favorite a track, and
2. the `♥` marker on the favorited row in the playlist.

Start under `dracula` (`red = #ff5555`, a strong red) and switch to
`vantablack` (`red = #cecece`, near-white). On `main` both hearts stay the
terminal's bright red through every switch. With this change the heart goes grey
with the rest of the vantablack UI and comes back red on the way home.

## How to test

Manually, against the running player:

1. Start `cliamp` with `theme = "dracula"` in `~/.config/cliamp/config.toml`.
2. Select a track and press `n` to favorite it. Note the `♥` in the status
   message and the `♥` marker on the playlist row.
3. From another shell: `cliamp theme vantablack`.
4. The title, seek bar, playlist and badges all repaint at once. On `main` the
   two hearts do not — they hold the same red they had at launch. With this
   change they repaint with everything else.
5. `cliamp theme dracula` switches back, and the hearts follow again.
6. The in-app theme picker (`t`) shows the same thing as live preview, and so
   does starting cliamp fresh under each theme.

Automatically:

```
go test ./ui/model/ -run TestFavoriteMarksFollowThemeChange -v
```

`TestFavoriteMarksFollowThemeChange` in `ui/model/styles_test.go` switches
between two themes through `SetTheme` — the function the IPC `theme` op and the
theme picker both call, so it drives the real reload path instead of assigning
the style — and asserts the foreground color lipgloss actually emits, parsed
back out of the rendered string and compared with the theme's own hex value.

Both halves of the fix are load-bearing and the test catches either one going
missing: reverting only the two `rebuildModelStyles()` lines, or only the
`view.go` change, each turns it red.

## Checklist

- [x] `make check` passes
- [x] `docs/` and `site/index.html` updated for user-facing changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Favorite heart indicators now update their colors immediately when the app theme changes.
  - Favorite added and removed status messages now consistently use the current theme styling.

- **Documentation**
  - Clarified that the theme’s red color is also used for the favorite heart indicator, in addition to errors and the top of the spectrum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->