### PR TITLE
fix(docs): correct docs and seek help that contradict the code

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -779,7 +779,7 @@ func volumeCommand() *cli.Command {
 func seekCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "seek",
-		Usage:     "seek to position in seconds",
+		Usage:     "seek by a relative offset in seconds",
 		ArgsUsage: "<seconds>",
 		Action: func(ctx context.Context, c *cli.Command) error {
 			if c.Args().Len() == 0 {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -205,7 +205,7 @@ entry. See [history.md](history.md).
 cliamp spotify reset                          # clear stored Spotify credentials
 ```
 
-Use `spotify reset` for persistent `rate-limited on /v1/me` warnings or stale authentication errors. Then restart cliamp and select Spotify to sign in again. See [spotify.md](spotify.md) for the setup guide.
+Use `spotify reset` for stale authentication errors, such as `401 Unauthorized` or a repeated sign-in prompt. Then restart cliamp and select Spotify to sign in again. It does not fix `rate-limited on /v1/me` warnings: those are `429` responses to an accepted token, so the app is out of quota rather than unauthorized. See [spotify.md](spotify.md) for the setup guide.
 
 ## cliamp:// Links
 
@@ -234,6 +234,7 @@ cliamp status                          # current state
 cliamp status --json                   # machine-readable state
 cliamp volume -5                       # adjust volume (dB)
 cliamp seek 30                         # seek relative to current position (seconds)
+cliamp remote call seek.absolute --params '{"value":90}'   # seek to 90s exactly
 cliamp load "Playlist Name"            # load a playlist
 cliamp queue /path/to/file.mp3         # queue a track
 cliamp shuffle [on|off|toggle]         # toggle or set shuffle

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -197,9 +197,14 @@ commits pending selections before it closes the browser.
 
 ## Provider browser (`N` key)
 
-Press `N` to open a provider. These providers use the same album, artist, and
-track screen keys: Navidrome, Lyrion, Plex, Jellyfin, Emby, Audiobookshelf,
-Spotify, Qobuz, Tidal, Mixcloud, Podcasts, and YouTube Music.
+Press `N` to open a provider. These providers share the browser keys below:
+Navidrome, Lyrion, Plex, Jellyfin, Emby, Audiobookshelf, Spotify, Qobuz,
+Tidal, Mixcloud, Podcasts, and YouTube Music. Artist and album screens exist
+only where the provider implements them: Navidrome, Lyrion, Jellyfin, Emby,
+Audiobookshelf, Qobuz, Tidal, and Mixcloud. Podcasts reuses those screens for
+categories and shows. Plex, Spotify, and YouTube Music have no artist or album
+screens; their playlists — and, for Plex and Spotify, saved albums — appear in
+the provider pane.
 
 | Key | Action |
 |---|---|

--- a/docs/lyrics.md
+++ b/docs/lyrics.md
@@ -4,7 +4,7 @@ Press `y` to show lyrics for the current track. For a local file, cliamp first u
 
 ## Modes
 
-- **Synced lyrics**: For local files, Navidrome tracks, and YouTube/yt-dlp tracks with a known duration, lyrics scroll automatically and highlight the active line during playback.
+- **Synced lyrics**: For any track whose playback position maps to song time, lyrics scroll automatically and highlight the active line during playback. That covers local files and provider tracks such as Navidrome, Spotify, and Qobuz, plus YouTube/yt-dlp tracks with a known duration.
 - **Scroll mode**: For plain lyrics without timestamps, live radio (ICY), and YouTube Live, use `j`/`k` or the arrow keys to scroll manually. The YouTube Live position is not relative to the song.
 
 cliamp keeps timestamps in embedded LRC lyrics. It shows embedded plain-text lyrics in scroll mode.

--- a/docs/spotify.md
+++ b/docs/spotify.md
@@ -36,7 +36,7 @@ Run `cliamp`, select Spotify, and press Enter to sign in. With your own `client_
 
 Spotify introduced the current Development Mode restrictions for new apps on February 11, 2026. It migrated existing Development Mode apps on March 9, 2026. Extended Quota Mode apps are not affected. See the Spotify [February 2026 migration guide](https://developer.spotify.com/documentation/web-api/tutorials/february-2026-migration-guide) for the full timeline.
 
-Search remains available in Development Mode, but `/v1/search` accepts at most **10 results per request**. A larger request returns `400 "Invalid limit"`. This does not mean search is blocked. Cliamp uses `offset` to page results in groups of 10. <kbd>Ctrl+F</kbd> returns the full result set.
+Search remains available in Development Mode, but `/v1/search` accepts at most **10 results per request**. A larger request returns `400 "Invalid limit"`. This does not mean search is blocked. Cliamp uses `offset` to page results in groups of 10. <kbd>Ctrl+F</kbd> asks for 20 results of each kind — albums, tracks, and episodes — so a Development Mode app fetches them as two pages of 10.
 
 Other Development Mode changes remove endpoints such as `/v1/browse/new-releases`. They restrict playlist items to playlists the user owns or collaborates on. `/v1/search` remains available and does not require Extended Quota Mode.
 
@@ -89,8 +89,8 @@ Podcast episodes work as tracks. Press `Ctrl+F` to search Spotify. Matching epis
 - **Playlist not showing**: Save or follow the playlist in Spotify. The provider lists only library playlists.
 - **Playback issues**: Spotify integration needs a Premium account. Free accounts cannot stream.
 - **Re-authenticate**: Run `cliamp spotify reset` to clear stored credentials. Then restart cliamp, select Spotify, and sign in again. This is the same as deleting `~/.config/cliamp/spotify_credentials.json`.
-- **Persistent "rate-limited" errors on `/v1/me`**: Stored authorization has expired or been revoked. Cliamp usually detects this at startup and prompts for sign-in. If it does not, run `cliamp spotify reset` and authenticate again. This is *not* a Spotify rate limit. Waiting does not fix it.
-- **`429 Too Many Requests` on search or playlist loading (using the built-in fallback)**: The built-in `client_id` is shared with librespot- and spotify-player-based clients. When the global pool is busy, Spotify limits requests for every client that uses it. Cliamp retries with exponential backoff. If errors continue, register a developer app and set `client_id` in `[spotify]`. Your app has a separate quota.
+- **Expired or revoked authorization**: Web API calls fail with `401 Unauthorized`, and playback asks for a new sign-in. Cliamp usually detects this at startup and prompts. If it does not, run `cliamp spotify reset` and authenticate again.
+- **`429 Too Many Requests`, including `rate-limited on /v1/me`**: Spotify accepted the credentials and throttled the *app*, so re-authenticating does not help. With the built-in `client_id`, the quota is shared with librespot- and spotify-player-based clients worldwide, and a busy pool limits every client that uses it. Cliamp retries with exponential backoff, honoring `Retry-After`. A `Retry-After` of hours (for example `86400`) means the app has no quota left for that window: register a developer app and set `client_id` in `[spotify]`. Your app has a separate quota.
 - **`400 "Invalid limit"` on <kbd>Ctrl+F</kbd>**: Development Mode apps limit `/v1/search` to 10 results per request. Cliamp pages results automatically. This error means the limit is now less than 10. Open an issue.
 
 ## Requirements


### PR DESCRIPTION
## Summary

Five places where the docs and the CLI help describe behaviour the code does not have. Docs-only, plus one `Usage:` string; no behaviour changes.

**1. `docs/spotify.md` sent users to re-authenticate for a rate limit, which cannot help and burns another authorization.**

The bullet read: "Persistent 'rate-limited' errors on `/v1/me`: Stored authorization has expired or been revoked. … This is *not* a Spotify rate limit. Waiting does not fix it," followed by `cliamp spotify reset`.

Root cause of the wrong diagnosis: that warning string is only reachable from a `429`. `webAPIWithBody` emits `spotify: web api rate-limited on %s` exclusively inside `if resp.StatusCode == http.StatusTooManyRequests` (`external/spotify/provider.go:593`, message at `:606`, terminal error at `:626`). Expired or revoked authorization takes different paths entirely: a dead refresh token (`invalid_grant`) becomes `playlist.ErrNeedsAuth` (`external/spotify/session.go:175-183`, `:331-339`), a missing token source likewise (`session.go:626`), and a rejected token from the API surfaces through the generic branch as `http status 401 Unauthorized: …` (`provider.go:615-622`). No credential problem can produce the "rate-limited" text.

Measured on a Premium account, built-in shared `client_id`, 2026-09-11: sign-in succeeded and `~/.config/cliamp/spotify_credentials.json` was written, then the very next `/v1/me` call returned `429` with `Retry-After: 86400`. Fresh credentials, immediately throttled — the block is on the app, not the token. The built-in `client_id` is librespot's, shared with spotify-player and cliamp worldwide, so its quota is a global pool.

Fixed by splitting the one bullet into the two cases it was conflating and merging the duplicate 429 bullet into it (`docs/spotify.md:92-93`): `401` plus a sign-in prompt means re-authenticate; `429` means Spotify accepted the credentials and throttled the app, and a `Retry-After` of hours means registering your own `client_id` — already documented at `docs/spotify.md:11-31` — is the only thing that helps. `docs/cli.md:208` repeated the same advice ("Use `spotify reset` for persistent `rate-limited on /v1/me` warnings") and is corrected the same way.

**2. `docs/spotify.md:39` claimed `Ctrl+F` "returns the full result set".**

The TUI asks for 20: `fetchSpotSearchCmd` calls `s.SearchTracks(ctx, query, 20)` (`ui/model/commands.go:554`). `SearchTracks` clamps to 1..50 and returns up to that many of each kind — albums, tracks and episodes (`external/spotify/provider.go:715-757`), paging in `devModeSearchLimit` (10) steps via `searchPaged` (`:684-701`). So a Development Mode app fetches 20 per kind as two pages of 10, which is what the line now says.

**3. `docs/keybindings.md:200-202` listed Spotify, Plex and YouTube Music among providers with artist and album screens.**

Those screens are gated on the optional interfaces: `providerSupportsBrowse` (`ui/model/providers.go:430-441`) and the route handlers (`ui/model/providers.go:544,553`, `ui/model/keys_nav.go:100-113`) type-assert `provider.ArtistBrowser` / `provider.AlbumBrowser` (`provider/interfaces.go:19-22,113-117`). Every provider was checked against the interfaces themselves, not just grepped for assertions: Lyrion, for example, implements both without a compile-time assertion (`external/lyrion/client.go:252,271,281`). Both interfaces: Navidrome, Lyrion, Jellyfin, Emby, Audiobookshelf, Qobuz, Tidal, Mixcloud. `ArtistBrowser` only, restricted to `BrowseArtistAlbums` for categories and shows: Podcasts (`external/podcast/provider.go:30,251-253`). Neither: Spotify (`external/spotify/provider.go:30-34` — `Searcher`, `PlaylistWriter`, `PlaylistCreator`, `CustomStreamer`, `Closer`, and no `Artists`/`AlbumList` methods anywhere in the package), Plex (`external/plex/provider.go:25-27`) and YouTube Music (`external/ytmusic/provider.go:471-571`, no browse methods). The list is now split into "shares the browser keys" and "has artist and album screens", so all three wrong entries are corrected, not just Spotify.

**4. `docs/lyrics.md:7` omitted Spotify from synced lyrics.**

`lyricsSyncable` (`ui/model/lyrics.go:67-84`) excludes only two things: a yt-dlp track with no duration, and a stream with no provider metadata. Spotify tracks are built with `Stream: false` and a real `DurationSecs` from the API (`external/spotify/provider_shared.go:174-175`) and their `spotify:track:` paths are not URLs, so `playlist.IsYTDL` is false (`playlist/playlist.go:209-212`) — they reach the final `return true`. The same applies to other provider tracks, e.g. Qobuz sets `Stream: true` with non-empty `ProviderMeta` (`external/qobuz/provider.go:477-478`). Rather than chase the provider list, the line now states the rule the function implements and gives examples.

**5. `commands.go:782` described `seek` as absolute; the op is relative.**

`cliamp seek` sends the `seek` op (`commands.go:792`), which both runtimes apply as an offset: `m.player.Seek(secondsDuration(request.Value))` (`ui/model/ipc_runtime.go:175-179`) and `playback.SeekMsg{Offset: …}` (`daemon_v2.go:223-224`), against `Player.Seek`, documented as "moves the playback position by the given duration (positive or negative)" (`player/player.go:517`). `seek.absolute` is the absolute op: it computes target minus current position (`ui/model/ipc_runtime.go:180-185`) or `SetPositionMsg` (`daemon_v2.go:225-226`). Measured: with playback at 43.5 s, `cliamp seek 20` landed at 65.0 s.

Only the help string was wrong — `docs/cli.md:236` and `docs/remote-control.md:162` already say `seek` is relative, so this makes `--help` agree with the docs that were already right. `docs/cli.md:237` now shows the absolute op, which was previously only discoverable from the operations table at `docs/remote-control.md:106`.

**The alternative reading, which is yours to make:** the bug is the behaviour, not the help text, and `seek` should take an absolute position. I did not do that, because `seek` has shipped as relative in both runtimes and every existing script, Lua plugin (`luaplugin/api_control.go:73-79`) and IPC caller would silently change meaning. Say so on this PR if you would rather change the op and I will redo it that way.

Not addressed here, to keep the diff narrow:

- The retry-exhausted error at `external/spotify/provider.go:626` still ends with "(try re-authenticating)", which is the same wrong hint in code rather than docs.
- The doc comment on `lyricsSyncable` (`ui/model/lyrics.go:61-66`) enumerates providers the way `docs/lyrics.md` did.
- `docs/keybindings.md:200` still omits Radio from the provider list, although Radio appears in the key table at `:213` and `:215`. Radio is a `GenreBrowser`, not an artist/album browser, so it is a separate gap.

## Screenshots / video

Not applicable — no UI change.

## How to test

Nothing to run for the docs; each changed line can be checked against the code it describes.

1. The 429 warning is reachable only from a 429, never from expired credentials:

   ```sh
   sed -n '589,626p' external/spotify/provider.go   # rate-limited text inside the StatusTooManyRequests branch
   sed -n '170,190p;325,340p' external/spotify/session.go   # invalid_grant -> ErrNeedsAuth, a separate path
   ```

   Then read `docs/spotify.md:92-93` and `docs/cli.md:208`.

2. `Ctrl+F` page size:

   ```sh
   sed -n '552,557p' ui/model/commands.go           # SearchTracks(ctx, query, 20)
   sed -n '684,701p;715,757p' external/spotify/provider.go
   ```

3. Browse capabilities, straight from the compile-time assertions:

   ```sh
   grep -rn "provider.ArtistBrowser  *=\|provider.AlbumBrowser  *=" external/ | grep -v _test
   grep -rn "func (.*) \(Artists()\|AlbumList(\)" external/ | grep -v _test   # catches Lyrion, which has no assertion
   sed -n '28,35p' external/spotify/provider.go
   sed -n '24,28p' external/plex/provider.go
   ```

   Compare with `docs/keybindings.md:200-207`.

4. Synced lyrics rule:

   ```sh
   sed -n '61,84p' ui/model/lyrics.go
   sed -n '168,179p' external/spotify/provider_shared.go   # Stream: false, real DurationSecs
   ```

5. The seek help, which is the one thing with output to look at:

   ```sh
   go build -o /tmp/cliamp-help . && /tmp/cliamp-help seek --help
   ```

   prints `cliamp seek - seek by a relative offset in seconds`. The op it sends is `seek`, handled at `ui/model/ipc_runtime.go:175-179` and `daemon_v2.go:223-224`. With a track playing, `cliamp status` before and after `cliamp seek 20` shows the position advance by 20 s rather than jump to 0:20.

`make check` output:

```
gofmt -l -w .
go vet ./...
go test ./...
ok  	github.com/bjarneo/cliamp	0.128s
ok  	github.com/bjarneo/cliamp/applog	0.014s
ok  	github.com/bjarneo/cliamp/cmd	1.050s
...
ok  	github.com/bjarneo/cliamp/external/spotify	0.141s
ok  	github.com/bjarneo/cliamp/player	1.432s
ok  	github.com/bjarneo/cliamp/ui	0.035s
ok  	github.com/bjarneo/cliamp/ui/model	0.491s
ok  	github.com/bjarneo/cliamp/upgrade	0.097s
```

All 53 packages report `ok`, with no `FAIL` and nothing left unformatted; the list is trimmed for length.

No tests are added. Four of the five changes are prose, and the fifth is a help string — a test pinning that wording would only restate the literal.

## Checklist

- [x] `make check` passes
- [x] `docs/` and `site/index.html` updated for user-facing changes — `docs/spotify.md`, `docs/cli.md`, `docs/keybindings.md` and `docs/lyrics.md` are updated. `site/index.html` needs no change: it carries none of these claims. It mentions `Ctrl+F` only as "search provider" (`site/index.html:672`), `←`/`→` as "seek 5s" (`:670`), and "synced lyrics" as a feature name (`:7,15,24,340`) with no provider list. It has no Spotify troubleshooting section, no artist/album browse list, and no CLI help text; `grep -c` for `429`, `client_id`, `Retry-After`, `result set` and `seek to position` returns 0 for each.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `seek` uses relative time offsets and added guidance for seeking to exact playback positions.
  * Improved Spotify troubleshooting for expired authentication, rate limiting, retry behavior, result pagination, and developer credentials.
  * Updated provider browser guidance to explain supported artist, album, category, show, playlist, and saved-album screens.
  * Expanded synced lyrics documentation to cover supported provider tracks, including Navidrome, Spotify, and Qobuz.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->