### PR TITLE
Smooth ClassicPeak sampling and redraws

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,6 +67,9 @@ eq = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 # Visualizer mode (leave empty for default Bars)
 # Options: Bars, BarsDot, Rain, BarsOutline, Bricks, Columns, ClassicPeak, Wave, Scatter, Flame, Retro, Pulse, Matrix, Binary, Sakura, Firework, Bubbles, Logo, Terrain, Scope, Heartbeat, Butterfly, Ascii, Firefly, Mosaic, Sand, Geyser, ClassicLED, Stereo, Mirror, Omarchy, RedSector, None
 # Mirror draws tapered Braille bars around a persistent horizontal center axis.
+# ClassicPeak uses smooth bars and floating peak caps, with sampling aligned
+# to audible playback and adaptive redraws for smooth motion.
+# Neighboring bands are averaged into each bar.
 visualizer = "Bars"
 
 # Visualizer volume linking (default: true)

--- a/site/index.html
+++ b/site/index.html
@@ -440,7 +440,7 @@ footer a{color:var(--fg-2)}
       </div>
       <div class="feat">
         <div class="feat-k">VISUALIZERS</div>
-        <p>31 built-in modes rendered in the terminal from live FFT data: spectrum bars, scope, wave, matrix, flame, and a true-stereo LED peak meter. <kbd>v</kbd> cycles, <kbd>V</kbd> goes full screen.</p>
+        <p>31 built-in modes rendered in the terminal from live FFT data: spectrum bars, scope, wave, matrix, flame, and a true-stereo LED peak meter. ClassicPeak uses smooth bars and floating peak caps, with sampling aligned to audible playback and adaptive redraws for smooth motion. Neighboring bands are averaged into each bar. <kbd>v</kbd> cycles, <kbd>V</kbd> goes full screen.</p>
       </div>
       <div class="feat">
         <div class="feat-k">SYNCED LYRICS</div>

--- a/ui/model/tick.go
+++ b/ui/model/tick.go
@@ -107,7 +107,7 @@ func (m *Model) visualizerTickContext(now time.Time) ui.VisTickContext {
 			}
 			buf := m.vis.EnsureSampleBuf(spec.FFTSize)
 			if !sampled || spec.FFTSize > sampledSize {
-				if spec.BandCount == 0 {
+				if spec.BandCount == 0 || m.vis.Mode == ui.VisClassicPeak {
 					samplesRead = m.player.WaveformSamplesInto(buf)
 				} else {
 					samplesRead = m.player.SamplesInto(buf)
@@ -187,6 +187,9 @@ func (m *Model) tickInterval() time.Duration {
 		}
 		if m.visualizerVisible() && (m.visualizer60FPS || m.vis.UsesRawSamples()) {
 			return ui.TickAnim
+		}
+		if m.visualizerVisible() && m.vis.Mode == ui.VisClassicPeak {
+			return min(d, ui.TickFast)
 		}
 		return ui.TickFast
 	}

--- a/ui/model/tick_test.go
+++ b/ui/model/tick_test.go
@@ -188,6 +188,28 @@ func TestTickIntervalVisualizer60FPS(t *testing.T) {
 	}
 }
 
+func TestClassicPeakPlaybackHonorsDriverCadence(t *testing.T) {
+	p := &playbackFakeEngine{playing: true}
+	m := Model{
+		player: p, vis: ui.NewVisualizer(float64(p.SampleRate())),
+		playlist: playlist.New(), width: 80, height: 24,
+	}
+	m.recomputeLayout()
+	m.SetVisualizer("ClassicPeak")
+	want := m.vis.TickInterval(m.visualizerTickContext(time.Time{}))
+	if got := m.tickInterval(); got != want || got >= ui.TickFast {
+		t.Fatalf("ClassicPeak playback tick = %v, want driver cadence %v faster than %v", got, want, ui.TickFast)
+	}
+	m.SetVisualizer60FPS(true)
+	if got := m.tickInterval(); got != ui.TickAnim {
+		t.Fatalf("ClassicPeak 60fps tick = %v, want %v", got, ui.TickAnim)
+	}
+	m.SetLowPower(true)
+	if got := m.tickInterval(); got != ui.TickLowPowerPlaying {
+		t.Fatalf("ClassicPeak low-power tick = %v, want %v", got, ui.TickLowPowerPlaying)
+	}
+}
+
 func TestTickIntervalRawSampleVisualizerUsesWaveCadence(t *testing.T) {
 	p := &playbackFakeEngine{playing: true}
 	m := Model{
@@ -210,24 +232,28 @@ func TestTickIntervalRawSampleVisualizerUsesWaveCadence(t *testing.T) {
 	}
 }
 
-func TestRawSampleVisualizerUsesWaveformTap(t *testing.T) {
-	p := &samplingFakeEngine{playbackFakeEngine: &playbackFakeEngine{playing: true}}
-	m := Model{
-		player:   p,
-		vis:      ui.NewVisualizer(float64(p.SampleRate())),
-		playlist: playlist.New(),
-		width:    80,
-		height:   24,
-	}
-	m.recomputeLayout()
-	m.SetVisualizer("Wave")
-	m.tickVisualizer(time.Unix(1, 0))
-
-	if p.waveformSampleCalls != 1 {
-		t.Fatalf("WaveformSamplesInto calls = %d, want 1", p.waveformSampleCalls)
-	}
-	if p.sampleCalls != 0 {
-		t.Fatalf("SamplesInto calls = %d, want 0", p.sampleCalls)
+func TestVisualizerSelectsAudibleTap(t *testing.T) {
+	for _, mode := range []string{"Wave", "ClassicPeak", "ClassicLED", "Bars"} {
+		t.Run(mode, func(t *testing.T) {
+			p := &samplingFakeEngine{playbackFakeEngine: &playbackFakeEngine{playing: true}}
+			m := Model{
+				player:   p,
+				vis:      ui.NewVisualizer(float64(p.SampleRate())),
+				playlist: playlist.New(),
+				width:    80,
+				height:   24,
+			}
+			m.recomputeLayout()
+			m.SetVisualizer(mode)
+			m.tickVisualizer(time.Unix(1, 0))
+			wantAudible := 0
+			if mode == "Wave" || mode == "ClassicPeak" {
+				wantAudible = 1
+			}
+			if p.waveformSampleCalls != wantAudible || p.sampleCalls != 1-wantAudible {
+				t.Fatalf("tap calls audible/latest = %d/%d, want %d/%d", p.waveformSampleCalls, p.sampleCalls, wantAudible, 1-wantAudible)
+			}
+		})
 	}
 }
 

--- a/ui/vis_classic_peak.go
+++ b/ui/vis_classic_peak.go
@@ -159,7 +159,26 @@ func (d *classicPeakDriver) animating(v *Visualizer) bool {
 
 func (d *classicPeakDriver) levels(v *Visualizer) []float64 {
 	activeCols := classicPeakColsForWidth(PanelWidth)
-	return resampleBandsLinear(v.bands, activeCols)
+	return classicPeakBands(v.bands, activeCols)
+}
+
+// Average all contributing bands when shrinking the spectrum. Point sampling
+// can skip narrow peaks entirely; fractional overlap keeps boundary bands from
+// jumping between columns as the panel is resized. Expansion still interpolates.
+func classicPeakBands(bands []float64, cols int) []float64 {
+	if cols <= 0 || cols >= len(bands) {
+		return resampleBandsLinear(bands, cols)
+	}
+	out := make([]float64, cols)
+	span := float64(len(bands)) / float64(cols)
+	for col := range out {
+		lo, hi := float64(col)*span, float64(col+1)*span
+		for b := int(lo); b < len(bands) && float64(b) < hi; b++ {
+			weight := min(hi, float64(b+1)) - max(lo, float64(b))
+			out[col] += bands[b] * weight / span
+		}
+	}
+	return out
 }
 
 func (d *classicPeakDriver) frameInterval(v *Visualizer) time.Duration {

--- a/ui/vis_classic_peak_signal_test.go
+++ b/ui/vis_classic_peak_signal_test.go
@@ -1,0 +1,42 @@
+package ui
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// Moving the FFT window across an unchanged bass tone must not make it pulse.
+// This exercises real analysis plus motion, rather than injecting fixed bands.
+func TestClassicPeakSteadyBassDoesNotFlicker(t *testing.T) {
+	withPanelWidth(t, 40)
+	for _, hz := range []float64{41.2, 55, 82.4, 110} {
+		for _, interval := range []time.Duration{16 * time.Millisecond, 32 * time.Millisecond, 50 * time.Millisecond} {
+			v := NewVisualizer(44100)
+			activateMode(t, v, VisClassicPeak)
+			d := classicPeakDriverFor(t, v)
+			spec := d.AnalysisSpec(v)
+			samples := make([]float64, spec.FFTSize)
+			var previous []float64
+			now := time.Unix(1, 0)
+			for frame := range 100 {
+				offset := float64(frame) * interval.Seconds() * v.sr
+				for i := range samples {
+					samples[i] = 0.6 * math.Sin(2*math.Pi*hz*(offset+float64(i))/v.sr)
+				}
+				d.Tick(v, VisTickContext{
+					Now: now.Add(time.Duration(frame) * interval), Playing: true,
+					Analyze: func(spec VisAnalysisSpec) []float64 { return v.Analyze(samples, spec) },
+				})
+				if frame > 20 {
+					for col, level := range d.barPos {
+						if jump := math.Abs(level - previous[col]); jump > 0.025 {
+							t.Fatalf("%g Hz at %v: bar %d jumped %.3f on a steady tone", hz, interval, col, jump)
+						}
+					}
+				}
+				previous = append(previous[:0], d.barPos...)
+			}
+		}
+	}
+}

--- a/ui/vis_classic_peak_test.go
+++ b/ui/vis_classic_peak_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"math"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -11,6 +12,43 @@ import (
 
 const classicPeakTestGlyphs = "⎺⎻⎼⎽"
 const classicPeakTestEpsilon = 1e-9
+
+func TestClassicPeakBandAveraging(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		bands []float64
+		cols  int
+		want  []float64
+	}{
+		{"pairs", []float64{0, 1, 0.4, 0.8}, 2, []float64{0.5, 0.6}},
+		{"fractional boundary", []float64{0, 0, 1, 0, 0}, 2, []float64{0.2, 0.2}},
+		{"one column", []float64{1, 0, 0, 0}, 1, []float64{0.25}},
+		{"same width", []float64{0.2, 0.7}, 2, []float64{0.2, 0.7}},
+		{"expanded", []float64{0, 1}, 3, []float64{0, 0.5, 1}},
+		{"empty", nil, 3, nil},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classicPeakBands(tt.bands, tt.cols)
+			if !slices.EqualFunc(got, tt.want, func(a, b float64) bool { return math.Abs(a-b) < 1e-9 }) {
+				t.Fatalf("bands = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassicPeakBandAveragingNeverSkipsNarrowPeaks(t *testing.T) {
+	for peak := range 64 {
+		bands := make([]float64, 64)
+		bands[peak] = 1
+		var total float64
+		for _, level := range classicPeakBands(bands, 19) {
+			total += level
+		}
+		if math.Abs(total-19.0/64) > 1e-9 {
+			t.Fatalf("peak at band %d: total %v, want preserved contribution %v", peak, total, 19.0/64)
+		}
+	}
+}
 
 func withPanelWidth(t *testing.T, width int) {
 	t.Helper()


### PR DESCRIPTION
## Summary
- Align ClassicPeak sampling with audible playback and adapt redraw cadence.
- Average neighboring spectrum bands for smoother bars without skipping narrow peaks.
- Add regression tests and update configuration docs and website.

## Testing
- Not run in this session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved the ClassicPeak visualizer with smoother bars and more stable peak levels, reducing flicker during steady audio.
  - ClassicPeak now aligns sampling more closely with playback and adapts its redraw cadence for more responsive, efficient animation.
  - Audio levels are averaged across neighboring frequency bands to provide clearer and more consistent visualization.

- **Documentation**
  - Added documentation describing ClassicPeak behavior, including peak caps, audio-aligned sampling, adaptive redraws, and band averaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->