### PR TITLE
fix(radio): permet de mettre en favori les stations parcourues

### DIFF
--- a/docs/provider-development.md
+++ b/docs/provider-development.md
@@ -55,6 +55,7 @@ are in `provider/interfaces.go`.
 | `PlaylistDeleter` | Remove playlists/tracks | `DeletePlaylist(name)`, `RemoveTrack(name, index)` |
 | `CustomStreamer` | Custom URI decode pipeline | `URISchemes()`, `NewStreamer(uri)` |
 | `FavoriteToggler` | Favorite toggling | `ToggleFavorite(id)` |
+| `TrackFavoriteToggler` | Favorite a track selected in a hierarchical browser | `ToggleTrackFavorite(track)` |
 | `Closer` | Cleanup on shutdown | `Close()` |
 | `Authenticator` | Interactive sign-in flow | `Authenticate() error` (in `playlist` package) |
 | `ResumeTarget` | Server-side resume position | `ResumeTarget(playlistID, tracks)` |

--- a/external/radio/countries.go
+++ b/external/radio/countries.go
@@ -334,6 +334,12 @@ func stationTracks(stations []CatalogStation) []playlist.Track {
 	for _, s := range stations {
 		track := stationTrack(s)
 		track.Title = formatCatalogName(s)
+		if s.Homepage != "" {
+			if track.ProviderMeta == nil {
+				track.ProviderMeta = make(map[string]string, 1)
+			}
+			track.ProviderMeta["radio.homepage"] = s.Homepage
+		}
 		tracks = append(tracks, track)
 	}
 	return tracks

--- a/external/radio/provider.go
+++ b/external/radio/provider.go
@@ -374,6 +374,52 @@ func (p *Provider) ToggleFavorite(id string) (added bool, name string, err error
 	return true, s.Name, p.favorites.Add(s)
 }
 
+// ToggleTrackFavorite toggles a station returned by the country or tag browser.
+func (p *Provider) ToggleTrackFavorite(track playlist.Track) (added bool, name string, err error) {
+	name = track.Title
+	if country := displayCountryName(track.Meta("radio.country")); country != "" {
+		name = strings.TrimSuffix(name, " · "+country)
+	}
+	if bitrate := track.Meta("radio.bitrate"); bitrate != "" {
+		name = strings.TrimSuffix(name, " ["+bitrate+"k]")
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return false, "", errors.New("radio: missing station metadata")
+	}
+
+	bitrate := 0
+	if raw := track.Meta("radio.bitrate"); raw != "" {
+		bitrate, _ = strconv.Atoi(raw)
+	}
+	station := CatalogStation{
+		Name:     name,
+		URL:      track.Path,
+		Country:  track.Meta("radio.country"),
+		State:    track.Meta("radio.state"),
+		Tags:     track.Genre,
+		Codec:    track.Meta("radio.codec"),
+		Bitrate:  bitrate,
+		Homepage: track.Meta("radio.homepage"),
+	}
+	if len(streamableStations([]CatalogStation{station})) != 1 {
+		return false, name, errors.New("radio: invalid station URL")
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.favorites.Contains(station.URL) {
+		if err := p.favorites.Remove(station.URL); err != nil {
+			return false, name, err
+		}
+		return false, name, nil
+	}
+	if err := p.favorites.Add(station); err != nil {
+		return false, name, err
+	}
+	return true, name, nil
+}
+
 // SetSearchResults activates search mode with the given results.
 // Playlists() will return search results instead of catalog stations.
 // Any pending search is invalidated.

--- a/external/radio/provider_test.go
+++ b/external/radio/provider_test.go
@@ -397,3 +397,37 @@ url = "http://c/"
 		t.Errorf("expected only 'complete', got %+v", stations)
 	}
 }
+
+func TestProviderFavoritesTrackFromCountryOrTagBrowser(t *testing.T) {
+	p := newTestProvider(t)
+	toggler, ok := any(p).(interface {
+		ToggleTrackFavorite(playlist.Track) (bool, string, error)
+	})
+	if !ok {
+		t.Fatal("radio provider does not support favoriting browsed tracks")
+	}
+
+	station := CatalogStation{
+		Name: "NRK P3", URL: "https://nrk.example/p3", Country: "Norway",
+		State: "Oslo", Tags: "pop,rock", Codec: "MP3", Bitrate: 192,
+		Homepage: "https://nrk.example/",
+	}
+	track := stationTracks([]CatalogStation{station})[0]
+
+	added, name, err := toggler.ToggleTrackFavorite(track)
+	if err != nil || !added || name != station.Name {
+		t.Fatalf("first toggle = (%v, %q, %v), want added %q", added, name, err, station.Name)
+	}
+	favorites := p.favorites.Stations()
+	if len(favorites) != 1 || !reflect.DeepEqual(favorites[0], station) {
+		t.Fatalf("favorites = %+v, want exact station metadata %+v", favorites, station)
+	}
+
+	added, name, err = toggler.ToggleTrackFavorite(track)
+	if err != nil || added || name != station.Name {
+		t.Fatalf("second toggle = (%v, %q, %v), want removed %q", added, name, err, station.Name)
+	}
+	if favorites := p.favorites.Stations(); len(favorites) != 0 {
+		t.Fatalf("favorites after removal = %+v, want none", favorites)
+	}
+}

--- a/provider/interfaces.go
+++ b/provider/interfaces.go
@@ -251,6 +251,12 @@ type FavoriteToggler interface {
 	ToggleFavorite(id string) (added bool, name string, err error)
 }
 
+// TrackFavoriteToggler is implemented by providers that can favorite tracks
+// returned by a hierarchical browser without a provider item ID.
+type TrackFavoriteToggler interface {
+	ToggleTrackFavorite(track playlist.Track) (added bool, name string, err error)
+}
+
 // CatalogLoader is implemented by providers that support lazy-loading
 // catalog pages from an external source (e.g. Radio Browser API).
 type CatalogLoader interface {

--- a/ui/model/command_registry.go
+++ b/ui/model/command_registry.go
@@ -206,10 +206,23 @@ var commandRegistry = []commandSpec{
 	{Mode: commandModeFileBrowser | commandModeNavBrowser | commandModePlaylistManager | commandModePlaylistPicker | commandModeDevicePicker, Keys: []string{"enter"}, KeyLabel: "Enter", Label: "Select", ContextHelp: true, Primary: true},
 	{Mode: commandModeNavBrowser, Keys: []string{"/"}, KeyLabel: "/", Label: "Filter", ContextHelp: true, Enabled: func(m Model) bool { return m.navBrowser.mode != navBrowseModeMenu }},
 	{Mode: commandModeNavBrowser, Keys: []string{"f"}, KeyLabel: "f", Label: "Favorite", ContextHelp: true, Prominent: true, Enabled: func(m Model) bool {
-		_, ok := m.navBrowser.prov.(provider.FavoriteToggler)
-		idx := m.selectedNavRawIndex(len(m.navBrowser.albums))
-		return ok && m.navView() == navViewAlbums && !m.navBrowser.loading && !m.navBrowser.albumLoading &&
-			idx >= 0 && m.navBrowser.albums[idx].ID != ""
+		if m.navBrowser.loading || m.navBrowser.albumLoading {
+			return false
+		}
+		switch m.navView() {
+		case navViewAlbums:
+			_, ok := m.navBrowser.prov.(provider.FavoriteToggler)
+			idx := m.selectedNavRawIndex(len(m.navBrowser.albums))
+			return ok && idx >= 0 && m.navBrowser.albums[idx].ID != ""
+		case navViewTracks:
+			if _, ok := m.navBrowser.prov.(provider.TrackFavoriteToggler); !ok {
+				return false
+			}
+			track, selected := m.selectedNavTrack()
+			return selected && track.Path != ""
+		default:
+			return false
+		}
 	}},
 	{Mode: commandModeNavBrowser, Keys: []string{"f"}, KeyLabel: "f", Label: "Favorite genre", LabelFor: func(m Model) string {
 		if genre, ok := m.selectedNavGenre(); ok && genre.Favorite {

--- a/ui/model/keys_nav.go
+++ b/ui/model/keys_nav.go
@@ -604,6 +604,25 @@ func (m *Model) handleNavTrackListKey(msg tea.KeyPressMsg) tea.Cmd {
 			}
 			return m.rearmPreload()
 		}
+	case "f":
+		favorites, ok := m.navBrowser.prov.(provider.TrackFavoriteToggler)
+		if !ok {
+			return nil
+		}
+		track, ok := m.selectedNavTrack()
+		if !ok {
+			return nil
+		}
+		added, name, err := favorites.ToggleTrackFavorite(track)
+		if err != nil {
+			m.status.Errorf(statusTTLDefault, "Favorite save failed: %s", err)
+			return nil
+		}
+		if added {
+			m.status.Showf(statusTTLMedium, "Favorited: %s", name)
+		} else {
+			m.status.Showf(statusTTLMedium, "Removed: %s", name)
+		}
 	case "esc", "h", "left", "backspace":
 		// Navigate back one level depending on the mode and how we got here.
 		m.navClearSearch()
@@ -632,6 +651,14 @@ func (m *Model) navDisplayedTracks() []playlist.Track {
 		tracks = append(tracks, m.navBrowser.tracks[i])
 	}
 	return tracks
+}
+
+func (m *Model) selectedNavTrack() (playlist.Track, bool) {
+	tracks := m.navDisplayedTracks()
+	if m.navBrowser.cursor < 0 || m.navBrowser.cursor >= len(tracks) {
+		return playlist.Track{}, false
+	}
+	return tracks[m.navBrowser.cursor], true
 }
 
 func (m *Model) navPlaybackTracks() []playlist.Track {

--- a/ui/model/provider_favorite_test.go
+++ b/ui/model/provider_favorite_test.go
@@ -170,3 +170,47 @@ func TestFavoriteActionAndHelpGuardSelection(t *testing.T) {
 		})
 	}
 }
+
+type favoriteTrackTestProvider struct {
+	commandsTestProvider
+	toggled  []playlist.Track
+	favorite bool
+}
+
+func (p *favoriteTrackTestProvider) ToggleTrackFavorite(track playlist.Track) (bool, string, error) {
+	p.toggled = append(p.toggled, track)
+	p.favorite = !p.favorite
+	return p.favorite, track.Title, nil
+}
+
+func TestFavoriteTrackFromNavBrowser(t *testing.T) {
+	withFrameWidth(t, 100)
+	p := &favoriteTrackTestProvider{commandsTestProvider: commandsTestProvider{name: "Radio"}}
+	m := keybindingTestModel()
+	m.navBrowser = navBrowserState{
+		prov:    p,
+		visible: true,
+		mode:    navBrowseModeByGenre,
+		screen:  navBrowseScreenTracks,
+		tracks: []playlist.Track{
+			{Path: "https://radio.example/other", Title: "Other", Stream: true, Realtime: true},
+			{Path: "https://radio.example/target", Title: "Target", Stream: true, Realtime: true},
+		},
+		search:    "target",
+		searchIdx: []int{1},
+	}
+
+	mode, _ := m.keymapContext()
+	if help := m.commandHelp(mode); !strings.Contains(help, "Favorite") {
+		t.Fatalf("favoritable track has no command help: %q", help)
+	}
+	if cmd := m.handleKey(tea.KeyPressMsg{Text: "f"}); cmd != nil {
+		t.Fatal("track favorite returned an unexpected command")
+	}
+	if len(p.toggled) != 1 || p.toggled[0].Path != "https://radio.example/target" {
+		t.Fatalf("favorite tracks = %+v, want filtered target", p.toggled)
+	}
+	if m.status.text != "Favorited: Target" {
+		t.Fatalf("status = %q, want favorite confirmation", m.status.text)
+	}
+}


### PR DESCRIPTION
Corrige #449 en permettant de mettre en favori les stations ouvertes depuis Genres ou Countries.

Tests : `make check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Favorite tracks directly from the navigation browser using the `f` key.
  * Track favorite actions now work with filtered results and provide success or error feedback.
  * Radio stations browsed by country or tag can be added to or removed from favorites while preserving station homepage details.
* **Documentation**
  * Updated provider development documentation to describe support for favoriting browsed tracks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->