### PR TITLE
fix(jellyfin): restore auth and streaming on Jellyfin 12

### DIFF
--- a/external/jellyfin/provider_test.go
+++ b/external/jellyfin/provider_test.go
@@ -188,7 +188,7 @@ func TestProviderRestoreTrackDefersAuthenticationUntilSourceResolution(t *testin
 	if err != nil {
 		t.Fatalf("ResolveSource() error: %v", err)
 	}
-	if want := "https://jf.example.com/Items/track-1/Download?api_key=new-token"; source != want {
+	if want := "https://jf.example.com/Items/track-1/Download?ApiKey=new-token&api_key=new-token"; source != want {
 		t.Fatalf("ResolveSource() = %q, want %q", source, want)
 	}
 	if got.Path != oldURL || got.Title != "Song" || got.Meta(provider.MetaJellyfinID) != "track-1" || !got.Stream {

--- a/external/jellyfin/provider_test.go
+++ b/external/jellyfin/provider_test.go
@@ -164,6 +164,9 @@ func TestProviderRestoreTrack(t *testing.T) {
 	}
 }
 
+// TestProviderRestoreTrackDefersAuthenticationUntilSourceResolution verifies
+// that restoring a saved stream URL performs no startup requests and defers
+// password authentication until source resolution.
 func TestProviderRestoreTrackDefersAuthenticationUntilSourceResolution(t *testing.T) {
 	p := newProvider(NewClient("https://jf.example.com", "", "", "user", "password"))
 	p.client.SetHTTPClient(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {

--- a/external/jellyfin/provider_test.go
+++ b/external/jellyfin/provider_test.go
@@ -120,6 +120,8 @@ func TestProviderCanReportPlayback(t *testing.T) {
 	}
 }
 
+// TestProviderRestoreTrack verifies that restoring a saved Jellyfin stream URL
+// refreshes credentials and preserves track metadata.
 func TestProviderRestoreTrack(t *testing.T) {
 	p := newProvider(NewClient("https://jf.example.com/media", "new-token", "user-1", "", ""))
 	tests := []struct {

--- a/internal/embyapi/client.go
+++ b/internal/embyapi/client.go
@@ -196,12 +196,13 @@ func (c *Client) Ping() error {
 	var raw json.RawMessage
 	if err := c.get(c.dialect.pingPath(), nil, &raw); err == nil {
 		return nil
-	} else if c.dialect.name() == "jellyfin" && c.user == "" && c.password == "" {
+	} else if c.dialect.name() == "jellyfin" && c.password == "" && c.token != "" {
 		var httpErr *httpError
 		if errors.As(err, &httpErr) && httpErr.statusCode == http.StatusBadRequest {
 			// API keys aren't owned by a user, so /Users/Me returns a 400
 			// (documented as "Token is not owned by a user.", sent without a
-			// body). Fall back to listing /Users to prove the key is valid.
+			// body), even when a username is configured alongside the key.
+			// Fall back to listing /Users to prove the key is valid.
 			return c.get("/Users", nil, &raw)
 		}
 		return err

--- a/internal/embyapi/client.go
+++ b/internal/embyapi/client.go
@@ -543,6 +543,8 @@ func (c *Client) StreamURL(itemID string) string {
 	return c.streamURL(itemID, c.authToken())
 }
 
+// streamURL builds a direct-download stream URL for an item, carrying both the
+// modern ApiKey and legacy api_key query parameters.
 func (c *Client) streamURL(itemID, token string) string {
 	// ApiKey is the auth query param Jellyfin reads on every version (including
 	// 10.12+/12 which disable legacy auth); api_key is the legacy alias that
@@ -575,6 +577,8 @@ func (c *Client) ReportNowPlaying(track playlist.Track, position time.Duration, 
 	})
 }
 
+// ReportScrobble reports playback progress and a stop event for the given
+// track to the server.
 func (c *Client) ReportScrobble(track playlist.Track, elapsed time.Duration, canSeek bool) error {
 	progress := playbackInfo{
 		CanSeek:       canSeek,
@@ -608,6 +612,8 @@ func (e *httpError) Error() string {
 	return fmt.Sprintf("%s: %s: http status %s", e.dialect, e.path, e.status)
 }
 
+// get executes a GET request against the endpoint, unmarshaling JSON into out
+// on success and returning a typed httpError for non-200 responses.
 func (c *Client) get(p string, params url.Values, out any) error {
 	if err := c.ensureAuth(); err != nil {
 		return err

--- a/internal/embyapi/client.go
+++ b/internal/embyapi/client.go
@@ -7,6 +7,7 @@ package embyapi
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -195,10 +196,15 @@ func (c *Client) Ping() error {
 	var raw json.RawMessage
 	if err := c.get(c.dialect.pingPath(), nil, &raw); err == nil {
 		return nil
-	} else if c.user == "" && c.password == "" {
-		// API keys aren't owned by a user, so /Users/Me returns 400.
-		// Fall back to listing /Users to prove the key is valid.
-		return c.get("/Users", nil, &raw)
+	} else if c.dialect.name() == "jellyfin" && c.user == "" && c.password == "" {
+		var httpErr *httpError
+		if errors.As(err, &httpErr) && httpErr.statusCode == http.StatusBadRequest {
+			// API keys aren't owned by a user, so /Users/Me returns a 400
+			// (documented as "Token is not owned by a user.", sent without a
+			// body). Fall back to listing /Users to prove the key is valid.
+			return c.get("/Users", nil, &raw)
+		}
+		return err
 	} else {
 		return err
 	}
@@ -587,6 +593,20 @@ func (c *Client) ReportScrobble(track playlist.Track, elapsed time.Duration, can
 	})
 }
 
+// httpError records an HTTP error response from an Emby or Jellyfin server.
+type httpError struct {
+	dialect    string
+	path       string
+	statusCode int
+	status     string
+	body       string
+}
+
+// Error returns the formatted error string without raw response bodies.
+func (e *httpError) Error() string {
+	return fmt.Sprintf("%s: %s: http status %s", e.dialect, e.path, e.status)
+}
+
 func (c *Client) get(p string, params url.Values, out any) error {
 	if err := c.ensureAuth(); err != nil {
 		return err
@@ -606,7 +626,18 @@ func (c *Client) get(p string, params url.Values, out any) error {
 	switch resp.StatusCode {
 	case http.StatusOK:
 	default:
-		return fmt.Errorf("%s: %s: http status %s", c.dialect.name(), p, resp.Status)
+		var bodyStr string
+		if resp.Body != nil {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+			bodyStr = strings.TrimSpace(string(body))
+		}
+		return &httpError{
+			dialect:    c.dialect.name(),
+			path:       p,
+			statusCode: resp.StatusCode,
+			status:     resp.Status,
+			body:       bodyStr,
+		}
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBody))

--- a/internal/embyapi/client.go
+++ b/internal/embyapi/client.go
@@ -193,7 +193,15 @@ type playbackStopInfo struct {
 // Ping checks that the server is reachable and the token is accepted.
 func (c *Client) Ping() error {
 	var raw json.RawMessage
-	return c.get(c.dialect.pingPath(), nil, &raw)
+	if err := c.get(c.dialect.pingPath(), nil, &raw); err == nil {
+		return nil
+	} else if c.user == "" && c.password == "" {
+		// API keys aren't owned by a user, so /Users/Me returns 400.
+		// Fall back to listing /Users to prove the key is valid.
+		return c.get("/Users", nil, &raw)
+	} else {
+		return err
+	}
 }
 
 // UserID returns the active user id, discovering it lazily when needed.
@@ -529,7 +537,14 @@ func (c *Client) StreamURL(itemID string) string {
 }
 
 func (c *Client) streamURL(itemID, token string) string {
-	v := url.Values{"api_key": {token}}
+	// ApiKey is the auth query param Jellyfin reads on every version (including
+	// 10.12+/12 which disable legacy auth); api_key is the legacy alias that
+	// older servers still accept. Send both so buffered stream requests that
+	// carry no headers work on any server.
+	v := url.Values{
+		"ApiKey":  {token},
+		"api_key": {token},
+	}
 
 	// Use the direct item download route rather than the Audio controller.
 	// On the live servers used for validation, the Audio endpoints returned

--- a/internal/embyapi/client.go
+++ b/internal/embyapi/client.go
@@ -566,6 +566,7 @@ func (c *Client) streamURL(itemID, token string) string {
 	return u
 }
 
+// ReportNowPlaying reports the currently playing track to the server.
 func (c *Client) ReportNowPlaying(track playlist.Track, position time.Duration, canSeek bool) error {
 	return c.postJSON("/Sessions/Playing", playbackInfo{
 		CanSeek:       canSeek,

--- a/internal/embyapi/client_test.go
+++ b/internal/embyapi/client_test.go
@@ -57,6 +57,8 @@ func TestEmbyPingUsesSystemInfo(t *testing.T) {
 	}
 }
 
+// TestJellyfinPingUsesUsersMe verifies that Ping hits the /Users/Me endpoint
+// for Jellyfin.
 func TestJellyfinPingUsesUsersMe(t *testing.T) {
 	c := mock(NewJellyfinClient("https://jf.example.com", "tok", "user-1", "", ""), func(req *http.Request) (*http.Response, error) {
 		if req.URL.Path != "/Users/Me" {
@@ -510,6 +512,8 @@ func TestAlbumsByLibrary(t *testing.T) {
 	}
 }
 
+// TestTracksParsing verifies that track dictionaries are parsed from the
+// server's Items response.
 func TestTracksParsing(t *testing.T) {
 	c := mock(NewJellyfinClient("https://jf.example.com", "tok", "user-1", "", ""), func(req *http.Request) (*http.Response, error) {
 		if req.URL.Path != "/Items" || req.URL.Query().Get("includeItemTypes") != "Audio" {
@@ -573,6 +577,8 @@ func TestStreamURLFromCurrentAuth(t *testing.T) {
 	}
 }
 
+// TestStreamItemID verifies that StreamItemID extracts the item id only from
+// URLs matching the configured server and download route.
 func TestStreamItemID(t *testing.T) {
 	c := NewJellyfinClient("https://jf.example.com/media", "new-token", "user-1", "", "")
 	tests := []struct {
@@ -633,6 +639,8 @@ func TestResolveSourceAuthenticatesWithPassword(t *testing.T) {
 	}
 }
 
+// TestResolveSourceAuthenticationFailure verifies that source resolution
+// returns no URL and surfaces the authentication error.
 func TestResolveSourceAuthenticationFailure(t *testing.T) {
 	c := mock(NewJellyfinClient("https://jf.example.com", "", "", "user", "password"), func(req *http.Request) (*http.Response, error) {
 		return &http.Response{

--- a/internal/embyapi/client_test.go
+++ b/internal/embyapi/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -69,12 +70,14 @@ func TestJellyfinPingUsesUsersMe(t *testing.T) {
 }
 
 func TestJellyfinPingAPIKeyFallsBackToUsers(t *testing.T) {
-	// API keys aren't owned by a user, so /Users/Me returns 400; /Users must
-	// succeed to prove the key is valid.
+	// API keys aren't owned by a user, so /Users/Me returns an empty-body 400;
+	// /Users must succeed to prove the key is valid.
+	var requested []string
 	c := mock(NewJellyfinClient("https://jf.example.com", "tok", "", "", ""), func(req *http.Request) (*http.Response, error) {
+		requested = append(requested, req.URL.Path)
 		switch req.URL.Path {
 		case "/Users/Me":
-			return &http.Response{StatusCode: 400, Status: "400 Bad Request", Body: io.NopCloser(bytes.NewBuffer([]byte("Token is not owned by a user.")))}, nil
+			return &http.Response{StatusCode: 400, Status: "400 Bad Request", Body: io.NopCloser(bytes.NewBuffer(nil))}, nil
 		case "/Users":
 			return jsonResponse(`[{"Id":"user-1","Name":"Alice"}]`), nil
 		default:
@@ -85,10 +88,15 @@ func TestJellyfinPingAPIKeyFallsBackToUsers(t *testing.T) {
 	if err := c.Ping(); err != nil {
 		t.Fatalf("Ping() with API key error: %v", err)
 	}
+	if len(requested) != 2 || requested[0] != "/Users/Me" || requested[1] != "/Users" {
+		t.Fatalf("requested paths = %v, want [/Users/Me, /Users]", requested)
+	}
 }
 
 func TestJellyfinPingAPIKeyBadTokenFails(t *testing.T) {
+	var requested []string
 	c := mock(NewJellyfinClient("https://jf.example.com", "bad-tok", "", "", ""), func(req *http.Request) (*http.Response, error) {
+		requested = append(requested, req.URL.Path)
 		switch req.URL.Path {
 		case "/Users/Me":
 			return &http.Response{StatusCode: 400, Status: "400 Bad Request", Body: io.NopCloser(bytes.NewBuffer(nil))}, nil
@@ -101,6 +109,67 @@ func TestJellyfinPingAPIKeyBadTokenFails(t *testing.T) {
 	})
 	if err := c.Ping(); err == nil {
 		t.Fatal("Ping() with invalid API key succeeded, want error")
+	}
+	if len(requested) != 2 || requested[0] != "/Users/Me" || requested[1] != "/Users" {
+		t.Fatalf("requested paths = %v, want [/Users/Me, /Users]", requested)
+	}
+}
+
+func TestJellyfinPingUnrelatedErrorDoesNotFallBackToUsers(t *testing.T) {
+	// /Users/Me failing with an error other than the API-key response must not
+	// trigger the /Users fallback.
+	c := mock(NewJellyfinClient("https://jf.example.com", "tok", "", "", ""), func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/Users/Me":
+			return &http.Response{StatusCode: 500, Status: "500 Internal Server Error", Body: io.NopCloser(bytes.NewBuffer([]byte("server error")))}, nil
+		case "/Users":
+			t.Fatal("unexpected fallback to /Users on server error")
+			return jsonResponse(`[{"Id":"user-1","Name":"Alice"}]`), nil
+		default:
+			t.Fatalf("unexpected path %s", req.URL.Path)
+			return nil, nil
+		}
+	})
+	if err := c.Ping(); err == nil {
+		t.Fatal("Ping() succeeded on 500 error, want error")
+	}
+}
+
+func TestJellyfinPingNon400WithTokenMessageDoesNotFallBackToUsers(t *testing.T) {
+	// A non-400 response carrying the API-key message must not fall back.
+	c := mock(NewJellyfinClient("https://jf.example.com", "tok", "", "", ""), func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/Users/Me":
+			return &http.Response{StatusCode: 401, Status: "401 Unauthorized", Body: io.NopCloser(bytes.NewBuffer([]byte("Token is not owned by a user.")))}, nil
+		case "/Users":
+			t.Fatal("unexpected fallback to /Users on non-400 response")
+			return jsonResponse(`[{"Id":"user-1","Name":"Alice"}]`), nil
+		default:
+			t.Fatalf("unexpected path %s", req.URL.Path)
+			return nil, nil
+		}
+	})
+	if err := c.Ping(); err == nil {
+		t.Fatal("Ping() succeeded on 401 error, want error")
+	}
+}
+
+func TestEmbyPingFailureDoesNotFallBackToUsers(t *testing.T) {
+	// Emby ping failures must return the original error, never fall back.
+	c := mock(NewEmbyClient("https://emby.example.com", "tok", "", "", ""), func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/System/Info":
+			return &http.Response{StatusCode: 401, Status: "401 Unauthorized", Body: io.NopCloser(bytes.NewBuffer(nil))}, nil
+		case "/Users":
+			t.Fatal("unexpected fallback to /Users on Emby ping failure")
+			return jsonResponse(`[{"Id":"user-1","Name":"Alice"}]`), nil
+		default:
+			t.Fatalf("unexpected path %s", req.URL.Path)
+			return nil, nil
+		}
+	})
+	if err := c.Ping(); err == nil {
+		t.Fatal("Ping() succeeded on Emby 401 error, want error")
 	}
 }
 
@@ -412,8 +481,20 @@ func TestStreamURL(t *testing.T) {
 
 func TestStreamURLFromCurrentAuth(t *testing.T) {
 	withToken := NewJellyfinClient("https://jf.example.com", "token", "user-1", "", "")
-	if got, ok := withToken.StreamURLFromCurrentAuth("track-1"); !ok || !strings.Contains(got, "api_key=token") {
-		t.Fatalf("StreamURLFromCurrentAuth() = (%q, %v), want current token", got, ok)
+	got, ok := withToken.StreamURLFromCurrentAuth("track-1")
+	if !ok {
+		t.Fatalf("StreamURLFromCurrentAuth() ok = false, want true")
+	}
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("StreamURLFromCurrentAuth() returned invalid URL %q: %v", got, err)
+	}
+	q := u.Query()
+	if q.Get("api_key") != "token" {
+		t.Fatalf("api_key = %q, want token (URL %q)", q.Get("api_key"), got)
+	}
+	if q.Get("ApiKey") != "token" {
+		t.Fatalf("ApiKey = %q, want token (URL %q)", q.Get("ApiKey"), got)
 	}
 
 	passwordOnly := NewJellyfinClient("https://jf.example.com", "", "", "user", "password")

--- a/internal/embyapi/client_test.go
+++ b/internal/embyapi/client_test.go
@@ -69,6 +69,8 @@ func TestJellyfinPingUsesUsersMe(t *testing.T) {
 	}
 }
 
+// TestJellyfinPingAPIKeyFallsBackToUsers verifies that Ping falls back to the
+// /Users listing when /Users/Me returns a 400 for a server-level API key.
 func TestJellyfinPingAPIKeyFallsBackToUsers(t *testing.T) {
 	// API keys aren't owned by a user, so /Users/Me returns an empty-body 400;
 	// /Users must succeed to prove the key is valid.
@@ -93,6 +95,8 @@ func TestJellyfinPingAPIKeyFallsBackToUsers(t *testing.T) {
 	}
 }
 
+// TestJellyfinPingAPIKeyWithUsernameFallsBackToUsers verifies that a username
+// configured alongside an API key still falls back to /Users.
 func TestJellyfinPingAPIKeyWithUsernameFallsBackToUsers(t *testing.T) {
 	// A username configured alongside an API key must not block the fallback:
 	// /Users/Me still returns 400 because the key isn't owned by a user.
@@ -117,6 +121,8 @@ func TestJellyfinPingAPIKeyWithUsernameFallsBackToUsers(t *testing.T) {
 	}
 }
 
+// TestJellyfinPingAPIKeyBadTokenFails verifies that Ping fails when an invalid
+// API key is rejected by both /Users/Me and /Users.
 func TestJellyfinPingAPIKeyBadTokenFails(t *testing.T) {
 	var requested []string
 	c := mock(NewJellyfinClient("https://jf.example.com", "bad-tok", "", "", ""), func(req *http.Request) (*http.Response, error) {
@@ -139,6 +145,8 @@ func TestJellyfinPingAPIKeyBadTokenFails(t *testing.T) {
 	}
 }
 
+// TestJellyfinPingUnrelatedErrorDoesNotFallBackToUsers verifies that a ping
+// failure other than the API-key 400 does not trigger the /Users fallback.
 func TestJellyfinPingUnrelatedErrorDoesNotFallBackToUsers(t *testing.T) {
 	// /Users/Me failing with an error other than the API-key response must not
 	// trigger the /Users fallback.
@@ -159,6 +167,8 @@ func TestJellyfinPingUnrelatedErrorDoesNotFallBackToUsers(t *testing.T) {
 	}
 }
 
+// TestJellyfinPingNon400WithTokenMessageDoesNotFallBackToUsers verifies that a
+// non-400 response carrying the API-key message does not trigger the fallback.
 func TestJellyfinPingNon400WithTokenMessageDoesNotFallBackToUsers(t *testing.T) {
 	// A non-400 response carrying the API-key message must not fall back.
 	c := mock(NewJellyfinClient("https://jf.example.com", "tok", "", "", ""), func(req *http.Request) (*http.Response, error) {
@@ -178,6 +188,8 @@ func TestJellyfinPingNon400WithTokenMessageDoesNotFallBackToUsers(t *testing.T) 
 	}
 }
 
+// TestEmbyPingFailureDoesNotFallBackToUsers verifies that Emby ping failures
+// never fall back to /Users.
 func TestEmbyPingFailureDoesNotFallBackToUsers(t *testing.T) {
 	// Emby ping failures must return the original error, never fall back.
 	c := mock(NewEmbyClient("https://emby.example.com", "tok", "", "", ""), func(req *http.Request) (*http.Response, error) {
@@ -197,6 +209,8 @@ func TestEmbyPingFailureDoesNotFallBackToUsers(t *testing.T) {
 	}
 }
 
+// TestJellyfinUserIDAPIKeyFallback verifies that user-id discovery falls back
+// to /Users and picks a user when authenticated with an API key.
 func TestJellyfinUserIDAPIKeyFallback(t *testing.T) {
 	// /Users/Me returns 400 for API keys; fall back to /Users and pick the
 	// first user.
@@ -225,6 +239,8 @@ func TestJellyfinUserIDAPIKeyFallback(t *testing.T) {
 	}
 }
 
+// TestJellyfinUserIDNon400ErrorNotMaskedByFallback verifies that a non-400
+// /Users/Me failure surfaces through UserID instead of the /Users fallback.
 func TestJellyfinUserIDNon400ErrorNotMaskedByFallback(t *testing.T) {
 	// A non-400 failure of /Users/Me must surface through UserID instead of
 	// being masked by the /Users fallback.
@@ -514,6 +530,8 @@ func TestTracksParsing(t *testing.T) {
 	}
 }
 
+// TestStreamURL verifies that StreamURL builds the download URL with both the
+// modern ApiKey and legacy api_key query parameters.
 func TestStreamURL(t *testing.T) {
 	c := NewEmbyClient("https://emby.example.com", "tok", "user-1", "", "")
 	u := c.StreamURL("track-1")
@@ -528,6 +546,9 @@ func TestStreamURL(t *testing.T) {
 	}
 }
 
+// TestStreamURLFromCurrentAuth verifies that StreamURLFromCurrentAuth embeds
+// the current token as both ApiKey and api_key, and returns no URL before
+// password authentication completes.
 func TestStreamURLFromCurrentAuth(t *testing.T) {
 	withToken := NewJellyfinClient("https://jf.example.com", "token", "user-1", "", "")
 	got, ok := withToken.StreamURLFromCurrentAuth("track-1")
@@ -575,6 +596,8 @@ func TestStreamItemID(t *testing.T) {
 	}
 }
 
+// TestResolveSourceAuthenticatesWithPassword verifies that source resolution
+// authenticates via password when no token is present and appends auth params.
 func TestResolveSourceAuthenticatesWithPassword(t *testing.T) {
 	for _, baseURL := range []string{"https://jf.example.com/media", "http://jf.lan:8096/media"} {
 		t.Run(baseURL, func(t *testing.T) {
@@ -627,6 +650,8 @@ func TestResolveSourceAuthenticationFailure(t *testing.T) {
 	}
 }
 
+// TestResolveSourceWithTokenDoesNotRequest ensures that resolving a stream URL
+// with a configured token sends no authentication request.
 func TestResolveSourceWithTokenDoesNotRequest(t *testing.T) {
 	c := mock(NewJellyfinClient("https://jf.example.com/media", "new-token", "", "", ""), func(req *http.Request) (*http.Response, error) {
 		t.Fatalf("unexpected request with configured token: %s", req.URL)

--- a/internal/embyapi/client_test.go
+++ b/internal/embyapi/client_test.go
@@ -93,6 +93,25 @@ func TestJellyfinPingAPIKeyFallsBackToUsers(t *testing.T) {
 	}
 }
 
+func TestJellyfinPingAPIKeyWithUsernameFallsBackToUsers(t *testing.T) {
+	// A username configured alongside an API key must not block the fallback:
+	// /Users/Me still returns 400 because the key isn't owned by a user.
+	c := mock(NewJellyfinClient("https://jf.example.com", "tok", "", "alice", ""), func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/Users/Me":
+			return &http.Response{StatusCode: 400, Status: "400 Bad Request", Body: io.NopCloser(bytes.NewBuffer(nil))}, nil
+		case "/Users":
+			return jsonResponse(`[{"Id":"user-1","Name":"Alice"}]`), nil
+		default:
+			t.Fatalf("unexpected path %s", req.URL.Path)
+			return nil, nil
+		}
+	})
+	if err := c.Ping(); err != nil {
+		t.Fatalf("Ping() with API key + username error: %v", err)
+	}
+}
+
 func TestJellyfinPingAPIKeyBadTokenFails(t *testing.T) {
 	var requested []string
 	c := mock(NewJellyfinClient("https://jf.example.com", "bad-tok", "", "", ""), func(req *http.Request) (*http.Response, error) {
@@ -198,6 +217,31 @@ func TestJellyfinUserIDAPIKeyFallback(t *testing.T) {
 	}
 	if len(libs) != 1 || libs[0].ID != "lib-1" {
 		t.Fatalf("libraries = %+v", libs)
+	}
+}
+
+func TestJellyfinUserIDNon400ErrorNotMaskedByFallback(t *testing.T) {
+	// A non-400 failure of /Users/Me must surface through UserID instead of
+	// being masked by the /Users fallback.
+	var requested []string
+	c := mock(NewJellyfinClient("https://jf.example.com", "tok", "", "", ""), func(req *http.Request) (*http.Response, error) {
+		requested = append(requested, req.URL.Path)
+		switch req.URL.Path {
+		case "/Users/Me":
+			return &http.Response{StatusCode: 401, Status: "401 Unauthorized", Body: io.NopCloser(bytes.NewBuffer(nil))}, nil
+		case "/Users":
+			t.Fatal("unexpected fallback to /Users on 401 response")
+			return jsonResponse(`[{"Id":"user-1","Name":"Alice"}]`), nil
+		default:
+			t.Fatalf("unexpected path %s", req.URL.Path)
+			return nil, nil
+		}
+	})
+	if _, err := c.UserID(); err == nil {
+		t.Fatal("UserID() succeeded on 401 error, want error")
+	}
+	if len(requested) != 1 || requested[0] != "/Users/Me" {
+		t.Fatalf("requested paths = %v, want [/Users/Me] only", requested)
 	}
 }
 

--- a/internal/embyapi/client_test.go
+++ b/internal/embyapi/client_test.go
@@ -96,7 +96,9 @@ func TestJellyfinPingAPIKeyFallsBackToUsers(t *testing.T) {
 func TestJellyfinPingAPIKeyWithUsernameFallsBackToUsers(t *testing.T) {
 	// A username configured alongside an API key must not block the fallback:
 	// /Users/Me still returns 400 because the key isn't owned by a user.
+	var requested []string
 	c := mock(NewJellyfinClient("https://jf.example.com", "tok", "", "alice", ""), func(req *http.Request) (*http.Response, error) {
+		requested = append(requested, req.URL.Path)
 		switch req.URL.Path {
 		case "/Users/Me":
 			return &http.Response{StatusCode: 400, Status: "400 Bad Request", Body: io.NopCloser(bytes.NewBuffer(nil))}, nil
@@ -109,6 +111,9 @@ func TestJellyfinPingAPIKeyWithUsernameFallsBackToUsers(t *testing.T) {
 	})
 	if err := c.Ping(); err != nil {
 		t.Fatalf("Ping() with API key + username error: %v", err)
+	}
+	if len(requested) != 2 || requested[0] != "/Users/Me" || requested[1] != "/Users" {
+		t.Fatalf("requested paths = %v, want [/Users/Me, /Users]", requested)
 	}
 }
 

--- a/internal/embyapi/client_test.go
+++ b/internal/embyapi/client_test.go
@@ -68,6 +68,70 @@ func TestJellyfinPingUsesUsersMe(t *testing.T) {
 	}
 }
 
+func TestJellyfinPingAPIKeyFallsBackToUsers(t *testing.T) {
+	// API keys aren't owned by a user, so /Users/Me returns 400; /Users must
+	// succeed to prove the key is valid.
+	c := mock(NewJellyfinClient("https://jf.example.com", "tok", "", "", ""), func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/Users/Me":
+			return &http.Response{StatusCode: 400, Status: "400 Bad Request", Body: io.NopCloser(bytes.NewBuffer([]byte("Token is not owned by a user.")))}, nil
+		case "/Users":
+			return jsonResponse(`[{"Id":"user-1","Name":"Alice"}]`), nil
+		default:
+			t.Fatalf("unexpected path %s", req.URL.Path)
+			return nil, nil
+		}
+	})
+	if err := c.Ping(); err != nil {
+		t.Fatalf("Ping() with API key error: %v", err)
+	}
+}
+
+func TestJellyfinPingAPIKeyBadTokenFails(t *testing.T) {
+	c := mock(NewJellyfinClient("https://jf.example.com", "bad-tok", "", "", ""), func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/Users/Me":
+			return &http.Response{StatusCode: 400, Status: "400 Bad Request", Body: io.NopCloser(bytes.NewBuffer(nil))}, nil
+		case "/Users":
+			return &http.Response{StatusCode: 401, Status: "401 Unauthorized", Body: io.NopCloser(bytes.NewBuffer(nil))}, nil
+		default:
+			t.Fatalf("unexpected path %s", req.URL.Path)
+			return nil, nil
+		}
+	})
+	if err := c.Ping(); err == nil {
+		t.Fatal("Ping() with invalid API key succeeded, want error")
+	}
+}
+
+func TestJellyfinUserIDAPIKeyFallback(t *testing.T) {
+	// /Users/Me returns 400 for API keys; fall back to /Users and pick the
+	// first user.
+	c := mock(NewJellyfinClient("https://jf.example.com", "tok", "", "", ""), func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/Users/Me":
+			return &http.Response{StatusCode: 400, Status: "400 Bad Request", Body: io.NopCloser(bytes.NewBuffer(nil))}, nil
+		case "/Users":
+			return jsonResponse(`[{"Id":"user-1","Name":"Alice"}]`), nil
+		case "/Users/user-1/Views":
+			return jsonResponse(`{"Items":[{"Id":"lib-1","Name":"Music","CollectionType":"music"}]}`), nil
+		default:
+			t.Fatalf("unexpected path %s", req.URL.Path)
+			return nil, nil
+		}
+	})
+	libs, err := c.MusicLibraries()
+	if err != nil {
+		t.Fatalf("MusicLibraries() error: %v", err)
+	}
+	if c.userID != "user-1" {
+		t.Fatalf("userID = %q after API key fallback, want user-1", c.userID)
+	}
+	if len(libs) != 1 || libs[0].ID != "lib-1" {
+		t.Fatalf("libraries = %+v", libs)
+	}
+}
+
 // --- Dialect-specific: Emby API-key user-id fallback ---
 
 func TestEmbyUserIDAPIKeyFallback(t *testing.T) {
@@ -341,6 +405,9 @@ func TestStreamURL(t *testing.T) {
 	if !strings.Contains(u, "api_key=tok") {
 		t.Fatalf("URL missing api_key: %q", u)
 	}
+	if !strings.Contains(u, "ApiKey=tok") {
+		t.Fatalf("URL missing ApiKey: %q", u)
+	}
 }
 
 func TestStreamURLFromCurrentAuth(t *testing.T) {
@@ -402,7 +469,7 @@ func TestResolveSourceAuthenticatesWithPassword(t *testing.T) {
 				if err != nil {
 					t.Fatalf("ResolveSource() error: %v", err)
 				}
-				if want := baseURL + "/Items/" + itemID + "/Download?api_key=new-token"; got != want {
+				if want := baseURL + "/Items/" + itemID + "/Download?ApiKey=new-token&api_key=new-token"; got != want {
 					t.Fatalf("ResolveSource() = %q, want %q", got, want)
 				}
 			}
@@ -439,7 +506,7 @@ func TestResolveSourceWithTokenDoesNotRequest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolveSource() error: %v", err)
 	}
-	if want := "https://jf.example.com/media/Items/track-1/Download?api_key=new-token"; got != want {
+	if want := "https://jf.example.com/media/Items/track-1/Download?ApiKey=new-token&api_key=new-token"; got != want {
 		t.Fatalf("ResolveSource() = %q, want %q", got, want)
 	}
 }

--- a/internal/embyapi/client_test.go
+++ b/internal/embyapi/client_test.go
@@ -268,6 +268,31 @@ func TestJellyfinUserIDNon400ErrorNotMaskedByFallback(t *testing.T) {
 	}
 }
 
+// TestJellyfinUserIDEmptyMeResponseErrors verifies that a /Users/Me 200 with an
+// empty user id fails immediately instead of entering the /Users fallback.
+func TestJellyfinUserIDEmptyMeResponseErrors(t *testing.T) {
+	var requested []string
+	c := mock(NewJellyfinClient("https://jf.example.com", "tok", "", "", ""), func(req *http.Request) (*http.Response, error) {
+		requested = append(requested, req.URL.Path)
+		switch req.URL.Path {
+		case "/Users/Me":
+			return jsonResponse(`{}`), nil
+		case "/Users":
+			t.Fatal("unexpected fallback to /Users on empty /Users/Me response")
+			return jsonResponse(`[{"Id":"user-1","Name":"Alice"}]`), nil
+		default:
+			t.Fatalf("unexpected path %s", req.URL.Path)
+			return nil, nil
+		}
+	})
+	if _, err := c.UserID(); err == nil {
+		t.Fatal("UserID() succeeded with empty /Users/Me id, want error")
+	}
+	if len(requested) != 1 || requested[0] != "/Users/Me" {
+		t.Fatalf("requested paths = %v, want [/Users/Me] only", requested)
+	}
+}
+
 // --- Dialect-specific: Emby API-key user-id fallback ---
 
 func TestEmbyUserIDAPIKeyFallback(t *testing.T) {

--- a/internal/embyapi/dialect.go
+++ b/internal/embyapi/dialect.go
@@ -1,6 +1,7 @@
 package embyapi
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -105,9 +106,18 @@ func (jellyfinDialect) applyAuth(req *http.Request, token, _, deviceID string) {
 func (jellyfinDialect) discoverUserID(c *Client) (string, error) {
 	// Try /Users/Me first (works for session tokens from password auth).
 	var me userDTO
-	if err := c.get("/Users/Me", nil, &me); err == nil && me.ID != "" {
+	meErr := c.get("/Users/Me", nil, &me)
+	if meErr == nil && me.ID != "" {
 		c.setUserID(me.ID)
 		return me.ID, nil
+	}
+
+	// API-key auth is the only case where /Users/Me legitimately fails (a key
+	// isn't owned by a user, so it returns 400). Preserve every other error so
+	// 401/403/5xx responses surface through UserID instead of being masked.
+	var httpErr *httpError
+	if meErr != nil && !(errors.As(meErr, &httpErr) && httpErr.statusCode == http.StatusBadRequest) {
+		return "", meErr
 	}
 
 	// Fall back to /Users for API key auth (a key isn't owned by a user, so

--- a/internal/embyapi/dialect.go
+++ b/internal/embyapi/dialect.go
@@ -92,6 +92,9 @@ func (jellyfinDialect) name() string     { return "jellyfin" }
 func (jellyfinDialect) pingPath() string { return "/Users/Me" }
 func (jellyfinDialect) metaKey() string  { return provider.MetaJellyfinID }
 
+// applyAuth sets Jellyfin authorization headers on req, using both the
+// standard Authorization and legacy X-Emby-Authorization headers for
+// compatibility across server versions.
 func (jellyfinDialect) applyAuth(req *http.Request, token, _, deviceID string) {
 	auth := fmt.Sprintf(`MediaBrowser Client="%s", Device="%s", DeviceId="%s", Version="%s"`,
 		appmeta.ClientName(), appmeta.DeviceName(), deviceID, appmeta.Version())
@@ -103,6 +106,8 @@ func (jellyfinDialect) applyAuth(req *http.Request, token, _, deviceID string) {
 	req.Header.Set("X-Emby-Authorization", auth)
 }
 
+// discoverUserID resolves the user id via /Users/Me, falling back to the
+// /Users listing only for the API-key case where /Users/Me returns 400.
 func (jellyfinDialect) discoverUserID(c *Client) (string, error) {
 	// Try /Users/Me first (works for session tokens from password auth).
 	var me userDTO

--- a/internal/embyapi/dialect.go
+++ b/internal/embyapi/dialect.go
@@ -116,16 +116,19 @@ func (jellyfinDialect) discoverUserID(c *Client) (string, error) {
 	// Try /Users/Me first (works for session tokens from password auth).
 	var me userDTO
 	meErr := c.get("/Users/Me", nil, &me)
-	if meErr == nil && me.ID != "" {
-		c.setUserID(me.ID)
-		return me.ID, nil
+	if meErr == nil {
+		if me.ID != "" {
+			c.setUserID(me.ID)
+			return me.ID, nil
+		}
+		return "", fmt.Errorf("jellyfin: current user response missing id")
 	}
 
 	// API-key auth is the only case where /Users/Me legitimately fails (a key
 	// isn't owned by a user, so it returns 400). Preserve every other error so
 	// 401/403/5xx responses surface through UserID instead of being masked.
 	var httpErr *httpError
-	if meErr != nil && !(errors.As(meErr, &httpErr) && httpErr.statusCode == http.StatusBadRequest) {
+	if !(errors.As(meErr, &httpErr) && httpErr.statusCode == http.StatusBadRequest) {
 		return "", fmt.Errorf("jellyfin: could not discover user id: %w", meErr)
 	}
 

--- a/internal/embyapi/dialect.go
+++ b/internal/embyapi/dialect.go
@@ -81,8 +81,10 @@ func embyAuthHeader(userID, token, deviceID string) string {
 		appmeta.ClientName(), appmeta.DeviceName(), deviceID, appmeta.Version(), token)
 }
 
-// jellyfinDialect speaks Jellyfin's `X-Emby-Authorization: MediaBrowser ...`
-// scheme and discovers the user id from /Users/Me only.
+// jellyfinDialect speaks Jellyfin's `MediaBrowser ...` auth scheme. Newer
+// servers (10.11.2+, 10.12) read the client from the standard Authorization
+// header on /Users/AuthenticateByName; older servers read X-Emby-Authorization.
+// We send both.
 type jellyfinDialect struct{}
 
 func (jellyfinDialect) name() string     { return "jellyfin" }
@@ -90,22 +92,43 @@ func (jellyfinDialect) pingPath() string { return "/Users/Me" }
 func (jellyfinDialect) metaKey() string  { return provider.MetaJellyfinID }
 
 func (jellyfinDialect) applyAuth(req *http.Request, token, _, deviceID string) {
+	auth := fmt.Sprintf(`MediaBrowser Client="%s", Device="%s", DeviceId="%s", Version="%s"`,
+		appmeta.ClientName(), appmeta.DeviceName(), deviceID, appmeta.Version())
 	if token != "" {
+		auth += fmt.Sprintf(`, Token="%s"`, token)
 		req.Header.Set("X-Emby-Token", token)
 	}
-	req.Header.Set("X-Emby-Authorization",
-		fmt.Sprintf(`MediaBrowser Client="%s", Device="%s", DeviceId="%s", Version="%s"`,
-			appmeta.ClientName(), appmeta.DeviceName(), deviceID, appmeta.Version()))
+	req.Header.Set("Authorization", auth)
+	req.Header.Set("X-Emby-Authorization", auth)
 }
 
 func (jellyfinDialect) discoverUserID(c *Client) (string, error) {
-	var u userDTO
-	if err := c.get("/Users/Me", nil, &u); err != nil {
-		return "", err
+	// Try /Users/Me first (works for session tokens from password auth).
+	var me userDTO
+	if err := c.get("/Users/Me", nil, &me); err == nil && me.ID != "" {
+		c.setUserID(me.ID)
+		return me.ID, nil
 	}
-	if u.ID == "" {
-		return "", fmt.Errorf("jellyfin: current user response missing id")
+
+	// Fall back to /Users for API key auth (a key isn't owned by a user, so
+	// /Users/Me returns 400).
+	var users []userDTO
+	if err := c.get("/Users", nil, &users); err != nil {
+		return "", fmt.Errorf("jellyfin: could not discover user id (set user_id in config): %w", err)
 	}
-	c.setUserID(u.ID)
-	return u.ID, nil
+	// Prefer user matching the configured username; otherwise take first entry.
+	for _, user := range users {
+		if strings.EqualFold(user.Name, c.user) {
+			c.setUserID(user.ID)
+			return user.ID, nil
+		}
+	}
+	if c.user != "" {
+		return "", fmt.Errorf("jellyfin: user %q not found — check the user name in config", c.user)
+	}
+	if len(users) > 0 && users[0].ID != "" {
+		c.setUserID(users[0].ID)
+		return users[0].ID, nil
+	}
+	return "", fmt.Errorf("jellyfin: could not discover user id — set user_id in config")
 }

--- a/internal/embyapi/dialect.go
+++ b/internal/embyapi/dialect.go
@@ -117,7 +117,7 @@ func (jellyfinDialect) discoverUserID(c *Client) (string, error) {
 	// 401/403/5xx responses surface through UserID instead of being masked.
 	var httpErr *httpError
 	if meErr != nil && !(errors.As(meErr, &httpErr) && httpErr.statusCode == http.StatusBadRequest) {
-		return "", meErr
+		return "", fmt.Errorf("jellyfin: could not discover user id: %w", meErr)
 	}
 
 	// Fall back to /Users for API key auth (a key isn't owned by a user, so

--- a/internal/embyapi/dialect.go
+++ b/internal/embyapi/dialect.go
@@ -73,6 +73,8 @@ func embyUnauthHeader(deviceID string) string {
 		appmeta.ClientName(), appmeta.DeviceName(), deviceID, appmeta.Version())
 }
 
+// embyAuthHeader builds Emby's Authorization header value for the given
+// device, user, and token.
 func embyAuthHeader(userID, token, deviceID string) string {
 	if userID != "" {
 		return fmt.Sprintf(`Emby UserId="%s", Client="%s", Device="%s", DeviceId="%s", Version="%s", Token="%s"`,
@@ -90,7 +92,9 @@ type jellyfinDialect struct{}
 
 func (jellyfinDialect) name() string     { return "jellyfin" }
 func (jellyfinDialect) pingPath() string { return "/Users/Me" }
-func (jellyfinDialect) metaKey() string  { return provider.MetaJellyfinID }
+
+// metaKey returns the ProviderMeta key Jellyfin item ids are stored under.
+func (jellyfinDialect) metaKey() string { return provider.MetaJellyfinID }
 
 // applyAuth sets Jellyfin authorization headers on req, using both the
 // standard Authorization and legacy X-Emby-Authorization headers for


### PR DESCRIPTION
## Summary

Fixes Jellyfin authentication and streaming on Jellyfin 12 (and 10.11.2+), where legacy auth handling broke both the connection check (`Ping`) and track playback.

## What changed

- **Auth headers**: Jellyfin 10.11.2+/12 read the client identity from the standard `Authorization` header on `/Users/AuthenticateByName`, while older servers read `X-Emby-Authorization`. The Jellyfin dialect now sends both (`MediaBrowser ...` scheme), keeping the legacy header for older servers.
- **Stream URLs**: Item download URLs now carry both the `ApiKey` and the legacy `api_key` query parameters, so buffered stream requests that carry no headers work on any server version.
- **User-id discovery**: `/Users/Me` returns 400 for server-level API keys because a key isn't owned by a user. Discovery now falls back to `/Users` and prefers the user matching the configured username.
- **Ping**: `Client.Ping` falls back to `/Users` only when the dialect is Jellyfin, both credentials are empty, and the ping returns HTTP 400. The fallback is anchored on a new typed `httpError` that preserves the status code while keeping raw response bodies out of error strings; unrelated failures and all Emby paths return the original error unchanged.

## Notes

- Emby is unaffected: the `/Users` fallback is gated to the Jellyfin dialect, and Emby's ping endpoint (`/System/Info`), auth scheme, and user-id discovery are untouched.
- Jellyfin's documented "Token is not owned by a user." message is sent as an empty response body, so the fallback matches on status 400 rather than body text.

## Testing

- Unit tests covering the API-key ping fallback (success and invalid-token paths), the non-400 / unrelated-error cases that must not fall back, Emby ping failures never falling back, and both auth query parameters in stream URLs.
- `make check` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Jellyfin authentication compatibility across supported authorization formats.
  * API-key connections now validate more reliably, including fallback user discovery where appropriate.
  * Stream URLs support both current and legacy API-key formats.
  * Improved connection error reporting with clearer status and response details.
  * Preserved specific authentication and library-access failures instead of applying inappropriate fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->