### PR TITLE
refactor(ui): centralize theme style initialization

### DIFF
--- a/ui/model/styles.go
+++ b/ui/model/styles.go
@@ -6,72 +6,31 @@ import (
 	"github.com/bjarneo/cliamp/ui"
 )
 
-// Model-specific lipgloss styles, rebuilt when the theme changes.
+// Model-specific lipgloss styles. They have no initializers: rebuildModelStyles
+// builds them from init for the default palette and again on every theme
+// change. A style omitted there renders unstyled under every theme.
 var (
-	titleStyle = lipgloss.NewStyle().
-			Foreground(ui.ColorTitle).
-			Bold(true)
-
-	trackStyle = lipgloss.NewStyle().
-			Foreground(ui.ColorAccent)
-
-	timeStyle = lipgloss.NewStyle().
-			Foreground(ui.ColorText)
-
-	statusStyle = lipgloss.NewStyle().
-			Foreground(ui.ColorPlaying).
-			Bold(true)
-
-	feedbackActivityStyle = lipgloss.NewStyle().
-				Foreground(ui.ColorDim)
-
-	feedbackSuccessStyle = lipgloss.NewStyle().
-				Foreground(ui.ColorPlaying).
-				Bold(true)
-
-	feedbackWarningStyle = lipgloss.NewStyle().
-				Foreground(ui.ColorWarning).
-				Bold(true)
-
-	dimStyle = lipgloss.NewStyle().
-			Foreground(ui.ColorDim)
-
-	labelStyle = lipgloss.NewStyle().
-			Foreground(ui.ColorText).
-			Bold(true)
-
-	eqActiveStyle = lipgloss.NewStyle().
-			Foreground(ui.ColorAccent).
-			Bold(true)
-
-	eqInactiveStyle = lipgloss.NewStyle().
-			Foreground(ui.ColorDim)
-
-	playlistActiveStyle = lipgloss.NewStyle().
-				Foreground(ui.ColorPlaying).
-				Bold(true)
-
-	playlistItemStyle = lipgloss.NewStyle().
-				Foreground(ui.ColorText)
-
-	playlistSelectedStyle = lipgloss.NewStyle().
-				Foreground(ui.ColorAccent).
-				Bold(true)
-
-	playlistUnavailableStyle = lipgloss.NewStyle().
-					Foreground(ui.ColorDim)
-
-	helpStyle = lipgloss.NewStyle().
-			Foreground(ui.ColorDim)
-
-	helpKeyStyle = lipgloss.NewStyle().
-			Foreground(ui.ColorKeyFG).
-			Background(ui.ColorKeyBG).
-			Bold(true)
-
-	errorStyle = lipgloss.NewStyle().
-			Foreground(ui.ColorError)
+	titleStyle               lipgloss.Style
+	trackStyle               lipgloss.Style
+	timeStyle                lipgloss.Style
+	statusStyle              lipgloss.Style
+	feedbackActivityStyle    lipgloss.Style
+	feedbackSuccessStyle     lipgloss.Style
+	feedbackWarningStyle     lipgloss.Style
+	dimStyle                 lipgloss.Style
+	labelStyle               lipgloss.Style
+	eqActiveStyle            lipgloss.Style
+	eqInactiveStyle          lipgloss.Style
+	playlistActiveStyle      lipgloss.Style
+	playlistItemStyle        lipgloss.Style
+	playlistSelectedStyle    lipgloss.Style
+	playlistUnavailableStyle lipgloss.Style
+	helpStyle                lipgloss.Style
+	helpKeyStyle             lipgloss.Style
+	errorStyle               lipgloss.Style
 )
+
+func init() { rebuildModelStyles() }
 
 // rebuildModelStyles reconstructs all model-specific lipgloss styles from current color variables.
 func rebuildModelStyles() {

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -26,21 +26,22 @@ const (
 	titleScrollInterval = 200 * time.Millisecond
 )
 
-// Pre-built styles for elements created per-render to avoid repeated allocation.
+// Pre-built styles for elements created per-render to avoid repeated
+// allocation. Built by rebuildModelStyles (styles.go), never here.
 var (
-	seekFillStyle = lipgloss.NewStyle().Foreground(ui.ColorSeekBar)
-	seekDimStyle  = lipgloss.NewStyle().Foreground(ui.ColorDim)
-	volBarStyle   = lipgloss.NewStyle().Foreground(ui.ColorVolume)
-	activeToggle  = lipgloss.NewStyle().Foreground(ui.ColorAccent).Bold(true)
+	seekFillStyle lipgloss.Style
+	seekDimStyle  lipgloss.Style
+	volBarStyle   lipgloss.Style
+	activeToggle  lipgloss.Style
 	// favMarkerStyle paints the favorite heart in the theme's red so it
 	// reads as a deliberate accent instead of inheriting the dim/unavailable
 	// look. The glyph carries U+FE0E (text presentation) so terminals render
 	// it as a compact font glyph rather than a large color emoji.
-	favMarkerStyle = lipgloss.NewStyle().Foreground(ui.ColorError)
+	favMarkerStyle lipgloss.Style
 	// favRemovedStyle mutes the same filled heart for unfavorite feedback:
 	// identical attractive glyph, faded to signal the removed state instead
 	// of switching to a thin outline glyph.
-	favRemovedStyle = lipgloss.NewStyle().Foreground(ui.ColorDim)
+	favRemovedStyle lipgloss.Style
 )
 
 // favHeart is the small, text-presentation favorite heart used everywhere the

--- a/ui/styles.go
+++ b/ui/styles.go
@@ -11,27 +11,29 @@ import (
 	"github.com/bjarneo/cliamp/theme"
 )
 
-// CLIAMP color palette using standard ANSI terminal colors (0-15).
-// These adapt to the user's terminal theme for consistent appearance.
+// CLIAMP color palette. With no theme configured these are the standard ANSI
+// terminal colors (0-15), which adapt to the user's terminal theme. They have
+// no initializers: ApplyThemeColors is the single place that sets them, from
+// init for the default palette and again on every theme change.
 var (
 	ColorBackground color.Color
-	ColorTitle      color.Color = lipgloss.ANSIColor(10) // bright green
-	ColorText       color.Color = lipgloss.ANSIColor(15) // bright white
-	ColorDim        color.Color = lipgloss.ANSIColor(7)  // white (light gray)
-	ColorAccent     color.Color = lipgloss.ANSIColor(11) // bright yellow
-	ColorPlaying    color.Color = lipgloss.ANSIColor(10) // bright green
-	ColorSeekBar    color.Color = lipgloss.ANSIColor(11) // bright yellow
-	ColorVolume     color.Color = lipgloss.ANSIColor(2)  // green
-	ColorError      color.Color = lipgloss.ANSIColor(9)  // bright red
-	ColorWarning    color.Color = lipgloss.ANSIColor(11) // bright yellow
-	ColorKeyBG      color.Color = lipgloss.ANSIColor(8)  // bright black (dark gray)
-	ColorKeyFG      color.Color = lipgloss.ANSIColor(15) // bright white
-
-	// Spectrum gradient: green -> yellow -> red
-	SpectrumLow  color.Color = lipgloss.ANSIColor(10) // bright green
-	SpectrumMid  color.Color = lipgloss.ANSIColor(11) // bright yellow
-	SpectrumHigh color.Color = lipgloss.ANSIColor(9)  // bright red
+	ColorTitle      color.Color
+	ColorText       color.Color
+	ColorDim        color.Color
+	ColorAccent     color.Color
+	ColorPlaying    color.Color
+	ColorSeekBar    color.Color
+	ColorVolume     color.Color
+	ColorError      color.Color
+	ColorWarning    color.Color
+	ColorKeyBG      color.Color
+	ColorKeyFG      color.Color
+	SpectrumLow     color.Color
+	SpectrumMid     color.Color
+	SpectrumHigh    color.Color
 )
+
+func init() { ApplyThemeColors(theme.Default()) }
 
 // PaddingH is the horizontal padding inside the frame.
 var PaddingH = 3

--- a/ui/visualizer.go
+++ b/ui/visualizer.go
@@ -200,10 +200,11 @@ func averageSpectrumRangeLinear(magnitudes []float64, loPos, hiPos float64) floa
 }
 
 // Pre-built styles for spectrum bar colors to avoid per-frame allocation.
+// Built by ApplyThemeColors (styles.go), never here.
 var (
-	specLowStyle  = lipgloss.NewStyle().Foreground(SpectrumLow)
-	specMidStyle  = lipgloss.NewStyle().Foreground(SpectrumMid)
-	specHighStyle = lipgloss.NewStyle().Foreground(SpectrumHigh)
+	specLowStyle  lipgloss.Style
+	specMidStyle  lipgloss.Style
+	specHighStyle lipgloss.Style
 )
 
 // Raw ANSI wrappers for the spectrum styles. Caching these once lets every
@@ -215,10 +216,6 @@ var (
 	specMidPrefix, specMidSuffix   string
 	specHighPrefix, specHighSuffix string
 )
-
-func init() {
-	refreshSpecANSI()
-}
 
 func refreshSpecANSI() {
 	specLowPrefix, specLowSuffix = splitStyleAroundProbe(specLowStyle)


### PR DESCRIPTION
## Summary
- Initialize the default palette through ApplyThemeColors.
- Build model and spectrum styles through the existing theme rebuild paths, removing duplicate initializers.

## Validation
- `make test`
- `make fmt-check vet`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * UI colors and visualizer spectrum styling now update consistently when the application theme changes.
  * Theme colors are applied automatically at startup, providing consistent default styling throughout the interface.

* **Bug Fixes**
  * Improved visual consistency for model views, controls, and spectrum displays after switching themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->