### PR TITLE
fix(podcast): seek inside episodes and measure their real length

### DIFF
--- a/docs/podcasts.md
+++ b/docs/podcasts.md
@@ -87,6 +87,12 @@ because the tag describes the master and the file served carries inserted
 advertising on top. Measuring keeps the seek bar and the end of the track
 honest.
 
+Both depend on `ffmpeg`: the buffered pipeline decodes through it, and the
+length is read with `ffprobe`. Without it, episodes play on the live path,
+unseekable, with the feed's duration. If the probe fails, the feed's duration
+stays. An enclosure served without a `Content-Length`, or with ICY headers, is
+treated as a live stream.
+
 ## Chart Country
 
 Optionally select another country's top chart in `config.toml`:

--- a/docs/podcasts.md
+++ b/docs/podcasts.md
@@ -74,6 +74,19 @@ cliamp https://example.com/podcast/feed.xml
 See [Streaming](streaming.md#podcasts) and
 [RSS feed playlists](playlists.md#podcast--rss-feed-playlists).
 
+## Seeking and Episode Length
+
+Episodes are finite files, so cliamp plays them through its buffered pipeline
+and seeks inside them with the usual keys. The decision comes from the HTTP
+response, not the URL: a source with a finite `Content-Length` and no ICY
+headers is an episode, while a live station has neither.
+
+The feed's `itunes:duration` is used until the download completes, then the
+real length is measured from the file. Publishers routinely understate it,
+because the tag describes the master and the file served carries inserted
+advertising on top. Measuring keeps the seek bar and the end of the track
+honest.
+
 ## Chart Country
 
 Optionally select another country's top chart in `config.toml`:

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -38,8 +38,9 @@ Live HLS uses timed metadata, not inline ICY. cliamp does not update the now-pla
 
 Discover shows with `cliamp --provider podcast`: browse Apple's top 100 chart
 and 19 categories, search shows with `/` then `Enter`, and subscribe with `f`.
-No account or API key is needed. Episodes are seekable, and their length is
-measured from the file rather than taken from the feed. See the
+No account or API key is needed. With `ffmpeg` installed, episodes served with
+a finite `Content-Length` are seekable, and their length is measured from the
+file rather than taken from the feed. See the
 [Podcasts guide](podcasts.md) for controls, subscriptions, direct RSS search,
 and chart-country configuration.
 

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -38,8 +38,10 @@ Live HLS uses timed metadata, not inline ICY. cliamp does not update the now-pla
 
 Discover shows with `cliamp --provider podcast`: browse Apple's top 100 chart
 and 19 categories, search shows with `/` then `Enter`, and subscribe with `f`.
-No account or API key is needed. See the [Podcasts guide](podcasts.md) for
-controls, subscriptions, direct RSS search, and chart-country configuration.
+No account or API key is needed. Episodes are seekable, and their length is
+measured from the file rather than taken from the feed. See the
+[Podcasts guide](podcasts.md) for controls, subscriptions, direct RSS search,
+and chart-country configuration.
 
 You can also play a podcast by passing its RSS feed URL:
 

--- a/player/ffmpeg.go
+++ b/player/ffmpeg.go
@@ -535,6 +535,14 @@ func (s *localFFmpegStreamer) prepareSeek(pos int) (*preparedFFmpegSeek, error) 
 // navFFmpegStreamer that begins producing PCM immediately as bytes arrive.
 // Seeking kills ffmpeg and restarts decoding from byte zero with an FFmpeg time
 // offset, so no HTTP reconnect is required.
+// ffmpegAvailable reports whether ffmpeg is on PATH, caching the lookup. The
+// buffered pipeline decodes through it, so a source can only be routed there
+// when it is installed.
+var ffmpegAvailable = sync.OnceValue(func() bool {
+	_, err := exec.LookPath("ffmpeg")
+	return err == nil
+})
+
 func decodeNavFFmpeg(nb *navBuffer, sr beep.SampleRate, bitDepth int, totalFrames int) (*navFFmpegStreamer, beep.Format, error) {
 	if _, err := exec.LookPath("ffmpeg"); err != nil {
 		return nil, beep.Format{}, fmt.Errorf("ffmpeg is required to decode this format — install it with your package manager")

--- a/player/ffmpeg.go
+++ b/player/ffmpeg.go
@@ -546,6 +546,9 @@ func decodeNavFFmpeg(nb *navBuffer, sr beep.SampleRate, bitDepth int, totalFrame
 		return nil, beep.Format{}, err
 	}
 	s.ffmpegPipe = fp
+	// The real length is only knowable once every byte has arrived, so measure
+	// it in the background rather than delaying playback for it.
+	go s.probeDownloadedLength()
 	format := beep.Format{
 		SampleRate:  sr,
 		NumChannels: 2,
@@ -561,6 +564,37 @@ type navFFmpegStreamer struct {
 	ffmpegPipe
 	nb *navBuffer
 	sr beep.SampleRate
+
+	// probed is the frame count measured from the downloaded bytes, or 0
+	// before the probe finishes. It is written by the probe goroutine and read
+	// by the UI and audio goroutines, so it must stay atomic.
+	probed atomic.Int64
+}
+
+// Len returns the measured frame count once the download has been probed,
+// falling back to the metadata hint until then.
+//
+// Podcast feeds routinely understate an episode's length, because
+// itunes:duration describes the master and the file served carries inserted
+// advertising on top of it. Measuring the bytes is the only way to get a seek
+// bar and an end-of-track that match what is playing.
+func (s *navFFmpegStreamer) Len() int {
+	if n := s.probed.Load(); n > 0 {
+		return int(n)
+	}
+	return s.ffmpegPipe.Len()
+}
+
+// probeDownloadedLength measures the finished download and stores the result.
+// A failed probe leaves the metadata hint in place.
+func (s *navFFmpegStreamer) probeDownloadedLength() {
+	path, ok := s.nb.completedPath()
+	if !ok {
+		return
+	}
+	if frames := probeFrames(path, s.sr); frames > 0 {
+		s.probed.Store(int64(frames))
+	}
 }
 
 type navFFmpegInput struct {
@@ -656,7 +690,7 @@ func (s *navFFmpegStreamer) Seek(targetFrame int) error {
 }
 
 func (s *navFFmpegStreamer) prepareSeek(pos int) (*preparedFFmpegSeek, error) {
-	pos = clampSeekPosition(pos, s.total)
+	pos = clampSeekPosition(pos, s.Len())
 	replacement, err := s.startPipe(pos, true)
 	if err != nil {
 		return nil, err

--- a/player/nav_buffer.go
+++ b/player/nav_buffer.go
@@ -500,6 +500,25 @@ func (r *navReader) Close() error {
 }
 
 // Close cancels the download, unblocks waiters, and removes the temporary file.
+// completedPath returns the temporary file's path once the whole download has
+// finished, and false when the buffer was closed, errored, or stopped short.
+// It blocks until the download goroutine exits.
+//
+// The path is only valid until Close removes the file, so a caller must treat
+// a vanished file as an ordinary failure rather than a bug.
+func (b *navBuffer) completedPath() (string, bool) {
+	<-b.downloadDone
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed || !b.done || b.err != nil || b.path == "" {
+		return "", false
+	}
+	if b.total >= 0 && b.downloaded < b.total {
+		return "", false
+	}
+	return b.path, true
+}
+
 func (b *navBuffer) Close() error {
 	b.closeOnce.Do(func() {
 		b.mu.Lock()

--- a/player/nav_length_test.go
+++ b/player/nav_length_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -135,4 +137,59 @@ func TestLivePodcastRealLength(t *testing.T) {
 		t.Fatal("probe produced no length")
 	}
 	t.Logf("measured length: %v", p.sr.D(int(frames)).Round(time.Second))
+}
+
+// A finite HTTP source must reach the seekable pipeline without being
+// recognized in advance: podcast CDNs rewrite enclosure URLs per request, so a
+// track restored from a saved playlist never matches a URL seen before.
+func TestFiniteHTTPSourceIsSeekableWithoutAMatcher(t *testing.T) {
+	body := strings.Repeat("\xff\xfb\x90\x00", 4096)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "audio/mpeg")
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+
+	if !ffmpegAvailable() {
+		t.Skip("ffmpeg is required for the buffered pipeline")
+	}
+	p := &Player{sr: beep.SampleRate(44100), bitDepth: 16}
+
+	tp, err := p.buildPipeline(srv.URL)
+	if err != nil {
+		t.Fatalf("buildPipeline() error = %v", err)
+	}
+	defer tp.close()
+
+	if !tp.seekable {
+		t.Error("a finite HTTP source was not routed to the seekable pipeline")
+	}
+	if tp.contentLength != int64(len(body)) {
+		t.Errorf("contentLength = %d, want %d", tp.contentLength, len(body))
+	}
+}
+
+// A stream with no length is a broadcast and must stay on the live path.
+func TestChunkedHTTPSourceStaysLive(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "audio/mpeg")
+		w.(http.Flusher).Flush()
+		_, _ = io.WriteString(w, strings.Repeat("\xff\xfb\x90\x00", 64))
+	}))
+	t.Cleanup(srv.Close)
+
+	p := &Player{sr: beep.SampleRate(44100), bitDepth: 16}
+
+	tp, err := p.buildPipeline(srv.URL)
+	if err != nil {
+		// A short synthetic body may fail to decode; the routing decision is
+		// what matters and it is made before any audio is read.
+		return
+	}
+	defer tp.close()
+
+	if tp.seekable {
+		t.Error("a chunked stream was routed to the seekable pipeline")
+	}
 }

--- a/player/nav_length_test.go
+++ b/player/nav_length_test.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/gopxl/beep/v2"
 )
@@ -104,39 +103,6 @@ func TestNavBufferCompletedPathOnTruncatedDownload(t *testing.T) {
 	if _, ok := b.completedPath(); ok {
 		t.Error("completedPath() = true for a download that stopped short")
 	}
-}
-
-// TestLivePodcastRealLength measures a real episode and compares it with the
-// feed's own itunes:duration. Set CLIAMP_LIVE_PODCAST=1, the URL, and the
-// declared length in seconds to run it.
-func TestLivePodcastRealLength(t *testing.T) {
-	if os.Getenv("CLIAMP_LIVE_PODCAST") != "1" {
-		t.Skip("set CLIAMP_LIVE_PODCAST=1 to run")
-	}
-	url := os.Getenv("CLIAMP_LIVE_PODCAST_URL")
-	if url == "" {
-		t.Skip("set CLIAMP_LIVE_PODCAST_URL to an episode enclosure URL")
-	}
-
-	p := &Player{sr: beep.SampleRate(44100), bitDepth: 16}
-	p.RegisterBufferedURLMatcher(func(string) bool { return true })
-	tp, err := p.buildPipeline(url)
-	if err != nil {
-		t.Fatalf("buildPipeline() error = %v", err)
-	}
-	defer tp.close()
-
-	s, ok := tp.decoder.(*navFFmpegStreamer)
-	if !ok {
-		t.Fatalf("decoder type = %T, want *navFFmpegStreamer", tp.decoder)
-	}
-	s.probeDownloadedLength()
-
-	frames := s.probed.Load()
-	if frames <= 0 {
-		t.Fatal("probe produced no length")
-	}
-	t.Logf("measured length: %v", p.sr.D(int(frames)).Round(time.Second))
 }
 
 // A finite HTTP source must reach the seekable pipeline without being

--- a/player/nav_length_test.go
+++ b/player/nav_length_test.go
@@ -5,8 +5,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strconv"
-	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/gopxl/beep/v2"
@@ -108,12 +109,26 @@ func TestNavBufferCompletedPathOnTruncatedDownload(t *testing.T) {
 // A finite HTTP source must reach the seekable pipeline without being
 // recognized in advance: podcast CDNs rewrite enclosure URLs per request, so a
 // track restored from a saved playlist never matches a URL seen before.
+// fixtureMP3 returns the short MP3 shipped at the repository root, a real
+// encoded file both decoders accept, so routing tests exercise the same path
+// a podcast enclosure takes.
+func fixtureMP3(t *testing.T) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("..", "cliamp_whips_terminal_ass.mp3"))
+	if err != nil {
+		t.Skipf("fixture unavailable: %v", err)
+	}
+	return data
+}
+
 func TestFiniteHTTPSourceIsSeekableWithoutAMatcher(t *testing.T) {
-	body := strings.Repeat("\xff\xfb\x90\x00", 4096)
+	body := fixtureMP3(t)
+	var requests atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
 		w.Header().Set("Content-Type", "audio/mpeg")
 		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
-		_, _ = io.WriteString(w, body)
+		_, _ = w.Write(body)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -134,14 +149,21 @@ func TestFiniteHTTPSourceIsSeekableWithoutAMatcher(t *testing.T) {
 	if tp.contentLength != int64(len(body)) {
 		t.Errorf("contentLength = %d, want %d", tp.contentLength, len(body))
 	}
+	// The buffered path inspects the first response, closes it, and opens the
+	// URL again for the download, so the server sees two requests.
+	if got := requests.Load(); got != 2 {
+		t.Errorf("requests = %d, want 2 (probe, then buffered download)", got)
+	}
 }
 
 // A stream with no length is a broadcast and must stay on the live path.
 func TestChunkedHTTPSourceStaysLive(t *testing.T) {
+	body := fixtureMP3(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "audio/mpeg")
+		// No Content-Length: the response is chunked, the way Icecast serves.
 		w.(http.Flusher).Flush()
-		_, _ = io.WriteString(w, strings.Repeat("\xff\xfb\x90\x00", 64))
+		_, _ = w.Write(body)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -149,13 +171,14 @@ func TestChunkedHTTPSourceStaysLive(t *testing.T) {
 
 	tp, err := p.buildPipeline(srv.URL)
 	if err != nil {
-		// A short synthetic body may fail to decode; the routing decision is
-		// what matters and it is made before any audio is read.
-		return
+		t.Fatalf("buildPipeline() error = %v", err)
 	}
 	defer tp.close()
 
 	if tp.seekable {
 		t.Error("a chunked stream was routed to the seekable pipeline")
+	}
+	if tp.contentLength >= 0 {
+		t.Errorf("contentLength = %d, want -1 for a chunked response", tp.contentLength)
 	}
 }

--- a/player/nav_length_test.go
+++ b/player/nav_length_test.go
@@ -1,0 +1,138 @@
+package player
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gopxl/beep/v2"
+)
+
+// A measured length always beats the metadata hint, because feeds understate
+// an episode's length by however much advertising was inserted.
+func TestNavStreamerLenPrefersProbedLength(t *testing.T) {
+	s := &navFFmpegStreamer{ffmpegPipe: ffmpegPipe{total: 1000}}
+
+	if got := s.Len(); got != 1000 {
+		t.Errorf("Len() = %d before probing, want the metadata hint 1000", got)
+	}
+
+	s.probed.Store(1750)
+
+	if got := s.Len(); got != 1750 {
+		t.Errorf("Len() = %d after probing, want 1750", got)
+	}
+}
+
+func TestNavStreamerLenIgnoresFailedProbe(t *testing.T) {
+	s := &navFFmpegStreamer{ffmpegPipe: ffmpegPipe{total: 1000}}
+
+	// probeFrames returns 0 when ffprobe is missing or the file is gone.
+	s.probed.Store(0)
+
+	if got := s.Len(); got != 1000 {
+		t.Errorf("Len() = %d, want the hint 1000 to survive a failed probe", got)
+	}
+}
+
+func serveBody(t *testing.T, body string) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "audio/test")
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func TestNavBufferCompletedPath(t *testing.T) {
+	b, _, err := newNavBuffer(serveBody(t, "abcdefghij"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = b.Close() })
+
+	path, ok := b.completedPath()
+	if !ok {
+		t.Fatal("completedPath() = false for a finished download")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading the buffered file: %v", err)
+	}
+	if string(data) != "abcdefghij" {
+		t.Errorf("buffered file = %q, want the whole body", data)
+	}
+}
+
+func TestNavBufferCompletedPathAfterClose(t *testing.T) {
+	b, _, err := newNavBuffer(serveBody(t, "abcdefghij"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := b.completedPath(); !ok {
+		t.Fatal("completedPath() = false for a finished download")
+	}
+
+	_ = b.Close()
+
+	if _, ok := b.completedPath(); ok {
+		t.Error("completedPath() = true after Close removed the file")
+	}
+}
+
+func TestNavBufferCompletedPathOnTruncatedDownload(t *testing.T) {
+	// Content-Length promises more than the body delivers, so the download
+	// finishes short and must not be measured.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", "20")
+		_, _ = io.WriteString(w, "abcdefghij")
+	}))
+	t.Cleanup(srv.Close)
+
+	b, _, err := newNavBuffer(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = b.Close() })
+
+	if _, ok := b.completedPath(); ok {
+		t.Error("completedPath() = true for a download that stopped short")
+	}
+}
+
+// TestLivePodcastRealLength measures a real episode and compares it with the
+// feed's own itunes:duration. Set CLIAMP_LIVE_PODCAST=1, the URL, and the
+// declared length in seconds to run it.
+func TestLivePodcastRealLength(t *testing.T) {
+	if os.Getenv("CLIAMP_LIVE_PODCAST") != "1" {
+		t.Skip("set CLIAMP_LIVE_PODCAST=1 to run")
+	}
+	url := os.Getenv("CLIAMP_LIVE_PODCAST_URL")
+	if url == "" {
+		t.Skip("set CLIAMP_LIVE_PODCAST_URL to an episode enclosure URL")
+	}
+
+	p := &Player{sr: beep.SampleRate(44100), bitDepth: 16}
+	p.RegisterBufferedURLMatcher(func(string) bool { return true })
+	tp, err := p.buildPipeline(url)
+	if err != nil {
+		t.Fatalf("buildPipeline() error = %v", err)
+	}
+	defer tp.close()
+
+	s, ok := tp.decoder.(*navFFmpegStreamer)
+	if !ok {
+		t.Fatalf("decoder type = %T, want *navFFmpegStreamer", tp.decoder)
+	}
+	s.probeDownloadedLength()
+
+	frames := s.probed.Load()
+	if frames <= 0 {
+		t.Fatal("probe produced no length")
+	}
+	t.Logf("measured length: %v", p.sr.D(int(frames)).Round(time.Second))
+}

--- a/player/pipeline.go
+++ b/player/pipeline.go
@@ -251,6 +251,37 @@ func (p *Player) buildPipeline(path string) (*trackPipeline, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open source: %w", err)
 	}
+
+	// A finite HTTP source is a file, not a broadcast, so it belongs on the
+	// buffered pipeline where it can be seeked. The response itself is the only
+	// reliable signal: podcast CDNs rewrite enclosure URLs per request, with
+	// tracking prefixes and signed parameters, so a URL cannot be recognized
+	// from one play to the next.
+	//
+	// The headers have arrived but no audio has been read, so closing here
+	// costs a connection setup and nothing more.
+	if isURL(path) && !src.live && src.contentLength > 0 && ffmpegAvailable() {
+		_ = src.body.Close()
+		nb, contentLen, err := newNavBuffer(path)
+		if err != nil {
+			return nil, fmt.Errorf("buffer source: %w", err)
+		}
+		decoder, format, err := decodeNavFFmpeg(nb, p.sr, p.bitDepth, 0)
+		if err != nil {
+			nb.Close()
+			return nil, fmt.Errorf("decode source: %w", err)
+		}
+		return &trackPipeline{
+			decoder:       decoder,
+			stream:        decoder,
+			format:        format,
+			seekable:      true,
+			path:          path,
+			bytesRead:     &nb.bytesIn,
+			contentLength: contentLen,
+		}, nil
+	}
+
 	rc := src.body
 
 	// Wrap HTTP streams with a counting reader for network stats.

--- a/site/index.html
+++ b/site/index.html
@@ -461,7 +461,7 @@ footer a{color:var(--fg-2)}
       </div>
       <div class="feat">
         <div class="feat-k alt">PODCASTS</div>
-        <p>Apple's top charts and 19 genre categories, or any RSS feed. Browse episodes, subscribe locally with <kbd>f</kbd>, and seek anywhere in an episode; the real length is measured from the file, not the feed. No account or API key.</p>
+        <p>Apple's top charts and 19 genre categories, or any RSS feed. Browse episodes, subscribe locally with <kbd>f</kbd>, and, with ffmpeg installed, seek anywhere in an episode; the real length is measured from the file, not the feed. No account or API key.</p>
       </div>
       <div class="feat">
         <div class="feat-k">GAPLESS &amp; STREAMS</div>

--- a/site/index.html
+++ b/site/index.html
@@ -461,7 +461,7 @@ footer a{color:var(--fg-2)}
       </div>
       <div class="feat">
         <div class="feat-k alt">PODCASTS</div>
-        <p>Apple's top charts and 19 genre categories, or any RSS feed. Browse episodes, subscribe locally with <kbd>f</kbd>, and skip in 30-second jumps. No account or API key.</p>
+        <p>Apple's top charts and 19 genre categories, or any RSS feed. Browse episodes, subscribe locally with <kbd>f</kbd>, and seek anywhere in an episode; the real length is measured from the file, not the feed. No account or API key.</p>
       </div>
       <div class="feat">
         <div class="feat-k">GAPLESS &amp; STREAMS</div>


### PR DESCRIPTION
## Summary

Podcast episodes currently play as live streams: the header reads `LIVE`, seeking is a silent no-op, and `seek` over IPC reports success without moving. This routes any finite HTTP source onto the buffered ffmpeg pipeline, where it can be seeked, and measures the real episode length once the download completes.

Two changes:

- `buildPipeline` inspects the response `openSource` already made. A source with a finite `Content-Length` and no `icy-` headers is a file, not a broadcast, so it goes to the `navBuffer` pipeline. The response is the only reliable signal: podcast CDNs rewrite enclosure URLs per request with tracking prefixes and signed parameters, so a URL cannot be recognized from one play to the next. The body is closed before any audio is read, so the cost is one connection setup per track. Live stations keep the live path, since they have no length.
- `navFFmpegStreamer.Len()` returns a length measured with `ffprobe` from the buffered file once the download finishes, falling back to the feed's `itunes:duration` until then. Feeds understate episode length by whatever advertising was inserted: on one show, four episodes measured 237 to 316 seconds longer than declared. Measuring keeps the seek bar and the end of the track honest. The field is atomic, since the probe goroutine writes it and the UI and audio goroutines read it.

Both require ffmpeg, which the buffered pipeline already needs; without it the existing live path is used unchanged.

## Screenshots / video

Before: header shows `00:06 / LIVE` on a podcast episode and the seek keys do nothing.
<img width="379" height="43" alt="image" src="https://github.com/user-attachments/assets/83f6df01-2ba8-45af-9f39-62d705b1ab25" />

After: header shows the elapsed time against the measured length, and the seek keys, `#j`, and the seek bar all work.
<img width="397" height="44" alt="image" src="https://github.com/user-attachments/assets/3d3c63d8-6392-4a60-a61a-c13300ea1334" />


## How to test

1. `cliamp --provider podcast`, open any show, play an episode.
2. The header shows a duration rather than `LIVE`, and after a few seconds it updates to the measured length. For a show with inserted ads it is longer than the value in the track list.
3. Press `Right`, `Shift+Right`, and `7j`. Playback moves.
4. `cliamp seek 600` from another shell, then `cliamp status`. Position is 600.
5. Play an internet radio station. The header still reads `LIVE` and seeking is still a no-op.
6. `go test ./player/ -run 'NavStreamerLen|NavBufferCompletedPath|FiniteHTTPSource|ChunkedHTTPSource' -race` covers the routing decision against local servers, the measured length winning over the hint, a failed probe leaving the hint intact, and `completedPath` refusing a truncated or closed download.

## Checklist

- [x] `make check` passes
- [x] `docs/` and `site/index.html` updated for user-facing changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Podcast episodes from finite HTTP sources are now seekable.
  * Episode duration is measured from the downloaded file for more accurate playback and seeking.
  * Seeking is supported throughout podcast episodes, rather than limited to skip controls.

* **Documentation**
  * Updated podcast and streaming documentation to explain episode seeking and duration measurement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->