### PR TITLE
feat(ui): show the controls in the minimal layout when the rows allow

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,6 +139,10 @@ The title, track line, time, visualizer, seek bar, and hint bar stay full width.
 Narrower terminals, simplified mode, overlays, and list views keep the stacked
 single-column layout, with shuffle and repeat back in the header.
 
+Below 16 rows the minimal layout drops the controls to keep a row for tracks.
+From 12 rows it carries the compact `EQ · VOL` and `SRC` rows again, and `Tab`
+reaches them; at 10 or 11 rows only the playlist is focusable.
+
 In full and compact playback layouts, `Tab` cycles from Playlist through Source,
 Volume, EQ, Shuffle, Repeat, and Speed, then returns to Playlist. `Shift+Tab`
 reverses the order. Only visible controls participate; Source is skipped when

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -142,7 +142,9 @@ single-column layout, with shuffle and repeat back in the header.
 Below 16 rows the minimal layout drops the controls to keep a row for tracks.
 It brings the compact `EQ · VOL` and `SRC` rows back as soon as they fit with
 one track row to spare: 12 rows, or 11 with the hint bar hidden. `Tab` reaches
-them when they are drawn. Below that only the playlist is focusable, but the
+them when they are drawn, with the same ring as the compact layout, including
+the shuffle and repeat badges when the header has room and the speed readout on
+the status line. Below that only the playlist is focusable, but the
 provider keys still work: `Esc` focuses the provider list, and `O`, `L`, `R`,
 and the other uppercase provider letters switch source directly.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,8 +140,11 @@ Narrower terminals, simplified mode, overlays, and list views keep the stacked
 single-column layout, with shuffle and repeat back in the header.
 
 Below 16 rows the minimal layout drops the controls to keep a row for tracks.
-From 12 rows it carries the compact `EQ · VOL` and `SRC` rows again, and `Tab`
-reaches them; at 10 or 11 rows only the playlist is focusable.
+It brings the compact `EQ · VOL` and `SRC` rows back as soon as they fit with
+one track row to spare: 12 rows, or 11 with the hint bar hidden. `Tab` reaches
+them when they are drawn. Below that only the playlist is focusable, but the
+provider keys still work: `Esc` focuses the provider list, and `O`, `L`, `R`,
+and the other uppercase provider letters switch source directly.
 
 In full and compact playback layouts, `Tab` cycles from Playlist through Source,
 Volume, EQ, Shuffle, Repeat, and Speed, then returns to Playlist. `Shift+Tab`

--- a/ui/model/layout.go
+++ b/ui/model/layout.go
@@ -37,9 +37,9 @@ type frameLayout struct {
 	minimalControls bool
 }
 
-// minimalControlsMinHeight is the terminal height at which the minimal tier
-// can afford the two control rows and still show a row of playlist.
-const minimalControlsMinHeight = 12
+// minimalControlRows is what the minimal tier adds when it can afford the
+// compact tier's controls: one row for EQ and volume, one for the source.
+const minimalControlRows = 2
 
 // minimalBaseRows is the minimal tier's chrome: track line, time, seek bar,
 // playlist header, hint bar, and status line. Unlike the other tiers it has no
@@ -173,11 +173,18 @@ func (m *Model) recomputeLayout() {
 		}
 	}
 	// The minimal tier normally drops the controls to keep a row for tracks.
-	// With a little more height it can carry the compact tier's two rows, so
-	// source, volume, and EQ stay in reach without growing the window.
-	if layout.tier == layoutMinimal && !contentFirst && !simplified && height >= minimalControlsMinHeight {
-		layout.minimalControls = true
-		layout.fixedRows += 2
+	// It carries the compact tier's two rows whenever they fit with at least
+	// one track row left, so hiding the hint bar buys them a row sooner: 11
+	// rows with it hidden, 12 with it shown.
+	if layout.tier == layoutMinimal && !contentFirst && !simplified {
+		chrome := layout.fixedRows
+		if m.hideHelpBar {
+			chrome--
+		}
+		if spare := height - 2*paddingV - layout.footerRows - chrome; spare >= minimalControlRows+1 {
+			layout.minimalControls = true
+			layout.fixedRows += minimalControlRows
+		}
 	}
 	// The settings pane, open or closed, belongs to the full-tier playback
 	// screen only: the denser tiers and the list-focused layouts have no room

--- a/ui/model/layout.go
+++ b/ui/model/layout.go
@@ -32,7 +32,19 @@ type frameLayout struct {
 	// source and volume share one row and the EQ, speed, and download readouts
 	// are not drawn at all.
 	closedSettings bool
+	// minimalControls adds the compact tier's source and EQ/volume rows to the
+	// minimal tier once the terminal has the height to spare for them.
+	minimalControls bool
 }
+
+// minimalControlsMinHeight is the terminal height at which the minimal tier
+// can afford the two control rows and still show a row of playlist.
+const minimalControlsMinHeight = 12
+
+// minimalBaseRows is the minimal tier's chrome: track line, time, seek bar,
+// playlist header, hint bar, and status line. Unlike the other tiers it has no
+// spacer above the footer, since at this height every row is a track.
+const minimalBaseRows = 6
 
 // chromeRowsFreed is how many stacked chrome rows the current layout does not
 // draw, and therefore hands to the playlist.
@@ -137,7 +149,7 @@ func (m *Model) recomputeLayout() {
 		layout.fixedRows = compactBaseRows + compactVisRows
 	default:
 		layout.tier = layoutMinimal
-		layout.fixedRows = 7
+		layout.fixedRows = minimalBaseRows
 	}
 	layout.baseVisualizerRows = layout.visualizerRows
 	contentFirst := m.usesContentFirstLayout()
@@ -159,6 +171,13 @@ func (m *Model) recomputeLayout() {
 		} else if layout.tier == layoutCompact {
 			layout.fixedRows = 9
 		}
+	}
+	// The minimal tier normally drops the controls to keep a row for tracks.
+	// With a little more height it can carry the compact tier's two rows, so
+	// source, volume, and EQ stay in reach without growing the window.
+	if layout.tier == layoutMinimal && !contentFirst && !simplified && height >= minimalControlsMinHeight {
+		layout.minimalControls = true
+		layout.fixedRows += 2
 	}
 	// The settings pane, open or closed, belongs to the full-tier playback
 	// screen only: the denser tiers and the list-focused layouts have no room

--- a/ui/model/minimal_tier_test.go
+++ b/ui/model/minimal_tier_test.go
@@ -13,17 +13,24 @@ func TestMinimalTierRowBudget(t *testing.T) {
 	tests := []struct {
 		name         string
 		height       int
+		hideHelpBar  bool
 		wantControls bool
 	}{
-		{"10 rows, no room for controls", 10, false},
-		{"11 rows, still none", 11, false},
-		{"12 rows, controls appear", 12, true},
-		{"15 rows, controls stay", 15, true},
+		{"10 rows, no room for controls", 10, false, false},
+		{"11 rows, still none", 11, false, false},
+		{"12 rows, controls appear", 12, false, true},
+		{"15 rows, controls stay", 15, false, true},
+		// Hiding the hint bar frees a row, so the controls arrive one row sooner.
+		{"10 rows with the hint bar hidden, still none", 10, true, false},
+		{"11 rows with the hint bar hidden, controls appear", 11, true, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			withFrameWidth(t, 60)
 			m := newColumnTestModel(60, tt.height)
+			if tt.hideHelpBar {
+				m.SetHideHelpBar(true)
+			}
 
 			if m.layout.tier != layoutMinimal {
 				t.Fatalf("tier = %v, want minimal", m.layout.tier)

--- a/ui/model/minimal_tier_test.go
+++ b/ui/model/minimal_tier_test.go
@@ -1,0 +1,85 @@
+package model
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+)
+
+// The minimal tier gives every row it can to the playlist: no spacer above
+// the footer, and the compact control rows only once the height allows them.
+func TestMinimalTierRowBudget(t *testing.T) {
+	tests := []struct {
+		name         string
+		height       int
+		wantControls bool
+	}{
+		{"10 rows, no room for controls", 10, false},
+		{"11 rows, still none", 11, false},
+		{"12 rows, controls appear", 12, true},
+		{"15 rows, controls stay", 15, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withFrameWidth(t, 60)
+			m := newColumnTestModel(60, tt.height)
+
+			if m.layout.tier != layoutMinimal {
+				t.Fatalf("tier = %v, want minimal", m.layout.tier)
+			}
+			if got := m.layout.minimalControls; got != tt.wantControls {
+				t.Errorf("minimalControls = %v, want %v", got, tt.wantControls)
+			}
+
+			frame := stripAnsi(m.View().Content)
+			if got := lipgloss.Height(frame); got > tt.height {
+				t.Errorf("frame height = %d, want <= %d\n%s", got, tt.height, frame)
+			}
+			if got := strings.Contains(frame, "EQ ["); got != tt.wantControls {
+				t.Errorf("EQ row drawn = %v, want %v\n%s", got, tt.wantControls, frame)
+			}
+			if got := m.effectivePlaylistVisible(); got < 1 {
+				t.Errorf("playlist rows = %d, want at least one track visible", got)
+			}
+		})
+	}
+}
+
+// Drawing the control rows is only useful if they can be focused, so the
+// minimal tier's focus ring must open up with them.
+func TestMinimalTierFocusFollowsControls(t *testing.T) {
+	tests := []struct {
+		name   string
+		height int
+		want   []focusArea
+	}{
+		{"without controls", 10, []focusArea{focusPlaylist}},
+		{"with controls", 12, []focusArea{focusPlaylist, focusProvPill, focusVolume, focusEQ}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withFrameWidth(t, 60)
+			m := newColumnTestModel(60, tt.height)
+
+			got := m.mainFocusAreas()
+			for _, want := range tt.want {
+				if !m.mainFocusAllowed(want) {
+					t.Errorf("focus %v not allowed; areas = %v", want, got)
+				}
+			}
+			if !tt.want[len(tt.want)-1].equalsAny(focusEQ) && m.mainFocusAllowed(focusEQ) {
+				t.Errorf("EQ focus allowed without a row to show it; areas = %v", got)
+			}
+		})
+	}
+}
+
+func (f focusArea) equalsAny(others ...focusArea) bool {
+	for _, o := range others {
+		if f == o {
+			return true
+		}
+	}
+	return false
+}

--- a/ui/model/minimal_tier_test.go
+++ b/ui/model/minimal_tier_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -53,8 +54,10 @@ func TestMinimalTierRowBudget(t *testing.T) {
 	}
 }
 
-// Drawing the control rows is only useful if they can be focused, so the
-// minimal tier's focus ring must open up with them.
+// Drawing the control rows is only useful if they can be focused. With them
+// drawn, the minimal tier's focus ring is the compact tier's: the settings
+// the rows show, the shuffle and repeat badges when the header has room for
+// them, and speed, which the status line shows and highlights in every tier.
 func TestMinimalTierFocusFollowsControls(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -62,7 +65,7 @@ func TestMinimalTierFocusFollowsControls(t *testing.T) {
 		want   []focusArea
 	}{
 		{"without controls", 10, []focusArea{focusPlaylist}},
-		{"with controls", 12, []focusArea{focusPlaylist, focusProvPill, focusVolume, focusEQ}},
+		{"with controls", 12, []focusArea{focusPlaylist, focusProvPill, focusVolume, focusEQ, focusShuffle, focusRepeat, focusSpeed}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -70,23 +73,24 @@ func TestMinimalTierFocusFollowsControls(t *testing.T) {
 			m := newColumnTestModel(60, tt.height)
 
 			got := m.mainFocusAreas()
-			for _, want := range tt.want {
-				if !m.mainFocusAllowed(want) {
-					t.Errorf("focus %v not allowed; areas = %v", want, got)
-				}
-			}
-			if !tt.want[len(tt.want)-1].equalsAny(focusEQ) && m.mainFocusAllowed(focusEQ) {
-				t.Errorf("EQ focus allowed without a row to show it; areas = %v", got)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("mainFocusAreas() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
-func (f focusArea) equalsAny(others ...focusArea) bool {
-	for _, o := range others {
-		if f == o {
-			return true
-		}
+// The ring with the controls drawn must be the compact tier's, so a Tab stop
+// added to one tier is not silently missing from the other.
+func TestMinimalTierWithControlsMatchesCompactFocusRing(t *testing.T) {
+	withFrameWidth(t, 60)
+	minimal := newColumnTestModel(60, 12)
+	compact := newColumnTestModel(60, 16)
+
+	if minimal.layout.tier != layoutMinimal || compact.layout.tier != layoutCompact {
+		t.Fatalf("tiers = %v, %v; want minimal and compact", minimal.layout.tier, compact.layout.tier)
 	}
-	return false
+	if got, want := minimal.mainFocusAreas(), compact.mainFocusAreas(); !slices.Equal(got, want) {
+		t.Errorf("minimal ring = %v, compact ring = %v", got, want)
+	}
 }

--- a/ui/model/model.go
+++ b/ui/model/model.go
@@ -83,7 +83,10 @@ func (f focusArea) label() string {
 // main playback screen and the provider playlist pane.
 func (m Model) mainFocusAreas() []focusArea {
 	areas := []focusArea{focusPlaylist}
-	if m.simplified || m.layout.tier == layoutMinimal || m.layout.tier == layoutTooSmall {
+	if m.simplified || m.layout.tier == layoutTooSmall {
+		return areas
+	}
+	if m.layout.tier == layoutMinimal && !m.layout.minimalControls {
 		return areas
 	}
 	if m.layout.twoColumn {

--- a/ui/model/view.go
+++ b/ui/model/view.go
@@ -273,8 +273,11 @@ func (m Model) mainSections(playlist string, includeTransient, contentFirst bool
 				m.renderTrackInfo(),
 				m.renderTimeStatus(),
 				m.renderSeekBar(),
-				m.renderPlaylistHeader(),
 			}
+			if m.layout.minimalControls {
+				sections = append(sections, m.renderCompactControls(), m.renderCompactSource())
+			}
+			sections = append(sections, m.renderPlaylistHeader())
 		default:
 			sections = []string{
 				m.renderTitle(),
@@ -311,10 +314,11 @@ func (m Model) mainSections(playlist string, includeTransient, contentFirst bool
 	if playlist != "" {
 		sections = append(sections, playlist)
 	}
-	if !m.layout.twoColumn && m.layout.tier != layoutCompact {
+	if !m.layout.twoColumn && m.layout.tier != layoutCompact && m.layout.tier != layoutMinimal {
 		// The two-column body needs no spacer above the hint bar: the settings
 		// pane's own blank tail already separates the footer from the columns.
-		// Compact chrome also omits it so the speed row stays on-screen.
+		// Compact chrome omits it so the speed row stays on-screen, and minimal
+		// omits it because a blank row there is a track row lost.
 		sections = append(sections, "")
 	}
 	if !m.hideHelpBar {


### PR DESCRIPTION
## Summary

Below 16 rows the minimal layout drops the controls entirely, so the source, volume, and EQ are unreachable except by their global keys, and the pane keeps a spacer row above the footer that a 10-row window cannot spare.

- The spacer is dropped for the minimal tier, the way compact already drops it, and the row goes to the playlist. `minimalBaseRows` documents the budget as six rows: track line, time, seek bar, playlist header, hint bar, status line.
- The compact tier's two control rows, `EQ · VOL` and `SRC`, are drawn in the minimal tier whenever they fit with at least one track row to spare. The threshold is computed from the rows actually free rather than a fixed height, so hiding the hint bar earns the controls one row sooner: 12 rows with it shown, 11 with it hidden.
- The focus ring opens up with the rows. When they are drawn it is the compact tier's ring: source, volume, EQ, the shuffle and repeat badges when the header has room, and speed, which the status line shows and highlights in every tier. When they are not drawn it stays on the playlist alone.

Rendered at 60 columns:

```
60x10   no controls, one track row
60x12   EQ [Rock] VOL +0dB / SRC [Local] 1/3, one track row
60x14   same, three track rows
```

## Screenshots / video

### 12 rows:
<img width="837" height="284" alt="image" src="https://github.com/user-attachments/assets/db2f6621-da22-4620-a97f-9f990f5f6253" />

### 10 rows:
<img width="829" height="206" alt="image" src="https://github.com/user-attachments/assets/3afdea45-b0a2-47f0-a713-6fd1cfd1b98e" />

## How to test

1. Resize the terminal to 60x10. No control rows; the playlist has one row and no blank row sits above the footer.
2. Resize to 60x12. `EQ` and `SRC` rows appear above the playlist header. `Tab` cycles through source, volume, and EQ.
3. Press `Ctrl+G` to hide the hint bar, then resize to 60x11. The controls appear at this height too.
4. `go test ./ui/model/ -run 'MinimalTier|TwoColumnLayoutTiers' -race`. The tests render the frame at 10, 11, 12, and 15 rows, with and without the hint bar, and check it fits the terminal, that `EQ` appears only when budgeted, and that the focus ring matches.

## Checklist

- [x] `make check` passes
- [x] `docs/` and `site/index.html` updated for user-facing changes (docs only; the site does not describe layout tiers)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Minimal terminal layouts now display compact playback, volume, EQ, source, shuffle/repeat, and speed controls when sufficient space is available.
  - Keyboard navigation focuses only controls currently displayed, while provider shortcuts remain available.
  - Adjusted playlist and hint-bar placement to better use limited screen space.

- **Documentation**
  - Added guidance for minimal-layout behavior on terminals shorter than 16 rows, including control visibility thresholds and keyboard navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
