### PR TITLE
ci: update GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,10 @@ jobs:
   go:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v7.0.0
         with:
           go-version-file: go.mod
           cache: true
@@ -36,8 +38,10 @@ jobs:
             goos: windows
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v7.0.0
         with:
           go-version-file: go.mod
       - name: Install codec libs (macOS)

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,7 +27,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
         with:
           ref: ${{ inputs.tag || github.event.workflow_run.head_branch }}
       - uses: actions/configure-pages@v6.0.0


### PR DESCRIPTION
## Summary

- Update `actions/checkout` from `v4` to `v7.0.1` in the CI workflow.
- Update `actions/setup-go` from `v5` to `v7.0.0`.
- Update the Pages workflow's `actions/checkout` patch release to `v7.0.1`.
- Keep `msys2/setup-msys2@v2` unchanged because the major tag already follows the current v2 release.

This removes the Node 20 deprecation warning emitted by `actions/checkout@v4`.

## Screenshots / video

Not applicable — CI-only change.

## How to test

1. Install and run the workflow linter:

   ```sh
   go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
   actionlint .github/workflows/ci.yml .github/workflows/pages.yml
   ```

2. Verify the GitHub Actions run on the branch:

   - [CI run #34741788261](https://github.com/legacycode-forks/cliamp/actions/runs/34741788261)
   - Linux `go` job: passed
   - macOS build: passed
   - Windows build: passed

## Checklist

- [x] Equivalent formatting, vet, staticcheck, security, race-test, coverage, shellcheck, and generated-file checks passed in CI.
- [x] `docs/` and `site/index.html` do not require updates for this CI-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated build, testing, cross-platform, and documentation-site deployment workflows to use newer action versions.
  * Improved workflow credential handling during repository checkout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->