### PR TITLE
ci: align local and GitHub checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,7 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y libasound2-dev libflac-dev libvorbis-dev libogg-dev libmpg123-dev shellcheck
       - run: go install honnef.co/go/tools/cmd/staticcheck@v0.6.1
       - run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
-      - run: make fmt-check vet staticcheck security
-      - run: go test -count=1 -race ./...
-      - run: make coverage
-      - run: shellcheck site/install.sh
-      - run: git diff --exit-code
+      - run: make ci
 
   build:
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,11 @@ security:
 	@command -v govulncheck >/dev/null 2>&1 || { echo "govulncheck is required"; exit 1; }
 	govulncheck ./...
 
-ci: fmt-check vet staticcheck test security
+ci: fmt-check vet staticcheck security
+	go test -count=1 -race ./...
+	$(MAKE) coverage
+	shellcheck site/install.sh
+	git diff --exit-code
 
 check: fmt vet test
 


### PR DESCRIPTION
## Summary

- Move the Linux CI checks into the existing `make ci` target.
- Run `make ci` from the Linux GitHub Actions job instead of duplicating individual commands in the workflow.
- Keep formatting, vet, static analysis, vulnerability scanning, race tests, coverage, shellcheck, and generated-file checks unchanged.

This makes the local `make ci` command match the Linux CI gate and prevents the two check lists from drifting apart.

## Screenshots / video

Not applicable — CI-only change.

## How to test

1. Run the local CI target after installing the project's development dependencies:

   ```sh
   make ci
   ```

2. Validate the workflow syntax:

   ```sh
   go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
   actionlint .github/workflows/ci.yml
   ```

3. Verify the GitHub Actions run on the branch:

   - [CI run #34742583718](https://github.com/legacycode-forks/cliamp/actions/runs/34742583718)
   - Linux `go` job: passed
   - macOS build: passed
   - Windows build: passed

## Checklist

- [x] `make ci` passes and covers the format, vet, and test checks from `make check`.
- [x] `docs/` and `site/index.html` do not require updates for this CI-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded continuous integration checks to include formatting, static analysis, security scanning, race-enabled tests, coverage validation, installer script checks, and detection of uncommitted changes.
* **Chores**
  * Consolidated CI validation into a single standardized command for more consistent automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->