### PR TITLE
ci: improve workflow observability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   go:
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -35,6 +40,7 @@ jobs:
           - os: windows-2025
             goos: windows
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5


### PR DESCRIPTION
## Summary

CI currently lets obsolete runs continue after a newer commit is pushed to the same pull request or branch. This unnecessarily consumes runner capacity and can delay useful feedback. CI jobs also have no explicit runtime limit, so a stalled job may occupy a runner indefinitely.

This change:

- cancels older in-progress CI runs when a newer run supersedes them
- adds a 20-minute timeout to the Linux, macOS, and Windows CI jobs

The 20-minute limit leaves substantial room above the latest full CI run:

| Job | Duration |
| --- | ---: |
| Linux | 1m43s |
| Windows | 2m09s |
| macOS | 2m15s |

This gives each job enough tolerance for runner, cache, dependency-download, or network variability while still terminating genuinely stalled executions.

The workflow stays functionally identical; the changes only make execution more predictable and reduce wasted CI time.

## Screenshots / video

N/A

## How to test

- Validate `.github/workflows/ci.yml` with `actionlint`.
- Verify the fork CI run completes on Linux, macOS, and Windows:
  https://github.com/legacycode-forks/cliamp/actions/runs/34745864820

- [x] I have tested these changes
- [x] I have reviewed my changes