### PR TITLE
fix(ui): persist theme picker selection

### DIFF
--- a/ui/model/overlays.go
+++ b/ui/model/overlays.go
@@ -53,11 +53,16 @@ func (m *Model) themePickerApply() bool {
 	return true
 }
 
-// themePickerSelect confirms the current selection and closes the picker.
+// themePickerSelect confirms the current selection, persists it, and closes the picker.
 func (m *Model) themePickerSelect() {
 	if !m.themePickerApply() {
 		return
 	}
+	themeName := m.ThemeName()
+	if themeName == theme.DefaultName {
+		themeName = ""
+	}
+	m.saveConfigKey("theme", fmt.Sprintf("%q", themeName))
 	m.themePicker.visible = false
 	m.themePicker.filtering = false
 	m.themePicker.filter = ""

--- a/ui/model/picker_filter_test.go
+++ b/ui/model/picker_filter_test.go
@@ -38,6 +38,41 @@ func TestThemePickerCancelHandlesRemovedTheme(t *testing.T) {
 	}
 }
 
+func TestThemePickerSelectPersistsSelectedTheme(t *testing.T) {
+	saver := &recordingConfigSaver{}
+	m := Model{
+		themes: []theme.Theme{
+			{Name: "Ayu", Accent: "#000000", BrightFG: "#ffffff", FG: "#111111", Green: "#00ff00", Yellow: "#ffff00", Red: "#ff0000"},
+		},
+		themePicker: themePickerState{visible: true, cursor: 1},
+		configSaver: saver,
+	}
+
+	m.themePickerSelect()
+
+	if got := saver.values["theme"]; got != `"Ayu"` {
+		t.Fatalf("saved theme = %q, want %q", got, `"Ayu"`)
+	}
+	if m.themePicker.visible {
+		t.Fatal("theme picker remains visible after selection")
+	}
+}
+
+func TestThemePickerSelectPersistsDefaultAsEmptyValue(t *testing.T) {
+	saver := &recordingConfigSaver{}
+	m := Model{
+		themes:      []theme.Theme{{Name: "Ayu"}},
+		themePicker: themePickerState{visible: true, cursor: 0},
+		configSaver: saver,
+	}
+
+	m.themePickerSelect()
+
+	if got := saver.values["theme"]; got != `""` {
+		t.Fatalf("saved default theme = %q, want %q", got, `""`)
+	}
+}
+
 func TestVisualizerPickerFilterPreservesModeIndex(t *testing.T) {
 	m := Model{
 		vis: ui.NewVisualizer(44_100),


### PR DESCRIPTION
## Summary

Persist the theme selected through the interactive theme picker so it survives restarts and unclean exits.

`themePickerSelect()` previously applied the selection only to the live session and never wrote the `theme` config key. This change uses the existing nil-safe `saveConfigKey` helper. The built-in Default theme is stored as an empty value, matching the existing exit-time and IPC persistence behavior.

Fixes #473

## Screenshots / video

Not applicable — this is a persistence-only fix with no UI changes.

## How to test

1. Run `make check`.
2. Run the targeted tests with `go test ./ui/model -run 'TestThemePickerSelect|TestThemePickerFilter|TestThemePickerCancel' -count=1`.
3. Start cliamp, press `t`, select a non-default theme, and press Enter.
4. Restart cliamp and verify that the selected theme is still active.
5. Select the Default theme and verify that the config stores an empty `theme` value.

## Checklist

- [x] `make check` passes
- [x] `docs/` and `site/index.html` updated for user-facing changes — not required; no user-facing interface or documentation changed